### PR TITLE
Fix CORS for Play 2.4.0

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/ApplicationController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ApplicationController.java
@@ -26,15 +26,4 @@ public class ApplicationController extends BaseController {
     public Result resetPassword() {
         return ok(views.html.resetPassword.render(Json.toJson(EMPTY_USER_SESSION).toString(), ASSETS_HOST, ASSETS_BUILD));
     }
-
-    // NOTE: I don't see this getting called...
-    public Result preflight(String all) {
-        response().setHeader(ACCESS_CONTROL_ALLOW_ORIGIN, "*");
-        response().setHeader(ACCESS_CONTROL_ALLOW_METHODS, "HEAD, GET, OPTIONS, POST, PUT, DELETE");
-        // Accept,  Accept-Language, Content-Language and Content-Type for normal HTML types are all allowed by default.
-        // We add Content-Type to specify JSON. We can add other headers here when needed, but wildcards don't always 
-        // seem to work, it's browser-dependent.
-        response().setHeader(ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type, User-Agent, Bridge-Session");
-        return ok();
-    }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -34,7 +34,7 @@ play.filters {
   # CORS filter configuration
   cors {
 
-    # The path prefixes to filter.
+    # The path prefixes to filter. "/" for all the paths.
     pathPrefixes = ["/"]
 
     # The allowed origins. If null, all origins are allowed.
@@ -44,7 +44,7 @@ play.filters {
     allowedHttpMethods = ["HEAD", "GET", "OPTIONS", "POST", "PUT", "DELETE"]
 
     # The allowed HTTP headers. If null, all headers are allowed.
-    allowedHttpHeaders = ["Content-Type", "User-Agent", "Bridge-Session"]
+    allowedHttpHeaders = ["Accept", "Content-Type", "User-Agent", "Bridge-Session"]
 
     # The exposed headers
     exposedHeaders = []

--- a/conf/routes
+++ b/conf/routes
@@ -1,5 +1,4 @@
 # Top level views
-OPTIONS    /*all                       @org.sagebionetworks.bridge.play.controllers.ApplicationController.preflight(all: String)
 GET        /                           @org.sagebionetworks.bridge.play.controllers.ApplicationController.loadApp
 GET        /index.html                 @org.sagebionetworks.bridge.play.controllers.ApplicationController.loadApp
 GET        /mobile/verifyEmail.html    @org.sagebionetworks.bridge.play.controllers.ApplicationController.verifyEmail


### PR DESCRIPTION
The preflight() method is not needed anymore.  CORS is completely controlled by CorsFilter which is configured in application.conf.

Added more tests to simulate more closely the requests sent by browsers.  The tests are able to reproduce the problem and verify the fix.
