### PR TITLE
Annotate tables with specific throughputs

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoBackfillRecord.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoBackfillRecord.java
@@ -14,14 +14,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 @DynamoDBTable(tableName = "BackfillRecord")
-public class DynamoBackfillRecord implements BackfillRecord, DynamoTable {
+public class DynamoBackfillRecord implements BackfillRecord {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private String taskId;
     private long timestamp;
     private Long version;
-    
+
     private String studyId;
     private String accountId;
     private String operation;

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoBackfillTask.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoBackfillTask.java
@@ -14,7 +14,7 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBVersionAttribute;
 
 @DynamoDBTable(tableName = "BackfillTask")
-public class DynamoBackfillTask implements BackfillTask, DynamoTable {
+public class DynamoBackfillTask implements BackfillTask {
 
     private static final String SEPARATOR = ":";
 

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoHealthCode.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoHealthCode.java
@@ -14,8 +14,9 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBVersionAttribute;
  * avoid collisions of health code. We do not trust that the underlying RNG
  * is always a solid one.
  */
+@DynamoThroughput(writeCapacity=50, readCapacity=50)
 @DynamoDBTable(tableName = "HealthCode")
-public class DynamoHealthCode implements DynamoTable {
+public class DynamoHealthCode {
 
     private String code;
     private Long version;

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataRecord.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataRecord.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @DynamoDBTable(tableName = "HealthDataRecord2")
-public class DynamoHealthDataRecord implements HealthDataRecord, DynamoTable {
+public class DynamoHealthDataRecord implements HealthDataRecord {
 
     private static final String GUID_FIELD = "guid";
     private static final String START_DATE_FIELD = "startDate";

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoHealthId.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoHealthId.java
@@ -10,8 +10,9 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBVersionAttribute;
 
+@DynamoThroughput(writeCapacity=50, readCapacity=50)
 @DynamoDBTable(tableName = "HealthId")
-public class DynamoHealthId implements HealthId, DynamoTable {
+public class DynamoHealthId implements HealthId {
 
     private String id;
     private String code;

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoInitializer.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoInitializer.java
@@ -103,6 +103,7 @@ public class DynamoInitializer {
             if (TableStatus.DELETING.toString().equalsIgnoreCase(status)) {
                 return;
             } else if (!TableStatus.ACTIVE.toString().equalsIgnoreCase(status)) {
+                // Must be active to be deleted
                 waitForActive(tableDscr);
             }
             logger.info("Deleting table " + table);
@@ -516,7 +517,10 @@ public class DynamoInitializer {
         }
     }
 
-    static void waitForActive(TableDescription table) {
+    /**
+     * Wait for the table to become ACTIVE.
+     */
+    private static void waitForActive(TableDescription table) {
         DescribeTableResult describeResult = DYNAMO.describeTable(
                 new DescribeTableRequest(table.getTableName()));
         table = describeResult.getTable();
@@ -531,7 +535,10 @@ public class DynamoInitializer {
         }
     }
 
-    static void waitForDelete(TableDescription table) {
+    /**
+     * Wait for the table to be deleted.
+     */
+    private static void waitForDelete(TableDescription table) {
         DescribeTableResult describeResult = DYNAMO.describeTable(
                 new DescribeTableRequest(table.getTableName()));
         table = describeResult.getTable();

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoParticipantOptions.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoParticipantOptions.java
@@ -16,7 +16,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.Maps;
 
 @DynamoDBTable(tableName = "ParticipantOptions")
-public class DynamoParticipantOptions implements DynamoTable { 
+public class DynamoParticipantOptions { 
     
     private String healthCode; // hash
     private String studyKey; // range

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSchedulePlan.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSchedulePlan.java
@@ -29,7 +29,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  * algorithms for assigning users their schedules.
  */
 @DynamoDBTable(tableName = "SchedulePlan")
-public class DynamoSchedulePlan implements SchedulePlan, DynamoTable {
+public class DynamoSchedulePlan implements SchedulePlan {
 
     private static final String GUID_PROPERTY = "guid";
     private static final String STUDY_KEY_PROPERTY = "studyKey";

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Lists;
 
 @DynamoDBTable(tableName = "Study")
-public class DynamoStudy implements Study, DynamoTable {
+public class DynamoStudy implements Study {
 
     // We need the unconfigured mapper for setData/getData.
     private static ObjectMapper mapper = new ObjectMapper();

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoStudyConsent1.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoStudyConsent1.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @DynamoDBTable(tableName = "StudyConsent1")
-public class DynamoStudyConsent1 implements StudyConsent, DynamoTable {
+public class DynamoStudyConsent1 implements StudyConsent {
 
     private String studyKey;
     private long createdOn;

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurvey.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurvey.java
@@ -27,7 +27,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 @DynamoDBTable(tableName = "Survey")
-public class DynamoSurvey implements Survey, DynamoTable {
+public class DynamoSurvey implements Survey {
     
     private static final String VERSION_FIELD = "version";
     private static final String NAME_FIELD = "name";

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyElement.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyElement.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.JsonNode;
 
 @DynamoDBTable(tableName = SurveyElementConstants.SURVEY_ELEMENT_TYPE)
-public class DynamoSurveyElement implements SurveyElement, DynamoTable {
+public class DynamoSurveyElement implements SurveyElement {
 
     private String surveyCompoundKey;
     private String guid;

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyResponse.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyResponse.java
@@ -26,7 +26,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Lists;
 
 @DynamoDBTable(tableName = "SurveyResponse")
-public class DynamoSurveyResponse implements SurveyResponse, DynamoTable {
+public class DynamoSurveyResponse implements SurveyResponse {
 
     private static final String HEALTH_CODE_PROPERTY = "healthCode";
     private static final String COMPLETED_ON_PROPERTY = "completedOn";

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoTable.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoTable.java
@@ -1,3 +1,0 @@
-package org.sagebionetworks.bridge.dynamodb;
-
-public interface DynamoTable {}

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoThroughput.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoThroughput.java
@@ -1,0 +1,13 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface DynamoThroughput {
+    long writeCapacity() default DynamoInitializer.WRITE_CAPACITY;
+    long readCapacity() default DynamoInitializer.READ_CAPACITY;
+}

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoThroughput.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoThroughput.java
@@ -8,6 +8,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface DynamoThroughput {
-    long writeCapacity() default DynamoInitializer.WRITE_CAPACITY;
-    long readCapacity() default DynamoInitializer.READ_CAPACITY;
+    long writeCapacity();
+    long readCapacity();
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUpload.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUpload.java
@@ -17,8 +17,9 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBVersionAttribute;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
 
+@DynamoThroughput(writeCapacity=50, readCapacity=50)
 @DynamoDBTable(tableName = "Upload")
-public class DynamoUpload implements Upload, DynamoTable {
+public class DynamoUpload implements Upload {
 
     private String uploadId;
     private long timestamp;

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUpload2.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUpload2.java
@@ -23,8 +23,9 @@ import org.sagebionetworks.bridge.models.upload.UploadStatus;
  * This DynamoDB table stores metadata for Bridge uploads. This class also defines global secondary indices, which can
  * be used for more efficient queries.
  */
+@DynamoThroughput(writeCapacity=50, readCapacity=50)
 @DynamoDBTable(tableName = "Upload2")
-public class DynamoUpload2 implements DynamoTable, Upload {
+public class DynamoUpload2 implements Upload {
     private long contentLength;
     private String contentMd5;
     private String contentType;

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchema.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchema.java
@@ -29,7 +29,7 @@ import org.sagebionetworks.bridge.validators.Validate;
  * with the DynamoDB mapper.
  */
 @DynamoDBTable(tableName = "UploadSchema")
-public class DynamoUploadSchema implements DynamoTable, UploadSchema {
+public class DynamoUploadSchema implements UploadSchema {
     private List<UploadFieldDefinition> fieldDefList;
     private String name;
     private int rev;

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUserConsent2.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUserConsent2.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @DynamoDBTable(tableName = "UserConsent2")
 @BridgeTypeName("UserConsent")
-public class DynamoUserConsent2 implements DynamoTable, UserConsent {
+public class DynamoUserConsent2 implements UserConsent {
 
     // Schema attributes
     private String healthCodeStudy; // <health-code>:<study-key>

--- a/app/org/sagebionetworks/bridge/dynamodb/TableNameOverrideFactory.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/TableNameOverrideFactory.java
@@ -9,7 +9,7 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
 
 public class TableNameOverrideFactory {
 
-    public static TableNameOverride getTableNameOverride(Class<? extends DynamoTable> clazz) {
+    public static TableNameOverride getTableNameOverride(Class<?> clazz) {
         BridgeConfig config = BridgeConfigFactory.getConfig();
         Environment env = config.getEnvironment();
         String tableName = clazz.getAnnotation(DynamoDBTable.class).tableName();

--- a/app/org/sagebionetworks/bridge/dynamodb/TableNameOverrideFactory.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/TableNameOverrideFactory.java
@@ -18,4 +18,8 @@ public class TableNameOverrideFactory {
         }
         return new TableNameOverride(env.name().toLowerCase() + "-" + config.getUser() + "-" + tableName);
     }
+
+    public static String getTableName(Class<?> clazz) {
+        return getTableNameOverride(clazz).getTableName();
+    }
 }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoInitializerTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoInitializerTest.java
@@ -13,15 +13,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import com.amazonaws.services.dynamodbv2.model.GlobalSecondaryIndex;
-import com.amazonaws.services.dynamodbv2.model.GlobalSecondaryIndexDescription;
-import com.amazonaws.services.dynamodbv2.model.KeyType;
-import com.amazonaws.services.dynamodbv2.model.Projection;
-import com.amazonaws.services.dynamodbv2.model.ProjectionType;
-import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughputDescription;
-import com.google.common.collect.ImmutableList;
-
-import org.junit.Ignore;
 import org.junit.Test;
 import org.sagebionetworks.bridge.config.BridgeConfig;
 import org.sagebionetworks.bridge.config.BridgeConfigFactory;
@@ -31,20 +22,26 @@ import org.sagebionetworks.bridge.exceptions.BridgeInitializationException;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
 import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
+import com.amazonaws.services.dynamodbv2.model.GlobalSecondaryIndex;
+import com.amazonaws.services.dynamodbv2.model.GlobalSecondaryIndexDescription;
 import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
+import com.amazonaws.services.dynamodbv2.model.KeyType;
 import com.amazonaws.services.dynamodbv2.model.LocalSecondaryIndex;
 import com.amazonaws.services.dynamodbv2.model.LocalSecondaryIndexDescription;
+import com.amazonaws.services.dynamodbv2.model.Projection;
+import com.amazonaws.services.dynamodbv2.model.ProjectionType;
+import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughputDescription;
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
 import com.amazonaws.services.dynamodbv2.model.TableDescription;
+import com.google.common.collect.ImmutableList;
 
 public class DynamoInitializerTest {
 
     private static final String PACKAGE = "org.sagebionetworks.bridge.dynamodb.test";
 
     @Test
-    @Ignore
     public void testGetAnnotatedTables() {
-        List<Class<?>> classes = DynamoInitializer.loadDynamoTableClasses(PACKAGE);
+        List<Class<? extends DynamoTable>> classes = DynamoInitializer.loadDynamoTableClasses(PACKAGE);
         List<TableDescription> tables = DynamoInitializer.getAnnotatedTables(classes);
         assertNotNull(tables);
         assertEquals(1, tables.size());
@@ -66,9 +63,8 @@ public class DynamoInitializerTest {
     }
 
     @Test
-    @Ignore
     public void testLoadDynamoTableClasses() {
-        List<Class<?>> classes = DynamoInitializer.loadDynamoTableClasses(PACKAGE);
+        List<Class<? extends DynamoTable>> classes = DynamoInitializer.loadDynamoTableClasses(PACKAGE);
         assertNotNull(classes);
         assertEquals(1, classes.size());
         Set<String> classSet = new HashSet<String>();
@@ -79,7 +75,6 @@ public class DynamoInitializerTest {
     }
 
     @Test
-    @Ignore
     public void testGetAttributeName() throws Exception {
         Method method = HealthDataRecordTest.class.getMethod("getStartDate");
         assertEquals("startDate", DynamoInitializer.getAttributeName(method));
@@ -88,7 +83,6 @@ public class DynamoInitializerTest {
     }
 
     @Test
-    @Ignore
     public void testGetAttributeType() throws Exception {
         Method method = HealthDataRecordTest.class.getMethod("getStartDate");
         assertEquals(ScalarAttributeType.N, DynamoInitializer.getAttributeType(method));
@@ -97,9 +91,8 @@ public class DynamoInitializerTest {
     }
 
     @Test
-    @Ignore
     public void testGetCreateTableRequest() {
-        List<Class<?>> classes = DynamoInitializer.loadDynamoTableClasses(PACKAGE);
+        List<Class<? extends DynamoTable>> classes = DynamoInitializer.loadDynamoTableClasses(PACKAGE);
         List<TableDescription> tables = DynamoInitializer.getAnnotatedTables(classes);
         TableDescription table = tables.get(0);
         CreateTableRequest request = DynamoInitializer.getCreateTableRequest(table);
@@ -144,9 +137,8 @@ public class DynamoInitializerTest {
     }
 
     @Test
-    @Ignore
     public void testCompareSchema() {
-        List<Class<?>> classes = DynamoInitializer.loadDynamoTableClasses(PACKAGE);
+        List<Class<? extends DynamoTable>> classes = DynamoInitializer.loadDynamoTableClasses(PACKAGE);
         List<TableDescription> tables = DynamoInitializer.getAnnotatedTables(classes);
         TableDescription table1 = tables.get(0);
         TableDescription table2 = copyTableDescription(table1);
@@ -155,9 +147,8 @@ public class DynamoInitializerTest {
     }
 
     @Test(expected = BridgeInitializationException.class)
-    @Ignore
     public void testCompareSchemaDifferentKeys() {
-        List<Class<?>> classes = DynamoInitializer.loadDynamoTableClasses(PACKAGE);
+        List<Class<? extends DynamoTable>> classes = DynamoInitializer.loadDynamoTableClasses(PACKAGE);
         List<TableDescription> tables = DynamoInitializer.getAnnotatedTables(classes);
         TableDescription table1 = tables.get(0);
         TableDescription table2 = copyTableDescription(table1);
@@ -165,10 +156,9 @@ public class DynamoInitializerTest {
         DynamoInitializer.compareSchema(table1, table2);
     }
 
-    @Ignore
     @Test(expected = BridgeInitializationException.class)
     public void testCompareSchemaDifferentGlobalIndex() {
-        List<Class<?>> classes = DynamoInitializer.loadDynamoTableClasses(PACKAGE);
+        List<Class<? extends DynamoTable>> classes = DynamoInitializer.loadDynamoTableClasses(PACKAGE);
         List<TableDescription> tables = DynamoInitializer.getAnnotatedTables(classes);
         TableDescription table1 = tables.get(0);
         TableDescription table2 = copyTableDescription(table1);
@@ -177,9 +167,8 @@ public class DynamoInitializerTest {
     }
 
     @Test(expected = BridgeInitializationException.class)
-    @Ignore
     public void testCompareSchemaDifferentLocalIndex() {
-        List<Class<?>> classes = DynamoInitializer.loadDynamoTableClasses(PACKAGE);
+        List<Class<? extends DynamoTable>> classes = DynamoInitializer.loadDynamoTableClasses(PACKAGE);
         List<TableDescription> tables = DynamoInitializer.getAnnotatedTables(classes);
         TableDescription table1 = tables.get(0);
         TableDescription table2 = copyTableDescription(table1);
@@ -188,7 +177,6 @@ public class DynamoInitializerTest {
     }
 
     @Test(expected = BridgeInitializationException.class)
-    @Ignore
     public void compareSecondaryIndicesZeroToOne() {
         // one index in table 2
         List<GlobalSecondaryIndexDescription> indexList2 = ImmutableList.of(new GlobalSecondaryIndexDescription());
@@ -198,7 +186,6 @@ public class DynamoInitializerTest {
     }
 
     @Test(expected = BridgeInitializationException.class)
-    @Ignore
     public void compareSecondaryIndicesOneToZero() {
         // one index in table 1
         List<GlobalSecondaryIndexDescription> indexList1 = ImmutableList.of(new GlobalSecondaryIndexDescription());
@@ -208,7 +195,6 @@ public class DynamoInitializerTest {
     }
 
     @Test(expected = BridgeInitializationException.class)
-    @Ignore
     public void compareSecondaryIndicesOneToTwo() {
         // one index in table 1
         List<GlobalSecondaryIndexDescription> indexList1 = ImmutableList.of(new GlobalSecondaryIndexDescription());
@@ -222,7 +208,6 @@ public class DynamoInitializerTest {
     }
 
     @Test(expected = BridgeInitializationException.class)
-    @Ignore
     public void compareSecondaryIndicesTwoToOne() {
         // two index in table 1
         List<GlobalSecondaryIndexDescription> indexList1 = ImmutableList.of(new GlobalSecondaryIndexDescription(),
@@ -236,20 +221,17 @@ public class DynamoInitializerTest {
     }
 
     @Test
-    @Ignore
     public void compareSecondaryIndicesNullToNull() {
         DynamoInitializer.compareSecondaryIndices("test-table", null, null, true);
     }
 
     @Test
-    @Ignore
     public void compareSecondaryIndicesZeroToZero() {
         DynamoInitializer.compareSecondaryIndices("test-table", Collections.emptyList(), Collections.emptyList(),
                 true);
     }
 
     @Test(expected = BridgeInitializationException.class)
-    @Ignore
     public void compareGlobalIndicesDifferentName() {
         // indices
         GlobalSecondaryIndexDescription sameIndex = makeGlobalIndex("same-index", "same-key",
@@ -265,7 +247,6 @@ public class DynamoInitializerTest {
     }
 
     @Test(expected = BridgeInitializationException.class)
-    @Ignore
     public void compareGlobalIndicesDifferentKeys() {
         // indices
         GlobalSecondaryIndexDescription sameIndex = makeGlobalIndex("same-index", "same-key",
@@ -281,7 +262,6 @@ public class DynamoInitializerTest {
     }
 
     @Test(expected = BridgeInitializationException.class)
-    @Ignore
     public void compareGlobalIndicesDifferentProjections() {
         // indices
         GlobalSecondaryIndexDescription sameIndex = makeGlobalIndex("same-index", "same-key",
@@ -299,7 +279,6 @@ public class DynamoInitializerTest {
     }
 
     @Test(expected = BridgeInitializationException.class)
-    @Ignore
     public void compareGlobalIndicesDifferentReadCapacity() {
         // indices
         GlobalSecondaryIndexDescription sameIndex = makeGlobalIndex("same-index", "same-key",
@@ -317,7 +296,6 @@ public class DynamoInitializerTest {
     }
 
     @Test(expected = BridgeInitializationException.class)
-    @Ignore
     public void compareGlobalIndicesDifferentWriteCapacity() {
         // indices
         GlobalSecondaryIndexDescription sameIndex = makeGlobalIndex("same-index", "same-key",
@@ -335,7 +313,6 @@ public class DynamoInitializerTest {
     }
 
     @Test
-    @Ignore
     public void compareSameGlobalIndicesInDifferentOrder() {
         // indices
         GlobalSecondaryIndexDescription index1 = makeGlobalIndex("index1", "key1", ProjectionType.ALL, 25, 25);
@@ -349,7 +326,6 @@ public class DynamoInitializerTest {
     }
 
     @Test(expected = BridgeInitializationException.class)
-    @Ignore
     public void compareLocalIndicesDifferentNames() {
         // indices
         LocalSecondaryIndexDescription sameIndex = makeLocalIndex("same-index", "same-key", ProjectionType.ALL);
@@ -364,7 +340,6 @@ public class DynamoInitializerTest {
     }
 
     @Test(expected = BridgeInitializationException.class)
-    @Ignore
     public void compareLocalIndicesDifferentKeys() {
         // indices
         LocalSecondaryIndexDescription sameIndex = makeLocalIndex("same-index", "same-key", ProjectionType.ALL);
@@ -379,7 +354,6 @@ public class DynamoInitializerTest {
     }
 
     @Test(expected = BridgeInitializationException.class)
-    @Ignore
     public void compareLocalIndicesDifferentProjections() {
         // indices
         LocalSecondaryIndexDescription sameIndex = makeLocalIndex("same-index", "same-key", ProjectionType.ALL);
@@ -394,7 +368,6 @@ public class DynamoInitializerTest {
     }
 
     @Test
-    @Ignore
     public void compareSameLocalIndicesInDifferentOrder() {
         // indices
         LocalSecondaryIndexDescription index1 = makeLocalIndex("index1", "key1", ProjectionType.ALL);

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoInitializerTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoInitializerTest.java
@@ -41,7 +41,7 @@ public class DynamoInitializerTest {
 
     @Test
     public void testGetAnnotatedTables() {
-        List<Class<? extends DynamoTable>> classes = DynamoInitializer.loadDynamoTableClasses(PACKAGE);
+        List<Class<?>> classes = DynamoInitializer.loadDynamoTableClasses(PACKAGE);
         List<TableDescription> tables = DynamoInitializer.getAnnotatedTables(classes);
         assertNotNull(tables);
         assertEquals(1, tables.size());
@@ -64,7 +64,7 @@ public class DynamoInitializerTest {
 
     @Test
     public void testLoadDynamoTableClasses() {
-        List<Class<? extends DynamoTable>> classes = DynamoInitializer.loadDynamoTableClasses(PACKAGE);
+        List<Class<?>> classes = DynamoInitializer.loadDynamoTableClasses(PACKAGE);
         assertNotNull(classes);
         assertEquals(1, classes.size());
         Set<String> classSet = new HashSet<String>();
@@ -92,7 +92,7 @@ public class DynamoInitializerTest {
 
     @Test
     public void testGetCreateTableRequest() {
-        List<Class<? extends DynamoTable>> classes = DynamoInitializer.loadDynamoTableClasses(PACKAGE);
+        List<Class<?>> classes = DynamoInitializer.loadDynamoTableClasses(PACKAGE);
         List<TableDescription> tables = DynamoInitializer.getAnnotatedTables(classes);
         TableDescription table = tables.get(0);
         CreateTableRequest request = DynamoInitializer.getCreateTableRequest(table);
@@ -138,7 +138,7 @@ public class DynamoInitializerTest {
 
     @Test
     public void testCompareSchema() {
-        List<Class<? extends DynamoTable>> classes = DynamoInitializer.loadDynamoTableClasses(PACKAGE);
+        List<Class<?>> classes = DynamoInitializer.loadDynamoTableClasses(PACKAGE);
         List<TableDescription> tables = DynamoInitializer.getAnnotatedTables(classes);
         TableDescription table1 = tables.get(0);
         TableDescription table2 = copyTableDescription(table1);
@@ -148,7 +148,7 @@ public class DynamoInitializerTest {
 
     @Test(expected = BridgeInitializationException.class)
     public void testCompareSchemaDifferentKeys() {
-        List<Class<? extends DynamoTable>> classes = DynamoInitializer.loadDynamoTableClasses(PACKAGE);
+        List<Class<?>> classes = DynamoInitializer.loadDynamoTableClasses(PACKAGE);
         List<TableDescription> tables = DynamoInitializer.getAnnotatedTables(classes);
         TableDescription table1 = tables.get(0);
         TableDescription table2 = copyTableDescription(table1);
@@ -158,7 +158,7 @@ public class DynamoInitializerTest {
 
     @Test(expected = BridgeInitializationException.class)
     public void testCompareSchemaDifferentGlobalIndex() {
-        List<Class<? extends DynamoTable>> classes = DynamoInitializer.loadDynamoTableClasses(PACKAGE);
+        List<Class<?>> classes = DynamoInitializer.loadDynamoTableClasses(PACKAGE);
         List<TableDescription> tables = DynamoInitializer.getAnnotatedTables(classes);
         TableDescription table1 = tables.get(0);
         TableDescription table2 = copyTableDescription(table1);
@@ -168,7 +168,7 @@ public class DynamoInitializerTest {
 
     @Test(expected = BridgeInitializationException.class)
     public void testCompareSchemaDifferentLocalIndex() {
-        List<Class<? extends DynamoTable>> classes = DynamoInitializer.loadDynamoTableClasses(PACKAGE);
+        List<Class<?>> classes = DynamoInitializer.loadDynamoTableClasses(PACKAGE);
         List<TableDescription> tables = DynamoInitializer.getAnnotatedTables(classes);
         TableDescription table1 = tables.get(0);
         TableDescription table2 = copyTableDescription(table1);

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoInitializerTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoInitializerTest.java
@@ -58,8 +58,8 @@ public class DynamoInitializerTest {
         assertEquals(5, table.getAttributeDefinitions().size());
         assertEquals(2, table.getLocalSecondaryIndexes().size());
         assertEquals(1, table.getGlobalSecondaryIndexes().size());
-        assertEquals(25L, table.getProvisionedThroughput().getReadCapacityUnits().longValue());
-        assertEquals(25L, table.getProvisionedThroughput().getWriteCapacityUnits().longValue());
+        assertEquals(30L, table.getProvisionedThroughput().getReadCapacityUnits().longValue());
+        assertEquals(50L, table.getProvisionedThroughput().getWriteCapacityUnits().longValue());
     }
 
     @Test
@@ -132,8 +132,8 @@ public class DynamoInitializerTest {
         assertEquals(5, attributes.size());
 
         // Throughput
-        assertEquals(25L, request.getProvisionedThroughput().getReadCapacityUnits().longValue());
-        assertEquals(25L, request.getProvisionedThroughput().getWriteCapacityUnits().longValue());
+        assertEquals(30L, request.getProvisionedThroughput().getReadCapacityUnits().longValue());
+        assertEquals(50L, request.getProvisionedThroughput().getWriteCapacityUnits().longValue());
     }
 
     @Test
@@ -270,40 +270,6 @@ public class DynamoInitializerTest {
                 ProjectionType.ALL, 25, 25);
         GlobalSecondaryIndexDescription diffIndex2 = makeGlobalIndex("diff-index", "diff-key",
                 ProjectionType.KEYS_ONLY, 25, 25);
-
-        List<GlobalSecondaryIndexDescription> indexList1 = ImmutableList.of(sameIndex, diffIndex1);
-        List<GlobalSecondaryIndexDescription> indexList2 = ImmutableList.of(sameIndex, diffIndex2);
-
-        // execute (expected exception)
-        DynamoInitializer.compareSecondaryIndices("test-table", indexList1, indexList2, true);
-    }
-
-    @Test(expected = BridgeInitializationException.class)
-    public void compareGlobalIndicesDifferentReadCapacity() {
-        // indices
-        GlobalSecondaryIndexDescription sameIndex = makeGlobalIndex("same-index", "same-key",
-                ProjectionType.ALL, 25, 25);
-        GlobalSecondaryIndexDescription diffIndex1 = makeGlobalIndex("diff-index", "diff-key",
-                ProjectionType.ALL, 25, 25);
-        GlobalSecondaryIndexDescription diffIndex2 = makeGlobalIndex("diff-index", "diff-key",
-                ProjectionType.ALL, 24, 25);
-
-        List<GlobalSecondaryIndexDescription> indexList1 = ImmutableList.of(sameIndex, diffIndex1);
-        List<GlobalSecondaryIndexDescription> indexList2 = ImmutableList.of(sameIndex, diffIndex2);
-
-        // execute (expected exception)
-        DynamoInitializer.compareSecondaryIndices("test-table", indexList1, indexList2, true);
-    }
-
-    @Test(expected = BridgeInitializationException.class)
-    public void compareGlobalIndicesDifferentWriteCapacity() {
-        // indices
-        GlobalSecondaryIndexDescription sameIndex = makeGlobalIndex("same-index", "same-key",
-                ProjectionType.ALL, 25, 25);
-        GlobalSecondaryIndexDescription diffIndex1 = makeGlobalIndex("diff-index", "diff-key",
-                ProjectionType.ALL, 25, 25);
-        GlobalSecondaryIndexDescription diffIndex2 = makeGlobalIndex("diff-index", "diff-key",
-                ProjectionType.ALL, 25, 21);
 
         List<GlobalSecondaryIndexDescription> indexList1 = ImmutableList.of(sameIndex, diffIndex1);
         List<GlobalSecondaryIndexDescription> indexList2 = ImmutableList.of(sameIndex, diffIndex2);

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoTestUtil.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoTestUtil.java
@@ -31,7 +31,7 @@ public class DynamoTestUtil {
                 secretKey));
     }
 
-    public static <T extends DynamoTable> void clearTable(Class<T> clazz) {
+    public static void clearTable(Class<?> clazz) {
         List<String> keyAttrs = getKeyAttrs(clazz);
         String tableName = TableNameOverrideFactory.getTableNameOverride(clazz).getTableName();
         ScanResult result = DYNAMO.scan((new ScanRequest(tableName)).withAttributesToGet(keyAttrs));
@@ -51,7 +51,7 @@ public class DynamoTestUtil {
         } while (items != null);
     }
 
-    private static <T extends DynamoTable> List<String> getKeyAttrs(Class<T> clazz) {
+    private static List<String> getKeyAttrs(Class<?> clazz) {
         List<String> keyAttrs = new ArrayList<String>();
         Method[] methods = clazz.getMethods();
         for (Method method : methods) {

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoTestUtil.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoTestUtil.java
@@ -16,7 +16,6 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.ScanRequest;
 import com.amazonaws.services.dynamodbv2.model.ScanResult;
@@ -34,8 +33,7 @@ public class DynamoTestUtil {
 
     public static <T extends DynamoTable> void clearTable(Class<T> clazz) {
         List<String> keyAttrs = getKeyAttrs(clazz);
-        String tableName = clazz.getAnnotation(DynamoDBTable.class).tableName();
-        tableName = DynamoInitializer.getTableName(tableName);
+        String tableName = TableNameOverrideFactory.getTableNameOverride(clazz).getTableName();
         ScanResult result = DYNAMO.scan((new ScanRequest(tableName)).withAttributesToGet(keyAttrs));
         List<Map<String, AttributeValue>> items = result.getItems();
         do {

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoTestUtil.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoTestUtil.java
@@ -33,7 +33,7 @@ public class DynamoTestUtil {
 
     public static void clearTable(Class<?> clazz) {
         List<String> keyAttrs = getKeyAttrs(clazz);
-        String tableName = TableNameOverrideFactory.getTableNameOverride(clazz).getTableName();
+        String tableName = TableNameOverrideFactory.getTableName(clazz);
         ScanResult result = DYNAMO.scan((new ScanRequest(tableName)).withAttributesToGet(keyAttrs));
         List<Map<String, AttributeValue>> items = result.getItems();
         do {

--- a/test/org/sagebionetworks/bridge/dynamodb/test/HealthDataRecordTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/test/HealthDataRecordTest.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.dynamodb.test;
 
+import org.sagebionetworks.bridge.dynamodb.DynamoThroughput;
 import org.sagebionetworks.bridge.dynamodb.JsonNodeMarshaller;
 import org.sagebionetworks.bridge.json.DateTimeJsonDeserializer;
 import org.sagebionetworks.bridge.json.DateTimeJsonSerializer;
@@ -17,6 +18,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
+@DynamoThroughput(writeCapacity = 50, readCapacity = 30)
 @DynamoDBTable(tableName = "HealthDataRecord")
 public class HealthDataRecordTest implements HealthDataRecord {
 

--- a/test/org/sagebionetworks/bridge/dynamodb/test/HealthDataRecordTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/test/HealthDataRecordTest.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.bridge.dynamodb.test;
 
-import org.sagebionetworks.bridge.dynamodb.DynamoTable;
 import org.sagebionetworks.bridge.dynamodb.JsonNodeMarshaller;
 import org.sagebionetworks.bridge.json.DateTimeJsonDeserializer;
 import org.sagebionetworks.bridge.json.DateTimeJsonSerializer;
@@ -19,7 +18,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @DynamoDBTable(tableName = "HealthDataRecord")
-public class HealthDataRecordTest implements HealthDataRecord, DynamoTable {
+public class HealthDataRecordTest implements HealthDataRecord {
 
     private String key;
     private String guid;


### PR DESCRIPTION
1) Remove the interface DynamoTable.
2) Add annotation DynamoThroughput. Use this annotation to specify throughputs that not the default values.
3) Remove the throughput validation on global indices.

TODO: Update throughputs via the initializer.
