### PR TITLE
Fix CORS for Safari

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -44,7 +44,7 @@ play.filters {
     allowedHttpMethods = ["HEAD", "GET", "OPTIONS", "POST", "PUT", "DELETE"]
 
     # The allowed HTTP headers. If null, all headers are allowed.
-    allowedHttpHeaders = ["Accept", "Content-Type", "User-Agent", "Bridge-Session"]
+    allowedHttpHeaders = ["Accept", "Content-Type", "User-Agent", "Bridge-Session", "Origin"]
 
     # The exposed headers
     exposedHeaders = []


### PR DESCRIPTION
Safari wants to send the header "Origin" in the pre-flight request, and needs the server to say it's okay before CORS will work in that browser.
