### PR TITLE
make upload schema schema type required

### DIFF
--- a/app/org/sagebionetworks/bridge/validators/UploadSchemaValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/UploadSchemaValidator.java
@@ -31,6 +31,7 @@ public class UploadSchemaValidator implements Validator {
      *     <li>name is null or empty</li>
      *     <li>revision is negative</li>
      *     <li>schemaId is null or empty</li>
+     *     <li>schemaType is null</li>
      *   </ul>
      * </p>
      *
@@ -70,8 +71,10 @@ public class UploadSchemaValidator implements Validator {
                 errors.rejectValue("schemaId", Validate.CANNOT_BE_BLANK);
             }
 
-            // TODO: add validation for schemaType once all the schemas have been updated and the integration tests
-            // start using it
+            // schema type
+            if (uploadSchema.getSchemaType() == null) {
+                errors.rejectValue("schemaType", Validate.CANNOT_BE_NULL);
+            }
         }
     }
 }

--- a/test/org/sagebionetworks/bridge/models/upload/UploadSchemaTest.java
+++ b/test/org/sagebionetworks/bridge/models/upload/UploadSchemaTest.java
@@ -157,6 +157,7 @@ public class UploadSchemaTest {
         schema.setName("happy schema");
         schema.setSchemaId("happy-schema");
         schema.setStudyId("test-study");
+        schema.setSchemaType(UploadSchemaType.IOS_DATA);
 
         // test field def list
         List<UploadFieldDefinition> fieldDefList = new ArrayList<>();
@@ -176,6 +177,7 @@ public class UploadSchemaTest {
         schema.setRevision(1);
         schema.setSchemaId("happy-schema-2");
         schema.setStudyId("test-study");
+        schema.setSchemaType(UploadSchemaType.IOS_SURVEY);
 
         // test field def list
         List<UploadFieldDefinition> fieldDefList = new ArrayList<>();
@@ -196,6 +198,7 @@ public class UploadSchemaTest {
         schema.setName("test schema");
         schema.setSchemaId("test-schema");
         schema.setStudyId("test-study");
+        schema.setSchemaType(UploadSchemaType.IOS_DATA);
 
         // validate
         Validate.entityThrowingException(UploadSchemaValidator.INSTANCE, schema);
@@ -209,6 +212,7 @@ public class UploadSchemaTest {
         schema.setSchemaId("test-schema");
         schema.setStudyId("test-study");
         schema.setFieldDefinitions(Collections.<UploadFieldDefinition>emptyList());
+        schema.setSchemaType(UploadSchemaType.IOS_DATA);
 
         // validate
         Validate.entityThrowingException(UploadSchemaValidator.INSTANCE, schema);
@@ -220,6 +224,7 @@ public class UploadSchemaTest {
         DynamoUploadSchema schema = new DynamoUploadSchema();
         schema.setSchemaId("test-schema");
         schema.setStudyId("test-study");
+        schema.setSchemaType(UploadSchemaType.IOS_DATA);
 
         // test field def list
         List<UploadFieldDefinition> fieldDefList = new ArrayList<>();
@@ -238,6 +243,7 @@ public class UploadSchemaTest {
         schema.setName("");
         schema.setSchemaId("test-schema");
         schema.setStudyId("test-study");
+        schema.setSchemaType(UploadSchemaType.IOS_DATA);
 
         // test field def list
         List<UploadFieldDefinition> fieldDefList = new ArrayList<>();
@@ -257,6 +263,7 @@ public class UploadSchemaTest {
         schema.setRevision(-1);
         schema.setSchemaId("test-schema");
         schema.setStudyId("test-study");
+        schema.setSchemaType(UploadSchemaType.IOS_DATA);
 
         // test field def list
         List<UploadFieldDefinition> fieldDefList = new ArrayList<>();
@@ -274,6 +281,7 @@ public class UploadSchemaTest {
         DynamoUploadSchema schema = new DynamoUploadSchema();
         schema.setName("test schema");
         schema.setStudyId("test-study");
+        schema.setSchemaType(UploadSchemaType.IOS_DATA);
 
         // test field def list
         List<UploadFieldDefinition> fieldDefList = new ArrayList<>();
@@ -292,10 +300,29 @@ public class UploadSchemaTest {
         schema.setName("test schema");
         schema.setSchemaId("");
         schema.setStudyId("test-study");
+        schema.setSchemaType(UploadSchemaType.IOS_DATA);
 
         // test field def list
         List<UploadFieldDefinition> fieldDefList = new ArrayList<>();
         fieldDefList.add(new DynamoUploadFieldDefinition.Builder().withName("good-field")
+                .withType(UploadFieldType.ATTACHMENT_BLOB).build());
+        schema.setFieldDefinitions(fieldDefList);
+
+        // validate
+        Validate.entityThrowingException(UploadSchemaValidator.INSTANCE, schema);
+    }
+
+    @Test(expected = InvalidEntityException.class)
+    public void validateNullSchemaType() {
+        // set up schema to validate
+        DynamoUploadSchema schema = new DynamoUploadSchema();
+        schema.setName("test schema");
+        schema.setSchemaId("test-schema");
+        schema.setStudyId("test-study");
+
+        // test field def list
+        List<UploadFieldDefinition> fieldDefList = new ArrayList<>();
+        fieldDefList.add(new DynamoUploadFieldDefinition.Builder().withName("test-field")
                 .withType(UploadFieldType.ATTACHMENT_BLOB).build());
         schema.setFieldDefinitions(fieldDefList);
 

--- a/test/org/sagebionetworks/bridge/services/UploadSchemaServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/UploadSchemaServiceTest.java
@@ -21,6 +21,7 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
 import org.sagebionetworks.bridge.models.upload.UploadFieldType;
 import org.sagebionetworks.bridge.models.upload.UploadSchema;
+import org.sagebionetworks.bridge.models.upload.UploadSchemaType;
 
 public class UploadSchemaServiceTest {
     @Test(expected = InvalidEntityException.class)
@@ -43,6 +44,7 @@ public class UploadSchemaServiceTest {
         DynamoUploadSchema schema = new DynamoUploadSchema();
         schema.setName("happy schema");
         schema.setSchemaId("happy-schema");
+        schema.setSchemaType(UploadSchemaType.IOS_DATA);
 
         // test field def list
         List<UploadFieldDefinition> fieldDefList = new ArrayList<>();


### PR DESCRIPTION
Schema Type was always intended to be required. However, I couldn't add it to the validator until everything was migrated. Now that everything is migrated, we can make it required.

Testing done:
- unit tests
- ran upload schema integration tests against my local box
