### PR TITLE
add tracker schemas to unpack uploads from iOS apps

### DIFF
--- a/conf/application-context.xml
+++ b/conf/application-context.xml
@@ -316,8 +316,13 @@
         <property name="trackers">
             <list>
                 <ref bean="pb-tracker"/>
+                <ref bean="cardio-walk-tracker"/>
+                <ref bean="diabetes-glucose-tracker"/>
+                <ref bean="ios-survey-tracker"/>
                 <ref bean="med-tracker"/>
-            </list>            
+                <ref bean="parkinson-tapping-tracker"/>
+                <ref bean="parkinson-walk-tracker"/>
+            </list>
         </property>
     </bean>
 
@@ -331,11 +336,46 @@
         <property name="schemaFile" value="file:conf/schemas/bloodpressure.json"/>
     </bean>
 
+    <bean id="cardio-walk-tracker" class="org.sagebionetworks.bridge.models.studies.Tracker">
+        <property name="name" value="6-Min Walk Test"/>
+        <property name="type" value="CardioWalk"/>
+        <property name="identifier" value="cardio-walk-tracker"/>
+        <property name="schemaFile" value="file:conf/schemas/cardio-walk-tracker.json"/>
+    </bean>
+
+    <bean id="diabetes-glucose-tracker" class="org.sagebionetworks.bridge.models.studies.Tracker">
+        <property name="name" value="Glucose Levels"/>
+        <property name="type" value="DiabetesGlucose"/>
+        <property name="identifier" value="diabetes-glucose-tracker"/>
+        <property name="schemaFile" value="file:conf/schemas/diabetes-glucose-tracker.json"/>
+    </bean>
+
+    <bean id="ios-survey-tracker" class="org.sagebionetworks.bridge.models.studies.Tracker">
+        <property name="name" value="iOS Survey Response"/>
+        <property name="type" value="IosSurvey"/>
+        <property name="identifier" value="ios-survey-tracker"/>
+        <property name="schemaFile" value="file:conf/schemas/ios-survey-tracker.json"/>
+    </bean>
+
     <bean id="med-tracker" class="org.sagebionetworks.bridge.models.studies.Tracker">
         <property name="name" value="Medication"/>
         <property name="type" value="Medication"/>
         <property name="identifier" value="med-tracker"/>
         <property name="schemaFile" value="file:conf/schemas/medication.json"/>
+    </bean>
+
+    <bean id="parkinson-tapping-tracker" class="org.sagebionetworks.bridge.models.studies.Tracker">
+        <property name="name" value="Tapping Activity"/>
+        <property name="type" value="ParkinsonTapping"/>
+        <property name="identifier" value="parkinson-tapping-tracker"/>
+        <property name="schemaFile" value="file:conf/schemas/parkinson-tapping-tracker.json"/>
+    </bean>
+
+    <bean id="parkinson-walk-tracker" class="org.sagebionetworks.bridge.models.studies.Tracker">
+        <property name="name" value="Timed Walking Task"/>
+        <property name="type" value="ParkinsonWalk"/>
+        <property name="identifier" value="parkinson-walk-tracker"/>
+        <property name="schemaFile" value="file:conf/schemas/parkinson-walk-tracker.json"/>
     </bean>
 
     <bean id="controllers.LunchController" parent="proxiedController">

--- a/conf/schemas/cardio-walk-tracker.json
+++ b/conf/schemas/cardio-walk-tracker.json
@@ -1,0 +1,22 @@
+{
+    "type": "object",
+    "required": ["startDate", "endDate", "data"],
+    "additionalProperties": false,
+    "properties": {
+        "key": {"type": "string"},
+        "guid": {"type": "string"},
+        "startDate": {"type": "string"},
+        "endDate": {"type": "string"},
+        "version": {"type": "number"},
+        "data": {
+            "type": "object",
+            "required": ["distance", "heartRateBPM", "stepCount"],
+            "additionalProperties": false,
+            "properties": {
+                "distance": {},
+                "heartRateBPM": {},
+                "stepCount": {}
+            }
+        }
+    }
+}

--- a/conf/schemas/diabetes-glucose-tracker.json
+++ b/conf/schemas/diabetes-glucose-tracker.json
@@ -1,0 +1,24 @@
+{
+    "type": "object",
+    "required": ["startDate", "endDate", "data"],
+    "additionalProperties": false,
+    "properties": {
+        "key": {"type": "string"},
+        "guid": {"type": "string"},
+        "startDate": {"type": "string"},
+        "endDate": {"type": "string"},
+        "version": {"type": "number"},
+        "data": {
+            "type": "object",
+            "required": ["indexPath", "period", "scheduledHour", "timeOfDay", "value"],
+            "additionalProperties": false,
+            "properties": {
+                "indexPath": {"type": "string"},
+                "period": {"type": "string"},
+                "scheduledHour": {"type": "number"},
+                "timeOfDay": {"type": "string"},
+                "value": {"type": "number"}
+            }
+        }
+    }
+}

