### PR TITLE
prevent whitelisted studies from recreating certs

### DIFF
--- a/app/org/sagebionetworks/bridge/services/StudyServiceImpl.java
+++ b/app/org/sagebionetworks/bridge/services/StudyServiceImpl.java
@@ -161,7 +161,12 @@ public class StudyServiceImpl implements StudyService {
 
             String directory = directoryDao.createDirectoryForStudy(study);
             study.setStormpathHref(directory);
-            uploadCertService.createCmsKeyPair(study.getIdentifier());
+
+            // do not create certs for whitelisted studies (legacy studies)
+            if (!studyWhitelist.contains(study.getIdentifier())) {
+                uploadCertService.createCmsKeyPair(study.getIdentifier());
+            }
+
             study = studyDao.createStudy(study);
             
             cacheProvider.setStudy(study);


### PR DESCRIPTION
Previously, if someone deleted and recreated the api study (or any study) on their local dev box (or any environment), or if a new teammate joined and bootstrapped Bridge for the first time, this would recreate the cert. Since certs are shared across all developers for any given environment, this would break all developers. Most notably, this would break integration tests, which have pre-encrypted uploads.

This is also a stability risk, as if someone accidentally recreated a study in prod, this would break prod.

This change is a simple patch so that any study in the white list (that is, the api test study and the 5 original studies) won't have its cert recreated.

Long-term, we'll need a more elegant and scalable solution, like having developers have their own S3 bucket, or checking if the cert exists before re-creating it.
