### PR TITLE
Upload Validation - don't write nulls

### DIFF
--- a/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler.java
+++ b/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler.java
@@ -300,7 +300,7 @@ public class IosSchemaValidationHandler implements UploadValidationHandler {
                     attachmentMap.put(fieldName, data);
                 } else {
                     JsonNode jsonData = jsonDataMap.get(fieldName);
-                    if (jsonData != null) {
+                    if (jsonData != null && !jsonData.isNull()) {
                         // Convert to raw bytes, then add to attachment map.
                         try {
                             attachmentMap.put(fieldName, BridgeObjectMapper.get().writeValueAsBytes(jsonData));
@@ -580,6 +580,10 @@ public class IosSchemaValidationHandler implements UploadValidationHandler {
         for (UploadFieldDefinition oneFieldDef : schema.getFieldDefinitions()) {
             String fieldName = oneFieldDef.getName();
             JsonNode fieldValue = dataFieldMap.get(fieldName);
+            if (fieldValue == null || fieldValue.isNull()) {
+                // Don't write null fields.
+                continue;
+            }
 
             if (ATTACHMENT_TYPE_SET.contains(oneFieldDef.getType())) {
                 try {

--- a/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2.java
+++ b/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2.java
@@ -381,14 +381,9 @@ public class IosSchemaValidationHandler2 implements UploadValidationHandler {
             } else if (jsonFieldnameSet.contains(fieldName)) {
                 copyJsonField(context, uploadId, flattenedJsonDataMap.get(fieldName), oneFieldDef, dataMap,
                         attachmentMap);
-            } else {
-                // if the field is not present, write a null to maintain compatibility with v1
-                dataMap.putNull(fieldName);
-
-                if (oneFieldDef.isRequired()) {
-                    // log a message only if the field is required (but missing)
-                    context.addMessage(String.format("Upload ID %s is missing required field %s", uploadId, fieldName));
-                }
+            } else if (oneFieldDef.isRequired()) {
+                // log a message only if the field is required (but missing)
+                context.addMessage(String.format("Upload ID %s is missing required field %s", uploadId, fieldName));
             }
         }
     }

--- a/test/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2Test.java
+++ b/test/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2Test.java
@@ -70,7 +70,9 @@ public class IosSchemaValidationHandler2Test {
                 new DynamoUploadFieldDefinition.Builder().withName("baz")
                         .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build(),
                 new DynamoUploadFieldDefinition.Builder().withName("optional").withRequired(false)
-                        .withType(UploadFieldType.STRING).build()));
+                        .withType(UploadFieldType.STRING).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("optional_attachment").withRequired(false)
+                        .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build()));
 
         DynamoUploadSchema jsonDataSchema = new DynamoUploadSchema();
         jsonDataSchema.setStudyId(TEST_STUDY_ID);
@@ -84,7 +86,9 @@ public class IosSchemaValidationHandler2Test {
                 new DynamoUploadFieldDefinition.Builder().withName("blob.json.blob")
                         .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build(),
                 new DynamoUploadFieldDefinition.Builder().withName("optional").withRequired(false)
-                        .withType(UploadFieldType.STRING).build()));
+                        .withType(UploadFieldType.STRING).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("optional_attachment").withRequired(false)
+                        .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build()));
 
         DynamoUploadSchema nonJsonDataSchema = new DynamoUploadSchema();
         nonJsonDataSchema.setStudyId(TEST_STUDY_ID);
@@ -98,7 +102,9 @@ public class IosSchemaValidationHandler2Test {
                 new DynamoUploadFieldDefinition.Builder().withName("jsonFile.json")
                         .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build(),
                 new DynamoUploadFieldDefinition.Builder().withName("optional").withRequired(false)
-                        .withType(UploadFieldType.STRING).build()));
+                        .withType(UploadFieldType.STRING).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("optional_attachment").withRequired(false)
+                        .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build()));
 
         DynamoUploadSchema mixedSchema = new DynamoUploadSchema();
         mixedSchema.setStudyId(TEST_STUDY_ID);
@@ -118,7 +124,9 @@ public class IosSchemaValidationHandler2Test {
                 new DynamoUploadFieldDefinition.Builder().withName("field.json.string")
                         .withType(UploadFieldType.STRING).build(),
                 new DynamoUploadFieldDefinition.Builder().withName("optional").withRequired(false)
-                        .withType(UploadFieldType.STRING).build()));
+                        .withType(UploadFieldType.STRING).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("optional_attachment").withRequired(false)
+                        .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build()));
 
         // mock upload schema service
         UploadSchemaService mockSchemaService = mock(UploadSchemaService.class);