--- a/conf/schemas/ios-survey-tracker.json
+++ b/conf/schemas/ios-survey-tracker.json
@@ -1,0 +1,24 @@
+{
+    "type": "object",
+    "required": ["startDate", "endDate", "data"],
+    "additionalProperties": false,
+    "properties": {
+        "key": {"type": "string"},
+        "guid": {"type": "string"},
+        "startDate": {"type": "string"},
+        "endDate": {"type": "string"},
+        "version": {"type": "number"},
+        "data": {
+            "type": "object",
+            "required": ["endDate", "identifier", "questionType", "startDate"],
+            "additionalProperties": false,
+            "properties": {
+                "answer": {},
+                "endDate": {"type": "string"},
+                "identifier": {"type": "string"},
+                "questionType": {"type": "string"},
+                "startDate": {"type": "string"}
+            }
+        }
+    }
+}

--- a/conf/schemas/parkinson-tapping-tracker.json
+++ b/conf/schemas/parkinson-tapping-tracker.json
@@ -1,0 +1,23 @@
+{
+    "type": "object",
+    "required": ["startDate", "endDate", "data"],
+    "additionalProperties": false,
+    "properties": {
+        "key": {"type": "string"},
+        "guid": {"type": "string"},
+        "startDate": {"type": "string"},
+        "endDate": {"type": "string"},
+        "version": {"type": "number"},
+        "data": {
+            "type": "object",
+            "required": ["ContainerSize", "LeftTargetFrame", "ParkinsonIntervalTappingRecords", "RightTargetFrame"],
+            "additionalProperties": false,
+            "properties": {
+                "ContainerSize": {"type": "string"},
+                "LeftTargetFrame": {"type": "string"},
+                "ParkinsonIntervalTappingRecords": {},
+                "RightTargetFrame": {"type": "string"}
+            }
+        }
+    }
+}

--- a/conf/schemas/parkinson-walk-tracker.json
+++ b/conf/schemas/parkinson-walk-tracker.json
@@ -1,0 +1,20 @@
+{
+    "type": "object",
+    "required": ["startDate", "endDate", "data"],
+    "additionalProperties": false,
+    "properties": {
+        "key": {"type": "string"},
+        "guid": {"type": "string"},
+        "startDate": {"type": "string"},
+        "endDate": {"type": "string"},
+        "version": {"type": "number"},
+        "data": {
+            "type": "object",
+            "required": ["items"],
+            "additionalProperties": false,
+            "properties": {
+                "items": {}
+            }
+        }
+    }
+}

