### PR TITLE
User delete fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ bower_components
 project/project/target
 project/target
 build
+TestScripts.java
 setup.sh
 .sass-cache
 .target

--- a/app/controllers/UserManagementController.java
+++ b/app/controllers/UserManagementController.java
@@ -2,7 +2,6 @@ package controllers;
 
 import org.sagebionetworks.bridge.json.JsonUtils;
 import org.sagebionetworks.bridge.models.SignUp;
-import org.sagebionetworks.bridge.models.User;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.services.UserAdminService;
 
@@ -37,9 +36,7 @@ public class UserManagementController extends BaseController {
 
     public Result deleteUser(String email) throws Exception {
         getAuthenticatedAdminSession();
-        Study study = studyService.getStudyByHostname(getHostname());
-        User user = authenticationService.getUser(study, email);
-        userAdminService.deleteUser(user);
+        userAdminService.deleteUser(email);
 
         return okResult("User deleted.");
     }

--- a/app/org/sagebionetworks/bridge/dao/HealthCodeDao.java
+++ b/app/org/sagebionetworks/bridge/dao/HealthCodeDao.java
@@ -6,6 +6,4 @@ public interface HealthCodeDao {
      * @return true, if the code does not exist yet and is set; false, if the code already exists.
      */
     boolean setIfNotExist(String code);
-    
-    void deleteCode(String healthCode);
 }

--- a/app/org/sagebionetworks/bridge/dao/HealthDataDao.java
+++ b/app/org/sagebionetworks/bridge/dao/HealthDataDao.java
@@ -19,4 +19,6 @@ public interface HealthDataDao {
     
     public void deleteHealthDataRecord(HealthDataKey key, String guid);
     
+    public void deleteHealthDataRecords(HealthDataKey key);
+    
 }

--- a/app/org/sagebionetworks/bridge/dao/HealthIdDao.java
+++ b/app/org/sagebionetworks/bridge/dao/HealthIdDao.java
@@ -15,6 +15,4 @@ public interface HealthIdDao {
      */
     String getCode(String id);
     
-    void deleteMapping(String healthCode);
-    
 }

--- a/app/org/sagebionetworks/bridge/dao/UserConsentDao.java
+++ b/app/org/sagebionetworks/bridge/dao/UserConsentDao.java
@@ -13,7 +13,7 @@ public interface UserConsentDao {
     void giveConsent(String healthCode, StudyConsent consent, ConsentSignature consentSignature);
 
     /**
-     * Withdraws consent to the specified study.
+     * Withdraws consent to the specified study. Currently this is only used by tests. 
      */
     void withdrawConsent(String healthCode, StudyConsent consent);
 

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoHealthCodeDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoHealthCodeDao.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.bridge.dynamodb;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import org.sagebionetworks.bridge.dao.HealthCodeDao;
@@ -33,16 +32,6 @@ public class DynamoHealthCodeDao implements HealthCodeDao {
             return true;
         } catch(ConditionalCheckFailedException e) {
             return false;
-        }
-    }
-
-    @Override
-    public void deleteCode(String healthCode) {
-        checkNotNull(healthCode);
-        DynamoHealthCode code = new DynamoHealthCode(healthCode);
-        DynamoHealthCode dynamoHealthCode = mapper.load(code);
-        if (dynamoHealthCode != null) {
-            mapper.delete(dynamoHealthCode);
         }
     }
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataDao.java
@@ -149,5 +149,12 @@ public class DynamoHealthDataDao implements HealthDataDao {
         DynamoHealthDataRecord dynamoRecord = new DynamoHealthDataRecord(key.toString(), guid, record);
         mapper.delete(dynamoRecord);
     }
+    
+    @Override
+    public void deleteHealthDataRecords(HealthDataKey key) {
+        List<HealthDataRecord> data = getAllHealthData(key);
+        List<FailedBatch> failures = mapper.batchDelete(data);
+        BridgeUtils.ifFailuresThrowException(failures);
+    }
 
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoHealthIdDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoHealthIdDao.java
@@ -1,24 +1,17 @@
 package org.sagebionetworks.bridge.dynamodb;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.util.List;
 
-import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.dao.HealthIdDao;
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper.FailedBatch;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig.ConsistentReads;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig.SaveBehavior;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBScanExpression;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
-import com.amazonaws.services.dynamodbv2.model.Condition;
 import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException;
 
 public class DynamoHealthIdDao implements HealthIdDao {
@@ -55,18 +48,5 @@ public class DynamoHealthIdDao implements HealthIdDao {
             return healthId.getCode();
         }
         return null;
-    }
-
-    @Override
-    public void deleteMapping(String healthCode) {
-        checkNotNull(healthCode);
-        DynamoDBScanExpression scan = new DynamoDBScanExpression();
-        Condition condition = new Condition();
-        condition.withComparisonOperator(ComparisonOperator.EQ);
-        condition.withAttributeValueList(new AttributeValue().withS(healthCode));
-        scan.addFilterCondition("code", condition);
-        List<DynamoHealthId> mappings = mapper.scan(DynamoHealthId.class, scan);
-        List<FailedBatch> failures = mapper.batchDelete(mappings);
-        BridgeUtils.ifFailuresThrowException(failures);
     }
 }

