### PR TITLE
Support for Bridge load via https on Heroku

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -47,8 +47,8 @@
         </div>
     </div>
     
-    <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.2.15/angular.min.js"></script>
-    <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.2.15/angular-route.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.15/angular.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.15/angular-route.js"></script>
     <script src="build/bridge.min.js"></script>
     <script>
     var _gaq = _gaq || [];


### PR DESCRIPTION
These don't load on Chrome unless they use the same protocol, otherwise it appears you can use https:// to access Bridge as deployed without further effort. We'll see.