--- a/test/global/JsonSchemaValidatorTest.java
+++ b/test/global/JsonSchemaValidatorTest.java
@@ -11,13 +11,19 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.fge.jsonschema.core.report.ProcessingReport;
 
 public class JsonSchemaValidatorTest {
+    private static final String RECORD_WRAPPER = "{\n" +
+            "   \"startDate\":\"2014-12-22T12:00:00-08:00\",\n" +
+            "   \"endDate\":\"2014-12-22T15:00:00-08:00\",\n" +
+            "   \"data\":%s\n" +
+            "}";
+    private static final String BAD_DATA = String.format(RECORD_WRAPPER, "{\"bad\":\"data\"}");
 
-    private ProcessingReport validate(String string) throws Exception {
+    private ProcessingReport validate(String trackerName, String string) throws Exception {
         ObjectMapper mapper = new ObjectMapper();
         JsonNode node = mapper.readTree(string);
 
         FileSystemResource resource = new FileSystemResource(
-                "conf/schemas/bloodpressure.json");
+                "conf/schemas/" + trackerName + ".json");
         Tracker tracker = new Tracker();
         tracker.setSchemaFile(resource);
         return new JsonSchemaValidator().validate(tracker, node);
@@ -25,20 +31,107 @@ public class JsonSchemaValidatorTest {
 
     @Test
     public void schemaValidationFails() throws Exception {
-        ProcessingReport report = validate("{\"k1\":\"v1\"}");
+        ProcessingReport report = validate("bloodpressure", "{\"k1\":\"v1\"}");
         assertTrue("Report should have errors", !report.isSuccess());
     }
 
     @Test
     public void schemaValidationSucceedsWithGuid() throws Exception {
-        ProcessingReport report = validate("{ \"guid\": \"asdf-zxfv-sdfg\", \"key\": \"1:1:asdf\", \"startDate\":\"date+time\", \"endDate\":\"date+time\", \"data\":{ \"systolic\":120, \"diastolic\":80 } }");
+        ProcessingReport report = validate("bloodpressure", "{ \"guid\": \"asdf-zxfv-sdfg\", \"key\": \"1:1:asdf\", \"startDate\":\"date+time\", \"endDate\":\"date+time\", \"data\":{ \"systolic\":120, \"diastolic\":80 } }");
         assertTrue("Report should have no errors", report.isSuccess());
     }
 
     @Test
     public void schemaValidationSucceedsWithoutGuid() throws Exception {
-        ProcessingReport report = validate("{ \"key\": \"1:1:asdf\", \"startDate\":\"date-time\", \"endDate\":\"date-time\", \"data\":{ \"systolic\":120, \"diastolic\":80 } }");
+        ProcessingReport report = validate("bloodpressure", "{ \"key\": \"1:1:asdf\", \"startDate\":\"date-time\", \"endDate\":\"date-time\", \"data\":{ \"systolic\":120, \"diastolic\":80 } }");
         assertTrue("Report should have no errors", report.isSuccess());
     }
 
+    @Test
+    public void cardioWalkFails() throws Exception {
+        ProcessingReport report = validate("cardio-walk-tracker", BAD_DATA);
+        assertTrue("Report should have errors", !report.isSuccess());
+    }
+
+    @Test
+    public void cardioWalkSucceeds() throws Exception {
+        String jsonData = "{\n" +
+                "   \"distance\":\"sample JSON blob\",\n" +
+                "   \"heartRateBPM\":\"sample JSON blob\",\n" +
+                "   \"stepCount\":\"sample JSON blob\"\n" +
+                "}";
+        ProcessingReport report = validate("cardio-walk-tracker", String.format(RECORD_WRAPPER, jsonData));
+        assertTrue("Report should have no errors", report.isSuccess());
+    }
+
+    @Test
+    public void diabetesGlucoseFails() throws Exception {
+        ProcessingReport report = validate("diabetes-glucose-tracker", BAD_DATA);
+        assertTrue("Report should have errors", !report.isSuccess());
+    }
+
+    @Test
+    public void diabetesGlucoseSucceeds() throws Exception {
+        String jsonData = "{\n" +
+                "   \"indexPath\":\"sample string\",\n" +
+                "   \"period\":\"sample string\",\n" +
+                "   \"scheduledHour\":42,\n" +
+                "   \"timeOfDay\":\"sample string\",\n" +
+                "   \"value\":42\n" +
+                "}";
+        ProcessingReport report = validate("diabetes-glucose-tracker", String.format(RECORD_WRAPPER, jsonData));
+        assertTrue("Report should have no errors", report.isSuccess());
+    }
+
+    @Test
+    public void iosSurveyFails() throws Exception {
+        ProcessingReport report = validate("ios-survey-tracker", BAD_DATA);
+        assertTrue("Report should have errors", !report.isSuccess());
+    }
+
+    @Test
+    public void iosSurveySucceeds() throws Exception {
+        String jsonData = "{\n" +
+                "   \"answer\":\"any type\",\n" +
+                "   \"endDate\":\"sample string\",\n" +
+                "   \"identifier\":\"sample string\",\n" +
+                "   \"questionType\":\"sample string\",\n" +
+                "   \"startDate\":\"sample string\"\n" +
+                "}";
+        ProcessingReport report = validate("ios-survey-tracker", String.format(RECORD_WRAPPER, jsonData));
+        assertTrue("Report should have no errors", report.isSuccess());
+    }
+
+    @Test
+    public void parkinsonTappingFails() throws Exception {
+        ProcessingReport report = validate("parkinson-tapping-tracker", BAD_DATA);
+        assertTrue("Report should have errors", !report.isSuccess());
+    }
+
+    @Test
+    public void parkinsonTappingSucceeds() throws Exception {
+        String jsonData = "{\n" +
+                "   \"ContainerSize\":\"sample string\",\n" +
+                "   \"LeftTargetFrame\":\"sample string\",\n" +
+                "   \"ParkinsonIntervalTappingRecords\":\"sample JSON blob\",\n" +
+                "   \"RightTargetFrame\":\"sample string\"\n" +
+                "}";
+        ProcessingReport report = validate("parkinson-tapping-tracker", String.format(RECORD_WRAPPER, jsonData));
+        assertTrue("Report should have no errors", report.isSuccess());
+    }
+
+    @Test
+    public void parkinsonWalkFails() throws Exception {
+        ProcessingReport report = validate("parkinson-walk-tracker", BAD_DATA);
+        assertTrue("Report should have errors", !report.isSuccess());
+    }
+
+    @Test
+    public void parkinsonWalkSucceeds() throws Exception {
+        String jsonData = "{\n" +
+                "   \"items\":\"sample JSON blob\"\n" +
+                "}";
+        ProcessingReport report = validate("parkinson-walk-tracker", String.format(RECORD_WRAPPER, jsonData));
+        assertTrue("Report should have no errors", report.isSuccess());
+    }
 }


### PR DESCRIPTION
Added tracker schemas for the different data types we're getting back from the iOS apps. We only look at the top-level keys. For any JSON blobs or for survey answers (which can be of any time), we use the empty schema, which allows any type and value.

For the timestamps in ios-survey-tracker, JSON doesn't have a native timestamp type, so I decided to treat them as strings. If we want to do stricter validation, I can add a rudimentary regex to the schema.

Testing:
- created unit tests to test schema validation
- added all 5 trackers to "api" study on my local dev instance. Called /api/v1/trackers and /api/v1/trackers/schema/(tracker) to validate that we can get the tracker schemas back.
- put data for all trackers (except ios-survey-tracker, which will never actually write health data) to verify that the data can be written back to the server.
