### PR TITLE
add record ID to upload validation logging

### DIFF
--- a/app/org/sagebionetworks/bridge/upload/UploadArtifactsHandler.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadArtifactsHandler.java
@@ -46,6 +46,7 @@ public class UploadArtifactsHandler implements UploadValidationHandler {
         HealthDataRecordBuilder recordBuilder = context.getHealthDataRecordBuilder();
         HealthDataRecord record = recordBuilder.build();
         String recordId = healthDataService.createOrUpdateRecord(record);
+        context.setRecordId(recordId);
 
         Map<String, byte[]> attachmentMap = context.getAttachmentsByFieldName();
         if (!attachmentMap.isEmpty()) {

--- a/app/org/sagebionetworks/bridge/upload/UploadValidationContext.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadValidationContext.java
@@ -23,6 +23,7 @@ public class UploadValidationContext {
     private Map<String, JsonNode> jsonDataMap;
     private HealthDataRecordBuilder healthDataRecordBuilder;
     private Map<String, byte[]> attachmentsByFieldName;
+    private String recordId;
 
     /**
      * This is the study that the upload lives in and is validated against. This is made available by the upload
@@ -155,6 +156,16 @@ public class UploadValidationContext {
         this.attachmentsByFieldName = attachmentsByFieldName;
     }
 
+    /** ID of the health data record created from the upload. This is created by the UploadArtifactsHandler. */
+    public String getRecordId() {
+        return recordId;
+    }
+
+    /** @see #getRecordId */
+    public void setRecordId(String recordId) {
+        this.recordId = recordId;
+    }
+
     /**
      * <p>
      * Makes a shallow copy of this object. The fields of the returned copy can be get and set without affecting the
@@ -182,6 +193,7 @@ public class UploadValidationContext {
         copy.jsonDataMap = this.jsonDataMap;
         copy.healthDataRecordBuilder = this.healthDataRecordBuilder;
         copy.attachmentsByFieldName = this.attachmentsByFieldName;
+        copy.recordId = this.recordId;
 
         // messageList is the only field that gets deep copied
         copy.messageList = new ArrayList<>(this.messageList);

--- a/app/org/sagebionetworks/bridge/upload/UploadValidationTask.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadValidationTask.java
@@ -99,8 +99,8 @@ public class UploadValidationTask implements Runnable {
         // write validation status to the upload DAO
         UploadStatus status = context.getSuccess() ? UploadStatus.SUCCEEDED : UploadStatus.VALIDATION_FAILED;
         uploadDao.writeValidationStatus(context.getUpload(), status, context.getMessageList());
-        logger.info(String.format("Upload validation for study %s, upload %s, with status %s",
-                context.getStudy().getIdentifier(), context.getUpload().getUploadId(), status));
+        logger.info(String.format("Upload validation for study %s, upload %s, record %s, with status %s",
+                context.getStudy().getIdentifier(), context.getUpload().getUploadId(), context.getRecordId(), status));
 
         // TODO: if validation fails, wipe the files from S3
     }

--- a/test/org/sagebionetworks/bridge/upload/UploadArtifactsHandlerTest.java
+++ b/test/org/sagebionetworks/bridge/upload/UploadArtifactsHandlerTest.java
@@ -144,6 +144,9 @@ public class UploadArtifactsHandlerTest {
         verify(mockS3Helper).writeBytesToS3(TestConstants.ATTACHMENT_BUCKET, ATTACHMENT_ID_BAR, BYTES_BAR);
         verify(mockS3Helper).writeBytesToS3(TestConstants.ATTACHMENT_BUCKET, ATTACHMENT_ID_FOO, BYTES_FOO);
 
+        // validate record ID in the context
+        assertEquals(TEST_RECORD_ID, context.getRecordId());
+
         // validate no messages on the context
         assertTrue(context.getMessageList().isEmpty());
     }

--- a/test/org/sagebionetworks/bridge/upload/UploadValidationContextTest.java
+++ b/test/org/sagebionetworks/bridge/upload/UploadValidationContextTest.java
@@ -45,6 +45,7 @@ public class UploadValidationContextTest {
         original.setJsonDataMap(jsonDataMap);
         original.setHealthDataRecordBuilder(recordBuilder);
         original.setAttachmentsByFieldName(attachmentMap);
+        original.setRecordId("test-record");
 
         // copy and validate
         UploadValidationContext copy = original.shallowCopy();
@@ -57,6 +58,7 @@ public class UploadValidationContextTest {
         assertSame(jsonDataMap, copy.getJsonDataMap());
         assertSame(recordBuilder, copy.getHealthDataRecordBuilder());
         assertSame(attachmentMap, copy.getAttachmentsByFieldName());
+        assertEquals("test-record", copy.getRecordId());
 
         assertEquals(1, copy.getMessageList().size());
         assertEquals("common message", copy.getMessageList().get(0));


### PR DESCRIPTION
When an upload successfully validates, we want the record IDs in the log in addition to the upload ID so we can track its progress through the data pipeline.

Testing done:
- unit tests for changed files
- upload integration tests
