### PR TITLE
add thread pool configs

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -7,3 +7,21 @@
 application.secret="this is not a secret as we are not using this"
 application.langs="en"
 application.global=global.GlobalWithFilters
+
+# Play framework app threads (Akka actors) are single-threaded by default. We have a lot of synchronous requests, so we
+# need more than just one thread.
+play {
+    akka {
+        akka.loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+        loglevel = WARNING
+        actor {
+            default-dispatcher = {
+                fork-join-executor {
+                    # This may need further tuning.
+                    parallelism-min = 20
+                    parallelism-max = 40
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Play framework's app thread pool (Akka actors) is single-threaded by default. This is bad for perf. CPU load in UAT is very low, so let's try scaling up to 20 min, 40 max.