--- a/app/org/sagebionetworks/bridge/redis/RedisKey.java
+++ b/app/org/sagebionetworks/bridge/redis/RedisKey.java
@@ -26,8 +26,13 @@ public interface RedisKey {
     /** User health code. */
     RedisKey HEALTH_CODE = new SimpleKey("health-code");
 
+    /** User (email). */
+    RedisKey USER = new SimpleKey("user");
+    
     /** Health code lock. */
     RedisKey HEALTH_CODE_LOCK = new CompoundKey((SimpleKey)HEALTH_CODE, (SimpleKey)LOCK);
+    
+    RedisKey USER_LOCK = new CompoundKey((SimpleKey)HEALTH_CODE, (SimpleKey)LOCK);
 
     String SEPARATOR = ":";
 

--- a/app/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -11,6 +11,8 @@ import org.sagebionetworks.bridge.models.User;
 import org.sagebionetworks.bridge.models.UserSession;
 import org.sagebionetworks.bridge.models.studies.Study;
 
+import com.stormpath.sdk.account.Account;
+
 public interface AuthenticationService {
 
     public UserSession getSession(String sessionToken);
@@ -29,4 +31,5 @@ public interface AuthenticationService {
     
     public User getUser(Study study, String email);
     
+    public UserSession createSessionFromAccount(Study study, Account account);
 }

--- a/app/org/sagebionetworks/bridge/services/AuthenticationServiceImpl.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationServiceImpl.java
@@ -39,7 +39,6 @@ import com.stormpath.sdk.application.Application;
 import com.stormpath.sdk.authc.AuthenticationRequest;
 import com.stormpath.sdk.authc.UsernamePasswordRequest;
 import com.stormpath.sdk.client.Client;
-import com.stormpath.sdk.directory.CustomData;
 import com.stormpath.sdk.directory.Directory;
 import com.stormpath.sdk.group.Group;
 import com.stormpath.sdk.group.GroupList;
@@ -237,7 +236,8 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         return null;
     }
 
-    private UserSession createSessionFromAccount(Study study, Account account) {
+    @Override
+    public UserSession createSessionFromAccount(Study study, Account account) {
 
         final UserSession session = new UserSession();
         session.setAuthenticated(true);

--- a/app/org/sagebionetworks/bridge/services/ConsentServiceImpl.java
+++ b/app/org/sagebionetworks/bridge/services/ConsentServiceImpl.java
@@ -140,20 +140,6 @@ public class ConsentServiceImpl implements ConsentService, ApplicationEventPubli
             caller.setConsent(false);
         };
         return caller;
-        /*
-        List<StudyConsent> consents = studyConsentDao.getConsents(study.getIdentifier());
-        for (StudyConsent consent : consents) {
-            if (userConsentDao.hasConsented(healthCode, consent)) {
-                decrementStudyEnrollment(study);
-                
-                withdrawn = true;
-            }
-        }
-        if (withdrawn) {
-            publisher.publishEvent(new UserUnenrolledEvent(caller, study));
-            caller.setConsent(false);
-        }
-        */
     }
 
     @Override

--- a/app/org/sagebionetworks/bridge/services/HealthDataService.java
+++ b/app/org/sagebionetworks/bridge/services/HealthDataService.java
@@ -20,4 +20,6 @@ public interface HealthDataService {
 
     public void deleteHealthDataRecord(HealthDataKey key, String guid);
     
+    public void deleteHealthDataRecords(HealthDataKey key);
+    
 }

--- a/app/org/sagebionetworks/bridge/services/HealthDataServiceImpl.java
+++ b/app/org/sagebionetworks/bridge/services/HealthDataServiceImpl.java
@@ -90,5 +90,12 @@ public class HealthDataServiceImpl implements HealthDataService {
 
         healthDataDao.deleteHealthDataRecord(key, guid);
     }
+    
+    @Override
+    public void deleteHealthDataRecords(HealthDataKey key) {
+        checkNotNull(key, "HealthDataKey cannot be null");
+        
+        healthDataDao.deleteHealthDataRecords(key);
+    }
 
 }

