### PR TITLE
downgrade newrelic to 3.14.0 (last known good); add rate limiting to upload validation backfill

### DIFF
--- a/app/org/sagebionetworks/bridge/services/backfill/UploadValidationBackfill.java
+++ b/app/org/sagebionetworks/bridge/services/backfill/UploadValidationBackfill.java
@@ -68,8 +68,14 @@ public class UploadValidationBackfill extends AsyncBackfillTemplate {
         // query and iterate over uploads
         List<? extends Upload> uploadList = uploadDao.getFailedUploadsForDates(startDate, endDate);
         for (Upload oneUpload : uploadList) {
-            String uploadId = oneUpload.getUploadId();
+            // rate limit so we down starve threads or brown out DDB
+            try {
+                Thread.sleep(50);
+            } catch (InterruptedException ex) {
+                logger.error("Interrupted while sleeping: " + ex.getMessage(), ex);
+            }
 
+            String uploadId = oneUpload.getUploadId();
             try {
                 // Call uploadComplete() to reset the upload status and uploadDate. This will make the upload
                 // eligible for validation again.

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-dynamodb" % "1.9.38",
   "com.amazonaws" % "aws-java-sdk-ses" % "1.9.38",
   // New Relic
-  "com.newrelic.agent.java" % "newrelic-agent" % "3.16.1",
+  "com.newrelic.agent.java" % "newrelic-agent" % "3.14.0",
   // Spring
   "org.springframework" % "spring-context" % "4.0.7.RELEASE",
   // Apache Commons


### PR DESCRIPTION
We believe newrelic 3.16.2 is causing boot timeouts in heroku, so we're downgrading back to 3.14.0 to see if that helps.

The upload validation backfill is estimated to affect up to 160k rows. Rate limit the backfill to 20/sec (50ms delay), to prevent starving threads or browning out DDB. At this rate, the backfill should complete in ~2.5 hours.
