### PR TITLE
Study via header

### DIFF
--- a/app/controllers/BaseController.java
+++ b/app/controllers/BaseController.java
@@ -11,7 +11,6 @@ import models.StatusMessage;
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.config.BridgeConfig;
-import org.sagebionetworks.bridge.dynamodb.DynamoInitializer;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.exceptions.ConsentRequiredException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;

--- a/app/controllers/BaseController.java
+++ b/app/controllers/BaseController.java
@@ -1,14 +1,17 @@
 package controllers;
 
 import javax.annotation.Nonnull;
+
 import java.util.Collection;
 
 import com.google.common.base.Strings;
+
 import models.StatusMessage;
 
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.config.BridgeConfig;
+import org.sagebionetworks.bridge.dynamodb.DynamoInitializer;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.exceptions.ConsentRequiredException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
@@ -20,6 +23,8 @@ import org.sagebionetworks.bridge.models.UserSession;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.services.AuthenticationService;
 import org.sagebionetworks.bridge.services.StudyService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import play.libs.Json;
 import play.mvc.Controller;
@@ -34,6 +39,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public abstract class BaseController extends Controller {
 
+    private static Logger logger = LoggerFactory.getLogger(BaseController.class);
+    
     private static ObjectMapper mapper = BridgeObjectMapper.get();
     
     protected AuthenticationService authenticationService;
@@ -152,17 +159,24 @@ public abstract class BaseController extends Controller {
         // For testing, we check a few places for a forced host value, first 
         // from the configuration, and then on every request, as a header from
         // the client.
-        if (!bridgeConfig.isProduction()) {
-            if (bridgeConfig.getHost() != null) {
-                return bridgeConfig.getHost();
-            }
-            String header = request().getHeader("Bridge-Host");
-            if (header != null) {
-                return header;
-            }
+        if (bridgeConfig.isLocal() && bridgeConfig.getHost() != null) {
+            logger.debug("Hostname retrieved from Bridge configuration file");
+            return bridgeConfig.getHost();
+        }
+        // You can directly declare the study in a header (this is our preferred way eventually).
+        String header = request().getHeader(BridgeConstants.BRIDGE_STUDY_HEADER);
+        if (header != null) {
+            logger.debug("Hostname reconstructed from Bridge-Study header");
+            return header+bridgeConfig.getStudyHostnamePostfix();
+        }
+        header = request().getHeader(BridgeConstants.BRIDGE_HOST_HEADER);
+        if (header != null) {
+            logger.debug("Hostname retrieved from Bridge-Host header");
+            return header;
         }
         String host = request().host();
         if (host.indexOf(":") > -1) {
+            logger.debug("Hostname retrieved from hostname of server");
             host = host.split(":")[0];
         }
         return host;

--- a/app/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/app/org/sagebionetworks/bridge/BridgeConstants.java
@@ -4,6 +4,10 @@ public class BridgeConstants {
 
     public static final String SESSION_TOKEN_HEADER = "Bridge-Session";
 
+    public static final String BRIDGE_STUDY_HEADER = "Bridge-Study";
+    
+    public static final String BRIDGE_HOST_HEADER = "Bridge-Host";
+    
     public static final String CUSTOM_DATA_HEALTH_CODE_SUFFIX = "_code";
 
     public static final String CUSTOM_DATA_CONSENT_SIGNATURE_SUFFIX = "_consent_signature";

--- a/test/controllers/ApplicationControllerTest.java
+++ b/test/controllers/ApplicationControllerTest.java
@@ -11,6 +11,7 @@ import static play.test.Helpers.testServer;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -29,7 +30,7 @@ public class ApplicationControllerTest {
             @Override
             public void run() {
                 WSRequestHolder holder = WS.url(TEST_BASE_URL + "/anything");
-                holder.setHeader("Bridge-Host", "api" + BridgeConfigFactory.getConfig().getStudyHostnamePostfix());
+                holder.setHeader(BridgeConstants.BRIDGE_HOST_HEADER, "api" + BridgeConfigFactory.getConfig().getStudyHostnamePostfix());
                 Response response = holder.options().get(TIMEOUT);
                 assertEquals(200, response.getStatus());
                 assertEquals("https://assets.sagebridge.org", response.getHeader(ACCESS_CONTROL_ALLOW_ORIGIN));

--- a/test/controllers/AuthenticationControllerTest.java
+++ b/test/controllers/AuthenticationControllerTest.java
@@ -65,7 +65,7 @@ public class AuthenticationControllerTest {
                 node.put(PASSWORD, testUser.getPassword());
                 
                 WSRequestHolder holder = WS.url(TEST_BASE_URL + SIGN_IN_URL);
-                holder.setHeader("Bridge-Host", "api" + BridgeConfigFactory.getConfig().getStudyHostnamePostfix());
+                holder.setHeader(BridgeConstants.BRIDGE_HOST_HEADER, "api" + BridgeConfigFactory.getConfig().getStudyHostnamePostfix());
                 Response response = holder.post(node).get(TIMEOUT);
                 
                 WS.Cookie cookie = response.getCookie(BridgeConstants.SESSION_TOKEN_HEADER);

--- a/test/controllers/BaseControllerTest.java
+++ b/test/controllers/BaseControllerTest.java
@@ -76,11 +76,6 @@ public class BaseControllerTest {
     }
     
     @Test
-    public void studyExtractableFromConfiguration() {
-        
-    }
-    
-    @Test
     public void studyExtractableFromBridgeHostHeader() {
         Http.Request mockRequest = mock(Http.Request.class);
         when(mockRequest.getHeader(BridgeConstants.BRIDGE_HOST_HEADER)).thenReturn(HOSTNAME);


### PR DESCRIPTION
Sending the study via a header, while the test configurations also use the existing study-specific hosts. When all clients are sending the header, we can switch all hosts over to a shared web services URL. Then all the study-specific hosts will be free for re-assignment.