--- a/app/org/sagebionetworks/bridge/services/StormPathUserAdminService.java
+++ b/app/org/sagebionetworks/bridge/services/StormPathUserAdminService.java
@@ -4,11 +4,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
 import org.sagebionetworks.bridge.dao.DistributedLockDao;
 import org.sagebionetworks.bridge.dao.HealthCodeDao;
 import org.sagebionetworks.bridge.dao.HealthIdDao;
-import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.exceptions.ConsentRequiredException;
 import org.sagebionetworks.bridge.models.SignIn;
@@ -21,18 +19,23 @@ import org.sagebionetworks.bridge.models.studies.ConsentSignature;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.Tracker;
 import org.sagebionetworks.bridge.redis.RedisKey;
+import org.sagebionetworks.bridge.stormpath.StormpathFactory;
 import org.sagebionetworks.bridge.validators.Validate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Validator;
 
 import com.stormpath.sdk.account.Account;
 import com.stormpath.sdk.account.AccountCriteria;
 import com.stormpath.sdk.account.AccountList;
 import com.stormpath.sdk.account.Accounts;
+import com.stormpath.sdk.application.Application;
 import com.stormpath.sdk.client.Client;
-import com.stormpath.sdk.directory.Directory;
 
 public class StormPathUserAdminService implements UserAdminService {
 
+    private static final Logger logger = LoggerFactory.getLogger(StormPathUserAdminService.class);
+    
     private AuthenticationService authenticationService;
     private ConsentService consentService;
     private HealthDataService healthDataService;
@@ -93,9 +96,9 @@ public class StormPathUserAdminService implements UserAdminService {
         Validate.entityThrowingException(validator, signUp);
         
         try {
-            Directory directory = getDirectory(study);
+            Application app = StormpathFactory.getStormpathApplication(stormpathClient);
             // Search for email and skip creation if it already exists.
-            if (userDoesNotExist(directory, signUp.getEmail())) {
+            if (userDoesNotExist(app, signUp.getEmail())) {
                 authenticationService.signUp(signUp, study, false);
             }
         } catch (Throwable t) {
@@ -125,139 +128,70 @@ public class StormPathUserAdminService implements UserAdminService {
     }
 
     @Override
-    public void revokeAllConsentRecords(User user, Study study) throws BridgeServiceException {
-        checkNotNull(user, "User cannot be null");
-        checkNotNull(study, "Study cannot be null");
-        
-        consentService.withdrawConsent(user, study);
-    }
-
-    @Override
     public void deleteUser(String userEmail) throws BridgeServiceException {
-        checkNotNull(userEmail, "User emailcannot be null");
-        for (Study study : studyService.getStudies()) {
-            deleteUserInStudyWithRetries(userEmail, study);
-        }
-    }
-
-    @Override
-    public void deleteUser(User user) throws BridgeServiceException {
-        checkNotNull(user, "User cannot be null");
-        for (Study study : studyService.getStudies()) {
-            deleteUserInStudyWithRetries(user, study);
-        }
-    }
-
-    private void deleteUserInStudyWithRetries(String userEmail, Study study) throws BridgeServiceException {
         checkNotNull(userEmail, "User email cannot be null");
-        checkNotNull(study, "Study cannot be null");
-        Directory directory = getDirectory(study);
-        Account account = getUserAccountByEmail(directory, userEmail);
-        if (account != null) {
-            User user = new User(account);
-            deleteUserInStudyWithRetries(user, study);
-        }
-    }
-
-    private void deleteUserInStudyWithRetries(User user, Study study) throws BridgeServiceException {
-        int retryCount = 0;
-        boolean shouldRetry = true;
-        while (shouldRetry) {
-            boolean deleted = deleteUserInStudy(user, study);
-            if (deleted) {
-                return;
-            }
-            shouldRetry = retryCount < 5;
-            retryCount++;
-            try {
-                Thread.sleep(100 * 2 ^ retryCount);
-            } catch(InterruptedException ie) {
-                throw new BridgeServiceException(ie);
-            }
-        }
-        throw new RuntimeException("Cannot delete user " + user.getEmail()
-                + " in study " + study.getName() + " after all the retries.");
-    }
-
-    private boolean deleteUserInStudy(User user, Study study) throws BridgeServiceException {
-        checkNotNull(user);
-        checkNotNull(study);
-        final String lockId = user.getId() + RedisKey.SEPARATOR + study.getIdentifier();
+        
+        String key = RedisKey.USER_LOCK.getRedisKey(userEmail);
         String lock = null;
         try {
-            lock = lockDao.acquireLock(User.class, lockId);
-            // Verify the user exists before doing this work. Otherwise, it just throws errors.
-            Directory directory = getDirectory(study);
-            Account account = getUserAccountByEmail(directory, user.getEmail());
+            lock = lockDao.acquireLock(User.class, key);
+            
+            Application app = StormpathFactory.getStormpathApplication(stormpathClient);
+            Account account = getUserAccountByEmail(app, userEmail);
             if (account != null) {
-                deleteUserAccount(study, user.getEmail());
-                revokeAllConsentRecords(user, study);
-                removeParticipantOptions(user);
-                removeAllHealthDataRecords(user, study);
-                removeHealthCodeAndIdMappings(user);
+                for (Study study : studyService.getStudies()) {
+                    User user = authenticationService.createSessionFromAccount(study, account).getUser();
+                    deleteUserInStudy(study, account, user);
+                }
+                account.delete();
+            }
+        } finally {
+            lockDao.releaseLock(User.class, key, lock);
+        }
+    }
+    
+    private boolean deleteUserInStudy(Study study, Account account, User user) throws BridgeServiceException {
+        checkNotNull(study);
+        checkNotNull(account);
+        checkNotNull(user);
+        
+        try {
+            // Are these things ever divorced? If you have a health code, you have a consent record
+            consentService.withdrawConsent(user, study);
+            if (user.getHealthCode() != null) {
+                String healthCode = user.getHealthCode();
+                optionsService.deleteAllParticipantOptions(healthCode);
+                removeAllHealthDataRecords(study, user);
+                healthIdDao.deleteMapping(healthCode);
+                healthCodeDao.deleteCode(healthCode);
             }
             return true;
         } catch (Throwable e) {
+            logger.error(e.getMessage(), e);
             return false;
-        } finally {
-            lockDao.releaseLock(User.class, lockId, lock);
-        }
-    }
-
-    private void removeParticipantOptions(User user) {
-        String healthCode = user.getHealthCode();
-        if (healthCode != null) {
-            optionsService.deleteAllParticipantOptions(healthCode);    
         }
     }
     
-    private void removeHealthCodeAndIdMappings(User user) {
-        String healthCode = user.getHealthCode();
-        healthIdDao.deleteMapping(healthCode);
-        healthCodeDao.deleteCode(healthCode);
-    }
-    
-    private void removeAllHealthDataRecords(User user, Study userStudy) throws BridgeServiceException {
+    private void removeAllHealthDataRecords(Study study, User user) throws BridgeServiceException {
         // This user may have never consented to research. Ignore if that's the case.
-        if (user.getHealthCode() != null) {
-            for (String trackerId : userStudy.getTrackers()) {
-                Tracker tracker = studyService.getTrackerByIdentifier(trackerId);
-                
-                HealthDataKey key = new HealthDataKey(userStudy, tracker, user);
-                List<HealthDataRecord> records = healthDataService.getAllHealthData(key);
-                for (HealthDataRecord record : records) {
-                    healthDataService.deleteHealthDataRecord(key, record.getGuid());
-                }
+        for (String trackerId : study.getTrackers()) {
+            Tracker tracker = studyService.getTrackerByIdentifier(trackerId);
+            
+            HealthDataKey key = new HealthDataKey(study, tracker, user);
+            List<HealthDataRecord> records = healthDataService.getAllHealthData(key);
+            for (HealthDataRecord record : records) {
+                healthDataService.deleteHealthDataRecord(key, record.getGuid());
             }
         }
     }
 
-    private void deleteUserAccount(Study userStudy, String userEmail) throws BridgeServiceException {
-        if (StringUtils.isBlank(userEmail)) {
-            throw new BadRequestException("User email cannot be blank");
-        }
-        try {
-            Directory directory = getDirectory(userStudy);
-            Account account = getUserAccountByEmail(directory, userEmail);
-            if (account != null) {
-                account.delete();
-            }
-        } catch (Exception e) {
-            throw new BridgeServiceException(e);
-        }
+    private boolean userDoesNotExist(Application app, String email) {
+        return (getUserAccountByEmail(app, email) == null);
     }
 
-    private Directory getDirectory(Study userStudy) {
-        return stormpathClient.getResource(userStudy.getStormpathHref(), Directory.class);
-    }
-
-    private boolean userDoesNotExist(Directory directory, String email) {
-        return (getUserAccountByEmail(directory, email) == null);
-    }
-
-    private Account getUserAccountByEmail(Directory directory, String email) {
+    private Account getUserAccountByEmail(Application app, String email) {
         AccountCriteria criteria = Accounts.where(Accounts.email().eqIgnoreCase(email));
-        AccountList accounts = directory.getAccounts(criteria);
+        AccountList accounts = app.getAccounts(criteria);
         return (accounts.iterator().hasNext()) ? accounts.iterator().next() : null;
     }
 }

--- a/app/org/sagebionetworks/bridge/services/UserAdminService.java
+++ b/app/org/sagebionetworks/bridge/services/UserAdminService.java
@@ -2,7 +2,6 @@ package org.sagebionetworks.bridge.services;
 
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.models.SignUp;
-import org.sagebionetworks.bridge.models.User;
 import org.sagebionetworks.bridge.models.UserSession;
 import org.sagebionetworks.bridge.models.studies.Study;
 
@@ -30,20 +29,6 @@ public interface UserAdminService {
             throws BridgeServiceException;
 
     /**
-     * Remove all consent records from the target user. The user's session (if
-     * the target user is signed in) will be updated to reflect this new state.
-     * 
-     * @param user
-     *            target user
-     * @param userStudy
-     *            the study of the target user
-     * @return UserSession for user with updated consent state
-     * 
-     * @throws BridgeServiceException
-     */
-    public void revokeAllConsentRecords(User user, Study userStudy) throws BridgeServiceException;
-
-    /**
      * Delete the target user.
      * 
      * @param userEmail
@@ -51,14 +36,5 @@ public interface UserAdminService {
      * @throws BridgeServiceException
      */
     public void deleteUser(String userEmail) throws BridgeServiceException;
-
-    /**
-     * Delete the target user.
-     * 
-     * @param user
-     *            target user
-     * @throws BridgeServiceException
-     */
-    public void deleteUser(User user) throws BridgeServiceException;
 
 }

--- a/conf/application-context.xml
+++ b/conf/application-context.xml
@@ -453,9 +453,6 @@
         <property name="studyService" ref="studyService" />
         <property name="stormpathClient" ref="stormpathClient" />
         <property name="distributedLockDao" ref="distributedLockDao"/>
-        <property name="optionsService" ref="optionsService"/>
-        <property name="healthIdDao" ref="healthIdDao"/>
-        <property name="healthCodeDao" ref="healthCodeDao"/>
         <property name="validator">
             <bean class="org.sagebionetworks.bridge.validators.SignUpValidator"/>
         </property>

--- a/test/org/sagebionetworks/bridge/TestUserAdminHelper.java
+++ b/test/org/sagebionetworks/bridge/TestUserAdminHelper.java
@@ -132,7 +132,7 @@ public class TestUserAdminHelper {
         if (testUser.getSession() != null) {
             // Delete using session if it exists
             authService.signOut(testUser.getSessionToken());
-            userAdminService.deleteUser(testUser.getUser());
+            userAdminService.deleteUser(testUser.getUser().getEmail());
         } else {
             // Otherwise delete using the user's email
             deleteUser(testUser.getStudy(), testUser.getEmail());
@@ -145,7 +145,7 @@ public class TestUserAdminHelper {
         
         User user = authService.getUser(study, email);
         if (user != null) {
-            userAdminService.deleteUser(user);
+            userAdminService.deleteUser(user.getEmail());
         }
     }
 

--- a/test/org/sagebionetworks/bridge/services/StormPathUserAdminServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/StormPathUserAdminServiceTest.java
@@ -79,7 +79,7 @@ public class StormPathUserAdminServiceTest {
     @After
     public void after() {
         if (testUser != null) {
-            userAdminService.deleteUser(testUser);
+            userAdminService.deleteUser(testUser.getEmail());
         }
     }
 
@@ -97,7 +97,7 @@ public class StormPathUserAdminServiceTest {
     public void deletedUserHasBeenDeleted() {
         testUser = service.createUser(signUp, study, true, true).getUser();
         
-        service.deleteUser(testUser);
+        service.deleteUser(testUser.getEmail());
         
         // This should fail with a 404.
         authService.signIn(study, new SignIn(signUp.getEmail(), signUp.getPassword()));


### PR DESCRIPTION
Reworking user deleting so that we don't redundantly search for directories, we just lock on the user's email and we avoid querying N times for N study consents. Also, we are retrieving the user's health code, which we were not doing, so that the user's records are properly deleted. This does not appear to have been working.
