### PR TITLE
Lock sign-in on both user name and study ID

### DIFF
--- a/app/org/sagebionetworks/bridge/services/AuthenticationServiceImpl.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationServiceImpl.java
@@ -40,7 +40,9 @@ import org.springframework.stereotype.Component;
 public class AuthenticationServiceImpl implements AuthenticationService {
     
     private final Logger logger = LoggerFactory.getLogger(AuthenticationServiceImpl.class);
-    
+
+    private final int LOCK_EXPIRE_IN_SECONDS = 5;
+
     private DistributedLockDao lockDao;
     private CacheProvider cacheProvider;
     private BridgeConfig config;
@@ -121,7 +123,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         String lockId = null;
         try {
             lockId = lockDao.acquireLock(SignIn.class,
-                    study.getIdentifier() + RedisKey.SEPARATOR + signIn.getUsername());
+                    study.getIdentifier() + RedisKey.SEPARATOR + signIn.getUsername(), LOCK_EXPIRE_IN_SECONDS);
             Account account = accountDao.authenticate(study, signIn);
             UserSession session = getSessionFromAccount(study, account);
             cacheProvider.setUserSession(session);
@@ -152,7 +154,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         
         String lockId = null;
         try {
-            lockId = lockDao.acquireLock(SignUp.class, signUp.getEmail());
+            lockId = lockDao.acquireLock(SignUp.class, signUp.getEmail(), LOCK_EXPIRE_IN_SECONDS);
             if (consentService.isStudyAtEnrollmentLimit(study)) {
                 throw new StudyLimitExceededException(study);
             }


### PR DESCRIPTION
We're seeing 0.5% of the sign-in requests get back ConcurrentModificationException "Lock already set".   We don't see such a high ratio in other places where the distributed lock is used.  I am **_guessing**_ we only lock on user during sign-in while the actual sign-in involves both the user and the study.  I suspect there are users using the same user name for more than one study.  This change is to help us understand why the race conditions occur.  Or, if the race conditions do happen naturally, try to queue up the sign-ins in a very limited manner -- retry at most 3 times with delay of 1 second in between.
