### PR TITLE
a few more minor fixes

### DIFF
--- a/app/org/sagebionetworks/bridge/services/AuthenticationServiceImpl.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationServiceImpl.java
@@ -129,7 +129,9 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 
             return session;
         } finally {
-            lockDao.releaseLock(SignIn.class, signIn.getUsername(), lockId);
+            if (lockId != null) {
+                lockDao.releaseLock(SignIn.class, signIn.getUsername(), lockId);
+            }
         }
 
     }

--- a/app/org/sagebionetworks/bridge/services/backfill/UploadValidationBackfill.java
+++ b/app/org/sagebionetworks/bridge/services/backfill/UploadValidationBackfill.java
@@ -2,14 +2,11 @@ package org.sagebionetworks.bridge.services.backfill;
 
 import java.util.List;
 
-import org.joda.time.LocalDate;
-import org.joda.time.format.ISODateTimeFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.dao.HealthCodeDao;
 import org.sagebionetworks.bridge.dao.UploadDao;
 import org.sagebionetworks.bridge.models.backfill.BackfillTask;
@@ -57,11 +54,10 @@ public class UploadValidationBackfill extends AsyncBackfillTemplate {
 
     @Override
     void doBackfill(BackfillTask task, BackfillCallback callback) {
-        // Backfill should go from 2015-04-21 (when we saw a drop in asthma activities) to yesterday (because today's
-        // data might include things being validated right now).
+        // Backfill should go from 2015-04-21 (when we saw a drop in asthma activities) to 2015-06-05 (when the
+        // memory fix hit prod).
         String startDate = "2015-04-21";
-        String endDate = LocalDate.now(BridgeConstants.LOCAL_TIME_ZONE).minusDays(1)
-                .toString(ISODateTimeFormat.date());
+        String endDate = "2015-06-05";
 
         recordMessage(task, callback, "Starting upload validation backfill from " + startDate + " to " + endDate);
 

--- a/app/org/sagebionetworks/bridge/stormpath/StormpathAccountDao.java
+++ b/app/org/sagebionetworks/bridge/stormpath/StormpathAccountDao.java
@@ -131,7 +131,12 @@ public class StormpathAccountDao implements AccountDao {
                 .setAccountStore(directory)
                 .setLogin(email.getEmail())
                 .build();
-        application.sendVerificationEmail(request);
+
+        try {
+            application.sendVerificationEmail(request);
+        } catch (ResourceException e) {
+            rethrowResourceException(e, null);
+        }
     }
 
     @Override

--- a/app/org/sagebionetworks/bridge/upload/UploadValidationTask.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadValidationTask.java
@@ -68,6 +68,9 @@ public class UploadValidationTask implements Runnable {
             try {
                 oneHandler.handle(context);
             } catch (RuntimeException | UploadValidationException ex) {
+                // Upload validation failed. Since there are a lot of garbage uploads, log this at the info level so it
+                // doesn't set off our alarms. Once the garbage uploads are cleaned up, we can bump this back up to
+                // warning.
                 context.setSuccess(false);
                 context.addMessage(String.format("Exception thrown from upload validation handler %s: %s: %s",
                         handlerName, ex.getClass().getName(), ex.getMessage()));
@@ -75,6 +78,13 @@ public class UploadValidationTask implements Runnable {
                                 "upload %s, filename %s: %s: %s", handlerName, context.getStudy().getIdentifier(),
                         context.getUpload().getUploadId(), context.getUpload().getFilename(), ex.getClass().getName(),
                         ex.getMessage()), ex);
+                break;
+            } catch (Throwable t) {
+                // Something really bad happened, like an OutOfMemoryError. Log this at the error level.
+                logger.error(String.format("Critical error in upload validation handler %s for study %s, " +
+                                "upload %s, filename %s: %s: %s", handlerName, context.getStudy().getIdentifier(),
+                        context.getUpload().getUploadId(), context.getUpload().getFilename(), t.getClass().getName(),
+                        t.getMessage()), t);
                 break;
             } finally {
                 long elapsedMillis = stopwatch.elapsed(TimeUnit.MILLISECONDS);


### PR DESCRIPTION
- fixed NullPointerException for signIn - If the lock fails, the finally block will try to release the lock for a null lock ID, which throws an NPE. This check prevents that NPE, and the original exception will be propagated.
- UploadValidationBackfill end date of June 5 - The fix was confirmed on June 5. Set the end date to that date instead of "yesterday".
- fixed ResourceException for invalid emails for resendEmailVerification - This is a common pattern in all of the other StormpathAccountDao calls, but we missed it for this one.
- UploadValidationTask - We catch RuntimeExceptions, but not Throwables. Since Throwables (specifically Errors) represent things like OutOfMemoryError, we want to log these as errors so that our logger picks them up. (Long-term, we'll need a way to integrate the exception interceptor with helper thread pools.)

Testing done:
- unit tests for all changed files
- loaded the local server and signed in/out
