### PR TITLE
Upgrade to Java 8

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  config.vm.box = "chef/ubuntu-14.04"
+  config.vm.box = "chef/ubuntu-14.10"
   config.vm.provision :shell, path: "bootstrap.sh"
   config.vm.network :forwarded_port, host: 6379, guest: 6379
   config.vm.network :forwarded_port, host: 9000, guest: 9000

--- a/app/controllers/BaseController.java
+++ b/app/controllers/BaseController.java
@@ -225,7 +225,7 @@ public abstract class BaseController extends Controller {
     }
 
     Result okResult(Object obj) {
-        return ok(mapper.valueToTree(obj));
+        return ok((JsonNode)mapper.valueToTree(obj));
     }
 
     Result okResult(Collection<?> items) throws Exception {
@@ -243,7 +243,7 @@ public abstract class BaseController extends Controller {
     }
 
     Result createdResult(Object obj) throws Exception {
-        return created(mapper.valueToTree(obj));
+        return created((JsonNode)mapper.valueToTree(obj));
     }
 
     // This is needed or tests fail. It appears to be a bug in Play Framework,

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -20,7 +20,7 @@ apt-get -q -y install vim bzip2 curl zip git
 apt-get -q -y install nfs-common
 
 # Java
-apt-get -q -y install openjdk-7-jdk
+apt-get -q -y install openjdk-8-jdk
 
 # Play
 su - vagrant -c "wget http://downloads.typesafe.com/typesafe-activator/1.3.2/typesafe-activator-1.3.2.zip"

--- a/system.properties
+++ b/system.properties
@@ -1,1 +1,1 @@
-java.runtime.version=1.7
+java.runtime.version=1.8


### PR DESCRIPTION
"Heroku currently uses OpenJDK 8 to run your application default." -- https://devcenter.heroku.com/articles/java-support

And it compiles and tests fine on the updated Vagrant box.

Can't think of other hurdles that prevents it from going to Java 8.
