### PR TITLE
Remove study ID backfill as it is done; refactor backfill record creation

### DIFF
--- a/app/controllers/BackfillChunksAdapter.java
+++ b/app/controllers/BackfillChunksAdapter.java
@@ -19,7 +19,7 @@ import play.mvc.Results.Chunks;
  */
 class BackfillChunksAdapter implements BackfillCallback {
 
-    private final ObjectMapper MAPPER = new ObjectMapper();
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private final Chunks.Out<String> chunksOut;
 

--- a/app/controllers/BackfillChunksAdapter.java
+++ b/app/controllers/BackfillChunksAdapter.java
@@ -8,12 +8,18 @@ import org.sagebionetworks.bridge.models.BackfillRecord;
 import org.sagebionetworks.bridge.models.BackfillTask;
 import org.sagebionetworks.bridge.services.backfill.BackfillCallback;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import play.mvc.Results.Chunks;
 
 /**
  * Adapts backfill callback to Play chunked responses.
  */
 class BackfillChunksAdapter implements BackfillCallback {
+
+    private final ObjectMapper MAPPER = new ObjectMapper();
 
     private final Chunks.Out<String> chunksOut;
 
@@ -35,7 +41,13 @@ class BackfillChunksAdapter implements BackfillCallback {
     public void newRecords(BackfillRecord... records) {
         checkNotNull(records);
         for (BackfillRecord record : records) {
-            chunksOut.write("<pre>" + record.getRecord() + "</pre>");
+            try {
+                JsonNode node = record.toJsonNode();
+                String prettyPrinted = MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(node);
+                chunksOut.write("<pre>" + prettyPrinted + "</pre>");
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 

--- a/app/org/sagebionetworks/bridge/dao/HealthCodeDao.java
+++ b/app/org/sagebionetworks/bridge/dao/HealthCodeDao.java
@@ -11,10 +11,4 @@ public interface HealthCodeDao {
      * @return The ID of the study associated with this health code; or null if the health code does not exist.
      */
     String getStudyIdentifier(String code);
-
-    // TODO: To be removed after backfill
-    /**
-     * For backfilling study ID.
-     */
-    boolean setStudyId(String code, String studyId);
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoBackfillRecord.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoBackfillRecord.java
@@ -9,7 +9,7 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIgnore;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBVersionAttribute;
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -95,15 +95,11 @@ public class DynamoBackfillRecord implements BackfillRecord, DynamoTable {
 
     @Override
     @DynamoDBIgnore
-    public String getRecord() {
+    public JsonNode toJsonNode() {
         ObjectNode node = MAPPER.createObjectNode();
         node.put("study", studyId);
         node.put("account", accountId);
         node.put("operation", operation);
-        try {
-            return MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(node);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
+        return node;
     }
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoHealthCodeDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoHealthCodeDao.java
@@ -46,39 +46,4 @@ public class DynamoHealthCodeDao implements HealthCodeDao {
         }
         return loaded.getStudyIdentifier();
     }
-
-    // TODO: To be removed after backfill
-    @Override
-    public boolean setStudyId(String code, String studyId) {
-        checkArgument(isNotBlank(code));
-        checkArgument(isNotBlank(studyId));
-        DynamoHealthCode key = new DynamoHealthCode();
-        key.setCode(code);
-        DynamoHealthCode loaded = mapper.load(key);
-        if (loaded == null) {
-            throw new RuntimeException("Can't find health code in DynamoDB");
-        }
-        String oldStudyId = loaded.getStudyIdentifier();
-        if (oldStudyId == null) {
-            loaded.setStudyIdentifier(studyId);
-            mapper.save(loaded);
-            return true;
-        } else if (!oldStudyId.equals(studyId)) {
-            throw new RuntimeException("DynamoDB has a different study ID for the health code");
-        }
-        return false;
-    }
-
-    // TODO: To be removed after backfill
-    boolean setIfNotExist(String code) {
-        checkArgument(isNotBlank(code));
-        try {
-            DynamoHealthCode toSave = new DynamoHealthCode();
-            toSave.setCode(code);
-            mapper.save(toSave);
-            return true;
-        } catch(ConditionalCheckFailedException e) {
-            return false;
-        }
-    }
 }

--- a/app/org/sagebionetworks/bridge/models/BackfillRecord.java
+++ b/app/org/sagebionetworks/bridge/models/BackfillRecord.java
@@ -2,6 +2,8 @@ package org.sagebionetworks.bridge.models;
 
 import org.sagebionetworks.bridge.json.BridgeTypeName;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 @BridgeTypeName("BackfillRecord")
 public interface BackfillRecord extends BridgeEntity {
 
@@ -9,5 +11,5 @@ public interface BackfillRecord extends BridgeEntity {
 
     long getTimestamp();
 
-    String getRecord();
+    JsonNode toJsonNode();
 }

--- a/app/org/sagebionetworks/bridge/services/backfill/BackfillRecordFactory.java
+++ b/app/org/sagebionetworks/bridge/services/backfill/BackfillRecordFactory.java
@@ -1,0 +1,91 @@
+package org.sagebionetworks.bridge.services.backfill;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.sagebionetworks.bridge.dao.BackfillDao;
+import org.sagebionetworks.bridge.models.BackfillRecord;
+import org.sagebionetworks.bridge.models.BackfillTask;
+import org.sagebionetworks.bridge.models.studies.Study;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.stormpath.sdk.account.Account;
+
+public class BackfillRecordFactory {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private BackfillDao backfillDao;
+    public void setBackfillDao(BackfillDao backfillDao) {
+        this.backfillDao = backfillDao;
+    }
+
+    /**
+     * Creates a new entry and saves it into permanent storage.
+     */
+    public BackfillRecord createAndSave(BackfillTask task, Study study, Account account, String operation) {
+        checkNotNull(task);
+        checkNotNull(study);
+        checkNotNull(account);
+        checkNotNull(operation);
+        return backfillDao.createRecord(task.getId(), study.getIdentifier(), account.getEmail(), operation);
+    }
+
+    /**
+     * Creates a new entry. Note the entry is not persisted anywhere. This is used for reporting the progress
+     * to the client only.
+     */
+    public BackfillRecord createOnly(BackfillTask task, Study study, Account account, final String message) {
+        checkNotNull(task);
+        checkNotNull(study);
+        checkNotNull(account);
+        checkNotNull(message);
+        final String taskId = task.getId();
+        final String studyId = study.getIdentifier();
+        final String accountId = account.getEmail();
+        return new BackfillRecord() {
+            @Override
+            public String getTaskId() {
+                return taskId;
+            }
+            @Override
+            public long getTimestamp() {
+                return DateTime.now(DateTimeZone.UTC).getMillis();
+            }
+            @Override
+            public JsonNode toJsonNode() {
+                ObjectNode node = MAPPER.createObjectNode();
+                node.put("study", studyId);
+                node.put("account", accountId);
+                node.put("message", message);
+                return node;
+            }
+        };
+    }
+
+    /**
+     * Creates a new entry. Note the entry is not persisted anywhere. This is used for reporting the progress
+     * to the client only.
+     */
+    public BackfillRecord createOnly(final BackfillTask task, final String message) {
+        checkNotNull(task);
+        checkNotNull(message);
+        return new BackfillRecord() {
+            @Override
+            public String getTaskId() {
+                return task.getId();
+            }
+            @Override
+            public long getTimestamp() {
+                return DateTime.now(DateTimeZone.UTC).getMillis();
+            }
+            @Override
+            public JsonNode toJsonNode() {
+                return MAPPER.createObjectNode().textNode(message);
+            }
+        };
+    }
+}

--- a/app/org/sagebionetworks/bridge/services/backfill/BackfillRecordFactory.java
+++ b/app/org/sagebionetworks/bridge/services/backfill/BackfillRecordFactory.java
@@ -24,7 +24,7 @@ public class BackfillRecordFactory {
     }
 
     /**
-     * Creates a new entry and saves it into permanent storage.
+     * Creates a new entry and saves it into permanent storage. Use this for real backfills.
      */
     public BackfillRecord createAndSave(BackfillTask task, Study study, Account account, String operation) {
         checkNotNull(task);

--- a/app/org/sagebionetworks/bridge/services/backfill/HealthCodeBackfill.java
+++ b/app/org/sagebionetworks/bridge/services/backfill/HealthCodeBackfill.java
@@ -32,6 +32,11 @@ public class HealthCodeBackfill extends AsyncBackfillTemplate {
         this.accountEncryptionService = accountEncryptionService;
     }
 
+    private BackfillRecordFactory backfillRecordFactory;
+    public void setBackfillRecordFactory(BackfillRecordFactory backfillRecordFactory) {
+        this.backfillRecordFactory = backfillRecordFactory;
+    }
+
     @Override
     int getLockExpireInSeconds() {
         return 30 * 60;
@@ -52,7 +57,8 @@ public class HealthCodeBackfill extends AsyncBackfillTemplate {
                         // This happens when the user creates a new account and consents in a study
                         // and has not consented in other studies yet.
                         healthId = accountEncryptionService.createAndSaveHealthCode(study, account);
-                        callback.newRecords(createRecord(task, study, account, "health code created"));
+                        callback.newRecords(backfillRecordFactory.createAndSave(
+                                task, study, account, "health code created"));
                     } 
                 }
             }

--- a/app/org/sagebionetworks/bridge/services/backfill/StudyIdBackfill.java
+++ b/app/org/sagebionetworks/bridge/services/backfill/StudyIdBackfill.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.bridge.services.backfill;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
 import java.util.List;
 
 import org.sagebionetworks.bridge.dao.HealthCodeDao;
@@ -63,9 +65,10 @@ public class StudyIdBackfill extends AsyncBackfillTemplate  {
                         try {
                             String healthCode = healthId.getCode();
                             if (healthCode != null) {
-                                boolean set = healthCodeDao.setStudyId(healthCode, study.getIdentifier());
-                                if (set) {
-                                    callback.newRecords(createRecord(task, study, account, "backfilled"));
+                                String studyId = healthCodeDao.getStudyIdentifier(healthCode);
+                                if (isBlank(studyId)) {
+                                    String operation = "Backfill needed as study ID is blank.";
+                                    callback.newRecords(createRecord(task, study, account, operation));
                                 }
                             }
                         } catch (final RuntimeException e) {

--- a/conf/application-context.xml
+++ b/conf/application-context.xml
@@ -469,7 +469,7 @@
     <bean id="backfillTemplate" abstract="true" class="org.sagebionetworks.bridge.services.backfill.AsyncBackfillTemplate">
         <property name="distributedLockDao" ref="distributedLockDao" />
         <property name="backfillDao" ref="backfillDao" />
-        <property name="backfillRecordFacotry" ref="backfillRecordFactory" />
+        <property name="backfillRecordFactory" ref="backfillRecordFactory" />
     </bean>
 
     <bean id="healthCodeBackfill" parent="backfillTemplate" class="org.sagebionetworks.bridge.services.backfill.HealthCodeBackfill">

--- a/conf/application-context.xml
+++ b/conf/application-context.xml
@@ -462,18 +462,25 @@
         <property name="participantOptionsDao" ref="participantOptionsDao"/>
     </bean>
 
-    <bean id="backfillTemplate" abstract="true" class="org.sagebionetworks.bridge.services.backfill.AsyncBackfillTemplate">
-        <property name="distributedLockDao" ref="distributedLockDao" />
+    <bean id="backfillRecordFactory" class="org.sagebionetworks.bridge.services.backfill.BackfillRecordFactory">
         <property name="backfillDao" ref="backfillDao" />
     </bean>
 
+    <bean id="backfillTemplate" abstract="true" class="org.sagebionetworks.bridge.services.backfill.AsyncBackfillTemplate">
+        <property name="distributedLockDao" ref="distributedLockDao" />
+        <property name="backfillDao" ref="backfillDao" />
+        <property name="backfillRecordFacotry" ref="backfillRecordFactory" />
+    </bean>
+
     <bean id="healthCodeBackfill" parent="backfillTemplate" class="org.sagebionetworks.bridge.services.backfill.HealthCodeBackfill">
+        <property name="backfillRecordFactory" ref="backfillRecordFactory" />
         <property name="stormpathClient" ref="stormpathClient" />
         <property name="studyService" ref="studyService" />
         <property name="accountEncryptionService" ref="accountEncryptionService" />
     </bean>
 
     <bean id="studyIdBackfill" parent="backfillTemplate" class="org.sagebionetworks.bridge.services.backfill.StudyIdBackfill">
+        <property name="backfillRecordFactory" ref="backfillRecordFactory" />
         <property name="stormpathClient" ref="stormpathClient" />
         <property name="studyService" ref="studyService" />
         <property name="healthCodeDao" ref="healthCodeDao" />

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoBackfillDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoBackfillDaoTest.java
@@ -23,13 +23,10 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 @ContextConfiguration("classpath:test-context.xml")
 @RunWith(SpringJUnit4ClassRunner.class)
 public class DynamoBackfillDaoTest {
-
-    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     @Resource
     private DynamoBackfillDao backfillDao;
@@ -91,7 +88,7 @@ public class DynamoBackfillDaoTest {
         assertEquals(1, backfillDao.getRecordCount("task1"));
         assertEquals("task1", record.getTaskId());
         assertTrue(record.getTimestamp() >= timestamp);
-        JsonNode json = MAPPER.readTree(record.getRecord());
+        JsonNode json = record.toJsonNode();
         assertEquals("study1", json.get("study").asText());
         assertEquals("account1", json.get("account").asText());
         assertEquals("op1", json.get("operation").asText());
@@ -107,14 +104,14 @@ public class DynamoBackfillDaoTest {
         assertTrue(iterator.hasNext());
         BackfillRecord record1 = iterator.next();
         assertEquals("task1", record1.getTaskId());
-        json = MAPPER.readTree(record1.getRecord());
+        json = record1.toJsonNode();
         assertEquals("study1", json.get("study").asText());
         assertEquals("account1", json.get("account").asText());
         assertEquals("op1", json.get("operation").asText());
         assertTrue(iterator.hasNext());
         BackfillRecord record2 = iterator.next();
         assertEquals("task1", record2.getTaskId());
-        json = MAPPER.readTree(record2.getRecord());
+        json = record2.toJsonNode();
         assertEquals("study1", json.get("study").asText());
         assertEquals("account2", json.get("account").asText());
         assertEquals("op2", json.get("operation").asText());
@@ -123,7 +120,7 @@ public class DynamoBackfillDaoTest {
         assertTrue(iterator.hasNext());
         BackfillRecord record3 = iterator.next();
         assertEquals("task3", record3.getTaskId());
-        json = MAPPER.readTree(record3.getRecord());
+        json = record3.toJsonNode();
         assertEquals("study3", json.get("study").asText());
         assertEquals("account3", json.get("account").asText());
         assertEquals("op3", json.get("operation").asText());

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoHealthCodeDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoHealthCodeDaoTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import javax.annotation.Resource;
 
@@ -38,24 +37,5 @@ public class DynamoHealthCodeDaoTest {
         assertFalse(healthCodeDao.setIfNotExist("123", "789"));
         assertEquals("789", healthCodeDao.getStudyIdentifier("123"));
         assertNull(healthCodeDao.getStudyIdentifier("xyz"));
-    }
-
-    @Test
-    public void testSetStudyId() {
-        healthCodeDao.setIfNotExist("123");
-        assertTrue(healthCodeDao.setStudyId("123", "789"));
-        assertFalse(healthCodeDao.setStudyId("123", "789"));
-        try {
-            healthCodeDao.setStudyId("123", "456");
-            fail();
-        } catch (RuntimeException e) {
-            assertTrue("Exception expected as a different study ID already exists", true);
-        }
-        try {
-            healthCodeDao.setStudyId("xyz", "789");
-            fail();
-        } catch (RuntimeException e) {
-            assertTrue("Exception expected as the health code does not exist", true);
-        }
     }
 }

--- a/test/org/sagebionetworks/bridge/services/backfill/BackfillRecordFactoryTest.java
+++ b/test/org/sagebionetworks/bridge/services/backfill/BackfillRecordFactoryTest.java
@@ -4,11 +4,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Test;
+import org.sagebionetworks.bridge.dao.BackfillDao;
 import org.sagebionetworks.bridge.models.BackfillRecord;
 import org.sagebionetworks.bridge.models.BackfillTask;
 import org.sagebionetworks.bridge.models.studies.Study;
@@ -17,6 +20,25 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.stormpath.sdk.account.Account;
 
 public class BackfillRecordFactoryTest {
+
+    @Test
+    public void testCreateAndSave() {
+        BackfillRecordFactory recordFactory = new BackfillRecordFactory();
+        BackfillDao backfillDao = mock(BackfillDao.class);
+        recordFactory.setBackfillDao(backfillDao);
+        BackfillTask task = mock(BackfillTask.class);
+        final String taskId = "Task ID";
+        when(task.getId()).thenReturn(taskId);
+        Study study = mock(Study.class);
+        final String studyId = "Study ID";
+        Account account = mock(Account.class);
+        final String accountId = "email@email.com";
+        when(account.getEmail()).thenReturn(accountId);
+        when(study.getIdentifier()).thenReturn(studyId);
+        final String operation = "Some operation";
+        recordFactory.createAndSave(task, study, account, operation);
+        verify(backfillDao, times(1)).createRecord(taskId, studyId, accountId, operation);
+    }
 
     @Test
     public void testCreateOnly() {

--- a/test/org/sagebionetworks/bridge/services/backfill/BackfillRecordFactoryTest.java
+++ b/test/org/sagebionetworks/bridge/services/backfill/BackfillRecordFactoryTest.java
@@ -1,0 +1,58 @@
+package org.sagebionetworks.bridge.services.backfill;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Test;
+import org.sagebionetworks.bridge.models.BackfillRecord;
+import org.sagebionetworks.bridge.models.BackfillTask;
+import org.sagebionetworks.bridge.models.studies.Study;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.stormpath.sdk.account.Account;
+
+public class BackfillRecordFactoryTest {
+
+    @Test
+    public void testCreateOnly() {
+        BackfillRecordFactory recordFactory = new BackfillRecordFactory();
+        BackfillTask task = mock(BackfillTask.class);
+        final String taskId = "Task ID";
+        when(task.getId()).thenReturn(taskId);
+        final String message = "this is a message";
+        BackfillRecord record = recordFactory.createOnly(task, message);
+        assertEquals(taskId, record.getTaskId());
+        assertTrue(record.getTimestamp() <= DateTime.now(DateTimeZone.UTC).getMillis());
+        JsonNode node = record.toJsonNode();
+        assertNotNull(node);
+        assertEquals(message, node.asText());
+    }
+
+    @Test
+    public void testCreateOnlyWithStudyAccount() {
+        BackfillRecordFactory recordFactory = new BackfillRecordFactory();
+        BackfillTask task = mock(BackfillTask.class);
+        final String taskId = "Task ID";
+        when(task.getId()).thenReturn(taskId);
+        Study study = mock(Study.class);
+        final String studyId = "Study ID";
+        when(study.getIdentifier()).thenReturn(studyId);
+        Account account = mock(Account.class);
+        final String accountId = "Account ID";
+        when(account.getEmail()).thenReturn(accountId);
+        final String message = "message";
+        BackfillRecord record = recordFactory.createOnly(task, study, account, message);
+        assertEquals(taskId, record.getTaskId());
+        assertTrue(record.getTimestamp() <= DateTime.now(DateTimeZone.UTC).getMillis());
+        JsonNode node = record.toJsonNode();
+        assertNotNull(node);
+        assertEquals(studyId, node.get("study").asText());
+        assertEquals(accountId, node.get("account").asText());
+        assertEquals(message, node.get("message").asText());
+    }
+}

--- a/test/org/sagebionetworks/bridge/services/backfill/TestBackfillService.java
+++ b/test/org/sagebionetworks/bridge/services/backfill/TestBackfillService.java
@@ -5,7 +5,7 @@ import org.joda.time.DateTimeZone;
 import org.sagebionetworks.bridge.models.BackfillRecord;
 import org.sagebionetworks.bridge.models.BackfillTask;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -41,15 +41,11 @@ public class TestBackfillService extends AsyncBackfillTemplate {
                 return DateTime.now(DateTimeZone.UTC).getMillis();
             }
             @Override
-            public String getRecord() {
+            public JsonNode toJsonNode() {
                 ObjectNode node = MAPPER.createObjectNode();
                 node.put(RECORD_FIELD, RECORD_1);
                 node.put(OPERATION_FIELD, OPERATION_1);
-                try {
-                    return MAPPER.writeValueAsString(node);
-                } catch (JsonProcessingException e) {
-                    throw new RuntimeException(e);
-                }
+                return node;
             }
         });
 
@@ -63,15 +59,11 @@ public class TestBackfillService extends AsyncBackfillTemplate {
                 return DateTime.now(DateTimeZone.UTC).getMillis();
             }
             @Override
-            public String getRecord() {
+            public JsonNode toJsonNode() {
                 ObjectNode node = MAPPER.createObjectNode();
                 node.put(RECORD_FIELD, RECORD_2);
                 node.put(OPERATION_FIELD, OPERATION_2);
-                try {
-                    return MAPPER.writeValueAsString(node);
-                } catch (JsonProcessingException e) {
-                    throw new RuntimeException(e);
-                }
+                return node;
             }
         };
 
@@ -85,15 +77,11 @@ public class TestBackfillService extends AsyncBackfillTemplate {
                 return DateTime.now(DateTimeZone.UTC).getMillis();
             }
             @Override
-            public String getRecord() {
+            public JsonNode toJsonNode() {
                 ObjectNode node = MAPPER.createObjectNode();
                 node.put(RECORD_FIELD, RECORD_3);
                 node.put(OPERATION_FIELD, OPERATION_3);
-                try {
-                    return MAPPER.writeValueAsString(node);
-                } catch (JsonProcessingException e) {
-                    throw new RuntimeException(e);
-                }
+                return node;
             }
         };
 


### PR DESCRIPTION
The change worth mentioning is the refactoring where I am moving the logic of creating backfill records to a new class BackillRecordFactory.  There record creation is split into 2 types -- one that persists a backfill record in Dynamo; the other does not persist into Dynamo.  The 2nd one can be used for dry runs to see what backfills are needed and to verify the backfill after it's done.
