### PR TITLE
Suppressing user session keys in the admin cache API

### DIFF
--- a/test/org/sagebionetworks/bridge/services/CacheAdminServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/CacheAdminServiceTest.java
@@ -52,6 +52,11 @@ public class CacheAdminServiceTest {
     }
     
     @Test(expected = BridgeServiceException.class)
+    public void doesNotRemoveUserSessions() {
+        adminService.removeItem("xh7YDmjGQuTKnfdv9iJb0:session:user");
+    }
+    
+    @Test(expected = BridgeServiceException.class)
     public void throwsExceptionWhenThereIsNoKey() {
         adminService.removeItem("not:a:key");
     }
@@ -68,7 +73,8 @@ public class CacheAdminServiceTest {
     
     private Jedis createStubJedis() {
         return new Jedis("") {
-            private Set<String> set = Sets.newHashSet("foo:study", "bar:session", "baz:Survey:view");
+            // xh7YDmjGQuTKnfdv9iJb0:session:user is an actual key we're suppressing
+            private Set<String> set = Sets.newHashSet("foo:study", "bar:session", "baz:Survey:view", "xh7YDmjGQuTKnfdv9iJb0:session:user");
 
             @Override
             public Set<String> keys(String pattern) {


### PR DESCRIPTION
With changes to session management, there were keys of the form <userId>:session:user being returned in the cache API. We don't want to list session-related Redis items, only other items more directly related to caching. These are now suppressed along with session keys.
