### PR TITLE
Disabling tests that are now in the SDK

### DIFF
--- a/app/org/sagebionetworks/bridge/models/UserProfile.java
+++ b/app/org/sagebionetworks/bridge/models/UserProfile.java
@@ -67,9 +67,6 @@ public class UserProfile {
     public String getEmail() {
         return this.email;
     }
-    public void setEmail(String email) {
-        this.email = email;
-    }
     
     private static String replaceWithEmpty(String s) {
         if (StringUtils.isBlank(s)) {

--- a/test/controllers/ScheduleControllerTest.java
+++ b/test/controllers/ScheduleControllerTest.java
@@ -13,6 +13,7 @@ import javax.annotation.Resource;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.sagebionetworks.bridge.TestUserAdminHelper;
@@ -32,6 +33,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 @ContextConfiguration("classpath:test-context.xml")
 @RunWith(SpringJUnit4ClassRunner.class)
+@Ignore // MOVED TO SDK
 public class ScheduleControllerTest {
     
     @Resource

--- a/test/controllers/SchedulePlanControllerTest.java
+++ b/test/controllers/SchedulePlanControllerTest.java
@@ -40,6 +40,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 
 @ContextConfiguration("classpath:test-context.xml")
 @RunWith(SpringJUnit4ClassRunner.class)
+@Ignore // MOVED TO SDK
 public class SchedulePlanControllerTest {
     
     @Resource
@@ -62,7 +63,6 @@ public class SchedulePlanControllerTest {
     }
 
     @Test
-    @Ignore // MOVED TO SDK
     public void normalUserCannotAccess() {
         running(testServer(3333), new TestUtils.FailableRunnable() {
             public void testCode() throws Exception {
@@ -83,7 +83,6 @@ public class SchedulePlanControllerTest {
     }
     
     @Test
-    @Ignore // MOVED TO SDK
     public void crudSchedulePlan() {
         running(testServer(3333), new TestUtils.FailableRunnable() {
             public void testCode() throws Exception {
@@ -123,7 +122,6 @@ public class SchedulePlanControllerTest {
     }
     
     @Test
-    @Ignore // MOVED TO SDK
     public void invalidPlanReturns400Error() {
         running(testServer(3333), new TestUtils.FailableRunnable() {
             public void testCode() throws Exception {
@@ -143,7 +141,6 @@ public class SchedulePlanControllerTest {
     }
     
     @Test
-    @Ignore // MOVED TO SDK
     public void noPlanReturns400() {
         running(testServer(3333), new TestUtils.FailableRunnable() {
             public void testCode() throws Exception {

--- a/test/controllers/UserManagementControllerTest.java
+++ b/test/controllers/UserManagementControllerTest.java
@@ -1,6 +1,7 @@
 package controllers;
 
 import static org.apache.commons.httpclient.HttpStatus.SC_CREATED;
+
 import static org.apache.commons.httpclient.HttpStatus.SC_OK;
 import static org.junit.Assert.assertEquals;
 import static org.sagebionetworks.bridge.TestConstants.SIGN_OUT_URL;
@@ -34,6 +35,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 @ContextConfiguration("classpath:test-context.xml")
 @RunWith(SpringJUnit4ClassRunner.class)
+@Ignore // MOVED TO SDK (WHICH DOES IT OVER AND OVER AGAIN)
 public class UserManagementControllerTest {
 
     @Resource
@@ -52,11 +54,6 @@ public class UserManagementControllerTest {
     }
 
     @Test
-    @Ignore
-    // This test sometimes succeeds, and sometimes fails with
-    // java.util.concurrent.TimeoutException: Futures timed out after [10000 milliseconds].
-    // The user is deleted in this case, there are no schedules to delete. This test is 
-    // going to move to the SDK and we'll try again there.
     public void canCreateAndDeleteUser() {
         running(testServer(3333), new FailableRunnable() {
             @Override

--- a/test/controllers/UserProfileControllerTest.java
+++ b/test/controllers/UserProfileControllerTest.java
@@ -13,6 +13,7 @@ import javax.annotation.Resource;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.sagebionetworks.bridge.TestUserAdminHelper;
@@ -29,6 +30,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 @ContextConfiguration("classpath:test-context.xml")
 @RunWith(SpringJUnit4ClassRunner.class)
+@Ignore // MOVED TO SDK
 public class UserProfileControllerTest {
 
     private ObjectMapper mapper = new ObjectMapper();


### PR DESCRIPTION
This includes one controller test that's failing, but that succeeds from the SDK (at least at last check-in).
