### PR TITLE
Upload Validation - Service and Handler Chain

### DIFF
--- a/app/controllers/UploadController.java
+++ b/app/controllers/UploadController.java
@@ -20,6 +20,7 @@ public class UploadController extends BaseController {
         this.uploadService = uploadService;
     }
 
+    /** Service handler for upload validation. This is configured by Spring. */
     @Autowired
     public void setUploadValidationService(UploadValidationService uploadValidationService) {
         this.uploadValidationService = uploadValidationService;
@@ -32,15 +33,19 @@ public class UploadController extends BaseController {
         return okResult(uploadSession);
     }
 
+    /**
+     * Signals to the Bridge server that the upload is complete. This kicks off the asynchronous validation process
+     * through the Upload Validation Service.
+     */
     public Result uploadComplete(String uploadId) throws Exception {
         getAuthenticatedAndConsentedSession();
-        Study study = studyService.getStudyByHostname(getHostname());
 
         // mark upload as complete
         Upload upload = uploadService.getUpload(uploadId);
         uploadService.uploadComplete(upload);
 
         // kick off upload validation
+        Study study = studyService.getStudyByHostname(getHostname());
         uploadValidationService.validateUpload(study, upload);
 
         return ok("Upload " + uploadId + " complete!");

--- a/app/controllers/UploadController.java
+++ b/app/controllers/UploadController.java
@@ -1,19 +1,28 @@
 package controllers;
 
 import org.sagebionetworks.bridge.models.UserSession;
+import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.upload.Upload;
 import org.sagebionetworks.bridge.models.upload.UploadRequest;
 import org.sagebionetworks.bridge.models.upload.UploadSession;
 import org.sagebionetworks.bridge.services.UploadService;
+import org.sagebionetworks.bridge.services.UploadValidationService;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import play.mvc.Result;
 
 public class UploadController extends BaseController {
 
     private UploadService uploadService;
+    private UploadValidationService uploadValidationService;
 
     public void setUploadService(UploadService uploadService) {
         this.uploadService = uploadService;
+    }
+
+    @Autowired
+    public void setUploadValidationService(UploadValidationService uploadValidationService) {
+        this.uploadValidationService = uploadValidationService;
     }
 
     public Result upload() throws Exception {
@@ -25,14 +34,17 @@ public class UploadController extends BaseController {
 
     public Result uploadComplete(String uploadId) throws Exception {
         getAuthenticatedAndConsentedSession();
+        Study study = studyService.getStudyByHostname(getHostname());
 
         // mark upload as complete
         Upload upload = uploadService.getUpload(uploadId);
         uploadService.uploadComplete(upload);
 
-        // TODO: kick off upload validation
+        // kick off upload validation
+        uploadValidationService.validateUpload(study, upload);
 
         return ok("Upload " + uploadId + " complete!");
     }
-    
+
+    // TODO: add API for get validation status and messages
 }

--- a/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
+++ b/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
@@ -32,13 +32,13 @@ import org.sagebionetworks.bridge.upload.UploadValidationHandler;
 @ComponentScan(basePackages = "org.sagebionetworks.bridge")
 @Configuration
 public class BridgeSpringConfig {
-    @Bean(name = "AsyncExecutorService")
+    @Bean(name = "asyncExecutorService")
     @Resource(name = "numAsyncWorkerThreads")
     public ExecutorService asyncExecutorService(Integer numAsyncWorkerThreads) {
         return Executors.newFixedThreadPool(numAsyncWorkerThreads);
     }
 
-    @Bean(name = "CmsEncryptorCache")
+    @Bean(name = "cmsEncryptorCache")
     @Autowired
     public LoadingCache<String, CmsEncryptor> cmsEncryptorCache(CmsEncryptorCacheLoader cacheLoader) {
         return CacheBuilder.newBuilder().build(cacheLoader);
@@ -60,7 +60,7 @@ public class BridgeSpringConfig {
         return s3Helper;
     }
 
-    @Bean(name = "UploadDdbMapper")
+    @Bean(name = "uploadDdbMapper")
     @Autowired
     public DynamoDBMapper uploadDdbMapper(AmazonDynamoDB client) {
         DynamoDBMapperConfig mapperConfig = new DynamoDBMapperConfig.Builder().withSaveBehavior(
@@ -71,7 +71,7 @@ public class BridgeSpringConfig {
     }
 
     // TODO: Remove this when the migration is done
-    @Bean(name = "UploadDdbMapperOld")
+    @Bean(name = "uploadDdbMapperOld")
     @Autowired
     public DynamoDBMapper uploadDdbMapperOld(AmazonDynamoDB client) {
         DynamoDBMapperConfig mapperConfig = new DynamoDBMapperConfig.Builder().withSaveBehavior(
@@ -81,7 +81,7 @@ public class BridgeSpringConfig {
         return new DynamoDBMapper(client, mapperConfig);
     }
 
-    @Bean(name = "UploadValidationHandlerList")
+    @Bean(name = "uploadValidationHandlerList")
     @Autowired
     public List<UploadValidationHandler> uploadValidationHandlerList(S3DownloadHandler s3DownloadHandler,
             DecryptAndUnzipHandler decryptAndUnzipHandler) {
@@ -91,7 +91,7 @@ public class BridgeSpringConfig {
         return ImmutableList.of(s3DownloadHandler, decryptAndUnzipHandler);
     }
 
-    @Bean(name = "UploadSchemaDdbMapper")
+    @Bean(name = "uploadSchemaDdbMapper")
     @Autowired
     public DynamoDBMapper uploadSchemaDdbMapper(AmazonDynamoDB client) {
         DynamoDBMapperConfig mapperConfig = new DynamoDBMapperConfig.Builder()

--- a/app/org/sagebionetworks/bridge/dao/UploadDao.java
+++ b/app/org/sagebionetworks/bridge/dao/UploadDao.java
@@ -1,9 +1,11 @@
 package org.sagebionetworks.bridge.dao;
 
 import javax.annotation.Nonnull;
+import java.util.List;
 
 import org.sagebionetworks.bridge.models.upload.Upload;
 import org.sagebionetworks.bridge.models.upload.UploadRequest;
+import org.sagebionetworks.bridge.models.upload.UploadStatus;
 
 public interface UploadDao {
     /**
@@ -33,4 +35,18 @@ public interface UploadDao {
      *         upload to mark as completed
      */
     void uploadComplete(@Nonnull Upload upload);
+
+    /**
+     * Persists the validation status and message list to the Upload metadata object.
+     *
+     * @param upload
+     *         Upload metadata object to write to, must be non-null
+     * @param status
+     *         upload status, generally VALIDATION_FAILED or SUCCEEDED, must be non-null
+     * @param validationMessageList
+     *         validation messages, generally used for error message, must be non-null and
+     *         non-empty, and must not contain null elements
+     */
+    void writeValidationStatus(@Nonnull Upload upload, @Nonnull UploadStatus status,
+            @Nonnull List<String> validationMessageList);
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUpload2.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUpload2.java
@@ -1,6 +1,8 @@
 package org.sagebionetworks.bridge.dynamodb;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
@@ -9,6 +11,7 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIndexHashKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMarshalling;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBVersionAttribute;
+import com.google.common.collect.ImmutableList;
 import org.joda.time.LocalDate;
 
 import org.sagebionetworks.bridge.BridgeUtils;
@@ -30,7 +33,7 @@ public class DynamoUpload2 implements DynamoTable, Upload {
     private UploadStatus status;
     private LocalDate uploadDate;
     private String uploadId;
-    private List<String> validationMessageList;
+    private final List<String> validationMessageList = new ArrayList<>();
     private Long version;
 
     /** This empty constructor is needed by the DynamoDB mapper. */
@@ -45,7 +48,6 @@ public class DynamoUpload2 implements DynamoTable, Upload {
         this.healthCode = healthCode;
         status = UploadStatus.REQUESTED;
         uploadId = BridgeUtils.generateGuid();
-        validationMessageList = new ArrayList<>();
     }
 
     /** {@inheritDoc} */
@@ -157,15 +159,43 @@ public class DynamoUpload2 implements DynamoTable, Upload {
         this.uploadId = uploadId;
     }
 
-    /** {@inheritDoc} */
+    /**
+     * Returns an immutable copy of the validation message list. Changes to the underlying message list will not be
+     * reflected in this copy. Note that the validation message list will be non-null and will not contain null
+     * messages.
+     *
+     * @see org.sagebionetworks.bridge.models.upload.Upload#getValidationMessageList
+     */
     @Override
-    public List<String> getValidationMessageList() {
-        return validationMessageList;
+    public @Nonnull List<String> getValidationMessageList() {
+        return ImmutableList.copyOf(validationMessageList);
     }
 
-    /** @see #getValidationMessageList */
-    public void setValidationMessageList(List<String> validationMessageList) {
-        this.validationMessageList = validationMessageList;
+    /**
+     * <p>
+     * Sets the validation message list. Internally, this clears all messages from the internal validation message
+     * list, then copies all elements from the given validation message list. Note that the validation message list
+     * must be non-null and must not contain null messages.
+     * </p>
+     * <p>
+     * The DynamoDB mapper needs this method, and it needs it to take a List of String.
+     * </p>
+     *
+     * @see org.sagebionetworks.bridge.models.upload.Upload#getValidationMessageList
+     */
+    public void setValidationMessageList(@Nonnull List<String> validationMessageList) {
+        this.validationMessageList.clear();
+        appendValidationMessages(validationMessageList);
+    }
+
+    /**
+     * Appends validation messages to the validation message list. Note that the validation message list must be
+     * non-null and must not contain null messages.
+     *
+     * @see org.sagebionetworks.bridge.models.upload.Upload#getValidationMessageList
+     */
+    public void appendValidationMessages(@Nonnull Collection<? extends String> validationMessageList) {
+        this.validationMessageList.addAll(validationMessageList);
     }
 
     /** DynamoDB version, used for optimistic locking */

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDao.java
@@ -33,7 +33,7 @@ public class DynamoUploadSchemaDao implements UploadSchemaDao {
      * This is the DynamoDB mapper that reads from and writes to our DynamoDB table. This is normally configured by
      * Spring.
      */
-    @Resource(name = "UploadSchemaDdbMapper")
+    @Resource(name = "uploadSchemaDdbMapper")
     public void setDdbMapper(DynamoDBMapper mapper) {
         this.mapper = mapper;
     }

--- a/app/org/sagebionetworks/bridge/services/UploadValidationService.java
+++ b/app/org/sagebionetworks/bridge/services/UploadValidationService.java
@@ -1,0 +1,32 @@
+package org.sagebionetworks.bridge.services;
+
+import java.util.concurrent.ExecutorService;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.upload.Upload;
+import org.sagebionetworks.bridge.upload.UploadValidationTask;
+import org.sagebionetworks.bridge.upload.UploadValidationTaskFactory;
+
+@Component
+public class UploadValidationService {
+    private ExecutorService asyncExecutorService;
+    private UploadValidationTaskFactory taskFactory;
+
+    @Autowired
+    public void setAsyncExecutorService(ExecutorService asyncExecutorService) {
+        this.asyncExecutorService = asyncExecutorService;
+    }
+
+    @Autowired
+    public void setTaskFactory(UploadValidationTaskFactory taskFactory) {
+        this.taskFactory = taskFactory;
+    }
+
+    public void validateUpload(Study study, Upload upload) {
+        UploadValidationTask task = taskFactory.newTask(study, upload);
+        asyncExecutorService.execute(task);
+    }
+}

--- a/app/org/sagebionetworks/bridge/services/UploadValidationService.java
+++ b/app/org/sagebionetworks/bridge/services/UploadValidationService.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.services;
 
+import javax.annotation.Nonnull;
 import java.util.concurrent.ExecutorService;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,22 +11,40 @@ import org.sagebionetworks.bridge.models.upload.Upload;
 import org.sagebionetworks.bridge.upload.UploadValidationTask;
 import org.sagebionetworks.bridge.upload.UploadValidationTaskFactory;
 
+/** Service handler for upload validation. */
 @Component
 public class UploadValidationService {
     private ExecutorService asyncExecutorService;
     private UploadValidationTaskFactory taskFactory;
 
+    /** Async thread pool. This is configured by Spring. */
     @Autowired
     public void setAsyncExecutorService(ExecutorService asyncExecutorService) {
         this.asyncExecutorService = asyncExecutorService;
     }
 
+    /** Task factory. This is configured by Spring. */
     @Autowired
     public void setTaskFactory(UploadValidationTaskFactory taskFactory) {
         this.taskFactory = taskFactory;
     }
 
-    public void validateUpload(Study study, Upload upload) {
+    /**
+     * <p>
+     * Kick off upload validation. Since upload validation can take some time, we handle this asynchronously. This
+     * method returns immediately. Call UploadService.getUpload() to check for validation status and messages.
+     * </p>
+     * <p>
+     * Study comes from the controller and upload comes from UploadService.getUpload(), so neither field is user input,
+     * so validation is not needed.
+     * </p>
+     *
+     * @param study
+     *         study this upload lives in
+     * @param upload
+     *         upload metadata object for the upload
+     */
+    public void validateUpload(@Nonnull Study study, @Nonnull Upload upload) {
         UploadValidationTask task = taskFactory.newTask(study, upload);
         asyncExecutorService.execute(task);
     }

--- a/app/org/sagebionetworks/bridge/upload/DecryptAndUnzipHandler.java
+++ b/app/org/sagebionetworks/bridge/upload/DecryptAndUnzipHandler.java
@@ -1,0 +1,31 @@
+package org.sagebionetworks.bridge.upload;
+
+import javax.annotation.Nonnull;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
+import org.sagebionetworks.bridge.services.UploadArchiveService;
+
+// TODO: Separate the decrypt, unzip, and the JSON parsing
+@Component
+public class DecryptAndUnzipHandler implements UploadValidationHandler {
+    private UploadArchiveService uploadArchiveService;
+
+    @Autowired
+    public void setUploadArchiveService(UploadArchiveService uploadArchiveService) {
+        this.uploadArchiveService = uploadArchiveService;
+    }
+
+    @Override
+    public void handle(@Nonnull UploadValidationContext context) throws UploadValidationException {
+        try {
+            uploadArchiveService.decryptAndUnzip(context.getStudy(), context.getData());
+
+            // TODO: write decrypted and unzipped results back into the context
+        } catch (BridgeServiceException ex) {
+            throw new UploadValidationException(ex);
+        }
+    }
+}

--- a/app/org/sagebionetworks/bridge/upload/DecryptAndUnzipHandler.java
+++ b/app/org/sagebionetworks/bridge/upload/DecryptAndUnzipHandler.java
@@ -5,27 +5,26 @@ import javax.annotation.Nonnull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.services.UploadArchiveService;
 
+/**
+ * Validation handler for decrypting, unzipping, and JSON parsing the upload. This handler reads from
+ * {@link org.sagebionetworks.bridge.upload.UploadValidationContext#getData}.
+ */
 // TODO: Separate the decrypt, unzip, and the JSON parsing
 @Component
 public class DecryptAndUnzipHandler implements UploadValidationHandler {
     private UploadArchiveService uploadArchiveService;
 
+    /** Upload archive service, which handles decrypting and unzipping of files. This is configured by Spring. */
     @Autowired
     public void setUploadArchiveService(UploadArchiveService uploadArchiveService) {
         this.uploadArchiveService = uploadArchiveService;
     }
 
+    /** {@inheritDoc} */
     @Override
-    public void handle(@Nonnull UploadValidationContext context) throws UploadValidationException {
-        try {
-            uploadArchiveService.decryptAndUnzip(context.getStudy(), context.getData());
-
-            // TODO: write decrypted and unzipped results back into the context
-        } catch (BridgeServiceException ex) {
-            throw new UploadValidationException(ex);
-        }
+    public void handle(@Nonnull UploadValidationContext context) {
+        uploadArchiveService.decryptAndUnzip(context.getStudy(), context.getData());
     }
 }

--- a/app/org/sagebionetworks/bridge/upload/S3DownloadHandler.java
+++ b/app/org/sagebionetworks/bridge/upload/S3DownloadHandler.java
@@ -9,17 +9,24 @@ import org.springframework.stereotype.Component;
 import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 import org.sagebionetworks.bridge.s3.S3Helper;
 
+/**
+ * Validation handler for downloading the upload from S3. This handler reads
+ * {@link org.sagebionetworks.bridge.upload.UploadValidationContext#getUpload} and writes the downloaded data (as a
+ * byte array) to {@link org.sagebionetworks.bridge.upload.UploadValidationContext#setData}.
+ */
 @Component
 public class S3DownloadHandler implements UploadValidationHandler {
     private static final String UPLOAD_BUCKET = BridgeConfigFactory.getConfig().getProperty("upload.bucket");
 
     private S3Helper s3Helper;
 
+    /** S3 helper, for downloading bytes from S3. This is configured by Spring. */
     @Resource(name = "s3Helper")
     public void setS3Helper(S3Helper s3Helper) {
         this.s3Helper = s3Helper;
     }
 
+    /** {@inheritDoc} */
     @Override
     public void handle(@Nonnull UploadValidationContext context) throws UploadValidationException {
         try {

--- a/app/org/sagebionetworks/bridge/upload/S3DownloadHandler.java
+++ b/app/org/sagebionetworks/bridge/upload/S3DownloadHandler.java
@@ -1,0 +1,32 @@
+package org.sagebionetworks.bridge.upload;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Resource;
+import java.io.IOException;
+
+import org.springframework.stereotype.Component;
+
+import org.sagebionetworks.bridge.config.BridgeConfigFactory;
+import org.sagebionetworks.bridge.s3.S3Helper;
+
+@Component
+public class S3DownloadHandler implements UploadValidationHandler {
+    private static final String UPLOAD_BUCKET = BridgeConfigFactory.getConfig().getProperty("upload.bucket");
+
+    private S3Helper s3Helper;
+
+    @Resource(name = "s3Helper")
+    public void setS3Helper(S3Helper s3Helper) {
+        this.s3Helper = s3Helper;
+    }
+
+    @Override
+    public void handle(@Nonnull UploadValidationContext context) throws UploadValidationException {
+        try {
+            byte[] s3Bytes = s3Helper.readS3FileAsBytes(UPLOAD_BUCKET, context.getUpload().getObjectId());
+            context.setData(s3Bytes);
+        } catch (IOException ex) {
+            throw new UploadValidationException(ex);
+        }
+    }
+}

--- a/app/org/sagebionetworks/bridge/upload/UploadValidationContext.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadValidationContext.java
@@ -8,6 +8,7 @@ import com.google.common.collect.ImmutableList;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.upload.Upload;
 
+/** This class encapsulates data read and generated during the process of upload validation. */
 public class UploadValidationContext {
     private Study study;
     private Upload upload;
@@ -15,42 +16,69 @@ public class UploadValidationContext {
     private List<String> messageList = new ArrayList<>();
     private byte[] data;
 
+    /**
+     * This is the study that the upload lives in and is validated against. This is made available by the upload
+     * validation service and is initially set by the upload validation task factory.
+     */
     public Study getStudy() {
         return study;
     }
 
+    /** @see #getStudy */
     public void setStudy(Study study) {
         this.study = study;
     }
 
+    /**
+     * This is the upload metadata object of the upload we're validating. This is made available by the upload
+     * validation service and is initially set by the upload validation task factory.
+     */
     public Upload getUpload() {
         return upload;
     }
 
+    /** @see #getUpload */
     public void setUpload(Upload upload) {
         this.upload = upload;
     }
 
+    /**
+     * True if the validation is successful so far. False if validation has failed. This is initially set to true, as
+     * validation tasks start off vacuously successful until they have failed. Once a validation handler has failed,
+     * the error handling code in UploadValidationTask will flip the success flag to false. Only UploadValidationTask
+     * will write to this field.
+     */
     public boolean getSuccess() {
         return success;
     }
 
+    /** @see #getSuccess */
     public void setSuccess(boolean success) {
         this.success = success;
     }
 
+    /**
+     * Validation messages for this task, such as error messages. This is initially empty, and messages can be appended
+     * by calling {@link #addMessage}. Messages are generally added by the error handling code in UploadValidationTask,
+     * but validation handlers can add messages for other reasons.
+     */
     public List<String> getMessageList() {
         return ImmutableList.copyOf(messageList);
     }
 
+    /** @see #getMessageList */
     public void addMessage(String msg) {
         messageList.add(msg);
     }
 
+    /**
+     * Raw upload data as bytes. This is set by the S3DownloadHandler.
+     */
     public byte[] getData() {
         return data;
     }
 
+    /** @see #getData */
     public void setData(byte[] data) {
         this.data = data;
     }

--- a/app/org/sagebionetworks/bridge/upload/UploadValidationContext.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadValidationContext.java
@@ -1,0 +1,57 @@
+package org.sagebionetworks.bridge.upload;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
+import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.upload.Upload;
+
+public class UploadValidationContext {
+    private Study study;
+    private Upload upload;
+    private boolean success = true;
+    private List<String> messageList = new ArrayList<>();
+    private byte[] data;
+
+    public Study getStudy() {
+        return study;
+    }
+
+    public void setStudy(Study study) {
+        this.study = study;
+    }
+
+    public Upload getUpload() {
+        return upload;
+    }
+
+    public void setUpload(Upload upload) {
+        this.upload = upload;
+    }
+
+    public boolean getSuccess() {
+        return success;
+    }
+
+    public void setSuccess(boolean success) {
+        this.success = success;
+    }
+
+    public List<String> getMessageList() {
+        return ImmutableList.copyOf(messageList);
+    }
+
+    public void addMessage(String msg) {
+        messageList.add(msg);
+    }
+
+    public byte[] getData() {
+        return data;
+    }
+
+    public void setData(byte[] data) {
+        this.data = data;
+    }
+}

--- a/app/org/sagebionetworks/bridge/upload/UploadValidationException.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadValidationException.java
@@ -1,5 +1,9 @@
 package org.sagebionetworks.bridge.upload;
 
+/**
+ * This exception represents an error in validating an upload. This is primarily used to wrap checked exceptions to
+ * keep the interface of {@link org.sagebionetworks.bridge.upload.UploadValidationHandler} clean.
+ */
 @SuppressWarnings("serial")
 public class UploadValidationException extends Exception {
     public UploadValidationException() {

--- a/app/org/sagebionetworks/bridge/upload/UploadValidationException.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadValidationException.java
@@ -1,0 +1,19 @@
+package org.sagebionetworks.bridge.upload;
+
+@SuppressWarnings("serial")
+public class UploadValidationException extends Exception {
+    public UploadValidationException() {
+    }
+
+    public UploadValidationException(String message) {
+        super(message);
+    }
+
+    public UploadValidationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public UploadValidationException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/app/org/sagebionetworks/bridge/upload/UploadValidationHandler.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadValidationHandler.java
@@ -2,6 +2,26 @@ package org.sagebionetworks.bridge.upload;
 
 import javax.annotation.Nonnull;
 
+/**
+ * <p>
+ * This interface represents a handler for a sub-task in upload validation. This allows us to break down our back-end
+ * dependencies individually into validation handlers. It also allows us to configure our handler chain in Spring
+ * configuration instead of in code.
+ * </p>
+ * <p>
+ * Over time, handlers will write additional data to the UploadValidationContext. Implementing handlers should clearly
+ * document which data they read and write from the validation context.
+ * </p>
+ */
 public interface UploadValidationHandler {
+    /**
+     * Invoke this handle to perform its validation sub-task on the given validation context.
+     *
+     * @param context
+     *         Upload validation context. This method will read from and write to the validation context. See
+     *         specific sub-classes for more details on which values are read and written
+     * @throws UploadValidationException
+     *         if upload validation fails
+     */
     void handle(@Nonnull UploadValidationContext context) throws UploadValidationException;
 }

--- a/app/org/sagebionetworks/bridge/upload/UploadValidationHandler.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadValidationHandler.java
@@ -1,0 +1,7 @@
+package org.sagebionetworks.bridge.upload;
+
+import javax.annotation.Nonnull;
+
+public interface UploadValidationHandler {
+    void handle(@Nonnull UploadValidationContext context) throws UploadValidationException;
+}

--- a/app/org/sagebionetworks/bridge/upload/UploadValidationTask.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadValidationTask.java
@@ -1,0 +1,59 @@
+package org.sagebionetworks.bridge.upload;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.sagebionetworks.bridge.dao.UploadDao;
+import org.sagebionetworks.bridge.models.upload.UploadStatus;
+
+public class UploadValidationTask implements Runnable {
+    private static final Logger LOG = LoggerFactory.getLogger(UploadValidationTask.class);
+
+    private final UploadValidationContext context;
+
+    private List<UploadValidationHandler> handlerList;
+    private UploadDao uploadDao;
+
+    /* package-scoped */ UploadValidationTask(UploadValidationContext context) {
+        this.context = context;
+    }
+
+    public void setHandlerList(List<UploadValidationHandler> handlerList) {
+        this.handlerList = handlerList;
+    }
+
+    public void setUploadDao(UploadDao uploadDao) {
+        this.uploadDao = uploadDao;
+    }
+
+    @Override
+    public void run() {
+        for (UploadValidationHandler oneHandler : handlerList) {
+            try {
+                oneHandler.handle(context);
+            } catch (UploadValidationException ex) {
+                // unwrap to find cause, if any
+                Throwable inner = ex.getCause() != null ? ex.getCause() : ex;
+
+                // log stuff, set the success flag, and break out of the loop
+                String handlerName = oneHandler.getClass().getName();
+                context.setSuccess(false);
+                context.addMessage(String.format("Error running upload validation handler %s: %s", handlerName,
+                        inner.getMessage()));
+                LOG.warn(String.format("Error running upload validation handler %s for study %s, upload %s",
+                        handlerName, context.getStudy().getIdentifier(), context.getUpload().getUploadId()), inner);
+                break;
+            }
+        }
+
+        // write validation status to the upload DAO
+        UploadStatus status = context.getSuccess() ? UploadStatus.SUCCEEDED : UploadStatus.VALIDATION_FAILED;
+        uploadDao.writeValidationStatus(context.getUpload(), status, context.getMessageList());
+        LOG.info(String.format("Upload validation for study %s, upload %s, with status %s",
+                context.getStudy().getIdentifier(), context.getUpload().getUploadId(), status));
+
+        // TODO: if validation fails, wipe the files from S3
+    }
+}

--- a/app/org/sagebionetworks/bridge/upload/UploadValidationTaskFactory.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadValidationTaskFactory.java
@@ -1,0 +1,39 @@
+package org.sagebionetworks.bridge.upload;
+
+import javax.annotation.Resource;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.sagebionetworks.bridge.dao.UploadDao;
+import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.upload.Upload;
+
+@Component
+public class UploadValidationTaskFactory {
+    private UploadDao uploadDao;
+    private List<UploadValidationHandler> handlerList;
+
+    @Autowired
+    public void setUploadDao(UploadDao uploadDao) {
+        this.uploadDao = uploadDao;
+    }
+
+    @Resource(name = "UploadValidationHandlerList")
+    public void setHandlerList(List<UploadValidationHandler> handlerList) {
+        this.handlerList = handlerList;
+    }
+
+    public UploadValidationTask newTask(Study study, Upload upload) {
+        // context
+        UploadValidationContext context = new UploadValidationContext();
+        context.setStudy(study);
+        context.setUpload(upload);
+
+        UploadValidationTask task = new UploadValidationTask(context);
+        task.setUploadDao(uploadDao);
+        task.setHandlerList(handlerList);
+        return task;
+    }
+}

--- a/app/org/sagebionetworks/bridge/upload/UploadValidationTaskFactory.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadValidationTaskFactory.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.upload;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Resource;
 import java.util.List;
 
@@ -10,30 +11,47 @@ import org.sagebionetworks.bridge.dao.UploadDao;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.upload.Upload;
 
+/**
+ * This class creates UploadValidationTask objects. It exists primarily so that we can avoid using context.getBean(),
+ * which forces unit tests to be Spring aware. With a factory instead of Spring context.getBean(), we can significantly
+ * simplify unit tests.
+ */
 @Component
 public class UploadValidationTaskFactory {
-    private UploadDao uploadDao;
     private List<UploadValidationHandler> handlerList;
+    private UploadDao uploadDao;
 
+    /** Validation handler list. This is configured by Spring. */
+    @Resource(name = "uploadValidationHandlerList")
+    public void setHandlerList(List<UploadValidationHandler> handlerList) {
+        this.handlerList = handlerList;
+    }
+
+    /** Upload DAO, used to write validation status. This is configured by Spring. */
     @Autowired
     public void setUploadDao(UploadDao uploadDao) {
         this.uploadDao = uploadDao;
     }
 
-    @Resource(name = "UploadValidationHandlerList")
-    public void setHandlerList(List<UploadValidationHandler> handlerList) {
-        this.handlerList = handlerList;
-    }
-
-    public UploadValidationTask newTask(Study study, Upload upload) {
+    /**
+     * Factory method for creating a validation task instance, for validating a single upload.
+     *
+     * @param study
+     *         study this upload lives in
+     * @param upload
+     *         upload metadata object for the upload
+     * @return upload validation task, which will validate the upload
+     */
+    public UploadValidationTask newTask(@Nonnull Study study, @Nonnull Upload upload) {
         // context
         UploadValidationContext context = new UploadValidationContext();
         context.setStudy(study);
         context.setUpload(upload);
 
+        // task
         UploadValidationTask task = new UploadValidationTask(context);
-        task.setUploadDao(uploadDao);
         task.setHandlerList(handlerList);
+        task.setUploadDao(uploadDao);
         return task;
     }
 }

--- a/test/org/sagebionetworks/bridge/TestConstants.java
+++ b/test/org/sagebionetworks/bridge/TestConstants.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.bridge;
 
+import org.sagebionetworks.bridge.config.BridgeConfigFactory;
+
 public class TestConstants {
     public static final String DUMMY_IMAGE_DATA = "VGhpcyBpc24ndCBhIHJlYWwgaW1hZ2Uu";
 
@@ -75,4 +77,6 @@ public class TestConstants {
     public static final String CANCEL_ACTION = "#cancelAct";
     public static final String CLOSE_ACTION = ".close";
     public static final String TOAST_DIALOG = ".humane";
+
+    public static final String UPLOAD_BUCKET = BridgeConfigFactory.getConfig().getProperty("upload.bucket");
 }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoUpload2Test.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoUpload2Test.java
@@ -1,0 +1,112 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+
+public class DynamoUpload2Test {
+    @Test
+    public void testGetSetValidationMessageList() {
+        DynamoUpload2 upload2 = new DynamoUpload2();
+
+        // initial get gives empty list
+        List<String> initialList = upload2.getValidationMessageList();
+        assertTrue(initialList.isEmpty());
+
+        // set and validate
+        upload2.setValidationMessageList(ImmutableList.of("first message"));
+        List<String> list2 = upload2.getValidationMessageList();
+        assertTrue(initialList.isEmpty());
+
+        assertEquals(1, list2.size());
+        assertEquals("first message", list2.get(0));
+
+        // set should overwrite
+        upload2.setValidationMessageList(ImmutableList.of("second message"));
+        List<String> list3 = upload2.getValidationMessageList();
+        assertTrue(initialList.isEmpty());
+
+        assertEquals(1, list2.size());
+        assertEquals("first message", list2.get(0));
+
+        assertEquals(1, list3.size());
+        assertEquals("second message", list3.get(0));
+    }
+
+    @Test
+    public void testGetAppendValidationMessageList() {
+        DynamoUpload2 upload2 = new DynamoUpload2();
+
+        // initial get gives empty list
+        List<String> initialList = upload2.getValidationMessageList();
+        assertTrue(initialList.isEmpty());
+
+        // append and validate
+        upload2.appendValidationMessages(ImmutableList.of("first message"));
+        List<String> list2 = upload2.getValidationMessageList();
+        assertTrue(initialList.isEmpty());
+
+        assertEquals(1, list2.size());
+        assertEquals("first message", list2.get(0));
+
+        // append again
+        upload2.appendValidationMessages(ImmutableList.of("second message"));
+        List<String> list3 = upload2.getValidationMessageList();
+        assertTrue(initialList.isEmpty());
+
+        assertEquals(1, list2.size());
+        assertEquals("first message", list2.get(0));
+
+        assertEquals(2, list3.size());
+        assertEquals("first message", list3.get(0));
+        assertEquals("second message", list3.get(1));
+    }
+
+    @Test
+    public void testGetSetAppendValidationMessageList() {
+        DynamoUpload2 upload2 = new DynamoUpload2();
+
+        // initial get gives empty list
+        List<String> initialList = upload2.getValidationMessageList();
+        assertTrue(initialList.isEmpty());
+
+        // set on an empty list
+        upload2.setValidationMessageList(ImmutableList.of("first message"));
+        List<String> list2 = upload2.getValidationMessageList();
+        assertTrue(initialList.isEmpty());
+
+        assertEquals(1, list2.size());
+        assertEquals("first message", list2.get(0));
+
+        // append on a set
+        upload2.appendValidationMessages(ImmutableList.of("second message"));
+        List<String> list3 = upload2.getValidationMessageList();
+        assertTrue(initialList.isEmpty());
+
+        assertEquals(1, list2.size());
+        assertEquals("first message", list2.get(0));
+
+        assertEquals(2, list3.size());
+        assertEquals("first message", list3.get(0));
+        assertEquals("second message", list3.get(1));
+
+        // set should overwrite the append
+        upload2.setValidationMessageList(ImmutableList.of("third message"));
+        List<String> list4 = upload2.getValidationMessageList();
+        assertTrue(initialList.isEmpty());
+
+        assertEquals(1, list2.size());
+        assertEquals("first message", list2.get(0));
+
+        assertEquals(2, list3.size());
+        assertEquals("first message", list3.get(0));
+        assertEquals("second message", list3.get(1));
+
+        assertEquals(1, list4.size());
+        assertEquals("third message", list4.get(0));
+    }
+}

--- a/test/org/sagebionetworks/bridge/services/UploadValidationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/UploadValidationServiceTest.java
@@ -1,0 +1,49 @@
+package org.sagebionetworks.bridge.services;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.ExecutorService;
+
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
+import org.sagebionetworks.bridge.dynamodb.DynamoUpload2;
+import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.upload.Upload;
+import org.sagebionetworks.bridge.upload.UploadValidationTask;
+import org.sagebionetworks.bridge.upload.UploadValidationTaskFactory;
+
+public class UploadValidationServiceTest {
+    @Test
+    public void test() {
+        // UploadValidationService is a simple call-through to the task factory and the async thread pool. As such, our
+        // test strategy is to verify that execution flows through to these dependencies.
+
+        // inputs
+        Study study = new DynamoStudy();
+        Upload upload = new DynamoUpload2();
+
+        // mock task
+        UploadValidationTask mockTask = mock(UploadValidationTask.class);
+
+        // mock task factory
+        UploadValidationTaskFactory mockTaskFactory = mock(UploadValidationTaskFactory.class);
+        when(mockTaskFactory.newTask(study, upload)).thenReturn(mockTask);
+
+        // mock async thread pool
+        ExecutorService mockExecutor = mock(ExecutorService.class);
+
+        // set up service
+        UploadValidationService svc = new UploadValidationService();
+        svc.setAsyncExecutorService(mockExecutor);
+        svc.setTaskFactory(mockTaskFactory);
+
+        // execute
+        svc.validateUpload(study, upload);
+
+        // validate
+        verify(mockExecutor).execute(mockTask);
+    }
+}

--- a/test/org/sagebionetworks/bridge/upload/DecryptAndUnzipHandlerTest.java
+++ b/test/org/sagebionetworks/bridge/upload/DecryptAndUnzipHandlerTest.java
@@ -1,0 +1,34 @@
+package org.sagebionetworks.bridge.upload;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.base.Charsets;
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
+import org.sagebionetworks.bridge.services.UploadArchiveService;
+
+public class DecryptAndUnzipHandlerTest {
+    @Test
+    public void test() {
+        // The handler is a simple pass-through to the UploadArchiveService, so just test that execution flows through
+        // to the service as expected.
+
+        // inputs
+        UploadValidationContext ctx = new UploadValidationContext();
+        ctx.setStudy(new DynamoStudy());
+        ctx.setData("test data".getBytes(Charsets.UTF_8));
+
+        // mock upload archive service
+        UploadArchiveService mockSvc = mock(UploadArchiveService.class);
+
+        // set up test handler
+        DecryptAndUnzipHandler handler = new DecryptAndUnzipHandler();
+        handler.setUploadArchiveService(mockSvc);
+
+        // execute and validate
+        handler.handle(ctx);
+        verify(mockSvc).decryptAndUnzip(ctx.getStudy(), ctx.getData());
+    }
+}

--- a/test/org/sagebionetworks/bridge/upload/S3DownloadHandlerTest.java
+++ b/test/org/sagebionetworks/bridge/upload/S3DownloadHandlerTest.java
@@ -1,0 +1,65 @@
+package org.sagebionetworks.bridge.upload;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import com.google.common.base.Charsets;
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.dynamodb.DynamoUpload2;
+import org.sagebionetworks.bridge.s3.S3Helper;
+
+@SuppressWarnings("unchecked")
+public class S3DownloadHandlerTest {
+    @Test
+    public void test() throws Exception {
+        // The handler is a simple pass-through to the S3Helper, so just test that execution flows through
+        // to the service as expected.
+
+        // inputs
+        DynamoUpload2 upload2 = new DynamoUpload2();
+        upload2.setUploadId("test-upload-id");
+
+        UploadValidationContext ctx = new UploadValidationContext();
+        ctx.setUpload(upload2);
+
+        // mock S3 helper
+        S3Helper mockS3Helper = mock(S3Helper.class);
+        when(mockS3Helper.readS3FileAsBytes(TestConstants.UPLOAD_BUCKET, "test-upload-id")).thenReturn(
+                "test data".getBytes(Charsets.UTF_8));
+
+        // set up test handler
+        S3DownloadHandler handler = new S3DownloadHandler();
+        handler.setS3Helper(mockS3Helper);
+
+        // execute and validate
+        handler.handle(ctx);
+        assertEquals("test data", new String(ctx.getData(), Charsets.UTF_8));
+    }
+
+    @Test(expected = UploadValidationException.class)
+    public void exception() throws Exception {
+        // inputs
+        DynamoUpload2 upload2 = new DynamoUpload2();
+        upload2.setUploadId("test-upload-id");
+
+        UploadValidationContext ctx = new UploadValidationContext();
+        ctx.setUpload(upload2);
+
+        // mock S3 helper
+        S3Helper mockS3Helper = mock(S3Helper.class);
+        when(mockS3Helper.readS3FileAsBytes(TestConstants.UPLOAD_BUCKET, "test-upload-id")).thenThrow(
+                IOException.class);
+
+        // set up test handler
+        S3DownloadHandler handler = new S3DownloadHandler();
+        handler.setS3Helper(mockS3Helper);
+
+        // execute
+        handler.handle(ctx);
+    }
+}

--- a/test/org/sagebionetworks/bridge/upload/UploadValidationTaskFactoryTest.java
+++ b/test/org/sagebionetworks/bridge/upload/UploadValidationTaskFactoryTest.java
@@ -1,0 +1,37 @@
+package org.sagebionetworks.bridge.upload;
+
+import static org.junit.Assert.assertSame;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
+import org.sagebionetworks.bridge.dynamodb.DynamoUpload2;
+import org.sagebionetworks.bridge.dynamodb.DynamoUploadDao;
+
+public class UploadValidationTaskFactoryTest {
+    @Test
+    public void test() {
+        // test dao and handlers
+        List<UploadValidationHandler> handlerList = Collections.emptyList();
+        DynamoUploadDao dao = new DynamoUploadDao();
+
+        // set up task factory
+        UploadValidationTaskFactory taskFactory = new UploadValidationTaskFactory();
+        taskFactory.setHandlerList(handlerList);
+        taskFactory.setUploadDao(dao);
+
+        // inputs
+        DynamoStudy study = new DynamoStudy();
+        DynamoUpload2 upload2 = new DynamoUpload2();
+
+        // execute and validate
+        UploadValidationTask task = taskFactory.newTask(study, upload2);
+        assertSame(study, task.getContext().getStudy());
+        assertSame(upload2, task.getContext().getUpload());
+        assertSame(handlerList, task.getHandlerList());
+        assertSame(dao, task.getUploadDao());
+    }
+}

--- a/test/org/sagebionetworks/bridge/upload/UploadValidationTaskTest.java
+++ b/test/org/sagebionetworks/bridge/upload/UploadValidationTaskTest.java
@@ -1,0 +1,121 @@
+package org.sagebionetworks.bridge.upload;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.notNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+import javax.annotation.Nonnull;
+
+import java.util.List;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.dao.UploadDao;
+import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
+import org.sagebionetworks.bridge.dynamodb.DynamoUpload2;
+import org.sagebionetworks.bridge.models.upload.UploadStatus;
+
+public class UploadValidationTaskTest {
+    @Test
+    public void happyCase() {
+        // test handlers
+        List<UploadValidationHandler> handlerList = ImmutableList.<UploadValidationHandler>of(
+                new MessageHandler("foo was here"), new MessageHandler("bar was here"),
+                new MessageHandler("kilroy was here"));
+
+        // execute
+        UploadValidationContext ctx = testHelper(handlerList, UploadStatus.SUCCEEDED);
+
+        // validate that the handlers ran by checking the messages they wrote
+        List<String> messageList = ctx.getMessageList();
+        assertEquals(3, messageList.size());
+        assertEquals("foo was here", messageList.get(0));
+        assertEquals("bar was here", messageList.get(1));
+        assertEquals("kilroy was here", messageList.get(2));
+    }
+
+    @Test
+    public void uploadValidationException() throws Exception {
+        testExceptionHelper(UploadValidationException.class);
+    }
+
+    @Test
+    public void runtimeException() throws Exception {
+        testExceptionHelper(RuntimeException.class);
+    }
+
+    // helper test method for the exception tests
+    private static void testExceptionHelper(Class<? extends Exception> exClass) throws Exception {
+        // test handlers
+        UploadValidationHandler fooHandler = new MessageHandler("foo succeeded");
+
+        UploadValidationHandler barHandler = mock(UploadValidationHandler.class);
+        doThrow(exClass).when(barHandler).handle(notNull(UploadValidationContext.class));
+
+        UploadValidationHandler bazHandler = mock(UploadValidationHandler.class);
+        verifyZeroInteractions(bazHandler);
+
+        List<UploadValidationHandler> handlerList = ImmutableList.of(fooHandler, barHandler, bazHandler);
+
+        // execute
+        UploadValidationContext ctx = testHelper(handlerList, UploadStatus.VALIDATION_FAILED);
+
+        // Validate validation messages. First message is foo handler. Second message is error message. Just check that
+        // the second message exists.
+        List<String> messageList = ctx.getMessageList();
+        assertEquals(2, messageList.size());
+        assertEquals("foo succeeded", messageList.get(0));
+        assertFalse(Strings.isNullOrEmpty(messageList.get(1)));
+    }
+
+    // helper test method, encapsulating core setup and validation
+    private static UploadValidationContext testHelper(List<UploadValidationHandler> handlerList,
+            UploadStatus expectedStatus) {
+        // input
+        DynamoStudy study = new DynamoStudy();
+        study.setIdentifier("test-study");
+
+        DynamoUpload2 upload2 = new DynamoUpload2();
+        upload2.setUploadId("test-upload");
+
+        UploadValidationContext ctx = new UploadValidationContext();
+        ctx.setStudy(study);
+        ctx.setUpload(upload2);
+
+        // mock dao
+        UploadDao mockDao = mock(UploadDao.class);
+
+        // set up validation task
+        UploadValidationTask task = new UploadValidationTask(ctx);
+        task.setHandlerList(handlerList);
+        task.setUploadDao(mockDao);
+
+        // execute
+        task.run();
+
+        // validate the upload dao write validation status call
+        verify(mockDao).writeValidationStatus(upload2, expectedStatus, ctx.getMessageList());
+
+        return ctx;
+    }
+
+    // Test handler that makes its presence known only by writing a message to the validation context.
+    private static class MessageHandler implements UploadValidationHandler {
+        private final String message;
+
+        public MessageHandler(String message) {
+            this.message = message;
+        }
+
+        @Override
+        public void handle(@Nonnull UploadValidationContext context) throws UploadValidationException {
+            context.addMessage(message);
+        }
+    }
+}


### PR DESCRIPTION
This is the prototype for the Upload Validation Service and Handler Chain. I still need to add unit tests, comments, and a little refactoring, and there's a merge conflict I still need to resolve. However, I'm making this available for an initial high-level design review.

The overall architecture is UploadController calls UploadService.getUpload(), then passes it to UploadService.uploadComplete() and UploadValidationService.validateUpload(). The UploadValidationService kicks off a separate thread that does the actual validation asynchronously. (We could have used Spring context.getBean() instead of creating UploadValidationTaskFactory, but for testing and code factoring, it felt cleaner to not have a hard dependency on Spring.)

The UploadValidationTask uses handlers, so we can easily add handlers in the future without bloating Validation Task. (Future improvement, non-short-circuiting handlers - handlers that can fail but still allow the next steps of handlers to happen. This is when having a message list is more useful than just having a single message.)

Also, UploadCertServiceTest likes to wipe our cert and priv-key buckets in the local domain. If that happens to you, just upload test/resources/cms/rsacert.pem and rsaprivkey.pem to their respective buckets and rename them to api.pem. (There's a code change to make UploadCertServiceTest not do that.)

What the handler chain currently does:
- download from S3
- decrypt and unzip
- writes validation status and messages back to DynamoDB

What we still need to do:
- add API for get validation status and messages
- separate decrypt from unzip and from JSON parsing
- validate against schemas
- write intermediate artifacts
- wipe the files from S3 if validation fails

Testing done:
- manually tested it with a good file (test/resources/cms/data/archive) and a bad file (regular old text file)
- TODO add unit tests
