### PR TITLE
Refactoring the email sender into some components

### DIFF
--- a/app/org/sagebionetworks/bridge/services/ConsentServiceImpl.java
+++ b/app/org/sagebionetworks/bridge/services/ConsentServiceImpl.java
@@ -20,6 +20,8 @@ import org.sagebionetworks.bridge.models.studies.StudyConsent;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.redis.JedisStringOps;
 import org.sagebionetworks.bridge.redis.RedisKey;
+import org.sagebionetworks.bridge.services.email.ConsentEmailProvider;
+import org.sagebionetworks.bridge.services.email.MimeTypeEmailProvider;
 import org.sagebionetworks.bridge.validators.ConsentAgeValidator;
 import org.sagebionetworks.bridge.validators.Validate;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -108,7 +110,8 @@ public class ConsentServiceImpl implements ConsentService {
         optionsService.setOption(study, user.getHealthCode(), sharingScope);
 
         if (sendEmail) {
-            sendMailService.sendConsentAgreement(user, consentSignature, studyConsent, sharingScope);
+            MimeTypeEmailProvider consentEmail = new ConsentEmailProvider(study, user, consentSignature, studyConsent, sharingScope);
+            sendMailService.sendEmail(consentEmail);
         }
 
         user.setConsent(true);
@@ -170,7 +173,8 @@ public class ConsentServiceImpl implements ConsentService {
         }
 
         final SharingScope sharingScope = optionsService.getSharingScope(user.getHealthCode());
-        sendMailService.sendConsentAgreement(user, consentSignature, consent, sharingScope);
+        MimeTypeEmailProvider consentEmail = new ConsentEmailProvider(study, user, consentSignature, consent, sharingScope); 
+        sendMailService.sendEmail(consentEmail);
     }
 
     @Override

--- a/app/org/sagebionetworks/bridge/services/ParticipantRosterGenerator.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantRosterGenerator.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.bridge.services;
 
 import java.util.Collections;
-
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -9,6 +8,8 @@ import java.util.List;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyParticipant;
+import org.sagebionetworks.bridge.services.email.MimeTypeEmailProvider;
+import org.sagebionetworks.bridge.services.email.ParticipantRosterProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,7 +59,9 @@ public class ParticipantRosterGenerator implements Runnable {
                 }
             }
             Collections.sort(participants, STUDY_PARTICIPANT_COMPARATOR);
-            sendMailService.sendStudyParticipantsRoster(study, participants);
+            
+            MimeTypeEmailProvider roster = new ParticipantRosterProvider(study, participants);
+            sendMailService.sendEmail(roster);
         } catch(Exception e) {
             logger.error(e.getMessage(), e);
         }

--- a/app/org/sagebionetworks/bridge/services/SendMailService.java
+++ b/app/org/sagebionetworks/bridge/services/SendMailService.java
@@ -1,18 +1,9 @@
 package org.sagebionetworks.bridge.services;
 
-import java.util.List;
-
-import org.sagebionetworks.bridge.dao.ParticipantOption.SharingScope;
-import org.sagebionetworks.bridge.models.User;
-import org.sagebionetworks.bridge.models.studies.ConsentSignature;
-import org.sagebionetworks.bridge.models.studies.Study;
-import org.sagebionetworks.bridge.models.studies.StudyConsent;
-import org.sagebionetworks.bridge.models.studies.StudyParticipant;
+import org.sagebionetworks.bridge.services.email.MimeTypeEmailProvider;
 
 public interface SendMailService {
 
-    void sendConsentAgreement(User caller, ConsentSignature consent, StudyConsent studyConsent,
-            SharingScope sharingScope);
+    public void sendEmail(MimeTypeEmailProvider provider);
 
-    void sendStudyParticipantsRoster(Study study, List<StudyParticipant> participants);
 }

