### PR TITLE
Older apps allow all caps passwords

### DIFF
--- a/app/org/sagebionetworks/bridge/DefaultStudyBootstrapper.java
+++ b/app/org/sagebionetworks/bridge/DefaultStudyBootstrapper.java
@@ -29,7 +29,7 @@ public class DefaultStudyBootstrapper {
             study.setStormpathHref("https://enterprise.stormpath.io/v1/directories/7fxheMcEARjm7X2XPBufSM");
             study.getUserProfileAttributes().add("phone");
             study.getUserProfileAttributes().add("can_be_recontacted");
-            study.setPasswordPolicy(new PasswordPolicy(2, false, false, false));
+            study.setPasswordPolicy(new PasswordPolicy(2, false, false, false, false));
             studyService.createStudy(study);
         }
     }

--- a/app/org/sagebionetworks/bridge/models/studies/PasswordPolicy.java
+++ b/app/org/sagebionetworks/bridge/models/studies/PasswordPolicy.java
@@ -20,22 +20,25 @@ public final class PasswordPolicy {
     /**
      * The password policy that is initially created for a study.
      */
-    public static final PasswordPolicy DEFAULT_PASSWORD_POLICY = new PasswordPolicy(8, true, true, true);
+    public static final PasswordPolicy DEFAULT_PASSWORD_POLICY = new PasswordPolicy(8, true, true, true, true);
     
     private final int minLength;
     private final boolean numericRequired;
     private final boolean symbolRequired;
+    private final boolean lowerCaseRequired;
     private final boolean upperCaseRequired;
     
     @JsonCreator
     public PasswordPolicy(@JsonProperty("minLength") int minLength,
-                    @JsonProperty("numericRequired") boolean requireNumeric,
-                    @JsonProperty("symbolRequired") boolean requireSymbol,
-                    @JsonProperty("UpperCaseRequired") boolean requireUpperCase) {
+                    @JsonProperty("numericRequired") boolean numericRequired,
+                    @JsonProperty("symbolRequired") boolean symbolRequired,
+                    @JsonProperty("lowerCaseRequired") boolean lowerCaseRequired,
+                    @JsonProperty("upperCaseRequired") boolean upperCaseRequired) {
         this.minLength = minLength;
-        this.numericRequired = requireNumeric;
-        this.symbolRequired = requireSymbol;
-        this.upperCaseRequired = requireUpperCase;
+        this.numericRequired = numericRequired;
+        this.symbolRequired = symbolRequired;
+        this.lowerCaseRequired = lowerCaseRequired;
+        this.upperCaseRequired = upperCaseRequired;
     }
     
     public int getMinLength() {
@@ -46,6 +49,9 @@ public final class PasswordPolicy {
     }
     public boolean isSymbolRequired() {
         return symbolRequired;
+    }
+    public boolean isLowerCaseRequired() {
+        return lowerCaseRequired;
     }
     public boolean isUpperCaseRequired() {
         return upperCaseRequired;
@@ -58,6 +64,7 @@ public final class PasswordPolicy {
         result = prime * result + Objects.hashCode(minLength);
         result = prime * result + Objects.hashCode(numericRequired);
         result = prime * result + Objects.hashCode(symbolRequired);
+        result = prime * result + Objects.hashCode(lowerCaseRequired);
         result = prime * result + Objects.hashCode(upperCaseRequired);
         return result;
     }
@@ -72,12 +79,13 @@ public final class PasswordPolicy {
         return (Objects.equals(minLength, other.minLength) && 
                 Objects.equals(numericRequired, other.numericRequired) &&
                 Objects.equals(symbolRequired, other.symbolRequired) &&
+                Objects.equals(lowerCaseRequired, other.lowerCaseRequired) &&
                 Objects.equals(upperCaseRequired, other.upperCaseRequired));
     }
 
     @Override
     public String toString() {
-        return String.format("PasswordPolicy [minLength=%s, numericRequired=%s, symbolRequired=%s, upperCaseRequired=%s]",
-            minLength, numericRequired, symbolRequired, upperCaseRequired);
+        return String.format("PasswordPolicy [minLength=%s, numericRequired=%s, symbolRequired=%s, lowerCaseRequired=%s, upperCaseRequired=%s]",
+            minLength, numericRequired, symbolRequired, lowerCaseRequired, upperCaseRequired);
     }
 }

--- a/app/org/sagebionetworks/bridge/stormpath/StormpathDirectoryDao.java
+++ b/app/org/sagebionetworks/bridge/stormpath/StormpathDirectoryDao.java
@@ -232,11 +232,11 @@ public class StormpathDirectoryDao implements DirectoryDao {
         
         PasswordStrength strength = passwordPolicy.getStrength();
         strength.setMaxLength(org.sagebionetworks.bridge.models.studies.PasswordPolicy.FIXED_MAX_LENGTH);
-        strength.setMinLowerCase(1);
         strength.setMinDiacritic(0);
         strength.setMinLength(study.getPasswordPolicy().getMinLength());
         strength.setMinNumeric(study.getPasswordPolicy().isNumericRequired() ? 1 : 0);
         strength.setMinSymbol(study.getPasswordPolicy().isSymbolRequired() ? 1 : 0);
+        strength.setMinLowerCase(study.getPasswordPolicy().isLowerCaseRequired() ? 1 : 0);
         strength.setMinUpperCase(study.getPasswordPolicy().isUpperCaseRequired() ? 1 : 0);
         strength.save();
         passwordPolicy.save();

--- a/test/org/sagebionetworks/bridge/DefaultStudyBootstrapperTest.java
+++ b/test/org/sagebionetworks/bridge/DefaultStudyBootstrapperTest.java
@@ -41,7 +41,7 @@ public class DefaultStudyBootstrapperTest {
         assertEquals("support@sagebridge.org", study.getSupportEmail());
         assertEquals("https://enterprise.stormpath.io/v1/directories/7fxheMcEARjm7X2XPBufSM", study.getStormpathHref());
         assertEquals(Sets.newHashSet("phone", "can_be_recontacted"), study.getUserProfileAttributes());
-        assertEquals(new PasswordPolicy(2, false, false, false), study.getPasswordPolicy());
+        assertEquals(new PasswordPolicy(2, false, false, false, false), study.getPasswordPolicy());
     }
     
 }

--- a/test/org/sagebionetworks/bridge/models/studies/PasswordPolicyTest.java
+++ b/test/org/sagebionetworks/bridge/models/studies/PasswordPolicyTest.java
@@ -17,14 +17,15 @@ public class PasswordPolicyTest {
     
     @Test
     public void canSerialize() throws Exception {
-        PasswordPolicy policy = new PasswordPolicy(8, true, false, true);
+        PasswordPolicy policy = new PasswordPolicy(8, true, true, true, true);
         
         String json = BridgeObjectMapper.get().writeValueAsString(policy);
         JsonNode node = BridgeObjectMapper.get().readTree(json);
         
         assertEquals(8, node.get("minLength").asInt());
         assertEquals(true, node.get("numericRequired").asBoolean());
-        assertEquals(false, node.get("symbolRequired").asBoolean());
+        assertEquals(true, node.get("symbolRequired").asBoolean());
+        assertEquals(true, node.get("lowerCaseRequired").asBoolean());
         assertEquals(true, node.get("upperCaseRequired").asBoolean());
         assertEquals("PasswordPolicy", node.get("type").asText());
         

--- a/test/org/sagebionetworks/bridge/services/StudyServiceImplTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceImplTest.java
@@ -158,7 +158,7 @@ public class StudyServiceImplTest {
         assertNotNull(rpTemplate.getBody());
         
         // Now change them and verify they are changed.
-        study.setPasswordPolicy(new PasswordPolicy(6, true, false, true));
+        study.setPasswordPolicy(new PasswordPolicy(6, true, false, false, true));
         study.setVerifyEmailTemplate(new EmailTemplate("subject *", "body ${url} *", MimeType.TEXT));
         study.setResetPasswordTemplate(new EmailTemplate("subject **", "body ${url} **", MimeType.TEXT));
         
@@ -167,6 +167,7 @@ public class StudyServiceImplTest {
         assertEquals(6, policy.getMinLength());
         assertTrue(policy.isNumericRequired());
         assertFalse(policy.isSymbolRequired());
+        assertFalse(policy.isLowerCaseRequired());
         assertTrue(policy.isUpperCaseRequired());
         
         veTemplate = study.getVerifyEmailTemplate();

--- a/test/org/sagebionetworks/bridge/stormpath/StormpathDirectoryDaoTest.java
+++ b/test/org/sagebionetworks/bridge/stormpath/StormpathDirectoryDaoTest.java
@@ -75,7 +75,7 @@ public class StormpathDirectoryDaoTest {
         assertDirectoriesAreEqual(study, "subject", "subject", directory, newDirectory);
         
         // Verify that we can update the directory.
-        study.setPasswordPolicy(new PasswordPolicy(3, false, false, false));
+        study.setPasswordPolicy(new PasswordPolicy(3, true, true, true, true));
         study.setResetPasswordTemplate(new EmailTemplate("new rp subject", "new rp body ${url}", MimeType.TEXT));
         study.setVerifyEmailTemplate(new EmailTemplate("new ve subject", "<p>new ve body ${url}</p>", MimeType.HTML));
         
@@ -111,9 +111,9 @@ public class StormpathDirectoryDaoTest {
         
         PasswordStrength strength = passwordPolicy.getStrength();
         assertEquals(PasswordPolicy.FIXED_MAX_LENGTH, strength.getMaxLength());
-        assertEquals(1, strength.getMinLowerCase());
         assertEquals(study.getPasswordPolicy().isNumericRequired() ? 1 : 0, strength.getMinNumeric());
         assertEquals(study.getPasswordPolicy().isSymbolRequired() ? 1 : 0, strength.getMinSymbol());
+        assertEquals(study.getPasswordPolicy().isLowerCaseRequired() ? 1 : 0, strength.getMinLowerCase());
         assertEquals(study.getPasswordPolicy().isUpperCaseRequired() ? 1 : 0, strength.getMinUpperCase());
         assertEquals(0, strength.getMinDiacritic());
         assertEquals(study.getPasswordPolicy().getMinLength(), strength.getMinLength());

--- a/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
@@ -26,13 +26,13 @@ public class StudyValidatorTest {
     // While 2 is not a good length, we must allow it for legacy reasons.
     @Test(expected = InvalidEntityException.class)
     public void minLengthCannotBeLessThan2() {
-        study.setPasswordPolicy(new PasswordPolicy(1, false, false, false));
+        study.setPasswordPolicy(new PasswordPolicy(1, false, false, false, false));
         Validate.entityThrowingException(StudyValidator.INSTANCE, study);
     }
     
     @Test(expected = InvalidEntityException.class)
     public void minLengthCannotBeMoreThan999() {
-        study.setPasswordPolicy(new PasswordPolicy(1000, false, false, false));
+        study.setPasswordPolicy(new PasswordPolicy(1000, false, false, false, false));
         Validate.entityThrowingException(StudyValidator.INSTANCE, study);
     }
     


### PR DESCRIPTION
Lower-case letter cannot be 'required', this must be configurable. They won't be required for legacy apps, but will be required for studies going forward.
