### PR TITLE
Upload Validation v2 - write null for absent fields to maintain compatibility with v1

### DIFF
--- a/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2.java
+++ b/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2.java
@@ -381,9 +381,14 @@ public class IosSchemaValidationHandler2 implements UploadValidationHandler {
             } else if (jsonFieldnameSet.contains(fieldName)) {
                 copyJsonField(context, uploadId, flattenedJsonDataMap.get(fieldName), oneFieldDef, dataMap,
                         attachmentMap);
-            } else if (oneFieldDef.isRequired()) {
-                // log a message only if the field is required (but missing)
-                context.addMessage(String.format("Upload ID %s is missing required field %s", uploadId, fieldName));
+            } else {
+                // if the field is not present, write a null to maintain compatibility with v1
+                dataMap.putNull(fieldName);
+
+                if (oneFieldDef.isRequired()) {
+                    // log a message only if the field is required (but missing)
+                    context.addMessage(String.format("Upload ID %s is missing required field %s", uploadId, fieldName));
+                }
             }
         }
     }

--- a/test/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2Test.java
+++ b/test/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2Test.java
@@ -68,7 +68,9 @@ public class IosSchemaValidationHandler2Test {
                 new DynamoUploadFieldDefinition.Builder().withName("bar_unit").withType(UploadFieldType.STRING)
                         .build(),
                 new DynamoUploadFieldDefinition.Builder().withName("baz")
-                        .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build()));
+                        .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("optional").withRequired(false)
+                        .withType(UploadFieldType.STRING).build()));
 
         DynamoUploadSchema jsonDataSchema = new DynamoUploadSchema();
         jsonDataSchema.setStudyId(TEST_STUDY_ID);
@@ -80,7 +82,9 @@ public class IosSchemaValidationHandler2Test {
                 new DynamoUploadFieldDefinition.Builder().withName("string.json.string")
                         .withType(UploadFieldType.STRING).build(),
                 new DynamoUploadFieldDefinition.Builder().withName("blob.json.blob")
-                        .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build()));
+                        .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("optional").withRequired(false)
+                        .withType(UploadFieldType.STRING).build()));
 
         DynamoUploadSchema nonJsonDataSchema = new DynamoUploadSchema();
         nonJsonDataSchema.setStudyId(TEST_STUDY_ID);
@@ -92,7 +96,9 @@ public class IosSchemaValidationHandler2Test {
                 new DynamoUploadFieldDefinition.Builder().withName("nonJsonFile.txt")
                         .withType(UploadFieldType.ATTACHMENT_BLOB).build(),
                 new DynamoUploadFieldDefinition.Builder().withName("jsonFile.json")
-                        .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build()));
+                        .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("optional").withRequired(false)
+                        .withType(UploadFieldType.STRING).build()));
 
         DynamoUploadSchema mixedSchema = new DynamoUploadSchema();
         mixedSchema.setStudyId(TEST_STUDY_ID);
@@ -110,6 +116,8 @@ public class IosSchemaValidationHandler2Test {
                 new DynamoUploadFieldDefinition.Builder().withName("field.json.attachment")
                         .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build(),
                 new DynamoUploadFieldDefinition.Builder().withName("field.json.string")
+                        .withType(UploadFieldType.STRING).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("optional").withRequired(false)
                         .withType(UploadFieldType.STRING).build()));
 
         // mock upload schema service
@@ -195,10 +203,11 @@ public class IosSchemaValidationHandler2Test {
         assertEquals(1, recordBuilder.getSchemaRevision());
 
         JsonNode dataNode = recordBuilder.getData();
-        assertEquals(3, dataNode.size());
+        assertEquals(4, dataNode.size());
         assertEquals("foo answer", dataNode.get("foo").textValue());
         assertEquals(42, dataNode.get("bar").intValue());
         assertEquals("lb", dataNode.get("bar_unit").textValue());
+        assertTrue(dataNode.get("optional").isNull());
 
         Map<String, byte[]> attachmentMap = context.getAttachmentsByFieldName();
         assertEquals(1, attachmentMap.size());
@@ -254,8 +263,9 @@ public class IosSchemaValidationHandler2Test {
         assertEquals(1, recordBuilder.getSchemaRevision());
 
         JsonNode dataNode = recordBuilder.getData();
-        assertEquals(1, dataNode.size());
+        assertEquals(2, dataNode.size());
         assertEquals("This is a string", dataNode.get("string.json.string").textValue());
+        assertTrue(dataNode.get("optional").isNull());
 
         Map<String, byte[]> attachmentMap = context.getAttachmentsByFieldName();
         assertEquals(1, attachmentMap.size());
@@ -308,7 +318,8 @@ public class IosSchemaValidationHandler2Test {
         assertEquals(1, recordBuilder.getSchemaRevision());
 
         JsonNode dataNode = recordBuilder.getData();
-        assertEquals(0, dataNode.size());
+        assertEquals(1, dataNode.size());
+        assertTrue(dataNode.get("optional").isNull());
 
         Map<String, byte[]> attachmentMap = context.getAttachmentsByFieldName();
         assertEquals(2, attachmentMap.size());
@@ -380,8 +391,9 @@ public class IosSchemaValidationHandler2Test {
         assertEquals(1, recordBuilder.getSchemaRevision());
 
         JsonNode dataNode = recordBuilder.getData();
-        assertEquals(2, dataNode.size());
+        assertEquals(3, dataNode.size());
         assertEquals("This is a string", dataNode.get("field.json.string").textValue());
+        assertTrue(dataNode.get("optional").isNull());
 
         JsonNode outputInlineJsonNode = dataNode.get("inline.json");
         assertEquals(1, outputInlineJsonNode.size());


### PR DESCRIPTION
v1 would write null for absent fields. v2 would just drop the absent fields altogether. This is causing a bunch of noise in in the v1-v2 validation, so I'm going to patch v2 to make validation easier.

Testing done:
- manually tested with an example file from production
- added to unit tests
