### PR TITLE
remove PDF Consent Docs to fix build break

### DIFF
--- a/app/org/sagebionetworks/bridge/services/SendMailViaAmazonService.java
+++ b/app/org/sagebionetworks/bridge/services/SendMailViaAmazonService.java
@@ -13,8 +13,6 @@ import java.util.Properties;
 import java.util.Set;
 
 import javax.annotation.Resource;
-import javax.activation.DataHandler;
-import javax.activation.DataSource;
 import javax.mail.Message;
 import javax.mail.MessagingException;
 import javax.mail.Session;
@@ -23,7 +21,6 @@ import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
 import javax.mail.internet.PreencodedMimeBodyPart;
-import javax.mail.util.ByteArrayDataSource;
 
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.format.DateTimeFormat;
@@ -40,7 +37,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.stereotype.Component;
-import org.xhtmlrenderer.pdf.ITextRenderer;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.regions.Region;
@@ -49,10 +45,8 @@ import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient;
 import com.amazonaws.services.simpleemail.model.RawMessage;
 import com.amazonaws.services.simpleemail.model.SendRawEmailRequest;
 import com.amazonaws.services.simpleemail.model.SendRawEmailResult;
-import com.fasterxml.jackson.core.util.ByteArrayBuilder;
 import com.google.common.base.Charsets;
 import com.google.common.io.CharStreams;
-import com.lowagie.text.DocumentException;
 
 @Component("sendEmailViaAmazonService")
 public class SendMailViaAmazonService implements SendMailService {
@@ -74,7 +68,6 @@ public class SendMailViaAmazonService implements SendMailService {
     private static final String MIME_TYPE_TSV = "text/tab-separated-value";
     private static final String MIME_TYPE_HTML = "text/html";
     private static final String MIME_TYPE_TEXT = "text/plain";
-    private static final String MIME_TYPE_PDF = "application/pdf";
     private static final String DELIMITER = "\t";
     private static final String NEWLINE = "\n";
     private static final Region region = Region.getRegion(Regions.US_EAST_1);
@@ -106,17 +99,6 @@ public class SendMailViaAmazonService implements SendMailService {
             final MimeBodyPart bodyPart = new MimeBodyPart();
             bodyPart.setContent(consentDoc, MIME_TYPE_HTML);
 
-            // Consent agreement as a PDF attachment
-            // Embed the signature image
-            String consentDocWithSig = consentDoc.replace("cid:consentSignature",
-                    "data:" + consentSignature.getImageMimeType() +
-                    ";base64," + consentSignature.getImageData());
-            final byte[] pdfBytes = createPdf(consentDocWithSig);
-            final MimeBodyPart pdfPart = new MimeBodyPart();
-            DataSource source = new ByteArrayDataSource(pdfBytes, MIME_TYPE_PDF);
-            pdfPart.setDataHandler(new DataHandler(source));
-            pdfPart.setFileName("consent.pdf");
-
             // Write signature image as an attachment, if it exists. Because of the validation in ConsentSignature, if
             // imageData is present, so will imageMimeType.
             // We need to send the signature image as an embedded image in an attachment because some email providers
@@ -137,10 +119,10 @@ public class SendMailViaAmazonService implements SendMailService {
             final String sendFromEmail = isNotBlank(study.getSupportEmail()) ?
                     String.format("%s <%s>", study.getName(), study.getSupportEmail()) : supportEmail;
 
-            sendEmailTo(subject, sendFromEmail, user.getEmail(), bodyPart, pdfPart, sigPart);
+            sendEmailTo(subject, sendFromEmail, user.getEmail(), bodyPart, sigPart);
             Set<String> emailAddresses = commaListToSet(study.getConsentNotificationEmail());
             for (String email : emailAddresses) {
-                sendEmailTo(subject, supportEmail, email, bodyPart, pdfPart, sigPart);
+                sendEmailTo(subject, supportEmail, email, bodyPart, sigPart);
             }
         } catch(IOException | MessagingException e) {
             throw new BridgeServiceException(e);
@@ -277,19 +259,6 @@ public class SendMailViaAmazonService implements SendMailService {
         sb.append( (value != null) ? value.replaceAll("\t", " ") : "" );
         if (withComma) {
             sb.append(DELIMITER);
-        }
-    }
- 
-    private byte[] createPdf(final String consentDoc) {
-        try (ByteArrayBuilder byteArrayBuilder = new ByteArrayBuilder();) {
-            ITextRenderer renderer = new ITextRenderer();
-            renderer.setDocumentFromString(consentDoc);
-            renderer.layout();
-            renderer.createPDF(byteArrayBuilder);
-            byteArrayBuilder.flush();
-            return byteArrayBuilder.toByteArray();
-        } catch (DocumentException e) {
-            throw new BridgeServiceException(e);
         }
     }
 }

--- a/test/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceConsentTest.java
+++ b/test/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceConsentTest.java
@@ -123,7 +123,6 @@ public class SendMailViaAmazonServiceConsentTest {
         assertTrue("Contains consent content", rawMessage.contains("Had this been a real study"));
         assertTrue("Name transposed to document", rawMessage.contains("Test 2"));
         assertTrue("Email transposed to document", rawMessage.contains(user.getEmail()));
-        assertTrue("Has the PDF consent document", rawMessage.contains("pdf"));
     }
 
     @Test


### PR DESCRIPTION
https://github.com/Sage-Bionetworks/BridgePF/pull/512/files was causing issues because it was trying to convert the HTML Consent Docs into PDFs as XML. However, the &reg; entity (R with a circle) was causing the XML parser to throw errors.

This change surgically removes the PDF code, with https://sagebionetworks.jira.com/browse/BRIDGE-387 to track the proper fix for this.

Testing done:
- Unit tests for Send Mail Service passed.
- Manually tested with the Breast Cancer Consent Doc (which has the offending entity). Tested that this repros with the old code and that it succeeds with the PDF code removed.
