### PR TITLE
raise zip file limit from 10mb to 25mb

### DIFF
--- a/conf/bridge.conf
+++ b/conf/bridge.conf
@@ -75,8 +75,8 @@ uat.upload.cms.priv.bucket = org-sagebridge-upload-cms-priv-uat
 prod.upload.cms.cert.bucket = org-sagebridge-upload-cms-cert-prod
 prod.upload.cms.priv.bucket = org-sagebridge-upload-cms-priv-prod
 
-// Maximum 10 MB per zip entry
-max.zip.entry.size = 10000000
+// Maximum 25 MB per zip entry
+max.zip.entry.size = 25000000
 // Maximum 100 zip entries per archive
 max.num.zip.entries = 100
 


### PR DESCRIPTION
We've found some files in prod that are as large as 17mb. Just to avoid breaking existing data streams, I'm raising the limit to 25mb. I will work with YML to make sure these files don't get too large.

Testing done:
- ran Upload integration tests
