### PR TITLE
refactor jedis.close into a util class; set testOnBorrow and testOnReturn to true

### DIFF
--- a/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
+++ b/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
@@ -199,6 +199,9 @@ public class BridgeSpringConfig {
         // configure Jedis pool
         JedisPoolConfig poolConfig = new JedisPoolConfig();
         poolConfig.setMaxTotal(config.getPropertyAsInt("redis.max.total"));
+        poolConfig.setTestOnBorrow(true);
+        poolConfig.setTestOnReturn(true);
+
         String host = config.getProperty("redis.host");
         int port = config.getPropertyAsInt("redis.port");
         int timeout = config.getPropertyAsInt("redis.timeout");

--- a/app/org/sagebionetworks/bridge/redis/JedisOps.java
+++ b/app/org/sagebionetworks/bridge/redis/JedisOps.java
@@ -175,8 +175,11 @@ public class JedisOps {
     private abstract class AbstractJedisTemplate<T> {
 
         T execute() {
-            try (Jedis jedis = jedisPool.getResource()) {
+            Jedis jedis = jedisPool.getResource();
+            try {
                 return execute(jedis);
+            } finally {
+                JedisUtil.closeJedisConnection(jedis);
             }
         }
 

--- a/app/org/sagebionetworks/bridge/redis/JedisTransaction.java
+++ b/app/org/sagebionetworks/bridge/redis/JedisTransaction.java
@@ -3,10 +3,7 @@ package org.sagebionetworks.bridge.redis;
 import java.util.List;
 
 import redis.clients.jedis.Jedis;
-import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.Transaction;
-import redis.clients.jedis.exceptions.JedisException;
-import redis.clients.util.Pool;
 
 /**
  * Provides abstraction over Jedis's transactions.
@@ -37,44 +34,32 @@ public class JedisTransaction implements AutoCloseable {
     }
 
     public List<Object> exec() {
-        try (Jedis jedis = this.jedis) {
+        try {
             return transaction.exec();
+        } finally {
+            close();
         }
     }
 
     public String discard() {
-        try (Jedis jedis = this.jedis) {
+        try {
             return transaction.discard();
+        } finally {
+            close();
         }
     }
 
     @Override
-    public void finalize() {
-        close();
+    public void finalize() throws Throwable {
+        try {
+            close();
+        } finally {
+            super.finalize();
+        }
     }
 
     @Override
     public void close() {
-        try {
-            jedis.close();
-        } catch (JedisException e) {
-            // Jedis throws an exception here on closed connections
-            // See https://github.com/xetorthio/jedis/issues/992
-            // We skip this particular exception
-            final String message = e.getMessage();
-            if (message != null && message.equals(
-                    "Could not return the resource to the pool")) {
-                StackTraceElement[] stackTrace = e.getStackTrace();
-                if (stackTrace != null && stackTrace.length > 0) {
-                    final StackTraceElement topFrame = stackTrace[0];
-                    final String className = topFrame.getClassName();
-                    if (className.equals(Pool.class.getName()) ||
-                            className.equals(JedisPool.class.getName())) {
-                        return;
-                    }
-                }
-            }
-            throw e;
-        }
+        JedisUtil.closeJedisConnection(jedis);
     }
 }

--- a/app/org/sagebionetworks/bridge/redis/JedisUtil.java
+++ b/app/org/sagebionetworks/bridge/redis/JedisUtil.java
@@ -1,0 +1,39 @@
+package org.sagebionetworks.bridge.redis;
+
+import javax.annotation.Nonnull;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.exceptions.JedisException;
+import redis.clients.util.Pool;
+
+/** Static utility functions for Jedis. */
+public class JedisUtil {
+    /**
+     * Closes a Jedis connection. This encapsulates logic to suppress the "Could not return the resource to the pool"
+     * exceptions, which is a known bug. See https://github.com/xetorthio/jedis/issues/992
+     */
+    public static void closeJedisConnection(@Nonnull Jedis jedis) {
+        try {
+            jedis.close();
+        } catch (JedisException e) {
+            // Jedis throws an exception here on closed connections
+            // See https://github.com/xetorthio/jedis/issues/992
+            // We skip this particular exception
+            final String message = e.getMessage();
+            if (message != null && message.equals(
+                    "Could not return the resource to the pool")) {
+                StackTraceElement[] stackTrace = e.getStackTrace();
+                if (stackTrace != null && stackTrace.length > 0) {
+                    final StackTraceElement topFrame = stackTrace[0];
+                    final String className = topFrame.getClassName();
+                    if (className.equals(Pool.class.getName()) ||
+                            className.equals(JedisPool.class.getName())) {
+                        return;
+                    }
+                }
+            }
+            throw e;
+        }
+    }
+}

--- a/test/org/sagebionetworks/bridge/redis/JedisTransactionTest.java
+++ b/test/org/sagebionetworks/bridge/redis/JedisTransactionTest.java
@@ -77,7 +77,7 @@ public class JedisTransactionTest {
     }
 
     @Test
-    public void testFinalize() throws Exception {
+    public void testFinalize() throws Throwable {
         try (JedisTransaction transaction = jedisOps.getTransaction()) {
             transaction.exec();
             transaction.finalize();


### PR DESCRIPTION
These changes work around a Jedis bug that throws exceptions on closing a connection and turns on the connection validation flags in the Jedis config. These are needed to solve the Jedis errors we're seeing in production.
