### PR TITLE
Remove the questions property from surveys

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurvey.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurvey.java
@@ -180,7 +180,7 @@ public class DynamoSurvey implements Survey {
 
     @Override
     @DynamoDBIgnore
-    @JsonProperty("questions")
+    @JsonIgnore
     public List<SurveyQuestion> getUnmodifiableQuestionList() {
         ImmutableList.Builder<SurveyQuestion> builder = new ImmutableList.Builder<SurveyQuestion>();
         for (SurveyElement element : elements) {

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.dynamodb;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
@@ -29,12 +30,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public class DynamoSurveyTest {
     
+    private Survey newSurvey;
     private Survey survey;
     
     @Before
     public void before() throws Exception {
         SurveyValidator validator = new SurveyValidator();
-        DynamoSurvey newSurvey = new TestSurvey(false);
+        newSurvey = new TestSurvey(false);
         try {
             Validate.entityThrowingException(validator, newSurvey);
         } catch(Throwable t) {
@@ -55,7 +57,8 @@ public class DynamoSurveyTest {
     
     @Test
     public void yetAnotherSerializationTest() {
-        assertEquals("Correct serialize/deserialize survey", survey.hashCode(), survey.hashCode());
+        // What? What does this even test?
+        assertEquals("Correct serialize/deserialize survey", newSurvey.hashCode(), survey.hashCode());
     }
     
     @Test
@@ -120,5 +123,16 @@ public class DynamoSurveyTest {
         // There's only one question in the question list
         assertEquals(1, survey.getUnmodifiableQuestionList().size());
         assertEquals(DynamoSurveyQuestion.class, survey.getUnmodifiableQuestionList().get(0).getClass());
+    }
+    
+    // This was a legacy property that we want removed. It cuts the size of surveys by half 
+    // (before compression)
+    @Test
+    public void surveyJsonDoesNotIncludeQuestionsProperty() throws Exception {
+        ObjectMapper mapper = BridgeObjectMapper.get();
+        String json = mapper.writeValueAsString(survey);
+        
+        System.out.println(json);
+        assertFalse(json.contains("\"questions\""));
     }
 }


### PR DESCRIPTION
It's deprecated and nearly identical to the elements property. Since Ymedia is currently using no surveys from the server, this can finally be removed without breaking the applications (they should have already moved to the elements property, but we couldn't completely confirm this).
