### PR TITLE
add delete Upload Schema APIs

### DIFF
--- a/app/controllers/UploadSchemaController.java
+++ b/app/controllers/UploadSchemaController.java
@@ -40,6 +40,41 @@ public class UploadSchemaController extends BaseController {
     }
 
     /**
+     * Play controller for DELETE /researcher/v1/uploadSchema/byIdAndRev/:schemaId/:rev. This API deletes an upload
+     * schema with the specified schema ID and revision. If the schema doesn't exist, this API throws a 404 exception.
+     *
+     * @param schemaId
+     *         schema ID of the upload schema to delete
+     * @param rev
+     *         revision number of the upload schema to delete, must be positive
+     * @return Play result with the OK message
+     */
+    public Result deleteUploadSchemaByIdAndRev(String schemaId, int rev) {
+        UserSession session = getAuthenticatedResearcherOrAdminSession();
+        StudyIdentifier studyIdentifier = session.getStudyIdentifier();
+
+        uploadSchemaService.deleteUploadSchemaByIdAndRev(studyIdentifier, schemaId, rev);
+        return okResult("Deleted schema");
+    }
+
+    /**
+     * Play controller for DELETE /researcher/v1/uploadSchema/byId/:schemaId. This API deletes all revisions of the
+     * upload schema with the specified schema ID. If there are no schemas with this schema ID, this API throws a 404
+     * exception.
+     *
+     * @param schemaId
+     *         schema ID of the upload schemas to delete, must be non-null and non-empty
+     * @return Play result with the OK message
+     */
+    public Result deleteUploadSchemaById(String schemaId) {
+        UserSession session = getAuthenticatedResearcherOrAdminSession();
+        StudyIdentifier studyIdentifier = session.getStudyIdentifier();
+
+        uploadSchemaService.deleteUploadSchemaById(studyIdentifier, schemaId);
+        return okResult("Deleted schemas");
+    }
+
+    /**
      * Play controller for GET /researcher/v1/uploadSchema/byId/:schemaId. This API fetches the upload schema with the
      * specified ID. If there is more than one revision of the schema, this fetches the latest revision. If the schema
      * doesn't exist, this API throws a 404 exception.
@@ -62,7 +97,6 @@ public class UploadSchemaController extends BaseController {
      * @return Play result with list of schemas for this study
      */
     public Result getUploadSchemasForStudy() throws Exception {
-        // TODO: When we implement worker accounts, they should have access to the API as well.
         UserSession session = getAuthenticatedResearcherOrAdminSession();
         StudyIdentifier studyId = session.getStudyIdentifier();
 

--- a/app/org/sagebionetworks/bridge/dao/UploadSchemaDao.java
+++ b/app/org/sagebionetworks/bridge/dao/UploadSchemaDao.java
@@ -22,9 +22,33 @@ public interface UploadSchemaDao {
     @Nonnull UploadSchema createOrUpdateUploadSchema(@Nonnull String studyId, @Nonnull UploadSchema uploadSchema);
 
     /**
+     * DAO method for deleting an upload schema with the specified study, schema ID, and revision. If the schema
+     * doesn't exist, this API throws an EntityNotFoundException.
+     *
+     * @param studyIdentifier
+     *         study to delete the upload schema from, must be non-null
+     * @param schemaId
+     *         schema ID of the upload schema to delete, must be non-null and non-empty
+     * @param rev
+     *         revision number of the upload schema to delete, must be positive
+     */
+    void deleteUploadSchemaByIdAndRev(@Nonnull StudyIdentifier studyIdentifier, @Nonnull String schemaId, int rev);
+
+    /**
+     * DAO method for deleting all revisions of the upload schema with the specified study and schema ID. If there are
+     * no schemas with this schema ID, this API throws an EntityNotFoundException.
+     *
+     * @param studyIdentifier
+     *         study to delete the upload schemas from, must be non-null
+     * @param schemaId
+     *         schema ID of the upload schemas to delete, must be non-null and non-empty
+     */
+    void deleteUploadSchemaById(@Nonnull StudyIdentifier studyIdentifier, @Nonnull String schemaId);
+
+    /**
      * DAO method for fetching upload schemas. This method fetches an upload schema for the specified study and schema
      * ID. If there is more than one revision of the schema, this fetches the latest revision. If the schema doesn't
-     * exist, this API throws an InvalidEntityException.
+     * exist, this API throws an EntityNotFoundException.
      *
      * @param studyId
      *         study to fetch the schema from, must be non-null and non-empty
@@ -43,6 +67,4 @@ public interface UploadSchemaDao {
      * @return a list of upload schemas
      */
     @Nonnull List<UploadSchema> getUploadSchemasForStudy(@Nonnull StudyIdentifier studyId);
-
-    // TODO add list and delete APIs
 }

--- a/app/org/sagebionetworks/bridge/services/UploadSchemaService.java
+++ b/app/org/sagebionetworks/bridge/services/UploadSchemaService.java
@@ -2,8 +2,7 @@ package org.sagebionetworks.bridge.services;
 
 import java.util.List;
 
-import com.google.common.base.Strings;
-
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.sagebionetworks.bridge.dao.UploadSchemaDao;
@@ -55,6 +54,53 @@ public class UploadSchemaService {
 
     /**
      * <p>
+     * Service handler for deleting an upload schema with the specified study, schema ID, and revision. If the schema
+     * doesn't exist, this API throws an EntityNotFoundException.
+     * </p>
+     * <p>
+     * This method validates the schema ID and rev. However, it does not validate the study, as that is not user input.
+     * </p>
+     *
+     * @param studyIdentifier
+     *         study to delete the upload schema from, provided by the controller
+     * @param schemaId
+     *         schema ID of the upload schema to delete, must be non-null and non-empty
+     * @param rev
+     *         revision number of the upload schema to delete, must be positive
+     */
+    public void deleteUploadSchemaByIdAndRev(StudyIdentifier studyIdentifier, String schemaId, int rev) {
+        if (StringUtils.isBlank(schemaId)) {
+            throw new BadRequestException(String.format("Invalid schema ID %s", schemaId));
+        }
+        if (rev <= 0) {
+            throw new BadRequestException("Schema revision must be positive");
+        }
+        uploadSchemaDao.deleteUploadSchemaByIdAndRev(studyIdentifier, schemaId, rev);
+    }
+
+    /**
+     * <p>
+     * Service handler for deleting all revisions of the upload schema with the specified study and schema ID. If there
+     * are no schemas with this schema ID, this API throws an EntityNotFoundException.
+     * </p>
+     * <p>
+     * This method validates the schema ID. However, it does not validate the study, as that is not user input.
+     * </p>
+     *
+     * @param studyIdentifier
+     *         study to delete the upload schemas from, provided by the controller
+     * @param schemaId
+     *         schema ID of the upload schemas to delete, must be non-null and non-empty
+     */
+    public void deleteUploadSchemaById(StudyIdentifier studyIdentifier, String schemaId) {
+        if (StringUtils.isBlank(schemaId)) {
+            throw new BadRequestException(String.format("Invalid schema ID %s", schemaId));
+        }
+        uploadSchemaDao.deleteUploadSchemaById(studyIdentifier, schemaId);
+    }
+
+    /**
+     * <p>
      * Service handler for fetching upload schemas. This method fetches an upload schema for the specified study and
      * schema ID. If there is more than one revision of the schema, this fetches the latest revision. If the schema
      * doesn't exist, this handler throws an InvalidEntityException.
@@ -70,7 +116,7 @@ public class UploadSchemaService {
      * @return the fetched schema, will be non-null
      */
     public UploadSchema getUploadSchema(StudyIdentifier studyIdentifier, String schemaId) {
-        if (Strings.isNullOrEmpty(schemaId)) {
+        if (StringUtils.isBlank(schemaId)) {
             throw new BadRequestException(String.format("Invalid schema ID %s", schemaId));
         }
         return uploadSchemaDao.getUploadSchema(studyIdentifier.getIdentifier(), schemaId);

--- a/conf/routes
+++ b/conf/routes
@@ -86,9 +86,11 @@ POST   /researcher/v1/study/participants @controllers.StudyController.sendStudyP
 POST   /researcher/v1/study              @controllers.StudyController.updateStudyForResearcher
 
 # Researchers - Upload Schemas
-GET    /researcher/v1/uploadSchema/byId/:schemaId  @controllers.UploadSchemaController.getUploadSchema(schemaId: String)
-GET    /researcher/v1/uploadSchema/forStudy   @controllers.UploadSchemaController.getUploadSchemasForStudy
 POST   /researcher/v1/uploadSchema            @controllers.UploadSchemaController.createOrUpdateUploadSchema
+GET    /researcher/v1/uploadSchema/byId/:schemaId  @controllers.UploadSchemaController.getUploadSchema(schemaId: String)
+DELETE /researcher/v1/uploadSchema/byId/:schemaId  @controllers.UploadSchemaController.deleteUploadSchemaById(schemaId: String)
+DELETE /researcher/v1/uploadSchema/byIdAndRev/:schemaId/:rev  @controllers.UploadSchemaController.deleteUploadSchemaByIdAndRev(schemaId: String, rev: Int)
+GET    /researcher/v1/uploadSchema/forStudy   @controllers.UploadSchemaController.getUploadSchemasForStudy
 
 # Admin - Studies
 GET    /admin/v1/studies/:identifier  @controllers.StudyController.getStudy(identifier: String)

--- a/test/controllers/UploadSchemaControllerTest.java
+++ b/test/controllers/UploadSchemaControllerTest.java
@@ -1,0 +1,180 @@
+package controllers;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import play.mvc.Http;
+import play.mvc.Result;
+import play.test.Helpers;
+
+import org.sagebionetworks.bridge.TestUtils;
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.UserSession;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
+import org.sagebionetworks.bridge.models.upload.UploadSchema;
+import org.sagebionetworks.bridge.services.UploadSchemaService;
+
+public class UploadSchemaControllerTest {
+    private static final String TEST_SCHEMA_ID = "controller-test-schema";
+    private static final String TEST_SCHEMA_JSON = "{\n" +
+            "   \"name\":\"Controller Test Schema\",\n" +
+            "   \"revision\":3,\n" +
+            "   \"schemaId\":\"controller-test-schema\",\n" +
+            "   \"fieldDefinitions\":[\n" +
+            "       {\n" +
+            "           \"name\":\"field-name\",\n" +
+            "           \"required\":true,\n" +
+            "           \"type\":\"STRING\"\n" +
+            "       }\n" +
+            "   ]\n" +
+            "}";
+
+    @Test
+    public void createSchema() throws Exception {
+        // mock session
+        StudyIdentifier studyIdentifier = new StudyIdentifierImpl("create-schema-study");
+        UserSession mockSession = new UserSession();
+        mockSession.setStudyIdentifier(studyIdentifier);
+
+        // mock request JSON
+        Http.Context.current.set(TestUtils.mockPlayContextWithJson(TEST_SCHEMA_JSON));
+
+        // mock UploadSchemaService
+        UploadSchemaService mockSvc = mock(UploadSchemaService.class);
+        ArgumentCaptor<UploadSchema> createdSchemaArgCaptor = ArgumentCaptor.forClass(UploadSchema.class);
+        when(mockSvc.createOrUpdateUploadSchema(eq(studyIdentifier), createdSchemaArgCaptor.capture())).thenReturn(
+                makeUploadSchema());
+
+        // spy controller
+        UploadSchemaController controller = spy(new UploadSchemaController());
+        controller.setUploadSchemaService(mockSvc);
+        doReturn(mockSession).when(controller).getAuthenticatedResearcherOrAdminSession();
+
+        // execute and validate
+        Result result = controller.createOrUpdateUploadSchema();
+        assertEquals(200, Helpers.status(result));
+
+        // JSON validation is already tested, so just check obvious things like schema
+        String resultJson = Helpers.contentAsString(result);
+        UploadSchema resultSchema = BridgeObjectMapper.get().readValue(resultJson, UploadSchema.class);
+        assertEquals(TEST_SCHEMA_ID, resultSchema.getSchemaId());
+
+        // validate intermediate args
+        UploadSchema createdSchemaArg = createdSchemaArgCaptor.getValue();
+        assertEquals(TEST_SCHEMA_ID, createdSchemaArg.getSchemaId());
+    }
+
+    @Test
+    public void deleteSchemaByIdAndRevSuccess() {
+        // mock session
+        StudyIdentifier studyIdentifier = new StudyIdentifierImpl("delete-schema-study");
+        UserSession mockSession = new UserSession();
+        mockSession.setStudyIdentifier(studyIdentifier);
+
+        // mock UploadSchemaService
+        UploadSchemaService mockSvc = mock(UploadSchemaService.class);
+
+        // spy controller
+        UploadSchemaController controller = spy(new UploadSchemaController());
+        controller.setUploadSchemaService(mockSvc);
+        doReturn(mockSession).when(controller).getAuthenticatedResearcherOrAdminSession();
+
+        // execute and validate
+        Result result = controller.deleteUploadSchemaByIdAndRev("delete-schema", 1);
+        assertEquals(200, Helpers.status(result));
+        verify(mockSvc).deleteUploadSchemaByIdAndRev(studyIdentifier, "delete-schema", 1);
+    }
+
+    @Test
+    public void deleteSchemaById() {
+        // mock session
+        StudyIdentifier studyIdentifier = new StudyIdentifierImpl("delete-schema-study");
+        UserSession mockSession = new UserSession();
+        mockSession.setStudyIdentifier(studyIdentifier);
+
+        // mock UploadSchemaService
+        UploadSchemaService mockSvc = mock(UploadSchemaService.class);
+
+        // spy controller
+        UploadSchemaController controller = spy(new UploadSchemaController());
+        controller.setUploadSchemaService(mockSvc);
+        doReturn(mockSession).when(controller).getAuthenticatedResearcherOrAdminSession();
+
+        // execute and validate
+        Result result = controller.deleteUploadSchemaById("delete-schema");
+        assertEquals(200, Helpers.status(result));
+        verify(mockSvc).deleteUploadSchemaById(studyIdentifier, "delete-schema");
+    }
+
+    @Test
+    public void getSchemaById() throws Exception {
+        // mock session
+        StudyIdentifier studyIdentifier = new StudyIdentifierImpl("get-schema-study");
+        UserSession mockSession = new UserSession();
+        mockSession.setStudyIdentifier(studyIdentifier);
+
+        // mock UploadSchemaService
+        UploadSchemaService mockSvc = mock(UploadSchemaService.class);
+        when(mockSvc.getUploadSchema(studyIdentifier, TEST_SCHEMA_ID)).thenReturn(makeUploadSchema());
+
+        // spy controller
+        UploadSchemaController controller = spy(new UploadSchemaController());
+        controller.setUploadSchemaService(mockSvc);
+        doReturn(mockSession).when(controller).getAuthenticatedResearcherOrAdminSession();
+
+        // execute and validate
+        Result result = controller.getUploadSchema(TEST_SCHEMA_ID);
+        assertEquals(200, Helpers.status(result));
+
+        // JSON validation is already tested, so just check obvious things like schema
+        String resultJson = Helpers.contentAsString(result);
+        UploadSchema resultSchema = BridgeObjectMapper.get().readValue(resultJson, UploadSchema.class);
+        assertEquals(TEST_SCHEMA_ID, resultSchema.getSchemaId());
+    }
+
+    @Test
+    public void getSchemasForStudy() throws Exception {
+        // mock session
+        StudyIdentifier studyIdentifier = new StudyIdentifierImpl("get-schema-study");
+        UserSession mockSession = new UserSession();
+        mockSession.setStudyIdentifier(studyIdentifier);
+
+        // mock UploadSchemaService
+        UploadSchemaService mockSvc = mock(UploadSchemaService.class);
+        when(mockSvc.getUploadSchemasForStudy(studyIdentifier)).thenReturn(ImmutableList.of(makeUploadSchema()));
+
+        // spy controller
+        UploadSchemaController controller = spy(new UploadSchemaController());
+        controller.setUploadSchemaService(mockSvc);
+        doReturn(mockSession).when(controller).getAuthenticatedResearcherOrAdminSession();
+
+        // execute and validate
+        Result result = controller.getUploadSchemasForStudy();
+        assertEquals(200, Helpers.status(result));
+
+        String resultJson = Helpers.contentAsString(result);
+        JsonNode resultNode = BridgeObjectMapper.get().readTree(resultJson);
+        assertEquals("ResourceList", resultNode.get("type").textValue());
+        assertEquals(1, resultNode.get("total").intValue());
+
+        JsonNode itemListNode = resultNode.get("items");
+        assertEquals(1, itemListNode.size());
+
+        UploadSchema resultSchema = BridgeObjectMapper.get().treeToValue(itemListNode.get(0), UploadSchema.class);
+        assertEquals(TEST_SCHEMA_ID, resultSchema.getSchemaId());
+    }
+
+    private static UploadSchema makeUploadSchema() throws Exception {
+        return BridgeObjectMapper.get().readValue(TEST_SCHEMA_JSON, UploadSchema.class);
+    }
+}

--- a/test/controllers/UserProfileControllerTest.java
+++ b/test/controllers/UserProfileControllerTest.java
@@ -15,6 +15,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import org.junit.Test;
+
+import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dao.ParticipantOption;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.models.User;
@@ -23,9 +25,6 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.services.ParticipantOptionsService;
 import org.sagebionetworks.bridge.services.ParticipantOptionsServiceImpl;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import play.mvc.Http;
 import play.mvc.Result;
@@ -38,7 +37,7 @@ public class UserProfileControllerTest {
     
     @Test
     public void canSubmitExternalIdentifier() throws Exception {
-        Http.Context.current.set(mockContext("{\"identifier\":\"ABC-123-XYZ\"}"));
+        Http.Context.current.set(TestUtils.mockPlayContextWithJson("{\"identifier\":\"ABC-123-XYZ\"}"));
         
         UserProfileController controller = controllerForExternalIdTests();
                 
@@ -53,7 +52,7 @@ public class UserProfileControllerTest {
     
     @Test
     public void externalIdentifierVerifiesIdentifierExists() throws Exception {
-        Http.Context.current.set(mockContext("{\"identifier\":\"\"}"));
+        Http.Context.current.set(TestUtils.mockPlayContextWithJson("{\"identifier\":\"\"}"));
         
         UserProfileController controller = controllerForExternalIdTests();
 
@@ -65,22 +64,7 @@ public class UserProfileControllerTest {
         }
         verifyNoMoreInteractions(optionsService);
     }
-    
-    private Http.Context mockContext(String json) throws Exception {
-        JsonNode node = new ObjectMapper().readTree(json);
-        
-        Http.RequestBody body = mock(Http.RequestBody.class);
-        when(body.asJson()).thenReturn(node);
-        
-        Http.Request request = mock(Http.Request.class);
-        when(request.body()).thenReturn(body);
 
-        Http.Context context = mock(Http.Context.class);
-        when(context.request()).thenReturn(request);
-
-        return context;
-    }    
-    
     private UserSession mockSession() {
         User user = mock(User.class);
         when(user.getHealthCode()).thenReturn("healthCode");

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -1,6 +1,12 @@
 package org.sagebionetworks.bridge;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.RandomStringUtils;
+import play.mvc.Http;
 
 public class TestUtils {
 
@@ -17,7 +23,22 @@ public class TestUtils {
             }
         }
     }
-    
+
+    public static Http.Context mockPlayContextWithJson(String json) throws Exception {
+        JsonNode node = new ObjectMapper().readTree(json);
+
+        Http.RequestBody body = mock(Http.RequestBody.class);
+        when(body.asJson()).thenReturn(node);
+
+        Http.Request request = mock(Http.Request.class);
+        when(request.body()).thenReturn(body);
+
+        Http.Context context = mock(Http.Context.class);
+        when(context.request()).thenReturn(request);
+
+        return context;
+    }
+
     public static String randomName() {
         return "test-" + RandomStringUtils.randomAlphabetic(5).toLowerCase();
     }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDaoTest.java
@@ -1,25 +1,34 @@
 package org.sagebionetworks.bridge.dynamodb;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.notNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
+
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBSaveExpression;
 import com.amazonaws.services.dynamodbv2.datamodeling.PaginatedQueryList;
+import com.amazonaws.services.dynamodbv2.model.WriteRequest;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
+import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.exceptions.ConcurrentModificationException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.upload.UploadSchema;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings({ "unchecked", "rawtypes" })
 public class DynamoUploadSchemaDaoTest {
     @Test
     public void createNewSchema() {
@@ -72,6 +81,148 @@ public class DynamoUploadSchemaDaoTest {
     }
 
     @Test
+    public void deleteSchemaByIdAndRev() {
+        // mock DDB mapper
+        DynamoDBMapper mockMapper = mock(DynamoDBMapper.class);
+        DynamoUploadSchema schemaToDelete = new DynamoUploadSchema();
+        ArgumentCaptor<DynamoUploadSchema> loadSchemaArgCaptor = ArgumentCaptor.forClass(DynamoUploadSchema.class);
+        when(mockMapper.load(loadSchemaArgCaptor.capture())).thenReturn(schemaToDelete);
+
+        // set up test dao and execute
+        DynamoUploadSchemaDao dao = new DynamoUploadSchemaDao();
+        dao.setDdbMapper(mockMapper);
+        dao.deleteUploadSchemaByIdAndRev(new StudyIdentifierImpl("test-study"), "delete-schema", 1);
+
+        // validate intermediate args
+        DynamoUploadSchema loadSchemaArg = loadSchemaArgCaptor.getValue();
+        assertEquals("test-study", loadSchemaArg.getStudyId());
+        assertEquals("delete-schema", loadSchemaArg.getSchemaId());
+        assertEquals(1, loadSchemaArg.getRevision());
+
+        // verify delete call
+        verify(mockMapper).delete(schemaToDelete);
+    }
+
+    @Test
+    public void deleteSchemaByIdAndRevNotFound() {
+        // mock DDB mapper
+        DynamoDBMapper mockMapper = mock(DynamoDBMapper.class);
+        ArgumentCaptor<DynamoUploadSchema> loadSchemaArgCaptor = ArgumentCaptor.forClass(DynamoUploadSchema.class);
+        when(mockMapper.load(loadSchemaArgCaptor.capture())).thenReturn(null);
+
+        // set up test dao and execute
+        DynamoUploadSchemaDao dao = new DynamoUploadSchemaDao();
+        dao.setDdbMapper(mockMapper);
+        Exception thrownEx = null;
+        try {
+            dao.deleteUploadSchemaByIdAndRev(new StudyIdentifierImpl("test-study"), "delete-schema", 1);
+            fail();
+        } catch (EntityNotFoundException ex) {
+            thrownEx = ex;
+        }
+        assertNotNull(thrownEx);
+
+        // validate intermediate args
+        DynamoUploadSchema loadSchemaArg = loadSchemaArgCaptor.getValue();
+        assertEquals("test-study", loadSchemaArg.getStudyId());
+        assertEquals("delete-schema", loadSchemaArg.getSchemaId());
+        assertEquals(1, loadSchemaArg.getRevision());
+    }
+
+    @Test
+    public void deleteSchemaById() {
+        // mock DDB mapper
+        DynamoDBMapper mockMapper = mock(DynamoDBMapper.class);
+
+        PaginatedQueryList<DynamoUploadSchema> mockQueryResult = mock(PaginatedQueryList.class);
+        when(mockQueryResult.isEmpty()).thenReturn(false);
+
+        ArgumentCaptor<DynamoDBQueryExpression> queryCaptor = ArgumentCaptor.forClass(DynamoDBQueryExpression.class);
+        when(mockMapper.query(eq(DynamoUploadSchema.class), queryCaptor.capture())).thenReturn(mockQueryResult);
+
+        when(mockMapper.batchDelete(mockQueryResult)).thenReturn(ImmutableList.<DynamoDBMapper.FailedBatch>of());
+
+        // set up test dao and execute
+        DynamoUploadSchemaDao dao = new DynamoUploadSchemaDao();
+        dao.setDdbMapper(mockMapper);
+        dao.deleteUploadSchemaById(new StudyIdentifierImpl("test-study"), "delete-schema");
+
+        // validate intermediate args
+        DynamoDBQueryExpression<DynamoUploadSchema> query = queryCaptor.getValue();
+        DynamoUploadSchema queryKey = query.getHashKeyValues();
+        assertEquals("test-study", queryKey.getStudyId());
+        assertEquals("delete-schema", queryKey.getSchemaId());
+    }
+
+    @Test
+    public void deleteSchemaByIdNotFound() {
+        // mock DDB mapper
+        DynamoDBMapper mockMapper = mock(DynamoDBMapper.class);
+
+        PaginatedQueryList<DynamoUploadSchema> mockQueryResult = mock(PaginatedQueryList.class);
+        when(mockQueryResult.isEmpty()).thenReturn(true);
+
+        ArgumentCaptor<DynamoDBQueryExpression> queryCaptor = ArgumentCaptor.forClass(DynamoDBQueryExpression.class);
+        when(mockMapper.query(eq(DynamoUploadSchema.class), queryCaptor.capture())).thenReturn(mockQueryResult);
+
+        // set up test dao and execute
+        DynamoUploadSchemaDao dao = new DynamoUploadSchemaDao();
+        dao.setDdbMapper(mockMapper);
+        Exception thrownEx = null;
+        try {
+            dao.deleteUploadSchemaById(new StudyIdentifierImpl("test-study"), "delete-schema");
+            fail();
+        } catch (EntityNotFoundException ex) {
+            thrownEx = ex;
+        }
+        assertNotNull(thrownEx);
+
+        // validate intermediate args
+        DynamoDBQueryExpression<DynamoUploadSchema> query = queryCaptor.getValue();
+        DynamoUploadSchema queryKey = query.getHashKeyValues();
+        assertEquals("test-study", queryKey.getStudyId());
+        assertEquals("delete-schema", queryKey.getSchemaId());
+    }
+
+    @Test
+    public void deleteSchemaByIdMapperException() {
+        // mock failed batch
+        // we have to mock extra stuff because BridgeUtils.ifFailuresThrowException() checks all these things
+        DynamoDBMapper.FailedBatch failure = new DynamoDBMapper.FailedBatch();
+        failure.setException(new Exception("dummy exception message"));
+        failure.setUnprocessedItems(ImmutableMap.<String, List<WriteRequest>>of());
+
+        // mock DDB mapper
+        DynamoDBMapper mockMapper = mock(DynamoDBMapper.class);
+
+        PaginatedQueryList<DynamoUploadSchema> mockQueryResult = mock(PaginatedQueryList.class);
+        when(mockQueryResult.isEmpty()).thenReturn(false);
+
+        ArgumentCaptor<DynamoDBQueryExpression> queryCaptor = ArgumentCaptor.forClass(DynamoDBQueryExpression.class);
+        when(mockMapper.query(eq(DynamoUploadSchema.class), queryCaptor.capture())).thenReturn(mockQueryResult);
+
+        when(mockMapper.batchDelete(mockQueryResult)).thenReturn(ImmutableList.of(failure));
+
+        // set up test dao and execute
+        DynamoUploadSchemaDao dao = new DynamoUploadSchemaDao();
+        dao.setDdbMapper(mockMapper);
+        Exception thrownEx = null;
+        try {
+            dao.deleteUploadSchemaById(new StudyIdentifierImpl("test-study"), "delete-schema");
+            fail();
+        } catch (BridgeServiceException ex) {
+            thrownEx = ex;
+        }
+        assertNotNull(thrownEx);
+
+        // validate intermediate args
+        DynamoDBQueryExpression<DynamoUploadSchema> query = queryCaptor.getValue();
+        DynamoUploadSchema queryKey = query.getHashKeyValues();
+        assertEquals("test-study", queryKey.getStudyId());
+        assertEquals("delete-schema", queryKey.getSchemaId());
+    }
+
+    @Test
     public void testGetSchema() {
         // mock DDB mapper
         DynamoDBMapper mockMapper = setupMockMapperWithSchema(makeUploadSchema("getStudy", "testSchema", 1));
@@ -97,6 +248,24 @@ public class DynamoUploadSchemaDaoTest {
         DynamoUploadSchemaDao dao = new DynamoUploadSchemaDao();
         dao.setDdbMapper(mockMapper);
         dao.getUploadSchema("getStudy", "testSchema");
+    }
+
+    @Test
+    public void getUploadSchemasForStudy() {
+        // mock result
+        List<UploadSchema> mockResult = ImmutableList.<UploadSchema>of(new DynamoUploadSchema());
+
+        // mock study ID index
+        DynamoIndexHelper mockStudyIdIndex = mock(DynamoIndexHelper.class);
+        when(mockStudyIdIndex.query(UploadSchema.class, "studyId", "test-study")).thenReturn(mockResult);
+
+        // set up test dao
+        DynamoUploadSchemaDao dao = new DynamoUploadSchemaDao();
+        dao.setStudyIdIndex(mockStudyIdIndex);
+
+        // execute and validate
+        List<UploadSchema> outputSchemaList = dao.getUploadSchemasForStudy(new StudyIdentifierImpl("test-study"));
+        assertSame(mockResult, outputSchemaList);
     }
 
     private static DynamoDBMapper setupMockMapperWithSchema(DynamoUploadSchema schema) {


### PR DESCRIPTION
Add the ability to delete Upload Schemas using researcher APIs. These APIs are useful for 2 reasons:
- gives researchers the ability to delete old schemas, so they don't clutter up Synapse (or Dynamo or any future researcher UI)
- allows integration tests to create schemas, then clean up after itself

Testing done:
- unit tests for DAO, service, and controllers
- manually tested by
  *\* creating schema "manual-test-schema" with revisions 1, 2, and 3
  *\* delete by ID and rev manual-test-schema v3 and verify that v1 and v2 were unaffected
  *\* delete by ID manual-test-schema and verify that all manual-test-schemas were deleted