@@ -203,11 +211,10 @@ public class IosSchemaValidationHandler2Test {
         assertEquals(1, recordBuilder.getSchemaRevision());
 
         JsonNode dataNode = recordBuilder.getData();
-        assertEquals(4, dataNode.size());
+        assertEquals(3, dataNode.size());
         assertEquals("foo answer", dataNode.get("foo").textValue());
         assertEquals(42, dataNode.get("bar").intValue());
         assertEquals("lb", dataNode.get("bar_unit").textValue());
-        assertTrue(dataNode.get("optional").isNull());
 
         Map<String, byte[]> attachmentMap = context.getAttachmentsByFieldName();
         assertEquals(1, attachmentMap.size());
@@ -263,9 +270,8 @@ public class IosSchemaValidationHandler2Test {
         assertEquals(1, recordBuilder.getSchemaRevision());
 
         JsonNode dataNode = recordBuilder.getData();
-        assertEquals(2, dataNode.size());
+        assertEquals(1, dataNode.size());
         assertEquals("This is a string", dataNode.get("string.json.string").textValue());
-        assertTrue(dataNode.get("optional").isNull());
 
         Map<String, byte[]> attachmentMap = context.getAttachmentsByFieldName();
         assertEquals(1, attachmentMap.size());
@@ -318,8 +324,7 @@ public class IosSchemaValidationHandler2Test {
         assertEquals(1, recordBuilder.getSchemaRevision());
 
         JsonNode dataNode = recordBuilder.getData();
-        assertEquals(1, dataNode.size());
-        assertTrue(dataNode.get("optional").isNull());
+        assertEquals(0, dataNode.size());
 
         Map<String, byte[]> attachmentMap = context.getAttachmentsByFieldName();
         assertEquals(2, attachmentMap.size());
@@ -391,9 +396,8 @@ public class IosSchemaValidationHandler2Test {
         assertEquals(1, recordBuilder.getSchemaRevision());
 
         JsonNode dataNode = recordBuilder.getData();
-        assertEquals(3, dataNode.size());
+        assertEquals(2, dataNode.size());
         assertEquals("This is a string", dataNode.get("field.json.string").textValue());
-        assertTrue(dataNode.get("optional").isNull());
 
         JsonNode outputInlineJsonNode = dataNode.get("inline.json");
         assertEquals(1, outputInlineJsonNode.size());

--- a/test/org/sagebionetworks/bridge/upload/IosSchemaValidationHandlerTest.java
+++ b/test/org/sagebionetworks/bridge/upload/IosSchemaValidationHandlerTest.java
@@ -76,8 +76,13 @@ public class IosSchemaValidationHandlerTest {
                 new DynamoUploadFieldDefinition.Builder().withName("string.json.string")
                         .withType(UploadFieldType.STRING).build(),
                 new DynamoUploadFieldDefinition.Builder().withName("blob.json.blob")
+                        .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("optional").withRequired(false)
+                        .withType(UploadFieldType.STRING).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("optional_attachment").withRequired(false)
                         .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build()));
 
+        // Non-JSON data doesn't support non-attachments.
         DynamoUploadSchema nonJsonDataSchema = new DynamoUploadSchema();
         nonJsonDataSchema.setStudyId("test-study");
         nonJsonDataSchema.setSchemaId("non-json-data");
@@ -87,6 +92,8 @@ public class IosSchemaValidationHandlerTest {
                 new DynamoUploadFieldDefinition.Builder().withName("nonJsonFile.txt")
                         .withType(UploadFieldType.ATTACHMENT_BLOB).build(),
                 new DynamoUploadFieldDefinition.Builder().withName("jsonFile.json")
+                        .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("optional_attachment").withRequired(false)
                         .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build()));
 
         // mock upload schema service


### PR DESCRIPTION
This is a partial reversal of https://github.com/Sage-Bionetworks/BridgePF/pull/643

After scrubbing the logs and doing more testing, it looks like v1 is inconsistent with how it handles nulls. Some code paths drop nulls, other code paths write through nulls. So in order to make v2 consistent with v1, I had to make v1 consistent with itself first.

I decided to drop nulls in all codepaths in v1 because
a. it's cleaner
b. writing nulls to attachments ends up writing attachments that contain the word "null", which is probably a bad thing

Testing done:
- manual test cases (pulled from prod data) with (1) non-JSON attachments (2) JSON with attachments (3) JSON without attachments
- updated unit tests to have optional fields in schemas, and check that the outputted data doesn't contain these fields
