### PR TITLE
Refactoring use of TestUserAdminHelper

### DIFF
--- a/app/controllers/UserManagementController.java
+++ b/app/controllers/UserManagementController.java
@@ -41,12 +41,13 @@ public class UserManagementController extends AdminController {
 
     public Result deleteUser(String email) throws Exception {
         getAuthenticatedAdminSession();
+        
         Study study = studyService.getStudyByHostname(getHostname());
         
         User user = authenticationService.getUser(study, email);
         userAdminService.deleteUser(user);
 
-        return okResult("Deleted user successfully.");
+        return okResult("User deleted.");
     }
 
     public Result revokeAllConsentRecords() throws Exception {
@@ -59,6 +60,6 @@ public class UserManagementController extends AdminController {
         User user = authenticationService.getUser(study, email);
         userAdminService.revokeAllConsentRecords(user, study);
 
-        return okResult("Revoked all consent records successfully.");
+        return okResult("All consent records revoked.");
     }
 }

--- a/app/org/sagebionetworks/bridge/services/HealthDataServiceImpl.java
+++ b/app/org/sagebionetworks/bridge/services/HealthDataServiceImpl.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.bridge.services;
 
 import static com.google.common.base.Preconditions.checkArgument;
-
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.List;

--- a/app/org/sagebionetworks/bridge/services/ScheduleChangeWorker.java
+++ b/app/org/sagebionetworks/bridge/services/ScheduleChangeWorker.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.bridge.services;
 
 import java.util.ArrayList;
-
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.Callable;

--- a/app/org/sagebionetworks/bridge/validators/PasswordResetValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/PasswordResetValidator.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.bridge.validators;
 
 import org.apache.commons.lang3.StringUtils;
-
 import org.sagebionetworks.bridge.models.PasswordReset;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;

--- a/app/org/sagebionetworks/bridge/validators/ScheduleValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/ScheduleValidator.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.validators;
 
-import static org.sagebionetworks.bridge.validators.Validate.*;
+import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
+import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NULL;
 
 import org.apache.commons.lang3.StringUtils;
 import org.sagebionetworks.bridge.models.schedules.Schedule;

--- a/app/org/sagebionetworks/bridge/validators/StudyConsentValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/StudyConsentValidator.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.bridge.validators;
 
 import org.apache.commons.lang3.StringUtils;
-
 import org.sagebionetworks.bridge.models.StudyConsentForm;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;

--- a/app/org/sagebionetworks/bridge/validators/UploadValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/UploadValidator.java
@@ -1,6 +1,6 @@
 package org.sagebionetworks.bridge.validators;
 
-import static org.sagebionetworks.bridge.validators.Validate.*;
+import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
 
 import org.apache.commons.codec.binary.Base64;
 import org.sagebionetworks.bridge.models.UploadRequest;

--- a/app/views/consent.scala.html
+++ b/app/views/consent.scala.html
@@ -8,8 +8,8 @@
     <base href="/"/>
     <script>window._session = @Html(auth);</script>
     <!-- These file names are updated by the grunt build; do not modify directly. -->
-    <link rel="stylesheet" href="../shared/build/bridge-shared.min.937b506a.css" />
-    <link rel="stylesheet" href="consent/build/consent.min.1a847cb1.css" />
+    <link rel="stylesheet" href="../shared/build/bridge-shared.min.aabcc93c.css" />
+    <link rel="stylesheet" href="consent/build/consent.min.e0e2fc12.css" />
 </head>
 <body ng-app="consent" ng-controller="ConsentController">
 

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -6,8 +6,8 @@
     <meta name="viewport" content="width=device-width" />
     <base href="/app/"/>
     <!-- These file names are updated by the grunt build; do not modify directly. -->
-    <link rel="stylesheet" href="../shared/build/bridge-shared.min.937b506a.css" />
-    <link rel="stylesheet" href="build/bridge.min.17b99f26.css" />
+    <link rel="stylesheet" href="../shared/build/bridge-shared.min.aabcc93c.css" />
+    <link rel="stylesheet" href="build/bridge.min.66c78b7a.css" />
     <script>window._session = @Html(auth);</script>
 </head>
 <body ng-app="bridge" ng-controller="ApplicationController">

--- a/app/views/neurod.scala.html
+++ b/app/views/neurod.scala.html
@@ -7,8 +7,8 @@
     <base href="/"/>
     <script>window._session = @Html(auth);</script>
     <!-- These file names are updated by the grunt build; do not modify directly. -->
-    <link rel="stylesheet" href="../shared/build/bridge-shared.min.937b506a.css" />
-    <link rel="stylesheet" href="neurod/build/neurod.min.1edd1d3e.css" />
+    <link rel="stylesheet" href="../shared/build/bridge-shared.min.aabcc93c.css" />
+    <link rel="stylesheet" href="neurod/build/neurod.min.cbeaff96.css" />
 </head>
 <body ng-app="neurod" ng-controller="MainController">
   

--- a/app/views/test.scala.html
+++ b/app/views/test.scala.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width" />
     <base href="/" />
     <script>window._session = @Html(auth);</script>
-    <link rel="stylesheet" href="../shared/build/bridge-shared.min.937b506a.css" />
+    <link rel="stylesheet" href="../shared/build/bridge-shared.min.aabcc93c.css" />
     <link rel="stylesheet" href="../test/css/test.css" />
 </head>
 <body>

--- a/test/controllers/AuthenticationControllerTest.java
+++ b/test/controllers/AuthenticationControllerTest.java
@@ -26,8 +26,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.TestUserAdminHelper;
+import org.sagebionetworks.bridge.TestUserAdminHelper.TestUser;
 import org.sagebionetworks.bridge.TestUtils;
-import org.sagebionetworks.bridge.models.UserSession;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -44,16 +44,16 @@ public class AuthenticationControllerTest {
     @Resource
     private TestUserAdminHelper helper;
     
-    private UserSession session;
+    private TestUser testUser;
     
     @Before
     public void before() {
-        session = helper.createUser(getClass().getSimpleName());
+        testUser = helper.createUser(getClass().getSimpleName());
     }
     
     @After
     public void after() {
-        helper.deleteUser(session, getClass().getSimpleName());
+        helper.deleteUser(testUser);
     }
     
     @Test
@@ -93,8 +93,8 @@ public class AuthenticationControllerTest {
         running(testServer(3333), new TestUtils.FailableRunnable() {
             public void testCode() throws Exception {
                 ObjectNode node = JsonNodeFactory.instance.objectNode();
-                node.put(USERNAME, session.getUser().getUsername());
-                node.put(PASSWORD, helper.getPassword());
+                node.put(USERNAME, testUser.getUsername());
+                node.put(PASSWORD, testUser.getPassword());
 
                 Response response = WS.url(TEST_BASE_URL + SIGN_IN_URL).post(node).get(TIMEOUT);
                 assertEquals("HTTP response indicates request OK", SC_OK, response.getStatus());
@@ -103,7 +103,7 @@ public class AuthenticationControllerTest {
                 assertEquals("Type is UserSession", "UserSessionInfo", node.get("type").asText());
                 assertNotNull("Session token is assigned", node.get(SESSION_TOKEN).asText());
                 String username = node.get(USERNAME).asText();
-                assertEquals("Username is for test2 user", session.getUser().getUsername(), username);
+                assertEquals("Username is for test2 user", testUser.getUsername(), username);
             }
         });
     }
@@ -113,8 +113,8 @@ public class AuthenticationControllerTest {
         running(testServer(3333), new TestUtils.FailableRunnable() {
             public void testCode() throws Exception {
                 ObjectNode node = JsonNodeFactory.instance.objectNode();
-                node.put(USERNAME, session.getUser().getUsername());
-                node.put(PASSWORD, helper.getPassword());
+                node.put(USERNAME, testUser.getUsername());
+                node.put(PASSWORD, testUser.getPassword());
                 Response response = WS.url(TEST_BASE_URL + SIGN_IN_URL).post(node).get(TIMEOUT);
                 
                 WS.Cookie cookie = response.getCookie(BridgeConstants.SESSION_TOKEN_HEADER);

--- a/test/controllers/AuthenticationControllerTest.java
+++ b/test/controllers/AuthenticationControllerTest.java
@@ -48,7 +48,7 @@ public class AuthenticationControllerTest {
     
     @Before
     public void before() {
-        testUser = helper.createUser(getClass().getSimpleName());
+        testUser = helper.createUser(AuthenticationControllerTest.class);
     }
     
     @After

--- a/test/controllers/ConsentControllerTest.java
+++ b/test/controllers/ConsentControllerTest.java
@@ -18,11 +18,10 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.sagebionetworks.bridge.TestConstants.TestUser;
 import org.sagebionetworks.bridge.TestUserAdminHelper;
+import org.sagebionetworks.bridge.TestUserAdminHelper.TestUser;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.json.DateUtils;
-import org.sagebionetworks.bridge.models.UserSession;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -38,16 +37,16 @@ public class ConsentControllerTest {
     @Resource
     private TestUserAdminHelper helper;
 
-    private UserSession session;
+    private TestUser testUser;
     
     @Before
     public void before() {
-        session = helper.createUser(getClass().getSimpleName());
+        testUser = helper.createUser(getClass().getSimpleName());
     }
 
     @After
     public void after() {
-        helper.deleteUser(session, getClass().getSimpleName());
+        helper.deleteUser(testUser);
     }
     
     @Test
@@ -57,39 +56,38 @@ public class ConsentControllerTest {
             public void testCode() throws Exception {
 
                 // Helper's user is already consented, so consenting again should fail.
-                Response giveConsentFail = TestUtils.getURL(session.getSessionToken(), CONSENT_URL).post("")
+                Response giveConsentFail = TestUtils.getURL(testUser.getSessionToken(), CONSENT_URL).post("")
                         .get(TIMEOUT);
                 assertEquals("give Consent fails with 400", SC_BAD_REQUEST, giveConsentFail.getStatus());
 
                 // Consenting turns data sharing on by default, so check that we can suspend sharing.
-                Response suspendDataSharing = TestUtils.getURL(session.getSessionToken(), SUSPEND_URL).post("")
+                Response suspendDataSharing = TestUtils.getURL(testUser.getSessionToken(), SUSPEND_URL).post("")
                         .get(TIMEOUT);
                 assertEquals("suspendDataSharing succeeds with 200", SC_OK, suspendDataSharing.getStatus());
 
                 // We've suspended data sharing, now check to see if we can resume data sharing.
-                Response resumeDataSharing = TestUtils.getURL(session.getSessionToken(), RESUME_URL).post("")
+                Response resumeDataSharing = TestUtils.getURL(testUser.getSessionToken(), RESUME_URL).post("")
                         .get(TIMEOUT);
                 assertEquals("resumeDataSharing succeeds with 200", SC_OK, resumeDataSharing.getStatus());
 
                 // Resume data sharing should be idempotent.
-                resumeDataSharing = TestUtils.getURL(session.getSessionToken(), RESUME_URL).post("").get(TIMEOUT);
+                resumeDataSharing = TestUtils.getURL(testUser.getSessionToken(), RESUME_URL).post("").get(TIMEOUT);
                 assertEquals("resumeDataSharing succeeds with 200", SC_OK, resumeDataSharing.getStatus());
 
-                UserSession session = null;
+                TestUser otherUser = null;
                 try {
-                    TestUser user = new TestUser("johnsmith");
-                    session = helper.createUser(user.getSignUp(), helper.getTestStudy(), true, false);
+                    otherUser = helper.createUser("johnsmith", null, true, false);
                     
                     // Consent new user again
                     ObjectNode node = JsonNodeFactory.instance.objectNode();
                     node.put("name", "John Smith");
                     node.put("birthdate", DateUtils.getISODate((new DateTime()).minusYears(20)));
 
-                    Response giveConsentSuccess = TestUtils.getURL(session.getSessionToken(), CONSENT_URL)
+                    Response giveConsentSuccess = TestUtils.getURL(testUser.getSessionToken(), CONSENT_URL)
                             .post(node.toString()).get(TIMEOUT);
                     assertEquals("Give consent succeeds with 201", SC_CREATED, giveConsentSuccess.getStatus());
                 } finally {
-                    helper.deleteUser(session);
+                    helper.deleteUser(otherUser);
                 }
             }
         });

--- a/test/controllers/ConsentControllerTest.java
+++ b/test/controllers/ConsentControllerTest.java
@@ -41,7 +41,7 @@ public class ConsentControllerTest {
     
     @Before
     public void before() {
-        testUser = helper.createUser(getClass().getSimpleName());
+        testUser = helper.createUser(ConsentControllerTest.class);
     }
 
     @After
@@ -76,14 +76,14 @@ public class ConsentControllerTest {
 
                 TestUser otherUser = null;
                 try {
-                    otherUser = helper.createUser("johnsmith", null, true, false);
+                    otherUser = helper.createUser(ConsentControllerTest.class, true, false);
                     
                     // Consent new user again
                     ObjectNode node = JsonNodeFactory.instance.objectNode();
                     node.put("name", "John Smith");
                     node.put("birthdate", DateUtils.getISODate((new DateTime()).minusYears(20)));
 
-                    Response giveConsentSuccess = TestUtils.getURL(testUser.getSessionToken(), CONSENT_URL)
+                    Response giveConsentSuccess = TestUtils.getURL(otherUser.getSessionToken(), CONSENT_URL)
                             .post(node.toString()).get(TIMEOUT);
                     assertEquals("Give consent succeeds with 201", SC_CREATED, giveConsentSuccess.getStatus());
                 } finally {

--- a/test/controllers/HealthDataControllerTest.java
+++ b/test/controllers/HealthDataControllerTest.java
@@ -24,10 +24,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.sagebionetworks.bridge.TestUserAdminHelper;
+import org.sagebionetworks.bridge.TestUserAdminHelper.TestUser;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoHealthDataRecord;
 import org.sagebionetworks.bridge.json.DateUtils;
-import org.sagebionetworks.bridge.models.UserSession;
 import org.sagebionetworks.bridge.models.healthdata.HealthDataRecord;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -54,7 +54,7 @@ public class HealthDataControllerTest {
     @Resource
     private TestUserAdminHelper helper;
     
-    private UserSession session;
+    private TestUser testUser;
 
     public HealthDataControllerTest() {
         mapper.setSerializationInclusion(Include.NON_NULL);
@@ -62,12 +62,12 @@ public class HealthDataControllerTest {
 
     @Before
     public void before() {
-        session = helper.createUser(getClass().getSimpleName());
+        testUser = helper.createUser(getClass().getSimpleName());
     }
 
     @After
     public void after() {
-        helper.deleteUser(session, getClass().getSimpleName());
+        helper.deleteUser(testUser);
     }
 
     @Test
@@ -76,7 +76,7 @@ public class HealthDataControllerTest {
             public void testCode() throws Exception {
 
                 List<HealthDataRecord> records = getTestRecords();
-                Response response = TestUtils.getURL(session.getSessionToken(), TRACKER_URL)
+                Response response = TestUtils.getURL(testUser.getSessionToken(), TRACKER_URL)
                         .post(mapper.writeValueAsString(records)).get(TIMEOUT);
                 assertEquals("HTTP response indicates response OK", SC_OK, response.getStatus());
 
@@ -90,14 +90,14 @@ public class HealthDataControllerTest {
     public void getAllHealthData() throws Exception {
         running(testServer(3333), new TestUtils.FailableRunnable() {
             public void testCode() throws Exception {
-                TestUtils.getURL(session.getSessionToken(), TRACKER_URL)
+                TestUtils.getURL(testUser.getSessionToken(), TRACKER_URL)
                         .post(mapper.writeValueAsString(getTestRecords())).get(TIMEOUT);
-                TestUtils.getURL(session.getSessionToken(), TRACKER_URL)
+                TestUtils.getURL(testUser.getSessionToken(), TRACKER_URL)
                         .post(mapper.writeValueAsString(getTestRecords())).get(TIMEOUT);
-                TestUtils.getURL(session.getSessionToken(), TRACKER_URL)
+                TestUtils.getURL(testUser.getSessionToken(), TRACKER_URL)
                         .post(mapper.writeValueAsString(getTestRecords())).get(TIMEOUT);
 
-                Response response = TestUtils.getURL(session.getSessionToken(), TRACKER_URL).get().get(TIMEOUT);
+                Response response = TestUtils.getURL(testUser.getSessionToken(), TRACKER_URL).get().get(TIMEOUT);
 
                 JsonNode body = response.asJson().get("items");
                 assertEquals("Returns 3 records", 3, body.size());
@@ -136,52 +136,52 @@ public class HealthDataControllerTest {
                 long time6 = thousandDaysAgo + threeDays * 6;
 
                 List<HealthDataRecord> records = getTestRecords(time1, time2 - 1);
-                Response response = TestUtils.getURL(session.getSessionToken(), TRACKER_URL)
+                Response response = TestUtils.getURL(testUser.getSessionToken(), TRACKER_URL)
                         .post(mapper.writeValueAsString(records)).get(TIMEOUT);
                 String id1 = retrieveNewId(response);
 
                 records = getTestRecords(time1, time3);
-                response = TestUtils.getURL(session.getSessionToken(), TRACKER_URL)
+                response = TestUtils.getURL(testUser.getSessionToken(), TRACKER_URL)
                         .post(mapper.writeValueAsString(records)).get(TIMEOUT);
                 String id2 = retrieveNewId(response);
 
                 records = getTestRecords(time4, time6);
-                response = TestUtils.getURL(session.getSessionToken(), TRACKER_URL)
+                response = TestUtils.getURL(testUser.getSessionToken(), TRACKER_URL)
                         .post(mapper.writeValueAsString(records)).get(TIMEOUT);
                 String id3 = retrieveNewId(response);
 
                 records = getTestRecords(time3, time4);
-                response = TestUtils.getURL(session.getSessionToken(), TRACKER_URL)
+                response = TestUtils.getURL(testUser.getSessionToken(), TRACKER_URL)
                         .post(mapper.writeValueAsString(records)).get(TIMEOUT);
                 String id4 = retrieveNewId(response);
 
                 records = getTestRecords(time5 + 1, time6);
-                response = TestUtils.getURL(session.getSessionToken(), TRACKER_URL)
+                response = TestUtils.getURL(testUser.getSessionToken(), TRACKER_URL)
                         .post(mapper.writeValueAsString(records)).get(TIMEOUT);
                 String id5 = retrieveNewId(response);
 
                 records = getTestRecords(time3, 0);
-                response = TestUtils.getURL(session.getSessionToken(), TRACKER_URL)
+                response = TestUtils.getURL(testUser.getSessionToken(), TRACKER_URL)
                         .post(mapper.writeValueAsString(records)).get(TIMEOUT);
                 String id6 = retrieveNewId(response);
 
                 Map<String, String> queryMap = ImmutableMap.of(START_DATE, DateUtils.convertToISODateTime(time2),
                         END_DATE, DateUtils.convertToISODateTime(time5));
-                response = TestUtils.getURL(session.getSessionToken(), TRACKER_URL, queryMap).get().get(TIMEOUT);
+                response = TestUtils.getURL(testUser.getSessionToken(), TRACKER_URL, queryMap).get().get(TIMEOUT);
                 List<String> ids = getIds(response);
                 assertTrue("Returns records 2, 3, 4, and 6", ids.containsAll(Lists.newArrayList(id2, id3, id4, id6)));
                 assertFalse("Does not contain records 1 or 5", ids.containsAll(Lists.newArrayList(id1, id5)));
 
                 queryMap = ImmutableMap.of(START_DATE, DateUtils.convertToISODateTime(time1), END_DATE,
                         DateUtils.convertToISODateTime(time3));
-                response = TestUtils.getURL(session.getSessionToken(), TRACKER_URL, queryMap).get().get(TIMEOUT);
+                response = TestUtils.getURL(testUser.getSessionToken(), TRACKER_URL, queryMap).get().get(TIMEOUT);
                 ids = getIds(response);
                 assertTrue("Returns records 1, 2, 4, and 6", ids.containsAll(Lists.newArrayList(id1, id2, id4, id6)));
                 assertFalse("Does not contain records 3 or 5", ids.containsAll(Lists.newArrayList(id3, id5)));
 
                 queryMap = ImmutableMap.of(START_DATE, DateUtils.convertToISODateTime(time4), END_DATE,
                         DateUtils.convertToISODateTime(time5));
-                response = TestUtils.getURL(session.getSessionToken(), TRACKER_URL, queryMap).get().get(TIMEOUT);
+                response = TestUtils.getURL(testUser.getSessionToken(), TRACKER_URL, queryMap).get().get(TIMEOUT);
                 ids = getIds(response);
                 assertTrue("Returns records 3, 4, and 6", ids.containsAll(Lists.newArrayList(id3, id4, id6)));
                 assertFalse("Does not contain records 1, 2 or 5", ids.containsAll(Lists.newArrayList(id1, id2, id5)));
@@ -195,7 +195,7 @@ public class HealthDataControllerTest {
             public void testCode() throws Exception {
                 List<HealthDataRecord> records = getTestRecords();
 
-                Response response = TestUtils.getURL(session.getSessionToken(), TRACKER_URL)
+                Response response = TestUtils.getURL(testUser.getSessionToken(), TRACKER_URL)
                         .post(mapper.writeValueAsString(records)).get(TIMEOUT);
                 assertEquals("Response status indicates OK response", SC_OK, response.getStatus());
 
@@ -208,12 +208,12 @@ public class HealthDataControllerTest {
                 onode.put("systolic", 200L);
 
                 // Save it (update)
-                response = TestUtils.getURL(session.getSessionToken(), RECORD_URL + id)
+                response = TestUtils.getURL(testUser.getSessionToken(), RECORD_URL + id)
                         .post(mapper.writeValueAsString(records.get(0))).get(TIMEOUT);
                 assertEquals("Response status indicates OK response", SC_OK, response.getStatus());
 
                 // Get it and verify that it was persisted.
-                response = TestUtils.getURL(session.getSessionToken(), RECORD_URL + id).get().get(TIMEOUT);
+                response = TestUtils.getURL(testUser.getSessionToken(), RECORD_URL + id).get().get(TIMEOUT);
                 JsonNode body = response.asJson();
                 long valueSaved = body.get("data").get("systolic").asLong();
                 assertEquals("Value saved is 200", 200L, valueSaved);
@@ -228,15 +228,15 @@ public class HealthDataControllerTest {
                 List<HealthDataRecord> records = getTestRecords();
 
                 // Create a record, retrieve its ID
-                Response response = TestUtils.getURL(session.getSessionToken(), TRACKER_URL)
+                Response response = TestUtils.getURL(testUser.getSessionToken(), TRACKER_URL)
                         .post(mapper.writeValueAsString(records)).get(TIMEOUT);
                 String id = retrieveNewId(response);
 
-                response = TestUtils.getURL(session.getSessionToken(), RECORD_URL + id).delete().get(TIMEOUT);
+                response = TestUtils.getURL(testUser.getSessionToken(), RECORD_URL + id).delete().get(TIMEOUT);
                 assertEquals("Response status indicates OK response", SC_OK, response.getStatus());
 
                 // Now this should generate a not found
-                response = TestUtils.getURL(session.getSessionToken(), RECORD_URL + id).get().get(TIMEOUT);
+                response = TestUtils.getURL(testUser.getSessionToken(), RECORD_URL + id).get().get(TIMEOUT);
                 assertEquals("Response status indicates data not found", SC_NOT_FOUND, response.getStatus());
             }
         });

--- a/test/controllers/HealthDataControllerTest.java
+++ b/test/controllers/HealthDataControllerTest.java
@@ -62,7 +62,7 @@ public class HealthDataControllerTest {
 
     @Before
     public void before() {
-        testUser = helper.createUser(getClass().getSimpleName());
+        testUser = helper.createUser(HealthDataControllerTest.class);
     }
 
     @After

--- a/test/controllers/ScheduleControllerTest.java
+++ b/test/controllers/ScheduleControllerTest.java
@@ -49,7 +49,7 @@ public class ScheduleControllerTest {
     
     @Before
     public void before() throws Exception {
-        testUser = helper.createUser(getClass().getSimpleName());
+        testUser = helper.createUser(ScheduleControllerTest.class);
         final User user = testUser.getUser();
         plan = schedulePlanDao.createSchedulePlan(new TestSimpleSchedulePlan());
         // wait until the schedules are created, as this is asynchronous

--- a/test/controllers/SchedulePlanControllerTest.java
+++ b/test/controllers/SchedulePlanControllerTest.java
@@ -36,7 +36,6 @@ import play.libs.WS.Response;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.google.common.collect.Lists;
 
 @ContextConfiguration("classpath:test-context.xml")
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -53,7 +52,7 @@ public class SchedulePlanControllerTest {
     @Before
     public void before() {
         Study study = studyService.getStudyByKey(TestConstants.TEST_STUDY_KEY);
-        testUser = helper.createUser(getClass().getSimpleName(), Lists.newArrayList(study.getResearcherRole()));
+        testUser = helper.createUser(SchedulePlanControllerTest.class, study.getResearcherRole());
     }
     
     @After
@@ -67,7 +66,7 @@ public class SchedulePlanControllerTest {
             public void testCode() throws Exception {
                 TestUser testUser2 = null;
                 try {
-                    testUser2 = helper.createUser("normal-test-user");
+                    testUser2 = helper.createUser(SchedulePlanControllerTest.class);
                     
                     SchedulePlan plan = new TestABSchedulePlan();
                     String json = BridgeObjectMapper.get().writeValueAsString(plan);

--- a/test/controllers/SchedulePlanControllerTest.java
+++ b/test/controllers/SchedulePlanControllerTest.java
@@ -18,15 +18,17 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUserAdminHelper;
+import org.sagebionetworks.bridge.TestUserAdminHelper.TestUser;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
-import org.sagebionetworks.bridge.models.SignUp;
-import org.sagebionetworks.bridge.models.UserSession;
+import org.sagebionetworks.bridge.models.Study;
 import org.sagebionetworks.bridge.models.schedules.SchedulePlan;
 import org.sagebionetworks.bridge.models.schedules.TestABSchedulePlan;
 import org.sagebionetworks.bridge.models.schedules.TestSimpleSchedulePlan;
+import org.sagebionetworks.bridge.services.StudyService;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -43,34 +45,37 @@ public class SchedulePlanControllerTest {
     @Resource
     private TestUserAdminHelper helper;
     
-    private UserSession session;
+    @Resource
+    private StudyService studyService;
+    
+    private TestUser testUser;
     
     @Before
     public void before() {
-        session = helper.createUser(getClass().getSimpleName(), Lists.newArrayList(helper.getTestStudy().getResearcherRole()));
+        Study study = studyService.getStudyByKey(TestConstants.TEST_STUDY_KEY);
+        testUser = helper.createUser(getClass().getSimpleName(), Lists.newArrayList(study.getResearcherRole()));
     }
     
     @After
     public void after() {
-        helper.deleteUser(session, getClass().getSimpleName());
+        helper.deleteUser(testUser);
     }
 
     @Test
     public void normalUserCannotAccess() {
         running(testServer(3333), new TestUtils.FailableRunnable() {
             public void testCode() throws Exception {
-                UserSession session = null;
+                TestUser testUser2 = null;
                 try {
-                    session = helper.createUser(new SignUp("normal-test-user", "normal-test-user@sagebridge.org",
-                            "P4ssword"), helper.getTestStudy(), true, true);
+                    testUser2 = helper.createUser("normal-test-user");
                     
                     SchedulePlan plan = new TestABSchedulePlan();
                     String json = BridgeObjectMapper.get().writeValueAsString(plan);
                     
-                    Response response = TestUtils.getURL(session.getSessionToken(), SCHEDULE_PLANS_URL).post(json).get(TIMEOUT);
+                    Response response = TestUtils.getURL(testUser2.getSessionToken(), SCHEDULE_PLANS_URL).post(json).get(TIMEOUT);
                     assertEquals("Returns 403", SC_FORBIDDEN, response.getStatus());
                 } finally {
-                    helper.deleteUser(session);
+                    helper.deleteUser(testUser2);
                 }
             }
         });
@@ -84,7 +89,7 @@ public class SchedulePlanControllerTest {
                 String json = BridgeObjectMapper.get().writeValueAsString(plan);
                 
                 // Create
-                Response response = TestUtils.getURL(session.getSessionToken(), SCHEDULE_PLANS_URL).post(json).get(TIMEOUT);
+                Response response = TestUtils.getURL(testUser.getSessionToken(), SCHEDULE_PLANS_URL).post(json).get(TIMEOUT);
                 assertEquals("Returns 201", SC_CREATED, response.getStatus());
                 JsonNode node = response.asJson();
                 assertNotNull("Returned plan has a guid", node.get("guid").asText());
@@ -98,18 +103,18 @@ public class SchedulePlanControllerTest {
                 json = BridgeObjectMapper.get().writeValueAsString(plan);
                 
                 String url = String.format(SCHEDULE_PLAN_URL, plan.getGuid());
-                response = TestUtils.getURL(session.getSessionToken(), url).post(json).get(TIMEOUT);
+                response = TestUtils.getURL(testUser.getSessionToken(), url).post(json).get(TIMEOUT);
                 assertEquals("Returns 200", SC_OK, response.getStatus());
                 
                 // Get
-                response = TestUtils.getURL(session.getSessionToken(), url).get().get(TIMEOUT); 
+                response = TestUtils.getURL(testUser.getSessionToken(), url).get().get(TIMEOUT); 
                 node = response.asJson();
                 assertEquals("Returns 200", SC_OK, response.getStatus());
                 assertEquals("Type is SchedulePlan", "SchedulePlan", node.get("type").asText());
                 assertEquals("Strategy type has been changed", "SimpleScheduleStrategy", node.get("strategy").get("type").asText());
                 
                 // Delete
-                response = TestUtils.getURL(session.getSessionToken(), url).delete().get(TIMEOUT);
+                response = TestUtils.getURL(testUser.getSessionToken(), url).delete().get(TIMEOUT);
                 assertEquals("Returns 200", SC_OK, response.getStatus());
             }
         });
@@ -124,7 +129,7 @@ public class SchedulePlanControllerTest {
                 String json = BridgeObjectMapper.get().writeValueAsString(plan);
                 
                 // Create
-                Response response = TestUtils.getURL(session.getSessionToken(), SCHEDULE_PLANS_URL).post(json).get(TIMEOUT);
+                Response response = TestUtils.getURL(testUser.getSessionToken(), SCHEDULE_PLANS_URL).post(json).get(TIMEOUT);
                 assertEquals("Returns 400", SC_BAD_REQUEST, response.getStatus());
                 
                 JsonNode node = response.asJson();
@@ -139,7 +144,7 @@ public class SchedulePlanControllerTest {
         running(testServer(3333), new TestUtils.FailableRunnable() {
             public void testCode() throws Exception {
                 // Create
-                Response response = TestUtils.getURL(session.getSessionToken(), SCHEDULE_PLANS_URL).post("").get(TIMEOUT);
+                Response response = TestUtils.getURL(testUser.getSessionToken(), SCHEDULE_PLANS_URL).post("").get(TIMEOUT);
                 assertEquals("Returns 400", SC_BAD_REQUEST, response.getStatus());
             }
         });

--- a/test/controllers/StudyConsentControllerTest.java
+++ b/test/controllers/StudyConsentControllerTest.java
@@ -30,7 +30,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.collect.Lists;
 
 @ContextConfiguration("classpath:test-context.xml")
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -51,8 +50,8 @@ public class StudyConsentControllerTest {
 
     @Before
     public void before() {
-        adminSession = helper.createUser("admin-" + getClass().getSimpleName(), Lists.newArrayList(BridgeConstants.ADMIN_GROUP));
-        userSession = helper.createUser("normal-" + getClass().getSimpleName());
+        adminSession = helper.createUser(StudyConsentControllerTest.class, BridgeConstants.ADMIN_GROUP);
+        userSession = helper.createUser(StudyConsentControllerTest.class);
     }
 
     @After

--- a/test/controllers/StudyConsentControllerTest.java
+++ b/test/controllers/StudyConsentControllerTest.java
@@ -18,8 +18,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.TestUserAdminHelper;
+import org.sagebionetworks.bridge.TestUserAdminHelper.TestUser;
 import org.sagebionetworks.bridge.TestUtils;
-import org.sagebionetworks.bridge.models.UserSession;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -45,9 +45,9 @@ public class StudyConsentControllerTest {
     @Resource
     private TestUserAdminHelper helper;
     
-    private UserSession adminSession;
+    private TestUser adminSession;
     
-    private UserSession userSession;
+    private TestUser userSession;
 
     @Before
     public void before() {
@@ -57,8 +57,8 @@ public class StudyConsentControllerTest {
 
     @After
     public void after() {
-        helper.deleteUser(adminSession, "admin-" + getClass().getSimpleName());
-        helper.deleteUser(userSession, "normal-" + getClass().getSimpleName());
+        helper.deleteUser(adminSession);
+        helper.deleteUser(userSession);
     }
 
     @Test

--- a/test/controllers/SurveyControllerTest.java
+++ b/test/controllers/SurveyControllerTest.java
@@ -75,9 +75,9 @@ public class SurveyControllerTest {
             surveyDao.closeSurvey(survey.getGuid(), survey.getVersionedOn());
             surveyDao.deleteSurvey(survey.getGuid(), survey.getVersionedOn());
         }
-        testUser = helper.createUser("user1");
-        testResearcher = helper.createUser("user2", Lists.newArrayList(study.getResearcherRole()));
-        testAdmin = helper.createUser("user3", Lists.newArrayList(BridgeConstants.ADMIN_GROUP));
+        testUser = helper.createUser(SurveyControllerTest.class);
+        testResearcher = helper.createUser(SurveyControllerTest.class, study.getResearcherRole());
+        testAdmin = helper.createUser(SurveyControllerTest.class, BridgeConstants.ADMIN_GROUP);
     }
 
     @After

--- a/test/controllers/SurveyControllerTest.java
+++ b/test/controllers/SurveyControllerTest.java
@@ -27,14 +27,17 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.sagebionetworks.bridge.BridgeConstants;
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUserAdminHelper;
+import org.sagebionetworks.bridge.TestUserAdminHelper.TestUser;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoSurveyDao;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
-import org.sagebionetworks.bridge.models.SignUp;
-import org.sagebionetworks.bridge.models.UserSession;
+import org.sagebionetworks.bridge.models.Study;
 import org.sagebionetworks.bridge.models.surveys.Survey;
 import org.sagebionetworks.bridge.models.surveys.TestSurvey;
+import org.sagebionetworks.bridge.services.StudyService;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -55,29 +58,33 @@ public class SurveyControllerTest {
     @Resource
     private DynamoSurveyDao surveyDao;
     
+    @Resource
+    private StudyService studyService;
+    
     private BridgeObjectMapper mapper = new BridgeObjectMapper();
 
-    private UserSession userSession;
-    private UserSession researcherSession;
-    private UserSession adminSession;
+    private TestUser testUser;
+    private TestUser testResearcher;
+    private TestUser testAdmin;
 
     @Before
     public void before() {
-        List<Survey> surveys = surveyDao.getSurveys(helper.getTestStudy().getKey());
+        Study study = studyService.getStudyByKey(TestConstants.TEST_STUDY_KEY);
+        List<Survey> surveys = surveyDao.getSurveys(study.getKey());
         for (Survey survey : surveys) {
             surveyDao.closeSurvey(survey.getGuid(), survey.getVersionedOn());
             surveyDao.deleteSurvey(survey.getGuid(), survey.getVersionedOn());
         }
-        userSession = helper.createUser(new SignUp("user1", "user1@sagebridge.org", "P4ssword"), helper.getTestStudy(), true, true);
-        researcherSession = helper.createUser(new SignUp("user2", "user2@sagebridge.org", "P4ssword", "teststudy_researcher"), helper.getTestStudy(), true, true);
-        adminSession = helper.createUser(new SignUp("user3", "user3@sagebridge.org", "P4ssword", "admin"), helper.getTestStudy(), true, true);
+        testUser = helper.createUser("user1");
+        testResearcher = helper.createUser("user2", Lists.newArrayList(study.getResearcherRole()));
+        testAdmin = helper.createUser("user3", Lists.newArrayList(BridgeConstants.ADMIN_GROUP));
     }
 
     @After
     public void after() throws Exception {
-        helper.deleteUser(userSession);
-        helper.deleteUser(researcherSession);
-        helper.deleteUser(adminSession);
+        helper.deleteUser(testUser);
+        helper.deleteUser(testResearcher);
+        helper.deleteUser(testAdmin);
     }
     
     @Test
@@ -86,7 +93,7 @@ public class SurveyControllerTest {
             public void testCode() throws Exception {
                 String content = new TestSurvey(true).toJSON(); // createSurveyObject("Name");
                 
-                Response response = TestUtils.getURL(userSession.getSessionToken(), SURVEYS_URL).post(content)
+                Response response = TestUtils.getURL(testUser.getSessionToken(), SURVEYS_URL).post(content)
                         .get(TIMEOUT);
                 
                 assertEquals("HTTP response indicates authorization error", SC_FORBIDDEN, response.getStatus());
@@ -98,9 +105,9 @@ public class SurveyControllerTest {
     public void saveAndRetrieveASurvey() {
         running(testServer(3333), new TestUtils.FailableRunnable() {
             public void testCode() throws Exception {
-                GuidVersionHolder keys = createSurvey(researcherSession.getSessionToken(), "Name");
+                GuidVersionHolder keys = createSurvey(testResearcher.getSessionToken(), "Name");
                 
-                JsonNode node = getSurvey(researcherSession.getSessionToken(), keys);
+                JsonNode node = getSurvey(testResearcher.getSessionToken(), keys);
 
                 ArrayNode questions = (ArrayNode)node.get("questions");
                 
@@ -115,17 +122,17 @@ public class SurveyControllerTest {
         running(testServer(3333), new TestUtils.FailableRunnable() {
             public void testCode() throws Exception {
 
-                GuidVersionHolder keys = createSurvey(researcherSession.getSessionToken(), "Name");
+                GuidVersionHolder keys = createSurvey(testResearcher.getSessionToken(), "Name");
 
-                GuidVersionHolder laterKeys = versionSurvey(researcherSession.getSessionToken(), keys);
+                GuidVersionHolder laterKeys = versionSurvey(testResearcher.getSessionToken(), keys);
                 
-                JsonNode node = getSurvey(researcherSession.getSessionToken(), laterKeys);
+                JsonNode node = getSurvey(testResearcher.getSessionToken(), laterKeys);
                 
                 boolean isPublished = node.get("published").asBoolean();
                 assertNotEquals("versionedOn has been updated", keys.versionedOn, laterKeys.versionedOn);
                 assertFalse("New survey is not published", isPublished);
 
-                isPublished = publishSurvey(researcherSession.getSessionToken(), laterKeys);
+                isPublished = publishSurvey(testResearcher.getSessionToken(), laterKeys);
                 assertTrue("New survey is published", isPublished);
             }
         });
@@ -135,11 +142,11 @@ public class SurveyControllerTest {
     public void getAllVersionsOfASurvey() {
         running(testServer(3333), new TestUtils.FailableRunnable() {
             public void testCode() throws Exception {
-                GuidVersionHolder keys = createSurvey(researcherSession.getSessionToken(), "Name");
+                GuidVersionHolder keys = createSurvey(testResearcher.getSessionToken(), "Name");
 
-                keys = versionSurvey(researcherSession.getSessionToken(), keys);
+                keys = versionSurvey(testResearcher.getSessionToken(), keys);
 
-                int count = getAllVersionsOfSurveysCount(researcherSession.getSessionToken(), keys);
+                int count = getAllVersionsOfSurveysCount(testResearcher.getSessionToken(), keys);
                 assertEquals("There are two versions for this survey", 2, count);
             }
         });        
@@ -149,26 +156,26 @@ public class SurveyControllerTest {
     public void canGetMostRecentOrRecentlyPublishedSurveys() {
         running(testServer(3333), new TestUtils.FailableRunnable() {
             public void testCode() throws Exception {
-                GuidVersionHolder keys = createSurvey(researcherSession.getSessionToken(), "Name 1");
-                keys = versionSurvey(researcherSession.getSessionToken(), keys);
-                keys = versionSurvey(researcherSession.getSessionToken(), keys);
+                GuidVersionHolder keys = createSurvey(testResearcher.getSessionToken(), "Name 1");
+                keys = versionSurvey(testResearcher.getSessionToken(), keys);
+                keys = versionSurvey(testResearcher.getSessionToken(), keys);
 
-                GuidVersionHolder keys2 = createSurvey(researcherSession.getSessionToken(), "Name 2");
-                keys2 = versionSurvey(researcherSession.getSessionToken(), keys2);
-                keys2 = versionSurvey(researcherSession.getSessionToken(), keys2);
+                GuidVersionHolder keys2 = createSurvey(testResearcher.getSessionToken(), "Name 2");
+                keys2 = versionSurvey(testResearcher.getSessionToken(), keys2);
+                keys2 = versionSurvey(testResearcher.getSessionToken(), keys2);
                 
-                GuidVersionHolder keys3 = createSurvey(researcherSession.getSessionToken(), "Name 3");
-                keys3 = versionSurvey(researcherSession.getSessionToken(), keys3);
-                keys3 = versionSurvey(researcherSession.getSessionToken(), keys3);
+                GuidVersionHolder keys3 = createSurvey(testResearcher.getSessionToken(), "Name 3");
+                keys3 = versionSurvey(testResearcher.getSessionToken(), keys3);
+                keys3 = versionSurvey(testResearcher.getSessionToken(), keys3);
 
-                List<GuidVersionHolder> versions = getMostRecentSurveys(researcherSession.getSessionToken());
+                List<GuidVersionHolder> versions = getMostRecentSurveys(testResearcher.getSessionToken());
                 assertEquals("There are two items", 3, versions.size());
                 assertEquals("Last version in list", keys3.versionedOn, versions.get(0).versionedOn);
                 assertEquals("Last version in list", keys2.versionedOn, versions.get(1).versionedOn);
                 
-                publishSurvey(researcherSession.getSessionToken(), keys);
-                publishSurvey(researcherSession.getSessionToken(), keys3);
-                versions = getMostRecentlyPublishedSurveys(researcherSession.getSessionToken());
+                publishSurvey(testResearcher.getSessionToken(), keys);
+                publishSurvey(testResearcher.getSessionToken(), keys3);
+                versions = getMostRecentlyPublishedSurveys(testResearcher.getSessionToken());
                 assertEquals("One published item", 2, versions.size());
                 assertEquals("Published version", keys3.versionedOn, versions.get(0).versionedOn);
                 assertEquals("Published version", keys.versionedOn, versions.get(1).versionedOn);
@@ -180,8 +187,8 @@ public class SurveyControllerTest {
     public void canUpdateASurveyAndTypesAreCorrect() {
         running(testServer(3333), new TestUtils.FailableRunnable() {
             public void testCode() throws Exception {
-                GuidVersionHolder keys = createSurvey(researcherSession.getSessionToken(), "Name");
-                ObjectNode node = (ObjectNode)getSurvey(researcherSession.getSessionToken(), keys);
+                GuidVersionHolder keys = createSurvey(testResearcher.getSessionToken(), "Name");
+                ObjectNode node = (ObjectNode)getSurvey(testResearcher.getSessionToken(), keys);
                 node.put("name", "Name Changed");
 
                 // Check all the types while we have a complete survey
@@ -199,9 +206,9 @@ public class SurveyControllerTest {
                 assertEquals("Type is MultiValueConstraints", "MultiValueConstraints", constraintTypeForQuestion(questions, 7));
                 assertEquals("Type is SurveyQuestionOption", "SurveyQuestionOption", questions.get(7).get("constraints").get("enumeration").get(0).get("type").asText());
                 
-                updateSurvey(researcherSession.getSessionToken(), keys, node);
+                updateSurvey(testResearcher.getSessionToken(), keys, node);
                 
-                node = (ObjectNode)getSurvey(researcherSession.getSessionToken(), keys);
+                node = (ObjectNode)getSurvey(testResearcher.getSessionToken(), keys);
                 String finalName = node.get("name").asText();
                 assertEquals("Name has been updated", "Name Changed", finalName);
             }
@@ -213,11 +220,11 @@ public class SurveyControllerTest {
     public void participantCannotRetrieveUnpublishedSurvey() {
         running(testServer(3333), new TestUtils.FailableRunnable() {
             public void testCode() throws Exception {
-                GuidVersionHolder keys = createSurvey(adminSession.getSessionToken(), "Name");
+                GuidVersionHolder keys = createSurvey(testAdmin.getSessionToken(), "Name");
                 
                 // Get survey using the user's api, the survey is not published
                 String url = String.format(USER_SURVEY_URL, keys.guid, keys.versionedOn);
-                Response response = TestUtils.getURL(userSession.getSessionToken(), url).get().get(TIMEOUT);
+                Response response = TestUtils.getURL(testUser.getSessionToken(), url).get().get(TIMEOUT);
                 assertEquals("Survey not found because it is not published", 404, response.getStatus());
             }
         });          

--- a/test/controllers/SurveyResponseControllerTest.java
+++ b/test/controllers/SurveyResponseControllerTest.java
@@ -64,7 +64,7 @@ public class SurveyResponseControllerTest {
     
     @Before
     public void before() {
-        testUser = helper.createUser(getClass().getSimpleName(), Lists.newArrayList(BridgeConstants.ADMIN_GROUP));
+        testUser = helper.createUser(SurveyResponseControllerTest.class, BridgeConstants.ADMIN_GROUP);
         survey = new TestSurvey(true);
         surveyDao.createSurvey(survey);
         DynamoInitializer.init(DynamoSurveyResponse.class);

--- a/test/controllers/SurveyResponseControllerTest.java
+++ b/test/controllers/SurveyResponseControllerTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.TestUserAdminHelper;
+import org.sagebionetworks.bridge.TestUserAdminHelper.TestUser;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoInitializer;
 import org.sagebionetworks.bridge.dynamodb.DynamoSurveyDao;
@@ -27,7 +28,6 @@ import org.sagebionetworks.bridge.dynamodb.DynamoSurveyResponse;
 import org.sagebionetworks.bridge.dynamodb.DynamoSurveyResponseDao;
 import org.sagebionetworks.bridge.dynamodb.DynamoTestUtil;
 import org.sagebionetworks.bridge.json.DateUtils;
-import org.sagebionetworks.bridge.models.UserSession;
 import org.sagebionetworks.bridge.models.surveys.MultiValueConstraints;
 import org.sagebionetworks.bridge.models.surveys.SurveyAnswer;
 import org.sagebionetworks.bridge.models.surveys.SurveyQuestion;
@@ -60,11 +60,11 @@ public class SurveyResponseControllerTest {
     private ObjectMapper mapper = new ObjectMapper();
     private TestSurvey survey;
     private String responseGuid;
-    private UserSession session;
+    private TestUser testUser;
     
     @Before
     public void before() {
-        session = helper.createUser(getClass().getSimpleName(), Lists.newArrayList(BridgeConstants.ADMIN_GROUP));
+        testUser = helper.createUser(getClass().getSimpleName(), Lists.newArrayList(BridgeConstants.ADMIN_GROUP));
         survey = new TestSurvey(true);
         surveyDao.createSurvey(survey);
         DynamoInitializer.init(DynamoSurveyResponse.class);
@@ -79,7 +79,7 @@ public class SurveyResponseControllerTest {
         if (survey != null) {
             surveyDao.deleteSurvey(survey.getGuid(), survey.getVersionedOn());    
         }
-        helper.deleteUser(session, getClass().getSimpleName());
+        helper.deleteUser(testUser);
     }
     
     @Test
@@ -110,7 +110,7 @@ public class SurveyResponseControllerTest {
                 String body = mapper.writeValueAsString(list);
                 
                 String url = String.format(NEW_SURVEY_RESPONSE, survey.getGuid(), DateUtils.convertToISODateTime(survey.getVersionedOn()));
-                Response response = TestUtils.getURL(session.getSessionToken(), url).post(body).get(TIMEOUT);
+                Response response = TestUtils.getURL(testUser.getSessionToken(), url).post(body).get(TIMEOUT);
 
                 assertEquals("Create new record returns 201", SC_CREATED, response.getStatus());
                 
@@ -122,7 +122,7 @@ public class SurveyResponseControllerTest {
                 // Check the types of this response object
                 
                 url = String.format(SURVEY_RESPONSE_URL, responseGuid);
-                response = TestUtils.getURL(session.getSessionToken(), url).get().get(TIMEOUT);
+                response = TestUtils.getURL(testUser.getSessionToken(), url).get().get(TIMEOUT);
                 JsonNode node = response.asJson();
                 assertEquals("Type is SurveyResponse", "SurveyResponse", node.get("type").asText());
 
@@ -215,7 +215,7 @@ public class SurveyResponseControllerTest {
                 
                 // Submit all these tricky examples of answers through the API.
                 String url = String.format(USER_SURVEY_URL, survey.getGuid(), DateUtils.convertToISODateTime(survey.getVersionedOn()));
-                Response response = TestUtils.getURL(session.getSessionToken(), url).post(array.toString()).get(TIMEOUT);
+                Response response = TestUtils.getURL(testUser.getSessionToken(), url).post(array.toString()).get(TIMEOUT);
                 assertEquals("Response successful", SC_CREATED, response.getStatus());
             }
         });

--- a/test/controllers/TrackerControllerTest.java
+++ b/test/controllers/TrackerControllerTest.java
@@ -13,8 +13,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.sagebionetworks.bridge.TestUserAdminHelper;
+import org.sagebionetworks.bridge.TestUserAdminHelper.TestUser;
 import org.sagebionetworks.bridge.TestUtils;
-import org.sagebionetworks.bridge.models.UserSession;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -29,16 +29,16 @@ public class TrackerControllerTest {
     @Resource
     private TestUserAdminHelper helper;
     
-    private UserSession session;
+    private TestUser testUser;
 
     @Before
     public void before() {
-        session = helper.createUser(getClass().getSimpleName());
+        testUser = helper.createUser(getClass().getSimpleName());
     }
 
     @After
     public void after() {
-        helper.deleteUser(session, getClass().getSimpleName());
+        helper.deleteUser(testUser);
     }
     
     @Test
@@ -46,7 +46,7 @@ public class TrackerControllerTest {
         running(testServer(3333), new TestUtils.FailableRunnable() {
             public void testCode() throws Exception {
 
-                Response response = TestUtils.getURL(session.getSessionToken(), TRACKERS_URL).get().get(TIMEOUT);
+                Response response = TestUtils.getURL(testUser.getSessionToken(), TRACKERS_URL).get().get(TIMEOUT);
                 assertEquals("HTTP response OK", 200, response.getStatus());
                 
                 JsonNode node = response.asJson().get("items").get(0);

--- a/test/controllers/TrackerControllerTest.java
+++ b/test/controllers/TrackerControllerTest.java
@@ -33,7 +33,7 @@ public class TrackerControllerTest {
 
     @Before
     public void before() {
-        testUser = helper.createUser(getClass().getSimpleName());
+        testUser = helper.createUser(TrackerControllerTest.class);
     }
 
     @After

--- a/test/controllers/UserManagementControllerTest.java
+++ b/test/controllers/UserManagementControllerTest.java
@@ -25,7 +25,6 @@ import org.sagebionetworks.bridge.TestUserAdminHelper;
 import org.sagebionetworks.bridge.TestUserAdminHelper.TestUser;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.TestUtils.FailableRunnable;
-import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 import org.sagebionetworks.bridge.dynamodb.DynamoTestUtil;
 import org.sagebionetworks.bridge.dynamodb.DynamoUserConsent2;
 import org.springframework.test.context.ContextConfiguration;
@@ -71,9 +70,10 @@ public class UserManagementControllerTest {
         running(testServer(3333), new FailableRunnable() {
             @Override
             public void testCode() throws Exception {
+                String prefix = TestUtils.randomString();
                 ObjectNode node = JsonNodeFactory.instance.objectNode();
-                node.put("email", BridgeConfigFactory.getConfig().getUser() + "-test-userAdmin@sagebridge.org");
-                node.put("username", "test-userAdmin");
+                node.put("email", prefix + "@sagebridge.org");
+                node.put("username", prefix);
                 node.put("password", "P4ssword");
                 node.put("consent", true);
 

--- a/test/controllers/UserProfileControllerTest.java
+++ b/test/controllers/UserProfileControllerTest.java
@@ -16,8 +16,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.sagebionetworks.bridge.TestUserAdminHelper;
+import org.sagebionetworks.bridge.TestUserAdminHelper.TestUser;
 import org.sagebionetworks.bridge.TestUtils;
-import org.sagebionetworks.bridge.models.UserSession;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -36,7 +36,7 @@ public class UserProfileControllerTest {
     @Resource
     private TestUserAdminHelper helper;
     
-    private UserSession session;
+    private TestUser testUser;
 
     public UserProfileControllerTest() {
         mapper.setSerializationInclusion(Include.NON_NULL);
@@ -44,12 +44,12 @@ public class UserProfileControllerTest {
     
     @Before
     public void before() {
-        session = helper.createUser(getClass().getSimpleName());
+        testUser = helper.createUser(getClass().getSimpleName());
     }
     
     @After
     public void after() {
-        helper.deleteUser(session, getClass().getSimpleName());
+        helper.deleteUser(testUser);
     }
 
     @Test
@@ -69,7 +69,7 @@ public class UserProfileControllerTest {
 
             @Override
             public void testCode() throws Exception {
-                Response response = TestUtils.getURL(session.getSessionToken(), PROFILE_URL).get().get(TIMEOUT);
+                Response response = TestUtils.getURL(testUser.getSessionToken(), PROFILE_URL).get().get(TIMEOUT);
 
                 JsonNode node = response.asJson();
                 assertNotNull("First name exists", node.get("firstName"));
@@ -87,7 +87,7 @@ public class UserProfileControllerTest {
             @Override
             public void testCode() throws Exception {
                 Response response = TestUtils.getURL("", PROFILE_URL)
-                        .post(mapper.writeValueAsString(session.getSessionToken())).get(TIMEOUT);
+                        .post(mapper.writeValueAsString(testUser.getSessionToken())).get(TIMEOUT);
 
                 assertEquals("HTTP Status should be 401", SC_UNAUTHORIZED, response.getStatus());
             }
@@ -100,8 +100,8 @@ public class UserProfileControllerTest {
 
             @Override
             public void testCode() throws Exception {
-                Response response = TestUtils.getURL(session.getSessionToken(), PROFILE_URL)
-                        .post(mapper.writeValueAsString(session.getUser())).get(TIMEOUT);
+                Response response = TestUtils.getURL(testUser.getSessionToken(), PROFILE_URL)
+                        .post(mapper.writeValueAsString(testUser.getUser())).get(TIMEOUT);
 
                 assertEquals("HTTP Status should be 200 OK", SC_OK, response.getStatus());
             }

--- a/test/controllers/UserProfileControllerTest.java
+++ b/test/controllers/UserProfileControllerTest.java
@@ -44,7 +44,7 @@ public class UserProfileControllerTest {
     
     @Before
     public void before() {
-        testUser = helper.createUser(getClass().getSimpleName());
+        testUser = helper.createUser(UserProfileControllerTest.class);
     }
     
     @After

--- a/test/org/sagebionetworks/bridge/TestConstants.java
+++ b/test/org/sagebionetworks/bridge/TestConstants.java
@@ -1,65 +1,9 @@
 package org.sagebionetworks.bridge;
 
-import java.util.List;
-
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.phantomjs.PhantomJSDriver;
-import org.sagebionetworks.bridge.config.BridgeConfigFactory;
-import org.sagebionetworks.bridge.models.SignIn;
-import org.sagebionetworks.bridge.models.SignUp;
-
-import com.google.common.collect.Lists;
 
 public class TestConstants {
-
-    public static class TestUser {
-        private final String username;
-        private final String email;
-        private final String password;
-        private final String[] roles;
-
-        /*
-        public TestUser(String username, String email, String password) {
-            String prefix = BridgeConfigFactory.getConfig().getUser() + "-";
-            this.username = prefix + username;
-            this.email = prefix + email;
-            this.password = password;
-            this.roles = null;
-        }
-        public TestUser(String username, String email, String password, String... roles) {
-            String prefix = BridgeConfigFactory.getConfig().getUser() + "-";
-            this.username = prefix + username;
-            this.email = prefix + email;
-            this.password = password;
-            this.roles = roles;
-        }
-        */
-        public TestUser(String tag) {
-            this(tag, Lists.<String>newArrayList());
-        }
-        public TestUser(String tag, List<String> roleList) {
-            String prefix = BridgeConfigFactory.getConfig().getUser() + "-";
-            this.username = prefix + tag;
-            this.email = prefix + tag + "@sagebridge.org";
-            this.password = "P4ssword";
-            this.roles = (roleList == null) ? null : roleList.toArray(new String[roleList.size()]);
-        }
-        public SignUp getSignUp() {
-            return new SignUp(username, email, password, roles);
-        }
-        public SignIn getSignIn() {
-            return new SignIn(username, password);
-        }
-        public String getUsername() {
-            return username;
-        }
-        public String getEmail() {
-            return email;
-        }
-        public String getPassword() {
-            return password;
-        }
-    }
 
     public static final String TEST_STUDY_KEY = "teststudy";
     public static final int TIMEOUT = 10000;

--- a/test/org/sagebionetworks/bridge/TestUserAdminHelper.java
+++ b/test/org/sagebionetworks/bridge/TestUserAdminHelper.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_KEY;
 
 import java.util.List;
@@ -18,10 +19,10 @@ import org.sagebionetworks.bridge.services.UserAdminService;
 import com.google.common.collect.Lists;
 
 /**
- * A support class that can be injected into any SpringJUnit4ClassRunner test that needs to create a test user before
- * performing some tests. This is an involved process because it goes through our regular UserAdminService class. It
- * requires that your bridge.conf specify the credentials of an existing user with admin privileges (such a user already
- * exists in the local and dev environments; you can get the credentials from Alx).
+ * A support class that can be injected into any SpringJUnit4ClassRunner test that needs to 
+ * create a test user before performing some tests. After (in a @Before method or a finally 
+ * block), call deleteUser() with the TestUser object that was returned, and the user will 
+ * be deleted (if there's a session, the session will also be cleaned up).
  */
 public class TestUserAdminHelper {
 
@@ -30,6 +31,54 @@ public class TestUserAdminHelper {
     UserAdminService userAdminService;
     AuthenticationService authService;
     StudyService studyService;
+    
+    public class TestUser {
+        private final String username;
+        private final String email;
+        private final String password;
+        private final String[] roles;
+        private final Study study;
+        private final UserSession session;
+
+        public TestUser(String username, String email, String password, List<String> roleList, Study study, UserSession session) {
+            this.username = username;
+            this.email = email;
+            this.password = password;
+            this.roles = (roleList == null) ? null : roleList.toArray(new String[roleList.size()]);
+            this.study = study;
+            this.session = session;
+        }
+        public SignUp getSignUp() {
+            return new SignUp(username, email, password, roles);
+        }
+        public SignIn getSignIn() {
+            return new SignIn(username, password);
+        }
+        public String getUsername() {
+            return username;
+        }
+        public String getEmail() {
+            return email;
+        }
+        public String getPassword() {
+            return password;
+        }
+        public UserSession getSession() {
+            return session;
+        }
+        public String getSessionToken() {
+            return (session == null) ? null : session.getSessionToken();
+        }
+        public User getUser() {
+            return (session == null) ? null : session.getUser();
+        }
+        public UserProfile getUserProfile() {
+            return (session == null) ? null : new UserProfile(session.getUser());
+        }
+        public Study getStudy() {
+            return study;
+        }
+    }
 
     public void setUserAdminService(UserAdminService userAdminService) {
         this.userAdminService = userAdminService;
@@ -43,15 +92,15 @@ public class TestUserAdminHelper {
         this.studyService = studyService;
     }
 
-    public UserSession createUser(String tag) {
+    public TestUser createUser(String tag) {
         return createUser(tag, Lists.<String>newArrayList());
     }
     
-    public UserSession createUser(String tag, List<String> roles) {
+    public TestUser createUser(String tag, List<String> roles) {
         return createUser(tag, roles, true, true);
     }
     
-    public UserSession createUser(String tag, List<String> roles, boolean signIn, boolean consent) {
+    public TestUser createUser(String tag, List<String> roles, boolean signIn, boolean consent) {
         String prefix = BridgeConfigFactory.getConfig().getUser() + "-";
         if (!tag.contains(prefix)) {
             tag = prefix + tag;
@@ -62,50 +111,37 @@ public class TestUserAdminHelper {
         return createUser(signUp, study, signIn, consent);
     }
     
-    public UserSession createUser(SignUp signUp, Study study, boolean signIn, boolean consent) {
-        return userAdminService.createUser(signUp, study, signIn, consent);
+    public TestUser createUser(SignUp signUp, Study study, boolean signIn, boolean consent) {
+        checkNotNull(signUp.getUsername());
+        checkNotNull(signUp.getEmail());
+        checkNotNull(signUp.getPassword());
+        checkNotNull(study);
+        
+        UserSession session = userAdminService.createUser(signUp, study, signIn, consent);
+        return new TestUser(signUp.getUsername(), signUp.getEmail(), signUp.getPassword(), signUp.getRoles(), study, session);
     }
 
-    public void deleteUser(UserSession session, String tag) {
-        deleteUser(session);
-        String prefix = BridgeConfigFactory.getConfig().getUser() + "-";
-        if (!tag.contains(prefix)) {
-            tag = prefix + tag;
+    public void deleteUser(TestUser testUser) {
+        checkNotNull(testUser);
+        
+        if (testUser.getSession() != null) {
+            // Delete using session if it exists
+            authService.signOut(testUser.getSessionToken());
+            userAdminService.deleteUser(testUser.getUser());
+        } else {
+            // Otherwise delete using the user's email
+            deleteUser(testUser.getStudy(), testUser.getEmail());
         }
-        userAdminService.deleteUser(tag + "@sagebridge.org");
     }
-
-    public void deleteUser(UserSession session) {
-        if (session != null) {
-            authService.signOut(session.getSessionToken());
-            userAdminService.deleteUser(session.getUser());
-        }
-    }
-
+    
     public void deleteUser(Study study, String email) {
+        checkNotNull(study);
+        checkNotNull(email);
+        
         User user = authService.getUser(study, email);
         if (user != null) {
             userAdminService.deleteUser(user);
         }
     }
-    
-    public String getPassword() {
-        return PASSWORD;
-    }
 
-    public Study getTestStudy() {
-        return studyService.getStudyByKey(TEST_STUDY_KEY);
-    }
-
-    public SignIn getSignIn(UserSession session) {
-        return new SignIn(session.getUser().getUsername(), PASSWORD);
-    }
-    
-    public SignIn getSignIn(UserSession session, String password) {
-        return new SignIn(session.getUser().getUsername(), password);
-    }
-
-    public UserProfile getUserProfile(UserSession session) {
-        return new UserProfile(session.getUser());
-    }
 }

--- a/test/org/sagebionetworks/bridge/TestUserAdminHelper.java
+++ b/test/org/sagebionetworks/bridge/TestUserAdminHelper.java
@@ -5,6 +5,7 @@ import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_KEY;
 
 import java.util.List;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 import org.sagebionetworks.bridge.models.SignIn;
 import org.sagebionetworks.bridge.models.SignUp;
@@ -15,8 +16,6 @@ import org.sagebionetworks.bridge.models.UserSession;
 import org.sagebionetworks.bridge.services.AuthenticationService;
 import org.sagebionetworks.bridge.services.StudyService;
 import org.sagebionetworks.bridge.services.UserAdminService;
-
-import com.google.common.collect.Lists;
 
 /**
  * A support class that can be injected into any SpringJUnit4ClassRunner test that needs to 
@@ -91,22 +90,29 @@ public class TestUserAdminHelper {
     public void setStudyService(StudyService studyService) {
         this.studyService = studyService;
     }
+    
+    public String makeRandomUserName(Class<?> cls) {
+        String clsPart = cls.getSimpleName();
+        String devPart = BridgeConfigFactory.getConfig().getUser();
+        String rndPart = RandomStringUtils.randomAlphabetic(4);
+        return String.format("%s-%s-%s", devPart, clsPart, rndPart);
+    }
 
-    public TestUser createUser(String tag) {
-        return createUser(tag, Lists.<String>newArrayList());
+    public TestUser createUser(Class<?> cls) {
+        return createUser(cls, (String[])null);
     }
     
-    public TestUser createUser(String tag, List<String> roles) {
-        return createUser(tag, roles, true, true);
+    public TestUser createUser(Class<?> cls, String... roles) {
+        checkNotNull(cls, "Class must not be null");
+        
+        return createUser(cls, true, true, roles);
     }
     
-    public TestUser createUser(String tag, List<String> roles, boolean signIn, boolean consent) {
-        String prefix = BridgeConfigFactory.getConfig().getUser() + "-";
-        if (!tag.contains(prefix)) {
-            tag = prefix + tag;
-        }
-        String[] rolesArray = (roles == null) ? null : roles.toArray(new String[] {});
-        SignUp signUp = new SignUp(tag, tag + "@sagebridge.org", PASSWORD, rolesArray);
+    public TestUser createUser(Class<?> cls, boolean signIn, boolean consent, String...roles) {
+        checkNotNull(cls, "Class must not be null");
+        
+        String name = makeRandomUserName(cls);
+        SignUp signUp = new SignUp(name, name + "@sagebridge.org", PASSWORD, roles);
         Study study = studyService.getStudyByKey(TEST_STUDY_KEY);
         return createUser(signUp, study, signIn, consent);
     }

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -3,13 +3,10 @@ package org.sagebionetworks.bridge;
 import static org.sagebionetworks.bridge.TestConstants.TEST_BASE_URL;
 
 import java.util.Map;
-import java.util.Random;
 import java.util.concurrent.Callable;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.io.BaseEncoding;
 
 import play.libs.WS;
 import play.libs.WS.WSRequestHolder;
@@ -17,8 +14,6 @@ import play.libs.WS.WSRequestHolder;
 public class TestUtils {
 
     private static Logger logger = LoggerFactory.getLogger(TestUtils.class);
-    
-    private static final Random random = new Random();
     
     public abstract static class FailableRunnable implements Runnable {
         public abstract void testCode() throws Exception;
@@ -54,12 +49,6 @@ public class TestUtils {
             Thread.sleep(200);
             processing = !callable.call();
         }
-    }
-    
-    public static String randomString() {
-        final byte[] buffer = new byte[10];
-        random.nextBytes(buffer);
-        return BaseEncoding.base64Url().omitPadding().encode(buffer);
     }
 
  }

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -3,10 +3,13 @@ package org.sagebionetworks.bridge;
 import static org.sagebionetworks.bridge.TestConstants.TEST_BASE_URL;
 
 import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.Callable;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.io.BaseEncoding;
 
 import play.libs.WS;
 import play.libs.WS.WSRequestHolder;
@@ -14,6 +17,8 @@ import play.libs.WS.WSRequestHolder;
 public class TestUtils {
 
     private static Logger logger = LoggerFactory.getLogger(TestUtils.class);
+    
+    private static final Random random = new Random();
     
     public abstract static class FailableRunnable implements Runnable {
         public abstract void testCode() throws Exception;
@@ -49,6 +54,12 @@ public class TestUtils {
             Thread.sleep(200);
             processing = !callable.call();
         }
+    }
+    
+    public static String randomString() {
+        final byte[] buffer = new byte[10];
+        random.nextBytes(buffer);
+        return BaseEncoding.base64Url().omitPadding().encode(buffer);
     }
 
  }

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -50,13 +50,5 @@ public class TestUtils {
             processing = !callable.call();
         }
     }
-    
-    // Useful in tests because Play Framework seems to disable all logging of the server code 
-    // during integration tests. This is a quick and dirty way to ping what is happening from 
-    // the integration tests. Remove references before committing code.
-    public static void output(String tag, String output) {
-        String str = String.format("\033[31m%s: \033[0m%s", tag, output);
-        System.out.println(str);
-    }
 
  }

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceImplTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceImplTest.java
@@ -29,7 +29,6 @@ import org.sagebionetworks.bridge.models.UserSession;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import com.google.common.collect.Lists;
 import com.stormpath.sdk.account.Account;
 import com.stormpath.sdk.client.Client;
 import com.stormpath.sdk.directory.Directory;
@@ -57,7 +56,7 @@ public class AuthenticationServiceImplTest {
     
     @Before
     public void before() {
-        testUser = helper.createUser(getClass().getSimpleName());
+        testUser = helper.createUser(AuthenticationServiceImplTest.class);
     }
     
     @After
@@ -129,7 +128,7 @@ public class AuthenticationServiceImplTest {
 
     @Test
     public void unconsentedUserMustSignTOU() throws Exception {
-        TestUser user = helper.createUser("authTestUser", null, false, false);
+        TestUser user = helper.createUser(AuthenticationServiceImplTest.class, false, false);
         try {
             // Create a user who has not consented.
             authService.signIn(user.getStudy(), user.getSignIn());
@@ -162,7 +161,7 @@ public class AuthenticationServiceImplTest {
     @Test
     public void createResearcherAndSignInWithoutConsentError() {
         Study study = studyService.getStudyByKey(TestConstants.TEST_STUDY_KEY);
-        TestUser researcher = helper.createUser("researcher", Lists.newArrayList(study.getResearcherRole()), false, false);
+        TestUser researcher = helper.createUser(AuthenticationServiceImplTest.class, false, false, study.getResearcherRole());
         try {
             authService.signIn(researcher.getStudy(), researcher.getSignIn());
             // no exception should have been thrown.
@@ -173,7 +172,7 @@ public class AuthenticationServiceImplTest {
 
     @Test
     public void createAdminAndSignInWithoutConsentError() {
-        TestUser researcher = helper.createUser("adminer", Lists.newArrayList(BridgeConstants.ADMIN_GROUP), false, false);
+        TestUser researcher = helper.createUser(AuthenticationServiceImplTest.class, false, false, BridgeConstants.ADMIN_GROUP);
         try {
             authService.signIn(researcher.getStudy(), researcher.getSignIn());
             // no exception should have been thrown.

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceImplTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceImplTest.java
@@ -14,6 +14,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.sagebionetworks.bridge.BridgeConstants;
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUserAdminHelper;
 import org.sagebionetworks.bridge.TestUserAdminHelper.TestUser;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
@@ -160,7 +161,8 @@ public class AuthenticationServiceImplTest {
     
     @Test
     public void createResearcherAndSignInWithoutConsentError() {
-        TestUser researcher = helper.createUser("researcher", null, false, false);
+        Study study = studyService.getStudyByKey(TestConstants.TEST_STUDY_KEY);
+        TestUser researcher = helper.createUser("researcher", Lists.newArrayList(study.getResearcherRole()), false, false);
         try {
             authService.signIn(researcher.getStudy(), researcher.getSignIn());
             // no exception should have been thrown.

--- a/test/org/sagebionetworks/bridge/services/ConsentServiceImplTest.java
+++ b/test/org/sagebionetworks/bridge/services/ConsentServiceImplTest.java
@@ -45,7 +45,7 @@ public class ConsentServiceImplTest {
 
     @Before
     public void before() {
-        testUser = helper.createUser(getClass().getSimpleName());
+        testUser = helper.createUser(ConsentServiceImplTest.class);
         studyConsent = studyConsentDao.addConsent(testUser.getStudy().getKey(), "/path/to", testUser.getStudy()
                 .getMinAge());
         studyConsentDao.setActive(studyConsent, true);

--- a/test/org/sagebionetworks/bridge/services/ConsentServiceImplTest.java
+++ b/test/org/sagebionetworks/bridge/services/ConsentServiceImplTest.java
@@ -10,11 +10,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.sagebionetworks.bridge.TestUserAdminHelper;
+import org.sagebionetworks.bridge.TestUserAdminHelper.TestUser;
 import org.sagebionetworks.bridge.dao.StudyConsentDao;
 import org.sagebionetworks.bridge.dao.UserConsentDao;
 import org.sagebionetworks.bridge.models.ConsentSignature;
 import org.sagebionetworks.bridge.models.StudyConsent;
-import org.sagebionetworks.bridge.models.UserSession;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -41,21 +41,21 @@ public class ConsentServiceImplTest {
     @Resource
     private TestUserAdminHelper helper;
     
-    private UserSession session;
+    private TestUser testUser;
 
     @Before
     public void before() {
-        session = helper.createUser(getClass().getSimpleName());
-        studyConsent = studyConsentDao.addConsent(helper.getTestStudy().getKey(), "/path/to", helper.getTestStudy()
+        testUser = helper.createUser(getClass().getSimpleName());
+        studyConsent = studyConsentDao.addConsent(testUser.getStudy().getKey(), "/path/to", testUser.getStudy()
                 .getMinAge());
         studyConsentDao.setActive(studyConsent, true);
     }
 
     @After
     public void after() {
-        helper.deleteUser(session, getClass().getSimpleName());
         studyConsentDao.setActive(studyConsent, false);
-        studyConsentDao.deleteConsent(helper.getTestStudy().getKey(), studyConsent.getCreatedOn());
+        studyConsentDao.deleteConsent(testUser.getStudy().getKey(), studyConsent.getCreatedOn());
+        helper.deleteUser(testUser);
     }
 
     @Test
@@ -64,19 +64,19 @@ public class ConsentServiceImplTest {
         boolean sendEmail = false;
 
         // Withdrawing and consenting again should return to original state.
-        consentService.withdrawConsent(session.getUser(), helper.getTestStudy());
-        consentService.consentToResearch(session.getUser(), researchConsent, helper.getTestStudy(), sendEmail);
-        boolean hasConsented = consentService.hasUserConsentedToResearch(session.getUser(), helper.getTestStudy());
+        consentService.withdrawConsent(testUser.getUser(), testUser.getStudy());
+        consentService.consentToResearch(testUser.getUser(), researchConsent, testUser.getStudy(), sendEmail);
+        boolean hasConsented = consentService.hasUserConsentedToResearch(testUser.getUser(), testUser.getStudy());
         assertTrue(hasConsented);
 
         // Suspend sharing should make isSharingData return false.
-        consentService.suspendDataSharing(session.getUser(), helper.getTestStudy());
-        boolean isSharing = consentService.isSharingData(session.getUser(), helper.getTestStudy());
+        consentService.suspendDataSharing(testUser.getUser(), testUser.getStudy());
+        boolean isSharing = consentService.isSharingData(testUser.getUser(), testUser.getStudy());
         assertFalse(isSharing);
 
         // Resume sharing should make isSharingData return true.
-        consentService.resumeDataSharing(session.getUser(), helper.getTestStudy());
-        isSharing = consentService.isSharingData(session.getUser(), helper.getTestStudy());
+        consentService.resumeDataSharing(testUser.getUser(), testUser.getStudy());
+        isSharing = consentService.isSharingData(testUser.getUser(), testUser.getStudy());
 
     }
 }

--- a/test/org/sagebionetworks/bridge/services/HealthDataServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/HealthDataServiceTest.java
@@ -42,7 +42,7 @@ public class HealthDataServiceTest {
     public void before() {
         DynamoInitializer.init(DynamoHealthDataRecord.class);
         DynamoTestUtil.clearTable(DynamoHealthDataRecord.class);
-        testUser = helper.createUser(getClass().getSimpleName());
+        testUser = helper.createUser(HealthDataServiceTest.class);
     }
     
     @After

--- a/test/org/sagebionetworks/bridge/services/HealthDataServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/HealthDataServiceTest.java
@@ -13,15 +13,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.sagebionetworks.bridge.TestUserAdminHelper;
+import org.sagebionetworks.bridge.TestUserAdminHelper.TestUser;
 import org.sagebionetworks.bridge.dynamodb.DynamoHealthDataRecord;
 import org.sagebionetworks.bridge.dynamodb.DynamoInitializer;
 import org.sagebionetworks.bridge.dynamodb.DynamoTestUtil;
 import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.models.Tracker;
-import org.sagebionetworks.bridge.models.UserSession;
 import org.sagebionetworks.bridge.models.healthdata.HealthDataKey;
 import org.sagebionetworks.bridge.models.healthdata.HealthDataRecord;
-import org.sagebionetworks.bridge.services.HealthDataServiceImpl;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -37,18 +36,18 @@ public class HealthDataServiceTest {
     @Resource
     private TestUserAdminHelper helper;
     
-    private UserSession session;
+    private TestUser testUser;
     
     @Before
     public void before() {
         DynamoInitializer.init(DynamoHealthDataRecord.class);
         DynamoTestUtil.clearTable(DynamoHealthDataRecord.class);
-        session = helper.createUser(getClass().getSimpleName());
+        testUser = helper.createUser(getClass().getSimpleName());
     }
     
     @After
     public void after() {
-        helper.deleteUser(session, getClass().getSimpleName());
+        helper.deleteUser(testUser);
     }
     
     private HealthDataRecord createHealthDataRecord() {
@@ -62,7 +61,7 @@ public class HealthDataServiceTest {
     private HealthDataKey createKey() {
         Tracker tracker = new Tracker();
         tracker.setId(1L);
-        return new HealthDataKey(helper.getTestStudy(), tracker, session.getUser());
+        return new HealthDataKey(testUser.getStudy(), tracker, testUser.getUser());
     }
 
     @Test

--- a/test/org/sagebionetworks/bridge/services/ScheduleChangeListenerTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduleChangeListenerTest.java
@@ -12,8 +12,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.sagebionetworks.bridge.BridgeUtils;
-import org.sagebionetworks.bridge.TestConstants.TestUser;
 import org.sagebionetworks.bridge.TestUserAdminHelper;
+import org.sagebionetworks.bridge.TestUserAdminHelper.TestUser;
 import org.sagebionetworks.bridge.dynamodb.DynamoInitializer;
 import org.sagebionetworks.bridge.dynamodb.DynamoSchedule;
 import org.sagebionetworks.bridge.dynamodb.DynamoScheduleDao;
@@ -28,7 +28,6 @@ import org.sagebionetworks.bridge.events.UserUnenrolledEvent;
 import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.models.Study;
 import org.sagebionetworks.bridge.models.User;
-import org.sagebionetworks.bridge.models.UserSession;
 import org.sagebionetworks.bridge.models.schedules.ActivityType;
 import org.sagebionetworks.bridge.models.schedules.Schedule;
 import org.sagebionetworks.bridge.models.schedules.SchedulePlan;
@@ -65,14 +64,12 @@ public class ScheduleChangeListenerTest {
     
     @Test
     public void addPlanThenEnrollUnenrollUser() throws Exception {
-        final TestUser testUser = new TestUser("enrollme");
-        final Study study = helper.getTestStudy();
-        UserSession session = null;
+        final TestUser testUser = helper.createUser("enrollme", null, true, false);
+        final User user = testUser.getUser();
+        final Study study = testUser.getStudy();
         try {
-            session = helper.createUser(testUser.getSignUp(), study, true, false);
-            final User user = session.getUser();
             
-            SchedulePlan plan = createSchedulePlan(user);
+            SchedulePlan plan = createSchedulePlan(study, user);
             schedulePlanDao.createSchedulePlan(plan);
             
             List<Schedule> schedules = scheduleDao.getSchedules(study, user);
@@ -96,7 +93,7 @@ public class ScheduleChangeListenerTest {
             schedules = scheduleDao.getSchedules(study, user);
             assertEquals("User left study and has no schedules", 0, schedules.size());
         } finally {
-            helper.deleteUser(session);
+            helper.deleteUser(testUser);
             waitFor(new Callable<Boolean>() {
                 @Override public Boolean call() throws Exception {
                     return (authService.getUser(study, testUser.getEmail()) == null);
@@ -107,24 +104,22 @@ public class ScheduleChangeListenerTest {
     
     @Test
     public void addUserThenCrudPlan() throws Exception {
-        final TestUser testUser = new TestUser("enrollme");
-        final Study study = helper.getTestStudy();
-        UserSession session = null; 
+        final TestUser testUser = helper.createUser("enrollme");
+        final Study study = testUser.getStudy();
+        final User user = testUser.getUser();
         try {
-            session = helper.createUser(testUser.getUsername());
-            final User user = session.getUser();
             
-            List<Schedule> schedules = scheduleDao.getSchedules(study, session.getUser());
+            List<Schedule> schedules = scheduleDao.getSchedules(study, user);
             assertEquals("No schedules because there's no plan", 0, schedules.size());
 
-            SchedulePlan plan = createSchedulePlan(session.getUser());
+            SchedulePlan plan = createSchedulePlan(study, user);
             listener.onApplicationEvent(new SchedulePlanCreatedEvent(plan));
             waitFor(new Callable<Boolean>() {
                 @Override public Boolean call() throws Exception {
                     return (scheduleDao.getSchedules(study, user).size() == 1);
                 }
             });
-            schedules = scheduleDao.getSchedules(study, session.getUser());
+            schedules = scheduleDao.getSchedules(study, user);
             assertEquals("There is now one schedule for the user", 1, schedules.size());
 
             updateSchedulePlan(plan);
@@ -135,7 +130,7 @@ public class ScheduleChangeListenerTest {
                     return (!sch.isEmpty() && "* * * * * *".equals(sch.get(0).getCronTrigger()));
                 }
             });
-            schedules = scheduleDao.getSchedules(study, session.getUser());
+            schedules = scheduleDao.getSchedules(study, user);
             assertEquals("There is still one schedule for the user", 1, schedules.size());
             assertEquals("That schedule shows an update", "* * * * * *", schedules.get(0).getCronTrigger());
 
@@ -145,11 +140,11 @@ public class ScheduleChangeListenerTest {
                     return (scheduleDao.getSchedules(study, user).size() == 0);
                 }
             });
-            schedules = scheduleDao.getSchedules(study, session.getUser());
+            schedules = scheduleDao.getSchedules(study, user);
             assertEquals("Now there is no schedule after the one plan was deleted", 0, schedules.size());
             
         } finally {
-            helper.deleteUser(session, getClass().getSimpleName());
+            helper.deleteUser(testUser);
             waitFor(new Callable<Boolean>() {
                 @Override public Boolean call() throws Exception {
                     return (authService.getUser(study, testUser.getEmail()) == null);
@@ -165,11 +160,11 @@ public class ScheduleChangeListenerTest {
         plan.setModifiedOn(DateUtils.getCurrentMillisFromEpoch());
     }
     
-    private SchedulePlan createSchedulePlan(User user) {
+    private SchedulePlan createSchedulePlan(Study study, User user) {
         String planGuid = BridgeUtils.generateGuid();
         
         Schedule schedule = new DynamoSchedule();
-        schedule.setStudyAndUser(helper.getTestStudy(), user);
+        schedule.setStudyAndUser(study, user);
         schedule.setSchedulePlanGuid(planGuid);
         schedule.setLabel("Task AAA");
         schedule.setActivityType(ActivityType.TASK);
@@ -187,7 +182,7 @@ public class ScheduleChangeListenerTest {
         plan.setGuid(planGuid);
         plan.setModifiedOn(DateUtils.getCurrentMillisFromEpoch());
         plan.setStrategy(strategy);
-        plan.setStudyKey(helper.getTestStudy().getKey());
+        plan.setStudyKey(study.getKey());
         return plan;
     }
 

--- a/test/org/sagebionetworks/bridge/services/ScheduleChangeListenerTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduleChangeListenerTest.java
@@ -64,7 +64,7 @@ public class ScheduleChangeListenerTest {
     
     @Test
     public void addPlanThenEnrollUnenrollUser() throws Exception {
-        final TestUser testUser = helper.createUser("enrollme", null, true, false);
+        final TestUser testUser = helper.createUser(ScheduleChangeListenerTest.class, true, false);
         final User user = testUser.getUser();
         final Study study = testUser.getStudy();
         try {
@@ -104,7 +104,7 @@ public class ScheduleChangeListenerTest {
     
     @Test
     public void addUserThenCrudPlan() throws Exception {
-        final TestUser testUser = helper.createUser("enrollme");
+        final TestUser testUser = helper.createUser(ScheduleChangeListenerTest.class);
         final Study study = testUser.getStudy();
         final User user = testUser.getUser();
         try {

--- a/test/org/sagebionetworks/bridge/services/StormPathUserAdminServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/StormPathUserAdminServiceTest.java
@@ -69,7 +69,7 @@ public class StormPathUserAdminServiceTest {
     @Before
     public void before() {
         study = studyService.getStudyByKey(TEST_STUDY_KEY);
-        signUp = new SignUp("testUser2", "testUser2@sagebridge.org", "P4ssword");
+        signUp = new SignUp(bridgeConfig.getUser() + "-admin", "admin@sagebridge.org", "P4ssword");
         
         SignIn signIn = new SignIn(bridgeConfig.getProperty("admin.email"), bridgeConfig.getProperty("admin.password"));
         authService.signIn(study, signIn).getUser();

--- a/test/org/sagebionetworks/bridge/services/StormPathUserAdminServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/StormPathUserAdminServiceTest.java
@@ -14,13 +14,13 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.sagebionetworks.bridge.TestConstants.TestUser;
 import org.sagebionetworks.bridge.config.BridgeConfig;
 import org.sagebionetworks.bridge.dynamodb.DynamoTestUtil;
 import org.sagebionetworks.bridge.dynamodb.DynamoUserConsent2;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.exceptions.ConsentRequiredException;
 import org.sagebionetworks.bridge.models.SignIn;
+import org.sagebionetworks.bridge.models.SignUp;
 import org.sagebionetworks.bridge.models.Study;
 import org.sagebionetworks.bridge.models.User;
 import org.sagebionetworks.bridge.models.UserSession;
@@ -51,13 +51,11 @@ public class StormPathUserAdminServiceTest {
     
     private Study study;
     
-    private TestUser test2 = new TestUser("testUser2");
+    private SignUp signUp;
     
     private User test2User;
     private User test3User;
     
-    private boolean setUpComplete = false;
-
     @BeforeClass
     public static void initialSetUp() {
         DynamoTestUtil.clearTable(DynamoUserConsent2.class);
@@ -70,14 +68,11 @@ public class StormPathUserAdminServiceTest {
 
     @Before
     public void before() {
-        if (!setUpComplete) {
-            study = studyService.getStudyByKey(TEST_STUDY_KEY);
-            
-            SignIn signIn = new SignIn(bridgeConfig.getProperty("admin.email"), bridgeConfig.getProperty("admin.password"));
-            authService.signIn(study, signIn).getUser();
-            
-            setUpComplete = true;
-        }
+        study = studyService.getStudyByKey(TEST_STUDY_KEY);
+        signUp = new SignUp("testUser2", "testUser2@sagebridge.org", "P4ssword");
+        
+        SignIn signIn = new SignIn(bridgeConfig.getProperty("admin.email"), bridgeConfig.getProperty("admin.password"));
+        authService.signIn(study, signIn).getUser();
     }
 
     @After
@@ -94,31 +89,31 @@ public class StormPathUserAdminServiceTest {
 
     @Test
     public void canCreateUserIdempotently() {
-        test2User = service.createUser(test2.getSignUp(), study, true, true).getUser();
-        test2User = service.createUser(test2.getSignUp(), study, true, true).getUser();
+        test2User = service.createUser(signUp, study, true, true).getUser();
+        test2User = service.createUser(signUp, study, true, true).getUser();
 
-        assertEquals("Correct email", test2.getSignUp().getEmail(), test2User.getEmail());
-        assertEquals("Correct username", test2.getSignUp().getUsername(), test2User.getUsername());
+        assertEquals("Correct email", signUp.getEmail(), test2User.getEmail());
+        assertEquals("Correct username", signUp.getUsername(), test2User.getUsername());
         assertTrue("Has consented", test2User.doesConsent());
     }
 
     @Test(expected = BridgeServiceException.class)
     public void deletedUserHasBeenDeleted() {
-        test2User = service.createUser(test2.getSignUp(), study, true, true).getUser();
+        test2User = service.createUser(signUp, study, true, true).getUser();
         
         service.deleteUser(test2User);
         
         // This should fail with a 404.
-        authService.signIn(study, test2.getSignIn());
+        authService.signIn(study, new SignIn(signUp.getEmail(), signUp.getPassword()));
     }
 
     @Test
     public void canCreateUserWithoutConsentingOrSigningUserIn() {
-        UserSession session1 = service.createUser(test2.getSignUp(), study, false, false);
+        UserSession session1 = service.createUser(signUp, study, false, false);
         assertNull("No session", session1);
         
         try {
-            authService.signIn(study, test2.getSignIn());
+            authService.signIn(study, new SignIn(signUp.getEmail(), signUp.getPassword()));
             fail("Should throw a consent required exception");
         } catch (ConsentRequiredException e) {
             test2User = e.getUserSession().getUser();

--- a/test/org/sagebionetworks/bridge/services/UploadServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/UploadServiceTest.java
@@ -27,11 +27,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.sagebionetworks.bridge.TestUserAdminHelper;
+import org.sagebionetworks.bridge.TestUserAdminHelper.TestUser;
 import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 import org.sagebionetworks.bridge.dao.UploadDao;
 import org.sagebionetworks.bridge.models.UploadRequest;
 import org.sagebionetworks.bridge.models.UploadSession;
-import org.sagebionetworks.bridge.models.UserSession;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -61,7 +61,7 @@ public class UploadServiceTest {
     @Resource
     private TestUserAdminHelper helper;
     
-    private UserSession session;
+    private TestUser testUser;
 
     private List<String> objectsToRemove;
 
@@ -81,7 +81,7 @@ public class UploadServiceTest {
             }
         }
         objectsToRemove = new ArrayList<String>();
-        session = helper.createUser(getClass().getSimpleName());
+        testUser = helper.createUser(getClass().getSimpleName());
     }
 
     @After
@@ -93,13 +93,13 @@ public class UploadServiceTest {
         } catch (AmazonClientException e) {
             e.printStackTrace();
         }
-        helper.deleteUser(session, getClass().getSimpleName());
+        helper.deleteUser(testUser);
     }
 
     @Test
     public void test() throws Exception {
         UploadRequest uploadRequest = createUploadRequest();
-        UploadSession uploadSession = uploadService.createUpload(session.getUser(), uploadRequest);
+        UploadSession uploadSession = uploadService.createUpload(testUser.getUser(), uploadRequest);
         final String uploadId = uploadSession.getId();
         final String objectId = uploadDao.getObjectId(uploadId);
         objectsToRemove.add(objectId);

--- a/test/org/sagebionetworks/bridge/services/UploadServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/UploadServiceTest.java
@@ -81,7 +81,7 @@ public class UploadServiceTest {
             }
         }
         objectsToRemove = new ArrayList<String>();
-        testUser = helper.createUser(getClass().getSimpleName());
+        testUser = helper.createUser(UploadServiceTest.class);
     }
 
     @After

--- a/test/org/sagebionetworks/bridge/services/UserProfileServiceImplTest.java
+++ b/test/org/sagebionetworks/bridge/services/UserProfileServiceImplTest.java
@@ -29,7 +29,7 @@ public class UserProfileServiceImplTest {
     
     @Before
     public void before() {
-        testUser = helper.createUser(getClass().getSimpleName());
+        testUser = helper.createUser(UserProfileServiceImplTest.class);
     }
     
     @After

--- a/test/org/sagebionetworks/bridge/services/UserProfileServiceImplTest.java
+++ b/test/org/sagebionetworks/bridge/services/UserProfileServiceImplTest.java
@@ -9,9 +9,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.sagebionetworks.bridge.TestUserAdminHelper;
+import org.sagebionetworks.bridge.TestUserAdminHelper.TestUser;
 import org.sagebionetworks.bridge.models.User;
 import org.sagebionetworks.bridge.models.UserProfile;
-import org.sagebionetworks.bridge.models.UserSession;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -25,25 +25,25 @@ public class UserProfileServiceImplTest {
     @Resource
     private TestUserAdminHelper helper;
     
-    private UserSession session;
+    private TestUser testUser;
     
     @Before
     public void before() {
-        session = helper.createUser(getClass().getSimpleName());
+        testUser = helper.createUser(getClass().getSimpleName());
     }
     
     @After
     public void after() {
-        helper.deleteUser(session, getClass().getSimpleName());
+        helper.deleteUser(testUser);
     }
     
     @Test
     public void canUpdateUserProfile() {
-        UserProfile userProfile = helper.getUserProfile(session);
+        UserProfile userProfile = testUser.getUserProfile();
         userProfile.setFirstName("Test");
         userProfile.setLastName("Powers");
         
-        User updatedUser = service.updateProfile(session.getUser(), userProfile);
+        User updatedUser = service.updateProfile(testUser.getUser(), userProfile);
         
         assertEquals("Test", updatedUser.getFirstName());
         assertEquals("Powers", updatedUser.getLastName());

--- a/test/org/sagebionetworks/bridge/validators/UploadValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/UploadValidatorTest.java
@@ -9,8 +9,6 @@ import org.junit.Test;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.UploadRequest;
-import org.sagebionetworks.bridge.validators.UploadValidator;
-import org.sagebionetworks.bridge.validators.Validate;
 import org.springframework.validation.Validator;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/test/webdriver/tests/ResetPasswordTest.java
+++ b/test/webdriver/tests/ResetPasswordTest.java
@@ -7,7 +7,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.sagebionetworks.bridge.TestUserAdminHelper;
-import org.sagebionetworks.bridge.models.UserSession;
+import org.sagebionetworks.bridge.TestUserAdminHelper.TestUser;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -52,16 +52,16 @@ public class ResetPasswordTest extends BaseIntegrationTest {
     public void resetPasswordSubmitsValidEmail() {
         call(new Callback<TestBrowser>() {
             public void invoke(TestBrowser browser) {
-                UserSession session = null;
+                TestUser testUser = null;
                 try {
-                    session = helper.createUser(getClass().getSimpleName());
+                    testUser = helper.createUser(getClass().getSimpleName());
                     
                     AppPage page = new AppPage(browser);
                     RequestResetPasswordDialog dialog = page.openSignInDialog().openResetPasswordDialog();
                     
-                    dialog.submitEmailAddress(session.getUser().getEmail());
+                    dialog.submitEmailAddress(testUser.getUser().getEmail());
                 } finally {
-                    helper.deleteUser(session, getClass().getSimpleName());
+                    helper.deleteUser(testUser);
                 }
             }
         });

--- a/test/webdriver/tests/ResetPasswordTest.java
+++ b/test/webdriver/tests/ResetPasswordTest.java
@@ -54,7 +54,7 @@ public class ResetPasswordTest extends BaseIntegrationTest {
             public void invoke(TestBrowser browser) {
                 TestUser testUser = null;
                 try {
-                    testUser = helper.createUser(getClass().getSimpleName());
+                    testUser = helper.createUser(ResetPasswordTest.class);
                     
                     AppPage page = new AppPage(browser);
                     RequestResetPasswordDialog dialog = page.openSignInDialog().openResetPasswordDialog();

--- a/test/webdriver/tests/SignInTest.java
+++ b/test/webdriver/tests/SignInTest.java
@@ -6,9 +6,9 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.sagebionetworks.bridge.TestUserAdminHelper;
+import org.sagebionetworks.bridge.TestUserAdminHelper.TestUser;
 import org.sagebionetworks.bridge.models.SignUp;
 import org.sagebionetworks.bridge.models.Study;
-import org.sagebionetworks.bridge.models.UserSession;
 import org.sagebionetworks.bridge.services.StudyServiceImpl;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -32,20 +32,19 @@ public class SignInTest extends BaseIntegrationTest {
     public void signIn() {
         call(new Callback<TestBrowser>() {
             public void invoke(TestBrowser browser) {
-                UserSession session = null;
+                TestUser testUser = null;
                 try {
-                    new SignUp("test", "test@sagebridge.org", "P4ssword");
                     SignUp signUp = new SignUp("test", "test@sagebridge.org", "P4ssword");
                     Study study = studyService.getStudyByKey("neurod");
-                    session = helper.createUser(signUp, study, true, true);
+                    testUser = helper.createUser(signUp, study, true, true);
                     
                     AppPage page = new AppPage(browser);
                     AppPage.SignInDialog signInDialog = page.openSignInDialog();
 
-                    signInDialog.signIn(session.getUser().getUsername(), "P4ssword");
+                    signInDialog.signIn(testUser.getUser().getUsername(), "P4ssword");
                     page.signOut();
                 } finally {
-                    helper.deleteUser(session);
+                    helper.deleteUser(testUser);
                 }
             }
         });


### PR DESCRIPTION
Making it harder to use incorrectly:
- takes a class and uses the simple name, along with dev's user name and random string, to create a unique user each time (that can be identified with its test if it is not cleaned up properly);
- createUser() methods return a TestUser, which is a handle that can be returned to deleteUser(testUser), regardless of whether a session is created or not, so user can be deleted each time.
