### PR TITLE
logging updates

### DIFF
--- a/app/interceptors/ExceptionInterceptor.java
+++ b/app/interceptors/ExceptionInterceptor.java
@@ -2,6 +2,7 @@ package interceptors;
 
 import java.util.Set;
 
+import com.google.common.collect.ImmutableSet;
 import models.ExceptionMessage;
 
 import org.aopalliance.intercept.MethodInterceptor;
@@ -16,6 +17,7 @@ import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.exceptions.NotAuthenticatedException;
+import org.sagebionetworks.bridge.exceptions.NotFoundException;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.models.UserSessionInfo;
 import org.slf4j.Logger;
@@ -28,23 +30,17 @@ import play.mvc.Http;
 import play.mvc.Results;
 
 import com.google.common.base.Throwables;
-import com.google.common.collect.Sets;
 
 @Component("exceptionInterceptor")
 public class ExceptionInterceptor implements MethodInterceptor {
 
     private static Logger logger = LoggerFactory.getLogger(ExceptionInterceptor.class);
-    
-    private static Set<Class<? extends BridgeServiceException>> quietExceptions = Sets.newHashSet();
-    static {
-        quietExceptions.add(BadRequestException.class);
-        quietExceptions.add(InvalidEntityException.class);
-        quietExceptions.add(EntityAlreadyExistsException.class);
-        quietExceptions.add(EntityNotFoundException.class);
-        quietExceptions.add(UnauthorizedException.class);
-        quietExceptions.add(NotAuthenticatedException.class);
-    }
-    
+
+    private static Set<Class<? extends BridgeServiceException>> quietExceptions = ImmutableSet.of(
+            BadRequestException.class, InvalidEntityException.class, EntityAlreadyExistsException.class,
+            EntityNotFoundException.class, NotFoundException.class, UnauthorizedException.class,
+            NotAuthenticatedException.class);
+
     private BridgeConfig config;
     
     @Autowired
@@ -57,8 +53,6 @@ public class ExceptionInterceptor implements MethodInterceptor {
         try {
             return method.proceed();
         } catch(Throwable throwable) {
-            throwable = Throwables.getRootCause(throwable);
-            
             // Consent exceptions return a session payload (you are signed in),
             // but a 412 error status code.
             if (throwable instanceof ConsentRequiredException) {

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadDao.java
@@ -16,6 +16,7 @@ import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
 import org.sagebionetworks.bridge.dao.UploadDao;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
+import org.sagebionetworks.bridge.exceptions.NotFoundException;
 import org.sagebionetworks.bridge.models.upload.Upload;
 import org.sagebionetworks.bridge.models.upload.UploadRequest;
 import org.sagebionetworks.bridge.models.upload.UploadStatus;
@@ -82,7 +83,7 @@ public class DynamoUploadDao implements UploadDao {
             }
         }
 
-        throw new BridgeServiceException(String.format("Upload ID %s not found", uploadId), HttpStatus.SC_NOT_FOUND);
+        throw new NotFoundException(String.format("Upload ID %s not found", uploadId));
     }
 
     /** {@inheritDoc} */

--- a/app/org/sagebionetworks/bridge/exceptions/NotFoundException.java
+++ b/app/org/sagebionetworks/bridge/exceptions/NotFoundException.java
@@ -1,0 +1,15 @@
+package org.sagebionetworks.bridge.exceptions;
+
+import org.apache.commons.httpclient.HttpStatus;
+
+/** Generic 404 NOT FOUND exception for things that aren't BridgeEntities. */
+@SuppressWarnings("serial")
+public class NotFoundException extends BridgeServiceException {
+    public NotFoundException(String message) {
+        super(message, HttpStatus.SC_NOT_FOUND);
+    }
+
+    public NotFoundException(Throwable throwable) {
+        super(throwable, HttpStatus.SC_NOT_FOUND);
+    }
+}

--- a/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler.java
+++ b/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler.java
@@ -20,8 +20,6 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -40,8 +38,6 @@ import org.sagebionetworks.bridge.services.UploadSchemaService;
 // so that it only runs in the iOS context.
 @Component
 public class IosSchemaValidationHandler implements UploadValidationHandler {
-    private static final Logger logger = LoggerFactory.getLogger(IosSchemaValidationHandler.class);
-
     private static final Set<UploadFieldType> ATTACHMENT_TYPE_SET = EnumSet.of(UploadFieldType.ATTACHMENT_BLOB,
             UploadFieldType.ATTACHMENT_CSV, UploadFieldType.ATTACHMENT_JSON_BLOB,
             UploadFieldType.ATTACHMENT_JSON_TABLE);
@@ -632,8 +628,8 @@ public class IosSchemaValidationHandler implements UploadValidationHandler {
         }
     }
 
+    // This method used to add warnings to the log. It has since been decided that these log warnings are not useful.
     private static void addMessageAndWarn(UploadValidationContext context, String message) {
         context.addMessage(message);
-        logger.warn(message);
     }
 }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoUploadDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoUploadDaoMockTest.java
@@ -20,7 +20,7 @@ import org.joda.time.LocalDate;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
-import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
+import org.sagebionetworks.bridge.exceptions.NotFoundException;
 import org.sagebionetworks.bridge.models.upload.Upload;
 import org.sagebionetworks.bridge.models.upload.UploadRequest;
 import org.sagebionetworks.bridge.models.upload.UploadStatus;
@@ -113,7 +113,7 @@ public class DynamoUploadDaoMockTest {
         try {
             dao.getUpload("test-get-404");
             fail();
-        } catch (BridgeServiceException ex) {
+        } catch (NotFoundException ex) {
             thrown = ex;
         }
         assertNotNull(thrown);


### PR DESCRIPTION
Changes include:
- ExceptionInterceptor quietExceptions uses ImmutableSet instead of a static instantiator. This is cleaner.
- Created NotFoundException to represent 404s not tied to BridgeEntities and added it to quietExceptions.
- Removed Throwables.getRootCause() from ExceptionInterceptor. The exception we're interested in is always the outermost exception, not the innermost exception.
- Updated DynamoUploadDao to use NotFoundException. This catches the /api/v1/upload/(null)/complete issue.
- Fixed warning format for calling upload complete for uploads that are already complete.
- Added try-catch to catch S3 exceptions in upload complete and wrap them in a NotFoundException.
- Removed generally non-useful warnings from IosSchemaValidationHandler. (The exception logged by UploadValidationTask is still useful, though.)

Testing done:
- /api/v1/upload/(null)/complete
- upload complete without uploading file to S3
- upload bad file, ensure validation messages aren't logged as warnings
- upload complete again, and verify warning format
