### PR TITLE
Fixing potential error in task events around re-answering survey questions

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoTaskEvent.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoTaskEvent.java
@@ -15,6 +15,7 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
 public class DynamoTaskEvent implements TaskEvent {
 
     private String healthCode;
+    private String answerValue;
     private Long timestamp;
     private String eventId;
     
@@ -26,6 +27,14 @@ public class DynamoTaskEvent implements TaskEvent {
     @Override
     public void setHealthCode(String healthCode) {
         this.healthCode = healthCode;
+    }
+    @Override
+    public String getAnswerValue() {
+        return answerValue;
+    }
+    @Override
+    public void setAnswerValue(String answerValue) {
+        this.answerValue = answerValue;
     }
     @Override
     public Long getTimestamp() {
@@ -51,7 +60,7 @@ public class DynamoTaskEvent implements TaskEvent {
         private TaskEventObjectType type;
         private String objectId;
         private TaskEventType eventType;
-        private String value;
+        private String answerValue;
         
         public Builder withHealthCode(String healthCode) {
             this.healthCode = healthCode;
@@ -77,18 +86,19 @@ public class DynamoTaskEvent implements TaskEvent {
             this.eventType = type;
             return this;
         }
-        public Builder withValue(String value) {
-            this.value = value;
+        public Builder withAnswerValue(String answerValue) {
+            this.answerValue = answerValue;
             return this;
         }
         private String getEventId() {
             if (type == null) {
                 return null;
             }
+            if (type == TaskEventObjectType.ENROLLMENT) {
+                return type.name().toLowerCase();
+            }
             String typeName = type.name().toLowerCase();
-            if (objectId != null && eventType != null && value != null) {
-                return String.format("%s:%s:%s=%s", typeName, objectId, eventType.name().toLowerCase(), value);
-            } else if (objectId != null && eventType != null) {
+            if (objectId != null && eventType != null) {
                 return String.format("%s:%s:%s", typeName, objectId, eventType.name().toLowerCase());
             } else if (objectId != null) {
                 return String.format("%s:%s", typeName, objectId);
@@ -101,7 +111,8 @@ public class DynamoTaskEvent implements TaskEvent {
             event.setHealthCode(healthCode);
             event.setTimestamp((timestamp == null) ? null : timestamp);
             event.setEventId(getEventId());
-            
+            event.setAnswerValue(answerValue);
+
             Validate.entityThrowingException(TaskEventValidator.INSTANCE, event);
             
             return event;

--- a/app/org/sagebionetworks/bridge/models/tasks/TaskEvent.java
+++ b/app/org/sagebionetworks/bridge/models/tasks/TaskEvent.java
@@ -9,6 +9,9 @@ public interface TaskEvent extends BridgeEntity {
     
     public String getEventId();
     public void setEventId(String eventId);
+
+    public String getAnswerValue();
+    public void setAnswerValue(String answerValue);
     
     public Long getTimestamp();
     public void setTimestamp(Long timestamp);

--- a/app/org/sagebionetworks/bridge/services/TaskEventService.java
+++ b/app/org/sagebionetworks/bridge/services/TaskEventService.java
@@ -26,7 +26,7 @@ public class TaskEventService {
     @Autowired
     public void setTaskEventDao(TaskEventDao taskEventDao) {
         this.taskEventDao = taskEventDao;
-    } // 
+    }
     
     public void publishEvent(String healthCode, UserConsent consent) {
         checkNotNull(consent);
@@ -48,7 +48,7 @@ public class TaskEventService {
             .withObjectType(TaskEventObjectType.QUESTION)
             .withObjectId(answer.getQuestionGuid())
             .withEventType(TaskEventType.ANSWERED)
-            .withValue(Joiner.on(",").join(answer.getAnswers())).build();
+            .withAnswerValue(Joiner.on(",").join(answer.getAnswers())).build();
         taskEventDao.publishEvent(event);
     }
     

--- a/app/org/sagebionetworks/bridge/validators/TaskEventValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/TaskEventValidator.java
@@ -26,7 +26,9 @@ public class TaskEventValidator implements Validator {
             errors.rejectValue("timestamp", "cannot be null");
         }
         if (event.getEventId() == null) {
-            errors.rejectValue("eventId", "cannot be null");
+            errors.rejectValue("eventId", "cannot be null (may be missing object or event type)");
+        } else if (event.getEventId().endsWith(":answered") && isBlank(event.getAnswerValue())) {
+            errors.rejectValue("answerValue", "cannot be null or blank if the event indicates the answer to a survey");
         }
     }
 }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoTaskEventDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoTaskEventDaoTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.dynamodb;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.util.Map;
 
@@ -34,31 +35,63 @@ public class DynamoTaskEventDaoTest {
     public void canCrudEvent() {
         DateTime time1 = DateTime.now();
         DateTime time2 = time1.plusDays(1);
-        DateTime time3 = time2.plusDays(1);
+        DateTime time3 = time1.plusDays(2);
+        DateTime time4 = time1.plusDays(3);
+        DateTime time5 = time1.plusDays(4);
         
-        TaskEvent event = new DynamoTaskEvent.Builder().withHealthCode("BBB").withObjectType(TaskEventObjectType.ENROLLMENT).withTimestamp(time1).build();
+        // This is an answer event. It's key should be "question:CCC:answered" with a value column
+        // the task event map should create a key with the value, such as "question:CCC:answered=value"
+        TaskEvent event = getEnrollmentEvent(time1);
         taskEventDao.publishEvent(event);
-
-        // Just create another task to verify records aren't colliding
-        event = new DynamoTaskEvent.Builder().withHealthCode("BBB").withObjectType(TaskEventObjectType.SURVEY)
-                        .withEventType(TaskEventType.FINISHED).withTimestamp(time3).withObjectId("AAA-BBB-CCC").build();
+        event = getSurveyFinishedEvent(time2);
+        taskEventDao.publishEvent(event);
+        event = getQuestionAnsweredEvent(time3, "someValue");
         taskEventDao.publishEvent(event);
         
         Map<String,DateTime> map = taskEventDao.getTaskEventMap("BBB");
-        assertEquals(2, map.size());
+        assertEquals(3, map.size());
         assertEquals(time1, map.get("enrollment"));
-        assertEquals(time3, map.get("survey:AAA-BBB-CCC:finished"));
+        assertEquals(time2, map.get("survey:AAA-BBB-CCC:finished"));
+        assertEquals(time3, map.get("question:DDD-EEE-FFF:answered=someValue"));
         
-        event = new DynamoTaskEvent.Builder().withHealthCode("BBB").withObjectType(TaskEventObjectType.ENROLLMENT).withTimestamp(time2).build();
+        // Update timestamp of answer event while keeping same answer
+        event = getQuestionAnsweredEvent(time4, "someValue");
         taskEventDao.publishEvent(event);
         
         map = taskEventDao.getTaskEventMap("BBB");
-        assertEquals(time2, map.get("enrollment"));
-
+        assertEquals(time4, map.get("question:DDD-EEE-FFF:answered=someValue"));
+        
+        // Update answer event with different answer and later timestamp
+        event = getQuestionAnsweredEvent(time5, "anotherAnswer");
+        taskEventDao.publishEvent(event);
+        
+        // Creates a different key in task event map. Researchers schedule against specific answers.
+        map = taskEventDao.getTaskEventMap("BBB");
+        assertEquals(time5, map.get("question:DDD-EEE-FFF:answered=anotherAnswer"));
+        // The key point here is that the other answer is no longer in the map, so there can't be 
+        // an "either or" scheduling conflict. The user can only answer one way or another on a 
+        // given question, even if the answer is updated.
+        assertNull(map.get("question:DDD-EEE-FFF:answered=someAnswer"));
+        
         taskEventDao.deleteTaskEvents("BBB");
         
         map = taskEventDao.getTaskEventMap("BBB");
         assertEquals(0, map.size());
     }
     
+    private DynamoTaskEvent getEnrollmentEvent(DateTime timestamp) {
+        return new DynamoTaskEvent.Builder().withHealthCode("BBB")
+            .withObjectType(TaskEventObjectType.ENROLLMENT).withTimestamp(timestamp).build();
+    }
+    
+    private DynamoTaskEvent getSurveyFinishedEvent(DateTime timestamp) {
+        return new DynamoTaskEvent.Builder().withHealthCode("BBB").withObjectType(TaskEventObjectType.SURVEY)
+            .withEventType(TaskEventType.FINISHED).withTimestamp(timestamp).withObjectId("AAA-BBB-CCC").build();
+    }
+    
+    private DynamoTaskEvent getQuestionAnsweredEvent(DateTime timestamp, String answer) {
+        return new DynamoTaskEvent.Builder().withHealthCode("BBB")
+            .withObjectType(TaskEventObjectType.QUESTION).withObjectId("DDD-EEE-FFF")
+            .withEventType(TaskEventType.ANSWERED).withAnswerValue(answer).withTimestamp(timestamp).build();
+    }
 }

--- a/test/org/sagebionetworks/bridge/services/TaskEventServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/TaskEventServiceTest.java
@@ -136,7 +136,7 @@ public class TaskEventServiceTest {
         ArgumentCaptor<TaskEvent> argument = ArgumentCaptor.forClass(TaskEvent.class);
         verify(taskEventDao).publishEvent(argument.capture());
         
-        assertEquals("question:BBB-CCC-DDD:answered=belgium", argument.getValue().getEventId());
+        assertEquals("question:BBB-CCC-DDD:answered", argument.getValue().getEventId());
         assertEquals(new Long(now.getMillis()), argument.getValue().getTimestamp());
         assertEquals("healthCode", argument.getValue().getHealthCode());
     }


### PR DESCRIPTION
This prevents the following scenario:
1. User answers a question and generates a task event (let's say question:foo:answered=A)
2. User returns later and answers question again with different answer (question:foo:answered=B)

Prior to this, both answers would be in the task event map handed to the scheduler. The scheduler assumes and either/or situation, for example, "schedule a series of tasks if the user answered 'A', or do nothing if the user answered 'B'". With both results in the task map, you get unpredictable results. Here, the users final answer means they shouldn't receive tasks, but they will.

Split out the answer from the key in the table, and only add it back when creating the event map for the scheduler. Now these events will update the same row in DDB, there will be only one entry in the map, and there will be no ambiguity about the answer.