--- a/app/org/sagebionetworks/bridge/services/UserProfileServiceImpl.java
+++ b/app/org/sagebionetworks/bridge/services/UserProfileServiceImpl.java
@@ -72,6 +72,9 @@ public class UserProfileServiceImpl implements UserProfileService {
         if (isBlank(study.getConsentNotificationEmail())) {
             throw new BridgeServiceException("Participant roster cannot be sent because no consent notification contact email exists for this study.");
         }
+        // Getting the study accounts would be the time-consuming activity here, but in fact only the 
+        // first page is retrieved and the rest is retrieved in the new thread during page iteration.
+        // Not clear though from this code, and could change with the implementation.
         Iterator<Account> accounts = accountDao.getStudyAccounts(study);
         executorService.submit(new ParticipantRosterGenerator(accounts, study, sendMailService));
     }

--- a/app/org/sagebionetworks/bridge/services/email/ConsentEmailProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/ConsentEmailProvider.java
@@ -58,14 +58,14 @@ public class ConsentEmailProvider implements MimeTypeEmailProvider {
     }
 
     @Override
-    public MimeTypeEmail getEmail(String defaultFromEmail) throws MessagingException {
+    public MimeTypeEmail getEmail(String defaultSender) throws MessagingException {
         MimeTypeEmailBuilder builder = new MimeTypeEmailBuilder();
         
         String subject = String.format(CONSENT_EMAIL_SUBJECT, study.getName());
         builder.withSubject(subject);
         
         final String sendFromEmail = isNotBlank(study.getSupportEmail()) ?
-                String.format("%s <%s>", study.getName(), study.getSupportEmail()) : defaultFromEmail;
+                String.format("%s <%s>", study.getName(), study.getSupportEmail()) : defaultSender;
         builder.withSender(sendFromEmail);
         
         builder.withRecipient(user.getEmail());

--- a/app/org/sagebionetworks/bridge/services/email/ConsentEmailProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/ConsentEmailProvider.java
@@ -1,0 +1,156 @@
+package org.sagebionetworks.bridge.services.email;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Set;
+
+import javax.activation.DataHandler;
+import javax.activation.DataSource;
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeBodyPart;
+import javax.mail.internet.PreencodedMimeBodyPart;
+import javax.mail.util.ByteArrayDataSource;
+
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.sagebionetworks.bridge.dao.ParticipantOption.SharingScope;
+import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
+import org.sagebionetworks.bridge.json.DateUtils;
+import org.sagebionetworks.bridge.models.User;
+import org.sagebionetworks.bridge.models.studies.ConsentSignature;
+import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.studies.StudyConsent;
+import org.springframework.core.io.FileSystemResource;
+import org.xhtmlrenderer.pdf.ITextRenderer;
+
+import com.fasterxml.jackson.core.util.ByteArrayBuilder;
+import com.google.common.io.CharStreams;
+import com.lowagie.text.DocumentException;
+
+public class ConsentEmailProvider implements MimeTypeEmailProvider {
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormat.forPattern("MMMM d, yyyy");
+    private static final String CONSENT_EMAIL_SUBJECT = "Consent Agreement for %s";
+    private static final String HEADER_CONTENT_DISPOSITION_CONSENT_VALUE = "inline";
+    private static final String HEADER_CONTENT_ID_CONSENT_VALUE = "<consentSignature>";
+    private static final String HEADER_CONTENT_DISPOSITION = "Content-Disposition";
+    private static final String HEADER_CONTENT_TRANSFER_ENCODING_VALUE = "base64";
+    private static final String SUB_TYPE_HTML = "html";
+    private static final String MIME_TYPE_PDF = "application/pdf";
+    
+    private User user;
+    private Study study;
+    private ConsentSignature consentSignature;
+    private StudyConsent studyConsent;
+    private SharingScope sharingScope;
+
+    public ConsentEmailProvider(Study study, User user, ConsentSignature consentSignature, StudyConsent studyConsent,
+            SharingScope sharingScope) {
+        this.study = study;
+        this.user = user;
+        this.consentSignature = consentSignature;
+        this.studyConsent = studyConsent;
+        this.sharingScope = sharingScope;
+    }
+
+    @Override
+    public MimeTypeEmail getEmail(String defaultFromEmail) throws MessagingException {
+        MimeTypeEmailBuilder builder = new MimeTypeEmailBuilder();
+        
+        String subject = String.format(CONSENT_EMAIL_SUBJECT, study.getName());
+        builder.withSubject(subject);
+        
+        final String sendFromEmail = isNotBlank(study.getSupportEmail()) ?
+                String.format("%s <%s>", study.getName(), study.getSupportEmail()) : defaultFromEmail;
+        builder.withSender(sendFromEmail);
+        
+        builder.withRecipient(user.getEmail());
+        Set<String> emailAddresses = commaListToSet(study.getConsentNotificationEmail());
+        for (String email : emailAddresses) {
+            builder.withRecipient(email);
+        }
+                
+        final String consentDoc = createSignedDocument();
+        
+        // Consent agreement as message body in HTML
+        final MimeBodyPart bodyPart = new MimeBodyPart();
+        bodyPart.setText(consentDoc, StandardCharsets.UTF_8.name(), SUB_TYPE_HTML);
+        builder.withMessageParts(bodyPart);
+        
+        // Consent agreement as a PDF attachment
+        // Embed the signature image
+        String consentDocWithSig = consentDoc.replace("cid:consentSignature",
+                "data:" + consentSignature.getImageMimeType() +
+                ";base64," + consentSignature.getImageData());
+        final byte[] pdfBytes = createPdf(consentDocWithSig);
+        final MimeBodyPart pdfPart = new MimeBodyPart();
+        DataSource source = new ByteArrayDataSource(pdfBytes, MIME_TYPE_PDF);
+        pdfPart.setDataHandler(new DataHandler(source));
+        pdfPart.setFileName("consent.pdf");
+        builder.withMessageParts(pdfPart);
+        
+        // Write signature image as an attachment, if it exists. Because of the validation in ConsentSignature, if
+        // imageData is present, so will imageMimeType.
+        // We need to send the signature image as an embedded image in an attachment because some email providers
+        // (notably Gmail) block inline Base64 images.
+        MimeBodyPart sigPart = null;
+        if (consentSignature.getImageData() != null) {
+            // Use pre-encoded MIME part since our image data is already base64 encoded.
+            sigPart = new PreencodedMimeBodyPart(HEADER_CONTENT_TRANSFER_ENCODING_VALUE);
+            sigPart.setContentID(HEADER_CONTENT_ID_CONSENT_VALUE);
+            sigPart.setHeader(HEADER_CONTENT_DISPOSITION, HEADER_CONTENT_DISPOSITION_CONSENT_VALUE);
+            sigPart.setContent(consentSignature.getImageData(), consentSignature.getImageMimeType());
+        }
+        builder.withMessageParts(sigPart);
+
+        return builder.build();
+    }
+
+    private String createSignedDocument() {
+        final String filePath = studyConsent.getPath();
+        final FileSystemResource resource = new FileSystemResource(filePath);
+        try (InputStreamReader isr = new InputStreamReader(resource.getInputStream(), StandardCharsets.UTF_8);) {
+            String consentAgreementHTML = CharStreams.toString(isr);
+            String signingDate = FORMATTER.print(DateUtils.getCurrentMillisFromEpoch());
+            String html = consentAgreementHTML.replace("@@name@@", consentSignature.getName());
+            html = html.replace("@@signing.date@@", signingDate);
+            html = html.replace("@@email@@", user.getEmail());
+            String sharing = "";
+            if (SharingScope.ALL_QUALIFIED_RESEARCHERS == sharingScope) {
+                sharing = "All Qualified Researchers";
+            } else if (SharingScope.SPONSORS_AND_PARTNERS == sharingScope) {
+                sharing = "Sponsors and Partners Only";
+            } else if (SharingScope.NO_SHARING == sharingScope) {
+                sharing = "Not Sharing";
+            }
+            html = html.replace("@@sharing@@", sharing);
+            return html;
+        } catch (IOException e) {
+            throw new BridgeServiceException(e);
+        }
+    }
+
+    private byte[] createPdf(final String consentDoc) {
+        try (ByteArrayBuilder byteArrayBuilder = new ByteArrayBuilder();) {
+            ITextRenderer renderer = new ITextRenderer();
+            renderer.setDocumentFromString(consentDoc);
+            renderer.layout();
+            renderer.createPDF(byteArrayBuilder);
+            byteArrayBuilder.flush();
+            return byteArrayBuilder.toByteArray();
+        } catch (DocumentException e) {
+            throw new BridgeServiceException(e);
+        }
+    }
+    
+    private Set<String> commaListToSet(String commaList) {
+        if (isNotBlank(commaList)) {
+            return org.springframework.util.StringUtils.commaDelimitedListToSet(commaList);    
+        }
+        return Collections.emptySet();
+    }
+}

--- a/app/org/sagebionetworks/bridge/services/email/ConsentEmailProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/ConsentEmailProvider.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge.services.email;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -113,7 +114,10 @@ public class ConsentEmailProvider implements MimeTypeEmailProvider {
     private String createSignedDocument() {
         final String filePath = studyConsent.getPath();
         final FileSystemResource resource = new FileSystemResource(filePath);
-        try (InputStreamReader isr = new InputStreamReader(resource.getInputStream(), StandardCharsets.UTF_8);) {
+        
+        try (InputStream is = resource.getInputStream();
+             InputStreamReader isr = new InputStreamReader(is, StandardCharsets.UTF_8);) {
+            
             String consentAgreementHTML = CharStreams.toString(isr);
             String signingDate = FORMATTER.print(DateUtils.getCurrentMillisFromEpoch());
             String html = consentAgreementHTML.replace("@@name@@", consentSignature.getName());

--- a/app/org/sagebionetworks/bridge/services/email/MimeTypeEmail.java
+++ b/app/org/sagebionetworks/bridge/services/email/MimeTypeEmail.java
@@ -1,0 +1,48 @@
+package org.sagebionetworks.bridge.services.email;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import java.util.List;
+
+import javax.mail.internet.MimeBodyPart;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * This is a light wrapper around the information needed to construct a MIME multi-part email 
+ * message using the Java mail API.
+ */
+public final class MimeTypeEmail {
+
+    private final String subject;
+    private final String senderAddress;
+    private final List<String> recipientAddresses;
+    private final List<MimeBodyPart> messageParts;
+    
+    MimeTypeEmail(String subject, String senderAddress, List<String> recipientAddresses, List<MimeBodyPart> messageParts) {
+        checkArgument(isNotBlank(senderAddress));
+        checkArgument(isNotBlank(subject));
+        checkArgument(isNotBlank(senderAddress));
+        checkArgument(recipientAddresses != null && !recipientAddresses.isEmpty());
+        checkArgument(messageParts != null && !messageParts.isEmpty());
+        
+        this.subject = subject;
+        this.senderAddress = senderAddress;
+        this.recipientAddresses = recipientAddresses;
+        this.messageParts = ImmutableList.copyOf(messageParts);
+    }
+    
+    public String getSubject() {
+        return subject;
+    }
+    public String getSenderAddress() {
+        return senderAddress;
+    }
+    public List<String> getRecipientAddresses() {
+        return recipientAddresses;
+    }
+    public List<MimeBodyPart> getMessageParts() {
+        return messageParts;
+    }
+}

--- a/app/org/sagebionetworks/bridge/services/email/MimeTypeEmailBuilder.java
+++ b/app/org/sagebionetworks/bridge/services/email/MimeTypeEmailBuilder.java
@@ -1,0 +1,42 @@
+package org.sagebionetworks.bridge.services.email;
+
+import java.util.List;
+
+import javax.mail.internet.MimeBodyPart;
+
+import com.google.common.collect.Lists;
+
+class MimeTypeEmailBuilder {
+
+    private String subject;
+    private String senderAddress;
+    private List<String> recipientAddresses = Lists.newArrayList();
+    private List<MimeBodyPart> messageParts = Lists.newArrayList();
+    
+    MimeTypeEmailBuilder withSubject(String subject) {
+        this.subject = subject;
+        return this;
+    }
+    MimeTypeEmailBuilder withSender(String senderAddress) {
+        this.senderAddress = senderAddress;
+        return this;
+    }
+    MimeTypeEmailBuilder withRecipient(String recipientAddress) {
+        this.recipientAddresses.add(recipientAddress);
+        return this;
+    }
+    MimeTypeEmailBuilder withMessageParts(MimeBodyPart... parts) {
+        if (parts != null) {
+            for (MimeBodyPart part : parts) {
+                if (part != null) {
+                    messageParts.add(part);    
+                }
+            }
+        }
+        return this;
+    }
+    MimeTypeEmail build() {
+        return new MimeTypeEmail(subject, senderAddress, recipientAddresses, messageParts);
+    }
+
+}

--- a/app/org/sagebionetworks/bridge/services/email/MimeTypeEmailProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/MimeTypeEmailProvider.java
@@ -4,6 +4,6 @@ import javax.mail.MessagingException;
 
 public interface MimeTypeEmailProvider {
 
-    public MimeTypeEmail getEmail(String defaultFromEmail) throws MessagingException;
+    public MimeTypeEmail getEmail(String defaultSender) throws MessagingException;
     
 }

--- a/app/org/sagebionetworks/bridge/services/email/MimeTypeEmailProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/MimeTypeEmailProvider.java
@@ -1,0 +1,9 @@
+package org.sagebionetworks.bridge.services.email;
+
+import javax.mail.MessagingException;
+
+public interface MimeTypeEmailProvider {
+
+    public MimeTypeEmail getEmail(String defaultFromEmail) throws MessagingException;
+    
+}

--- a/app/org/sagebionetworks/bridge/services/email/ParticipantRosterProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/ParticipantRosterProvider.java
@@ -1,0 +1,125 @@
+package org.sagebionetworks.bridge.services.email;
+
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
+import java.util.List;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeBodyPart;
+
+import org.apache.commons.lang3.StringUtils;
+import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.studies.StudyParticipant;
+
+public class ParticipantRosterProvider implements MimeTypeEmailProvider {
+
+    private static final String PARTICIPANTS_EMAIL_SUBJECT = "Study participants for %s";
+    private static final String HEADER_CONTENT_DISPOSITION_PARTICIPANTS_VALUE = "attachment; filename=participants.tsv";
+    private static final String HEADER_CONTENT_ID_PARTICIPANTS_VALUE = "<participantsTSV>";
+    private static final String MIME_TYPE_TSV = "text/tab-separated-value";
+    private static final String DELIMITER = "\t";
+    private static final String NEWLINE = "\n";
+    private static final String HEADER_CONTENT_DISPOSITION = "Content-Disposition";
+    private static final String HEADER_CONTENT_TRANSFER_ENCODING = "Content-Transfer-Encoding";
+    private static final String HEADER_CONTENT_TRANSFER_ENCODING_VALUE = "base64";
+    private static final String MIME_TYPE_TEXT = "text/plain";
+    
+    private Study study;
+    private List<StudyParticipant> participants;
+    
+    public ParticipantRosterProvider(Study study, List<StudyParticipant> participants) {
+        this.study = study;
+        this.participants = participants;
+    }
+    
+    @Override
+    public MimeTypeEmail getEmail(String defaultFromEmail) throws MessagingException {
+        MimeTypeEmailBuilder builder = new MimeTypeEmailBuilder();
+        
+        builder.withSender(defaultFromEmail).withRecipient(study.getConsentNotificationEmail());
+        
+        String subject = String.format(PARTICIPANTS_EMAIL_SUBJECT, study.getName());
+        builder.withSubject(subject);
+        
+        MimeBodyPart body = new MimeBodyPart();
+        body.setContent(createInlineParticipantRoster(), MIME_TYPE_TEXT);
+        builder.withMessageParts(body);
+        
+        MimeBodyPart tsvFile = new MimeBodyPart();
+        tsvFile.setContentID(HEADER_CONTENT_ID_PARTICIPANTS_VALUE);
+        tsvFile.setHeader(HEADER_CONTENT_DISPOSITION, HEADER_CONTENT_DISPOSITION_PARTICIPANTS_VALUE);
+        tsvFile.setHeader(HEADER_CONTENT_TRANSFER_ENCODING, HEADER_CONTENT_TRANSFER_ENCODING_VALUE); 
+        tsvFile.setContent(createParticipantTSV(), MIME_TYPE_TSV);
+        builder.withMessageParts(tsvFile);
+        
+        return builder.build();
+    }
+    
+    List<StudyParticipant> getParticipants() {
+        return participants;
+    }
+    
+    String createInlineParticipantRoster() {
+        StringBuilder sb = new StringBuilder();
+        if (participants.size() == 0) {
+            sb.append("There are no users enrolled in this study.");
+        } else if (participants.size() == 1) {
+            sb.append("There is 1 user enrolled in this study:");
+        } else {
+            sb.append("There are "+participants.size()+" users enrolled in this study:");
+        }
+        sb.append(NEWLINE);
+        for (int i=0; i < participants.size(); i++) {
+            StudyParticipant participant = participants.get(i);
+            
+            sb.append(NEWLINE).append(participant.getEmail()).append(" (");
+            if (isEmpty(participant.getFirstName()) && isEmpty(participant.getLastName())) {
+                sb.append("No name given");
+            } else if (isNotEmpty(participant.getFirstName()) && isNotEmpty(participant.getLastName())) {
+                sb.append(participant.getFirstName()).append(" ").append(participant.getLastName());
+            } else {
+                sb.append(participant.getFirstName());
+                sb.append(participant.getLastName());
+            }
+            sb.append(")"+NEWLINE);
+            sb.append("Phone: ").append(participant.getPhone()).append(NEWLINE);    
+            for (String attribute : study.getUserProfileAttributes()) {
+                sb.append(StringUtils.capitalize(attribute)).append(": ").append(participant.getEmpty(attribute)).append(NEWLINE);
+            }
+        }
+        return sb.toString();
+    }
+
+    String createParticipantTSV() {
+        StringBuilder sb = new StringBuilder();
+        append(sb, "Email", false);
+        append(sb, "First Name", true);
+        append(sb, "Last Name", true);
+        append(sb, "Phone", true);
+        for (String attribute : study.getUserProfileAttributes()) {
+            append(sb, StringUtils.capitalize(attribute), true);
+        }
+        sb.append(NEWLINE);
+        for (int i=0; i < participants.size(); i++) {
+            StudyParticipant participant = participants.get(i);
+            append(sb, participant.getEmail(), false);
+            append(sb, participant.getFirstName(), true);
+            append(sb, participant.getLastName(), true);
+            append(sb, participant.getPhone(), true);
+            for (String attribute : study.getUserProfileAttributes()) {
+                append(sb, participant.getEmpty(attribute), true);
+            }
+            sb.append(NEWLINE);
+        }
+        return sb.toString();
+    }
+    
+    private void append(StringBuilder sb, String value, boolean withComma) {
+        if (withComma) {
+            sb.append(DELIMITER);
+        }
+        sb.append(value.replaceAll("\t", " "));
+    }
+
+}

--- a/app/org/sagebionetworks/bridge/services/email/ParticipantRosterProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/ParticipantRosterProvider.java
@@ -34,10 +34,10 @@ public class ParticipantRosterProvider implements MimeTypeEmailProvider {
     }
     
     @Override
-    public MimeTypeEmail getEmail(String defaultFromEmail) throws MessagingException {
+    public MimeTypeEmail getEmail(String defaultSender) throws MessagingException {
         MimeTypeEmailBuilder builder = new MimeTypeEmailBuilder();
         
-        builder.withSender(defaultFromEmail).withRecipient(study.getConsentNotificationEmail());
+        builder.withSender(defaultSender).withRecipient(study.getConsentNotificationEmail());
         
         String subject = String.format(PARTICIPANTS_EMAIL_SUBJECT, study.getName());
         builder.withSubject(subject);

--- a/test/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceConsentTest.java
+++ b/test/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceConsentTest.java
@@ -20,6 +20,7 @@ import org.sagebionetworks.bridge.models.User;
 import org.sagebionetworks.bridge.models.studies.ConsentSignature;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyConsent;
+import org.sagebionetworks.bridge.services.email.ConsentEmailProvider;
 
 import com.amazonaws.regions.Region;
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient;
@@ -60,7 +61,6 @@ public class SendMailViaAmazonServiceConsentTest {
         service = new SendMailViaAmazonService();
         service.setSupportEmail(FROM_DEFAULT_AS_FORMATTED);
         service.setEmailClient(emailClient);
-        service.setStudyService(studyService);
 
         studyConsent = new StudyConsent() {
             @Override
@@ -93,7 +93,9 @@ public class SendMailViaAmazonServiceConsentTest {
         ConsentSignature consent = ConsentSignature.create("Test 2", "1950-05-05", null, null);
         User user = new User();
         user.setEmail("test-user@sagebase.org");
-        service.sendConsentAgreement(user, consent, studyConsent, SharingScope.NO_SHARING);
+        
+        ConsentEmailProvider provider = new ConsentEmailProvider(study, user, consent, studyConsent, SharingScope.NO_SHARING);
+        service.sendEmail(provider);
 
         verify(emailClient).sendRawEmail(argument.capture());
         SendRawEmailRequest req = argument.getValue();
@@ -105,7 +107,9 @@ public class SendMailViaAmazonServiceConsentTest {
         ConsentSignature consent = ConsentSignature.create("Test 2", "1950-05-05", null, null);
         User user = new User();
         user.setEmail("test-user@sagebase.org");
-        service.sendConsentAgreement(user, consent, studyConsent, SharingScope.SPONSORS_AND_PARTNERS);
+        
+        ConsentEmailProvider provider = new ConsentEmailProvider(study, user, consent, studyConsent, SharingScope.SPONSORS_AND_PARTNERS);
+        service.sendEmail(provider);
 
         verify(emailClient).setRegion(any(Region.class));
         verify(emailClient).sendRawEmail(argument.capture());
@@ -134,7 +138,9 @@ public class SendMailViaAmazonServiceConsentTest {
                 TestConstants.DUMMY_IMAGE_DATA, "image/fake");
         User user = new User();
         user.setEmail("test-user@sagebase.org");
-        service.sendConsentAgreement(user, consent, studyConsent, SharingScope.SPONSORS_AND_PARTNERS);
+        
+        ConsentEmailProvider provider = new ConsentEmailProvider(study, user, consent, studyConsent, SharingScope.SPONSORS_AND_PARTNERS);
+        service.sendEmail(provider);
 
         verify(emailClient).setRegion(any(Region.class));
         verify(emailClient).sendRawEmail(argument.capture());

--- a/test/org/sagebionetworks/bridge/services/email/ConsentEmailProviderTest.java
+++ b/test/org/sagebionetworks/bridge/services/email/ConsentEmailProviderTest.java
@@ -1,0 +1,5 @@
+package org.sagebionetworks.bridge.services.email;
+
+public class ConsentEmailProviderTest {
+
+}

--- a/test/org/sagebionetworks/bridge/services/email/ConsentEmailProviderTest.java
+++ b/test/org/sagebionetworks/bridge/services/email/ConsentEmailProviderTest.java
@@ -1,5 +1,0 @@
-package org.sagebionetworks.bridge.services.email;
-
-public class ConsentEmailProviderTest {
-
-}

--- a/test/org/sagebionetworks/bridge/services/email/ParticipantRosterProviderTest.java
+++ b/test/org/sagebionetworks/bridge/services/email/ParticipantRosterProviderTest.java
@@ -1,0 +1,111 @@
+package org.sagebionetworks.bridge.services.email;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
+import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.studies.StudyParticipant;
+
+import com.google.common.collect.Lists;
+
+public class ParticipantRosterProviderTest {
+    
+    private Study study;
+
+    @Before
+    public void setUp() throws Exception {
+        study = new DynamoStudy();
+        study.setName("Test Study");
+        study.setConsentNotificationEmail("consent-notification@test.com");
+        study.getUserProfileAttributes().add("recontact");
+    }
+
+    @Test
+    public void participantsCorrectlyDescribedInText() {
+        StudyParticipant participant = new StudyParticipant();
+        participant.setFirstName("First");
+        participant.setLastName("Last");
+        participant.setEmail("test@test.com");
+        participant.setPhone("(123) 456-7890");
+        participant.put("recontact", "true");
+        List<StudyParticipant> participants = Lists.newArrayList(participant);
+
+        ParticipantRosterProvider provider = new ParticipantRosterProvider(study, participants);
+        String output = provider.createInlineParticipantRoster();
+        
+        assertEquals("There is 1 user enrolled in this study:\n\ntest@test.com (First Last)\nPhone: (123) 456-7890\nRecontact: true\n", output);
+        
+        participant.setLastName(null);
+        output = provider.createInlineParticipantRoster();
+        assertEquals("There is 1 user enrolled in this study:\n\ntest@test.com (First)\nPhone: (123) 456-7890\nRecontact: true\n", output);
+        
+        participant.setFirstName(null);
+        participant.setLastName("Last");
+        output = provider.createInlineParticipantRoster();
+        assertEquals("There is 1 user enrolled in this study:\n\ntest@test.com (Last)\nPhone: (123) 456-7890\nRecontact: true\n", output);
+        
+        participant.setPhone(null);
+        output = provider.createInlineParticipantRoster();
+        assertEquals("There is 1 user enrolled in this study:\n\ntest@test.com (Last)\nPhone: \nRecontact: true\n", output);
+        
+        participant.remove("recontact");
+        output = provider.createInlineParticipantRoster();
+        assertEquals("There is 1 user enrolled in this study:\n\ntest@test.com (Last)\nPhone: \nRecontact: \n", output);
+        
+        StudyParticipant numberTwo = new StudyParticipant();
+        numberTwo.setEmail("test2@test.com");
+        
+        participants.add(numberTwo);
+        output = provider.createInlineParticipantRoster();
+        assertTrue(output.contains("There are 2 users enrolled in this study:"));
+        
+        participants.clear();
+        output = provider.createInlineParticipantRoster();
+        assertTrue(output.contains("There are no users enrolled in this study."));
+    }
+    
+    @Test
+    public void participantsCorrectlyDescribedInCSV() {
+        StudyParticipant participant = new StudyParticipant();
+        participant.setFirstName("First");
+        participant.setLastName("Last");
+        participant.setEmail("test@test.com");
+        // Tab snuck into this string should be converted to a space
+        participant.setPhone("(123)\t456-7890");
+        List<StudyParticipant> participants = Lists.newArrayList(participant);
+
+        ParticipantRosterProvider provider = new ParticipantRosterProvider(study, participants);
+        String output = provider.createParticipantTSV();
+        assertEquals("Email\tFirst Name\tLast Name\tPhone\tRecontact\ntest@test.com\tFirst\tLast\t(123) 456-7890\t\n", output);
+        
+        participant.setLastName(null);
+        output = provider.createParticipantTSV();
+        assertEquals("Email\tFirst Name\tLast Name\tPhone\tRecontact\ntest@test.com\tFirst\t\t(123) 456-7890\t\n", output);
+        
+        participant.setFirstName(null);
+        participant.setLastName("Last");
+        output = provider.createParticipantTSV();
+        assertEquals("Email\tFirst Name\tLast Name\tPhone\tRecontact\ntest@test.com\t\tLast\t(123) 456-7890\t\n", output);
+        
+        participant.setPhone(null);
+        output = provider.createParticipantTSV();
+        assertEquals("Email\tFirst Name\tLast Name\tPhone\tRecontact\ntest@test.com\t\tLast\t\t\n", output);
+        
+        StudyParticipant numberTwo = new StudyParticipant();
+        numberTwo.setEmail("test2@test.com");
+        
+        participants.add(numberTwo);
+        output = provider.createParticipantTSV();
+        assertEquals("Email\tFirst Name\tLast Name\tPhone\tRecontact\ntest@test.com\t\tLast\t\t\ntest2@test.com\t\t\t\t\n", output);
+        
+        participants.clear();
+        output = provider.createParticipantTSV();
+        assertEquals("Email\tFirst Name\tLast Name\tPhone\tRecontact\n", output);
+    }
+
+}


### PR DESCRIPTION
The SendEmailService implementation was factored out so the service just sends email, and takes a parameter object, MimeTypeEmail, that has all the content for the email.

There's a new package with two MimeTypeEmailProvider implementations that create the consent email, and the roster email, respectively. That package also includes a builder for the email object. 
