### PR TITLE
Disable the Content-Security-Policy header

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -28,7 +28,7 @@ play.filters {
     permittedCrossDomainPolicies = "master-only"
 
     # The Content-Security-Policy header. If null, the header is not set.
-    contentSecurityPolicy = "default-src 'self'"
+    contentSecurityPolicy = null
   }
 
   # CORS filter configuration


### PR DESCRIPTION
Suspect that this also causes the link failures on researcher ui. 
