### PR TITLE
add getConsentSignature API to support SDK integration tests

### DIFF
--- a/app/controllers/ConsentController.java
+++ b/app/controllers/ConsentController.java
@@ -24,6 +24,13 @@ public class ConsentController extends BaseController {
         this.optionsService = optionsService;
     }
 
+    public Result getConsentSignature() throws Exception {
+        final UserSession session = getAuthenticatedAndConsentedSession();
+        final Study study = studyService.getStudyByHostname(getHostname());
+        ConsentSignature sig = consentService.getConsentSignature(session.getUser(), study);
+        return okResult(sig);
+    }
+
     public Result give() throws Exception {
         final UserSession session = getAuthenticatedSession();
         final ConsentSignature consent = ConsentSignature.createFromJson(requestToJSON(request()));

--- a/app/org/sagebionetworks/bridge/dao/UserConsentDao.java
+++ b/app/org/sagebionetworks/bridge/dao/UserConsentDao.java
@@ -34,9 +34,10 @@ public interface UserConsentDao {
      * @return
      */
     UserConsent getUserConsent(String healthCode, StudyConsent consent);
-    
+
     /**
-     * Returns the consent signature, consisting of the signature name and birthdate.
+     * Returns a non-null consent signature, consisting of the signature name and birthdate. Throws
+     * EntityNotFoundException if no consent signature is found.
      */
     ConsentSignature getConsentSignature(String healthCode, StudyConsent consent);
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUserConsentDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUserConsentDao.java
@@ -53,7 +53,8 @@ public class DynamoUserConsentDao implements UserConsentDao {
         DynamoUserConsent2 consent = new DynamoUserConsent2(healthCode, studyConsent);
         return mapper.load(consent);
     }
-    
+
+    /** Returns a non-null consent signature. Throws EntityNotFoundException if no consent signature is found. */
     @Override
     public ConsentSignature getConsentSignature(String healthCode, StudyConsent consent) {
         ConsentSignature signature = getConsentSignature2(healthCode, consent);
@@ -99,6 +100,7 @@ public class DynamoUserConsentDao implements UserConsentDao {
         return mapper.load(consent) != null;
     }
 
+    /** Returns a non-null consent signature. Throws EntityNotFoundException if no consent signature is found. */
     ConsentSignature getConsentSignature2(String healthCode, StudyConsent studyConsent) {
         DynamoUserConsent2 consent = new DynamoUserConsent2(healthCode, studyConsent);
         consent = mapper.load(consent);

--- a/app/org/sagebionetworks/bridge/services/ConsentService.java
+++ b/app/org/sagebionetworks/bridge/services/ConsentService.java
@@ -6,6 +6,8 @@ import org.sagebionetworks.bridge.models.studies.Study;
 
 public interface ConsentService {
 
+    public ConsentSignature getConsentSignature(User caller, Study study);
+
     public User consentToResearch(User caller, ConsentSignature researchConsent, Study study, boolean sendEmail);
 
     public boolean hasUserConsentedToResearch(User caller, Study study);

--- a/app/org/sagebionetworks/bridge/services/ConsentServiceImpl.java
+++ b/app/org/sagebionetworks/bridge/services/ConsentServiceImpl.java
@@ -58,6 +58,19 @@ public class ConsentServiceImpl implements ConsentService, ApplicationEventPubli
     }
 
     @Override
+    public ConsentSignature getConsentSignature(final User caller, final Study study) {
+        checkNotNull(caller, Validate.CANNOT_BE_NULL, "user");
+        checkNotNull(study, Validate.CANNOT_BE_NULL, "study");
+
+        final StudyConsent consent = studyConsentDao.getConsent(study.getIdentifier());
+        if (consent == null) {
+            throw new EntityNotFoundException(StudyConsent.class);
+        }
+        ConsentSignature consentSignature = userConsentDao.getConsentSignature(caller.getHealthCode(), consent);
+        return consentSignature;
+    }
+
+    @Override
     public User consentToResearch(final User caller, final ConsentSignature consentSignature, 
         final Study study, final boolean sendEmail) throws BridgeServiceException {
         

--- a/conf/routes
+++ b/conf/routes
@@ -44,6 +44,7 @@ GET    /api/v1/schedules   @controllers.ScheduleController.getSchedules
 
 # API - Consent
 POST   /api/v1/consent                       @controllers.ConsentController.give
+GET    /api/v1/consent                       @controllers.ConsentController.getConsentSignature
 POST   /api/v1/consent/email                 @controllers.ConsentController.emailCopy
 POST   /api/v1/consent/dataSharing/suspend   @controllers.ConsentController.suspendDataSharing
 POST   /api/v1/consent/dataSharing/resume    @controllers.ConsentController.resumeDataSharing


### PR DESCRIPTION
Add getConsentSignature API to support SDK integration tests. All tests pass. Tested manually using Firefox Poster.
