### PR TITLE
Logical delete, simplification of rules around delete and publish

### DIFF
--- a/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
+++ b/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
@@ -13,6 +13,8 @@ import org.sagebionetworks.bridge.dynamodb.DynamoHealthDataAttachment;
 import org.sagebionetworks.bridge.dynamodb.DynamoHealthDataRecord;
 import org.sagebionetworks.bridge.dynamodb.DynamoIndexHelper;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudyConsent1;
+import org.sagebionetworks.bridge.dynamodb.DynamoSurvey;
+import org.sagebionetworks.bridge.dynamodb.DynamoSurveyElement;
 import org.sagebionetworks.bridge.dynamodb.DynamoSurveyResponse;
 import org.sagebionetworks.bridge.dynamodb.DynamoTask;
 import org.sagebionetworks.bridge.dynamodb.DynamoTaskEvent;
@@ -167,6 +169,18 @@ public class BridgeSpringConfig {
     @Autowired
     public DynamoDBMapper studyConsentDdbMapper(AmazonDynamoDB client) {
         return getMapperForClass(client, DynamoStudyConsent1.class);
+    }
+    
+    @Bean(name = "surveyMapper")
+    @Autowired
+    public DynamoDBMapper surveyDdbMapper(AmazonDynamoDB client) {
+        return getMapperForClass(client, DynamoSurvey.class);
+    }
+    
+    @Bean(name = "surveyElementMapper")
+    @Autowired
+    public DynamoDBMapper surveyElementDdbMapper(AmazonDynamoDB client) {
+        return getMapperForClass(client, DynamoSurveyElement.class);
     }
     
     @Bean(name = "healthDataHealthCodeIndex")

--- a/app/org/sagebionetworks/bridge/dao/SurveyDao.java
+++ b/app/org/sagebionetworks/bridge/dao/SurveyDao.java
@@ -8,34 +8,47 @@ import org.sagebionetworks.bridge.models.surveys.Survey;
 
 public interface SurveyDao {
 
+    /**
+     * Create a new survey. 
+     * @param survey
+     * @return
+     */
     public Survey createSurvey(Survey survey);
     
+    /**
+     * Update an unpublished survey. A survey version can be edited until it is published.
+     * @param survey
+     * @return
+     */
     public Survey updateSurvey(Survey survey);
     
-    public Survey versionSurvey(GuidCreatedOnVersionHolder keys);
-    
-    public Survey publishSurvey(GuidCreatedOnVersionHolder keys);
-    
     /**
-     * Delete a survey. If a survey is published, or if there is a schedule plan
-     * that references the survey or a survey response based on the survey, then 
-     * the survey cannot be deleted. The survey responses and schedule plans must 
-     * first be deleted, and the survey closed (unpublished), before the survey 
-     * can be deleted.
-     *  
-     * @param studyIdentifier
-     * @param keys
-     */
-    public void deleteSurvey(StudyIdentifier studyIdentifier, GuidCreatedOnVersionHolder keys);
-    
-    /**
-     * Unpublish the survey, closing out any active records that are still 
-     * pointing to this survey. 
+     * Version this survey (create a copy with a new createdOn timestamp). New versions are 
+     * created unpublished and can be modified.
      * @param keys
      * @return
      */
-    public Survey closeSurvey(GuidCreatedOnVersionHolder keys);
-
+    public Survey versionSurvey(GuidCreatedOnVersionHolder keys);
+    
+    /**
+     * Make this version of this survey available for scheduling. One scheduled for publishing, 
+     * a survey version can no longer be changed (it can still be the source of a new version).  
+     * There can be more than one published version of a survey.
+     * @param keys
+     * @return
+     */
+    public Survey publishSurvey(GuidCreatedOnVersionHolder keys);
+    
+    /**
+     * Delete this survey. Survey still exists in system and can be retrieved by direct reference
+     * (URLs that directly reference the GUID and createdOn timestamp of the survey), put cannot be 
+     * retrieved in any list of surveys, and is no longer considered when finding the most recently 
+     * published version of the survey. 
+     *  
+     * @param keys
+     */
+    public void deleteSurvey(GuidCreatedOnVersionHolder keys);
+    
     /**
      * Get a specific version of a survey.
      * @param keys

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurvey.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurvey.java
@@ -34,6 +34,7 @@ public class DynamoSurvey implements Survey {
     private String name;
     private String identifier;
     private boolean published;
+    private boolean deleted;
     private Integer schemaRevision;
     private List<SurveyElement> elements;
     
@@ -62,6 +63,7 @@ public class DynamoSurvey implements Survey {
         setName(survey.getName());
         setIdentifier(survey.getIdentifier());
         setPublished(survey.isPublished());
+        setDeleted(survey.isDeleted());
         setSchemaRevision(survey.getSchemaRevision());
         for (SurveyElement element : survey.getElements()) {
             elements.add(SurveyElementFactory.fromDynamoEntity(element));
@@ -162,6 +164,17 @@ public class DynamoSurvey implements Survey {
     }
 
     @Override
+    @DynamoDBAttribute
+    public boolean isDeleted() {
+        return deleted;
+    }
+
+    @Override
+    public void setDeleted(boolean deleted) {
+        this.deleted = deleted;
+    }
+    
+    @Override
     public Integer getSchemaRevision() {
         return schemaRevision;
     }
@@ -212,6 +225,7 @@ public class DynamoSurvey implements Survey {
         result = prime * result + Objects.hashCode(name);
         result = prime * result + Objects.hashCode(identifier);
         result = prime * result + Objects.hashCode(published);
+        result = prime * result + Objects.hashCode(deleted);
         result = prime * result + Objects.hashCode(schemaRevision);
         result = prime * result + Objects.hashCode(elements);
         return result;
@@ -233,14 +247,14 @@ public class DynamoSurvey implements Survey {
                 && Objects.equals(this.name, that.name)
                 && Objects.equals(this.identifier, that.identifier)
                 && Objects.equals(this.published, that.published)
+                && Objects.equals(this.deleted, that.deleted)
                 && Objects.equals(this.schemaRevision, that.schemaRevision)
                 && Objects.equals(this.elements, that.elements);
     }
 
     @Override
     public String toString() {
-        return "DynamoSurvey [studyKey=" + studyKey + ", guid=" + guid + ", createdOn=" + createdOn + ", modifiedOn="
-                + modifiedOn + ", version=" + version + ", name=" + name + ", identifier=" + identifier
-                + ", published=" + published + ", schemaRevision=" + schemaRevision + ", elements=" + elements + "]";
+        return String.format("DynamoSurvey [studyKey=%s, guid=%s, createdOn=%s, modifiedOn=%s, version=%s, name=%s, identifier=%s, published=%s, deleted=%s, schemaRevision=%s, elements=%s]",
+            studyKey, guid, createdOn, modifiedOn, version, name, identifier, published, deleted, schemaRevision, elements);
     }
 }

--- a/app/org/sagebionetworks/bridge/exceptions/PublishedSurveyException.java
+++ b/app/org/sagebionetworks/bridge/exceptions/PublishedSurveyException.java
@@ -6,12 +6,16 @@ import org.sagebionetworks.bridge.models.surveys.Survey;
 public class PublishedSurveyException extends BridgeServiceException {
     
     private final Survey survey;
-    
-    public PublishedSurveyException(Survey survey) {
-        super("A published survey cannot be updated or deleted (only closed).", 400);
+
+    public PublishedSurveyException(Survey survey, String message) {
+        super(message, 400);
         this.survey = survey;
     }
-
+    
+    public PublishedSurveyException(Survey survey) {
+        this(survey, "A published survey cannot be updated or deleted (only closed).");
+    }
+    
     public Survey getSurvey() {
         return survey;
     }

--- a/app/org/sagebionetworks/bridge/models/surveys/Survey.java
+++ b/app/org/sagebionetworks/bridge/models/surveys/Survey.java
@@ -37,6 +37,9 @@ public interface Survey extends GuidCreatedOnVersionHolder, BridgeEntity  {
     public boolean isPublished();
     public void setPublished(boolean published);
 
+    public boolean isDeleted();
+    public void setDeleted(boolean deleted);
+    
     /**
      * Gets the upload schema revision that corresponds to this survey. See
      * {@link org.sagebionetworks.bridge.models.upload.UploadSchema#getRevision} for more details.

--- a/app/org/sagebionetworks/bridge/play/controllers/SurveyController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/SurveyController.java
@@ -170,7 +170,7 @@ public class SurveyController extends BaseController {
         Survey survey = surveyService.getSurvey(keys);
         verifySurveyIsInStudy(session, studyId, survey);
         
-        surveyService.deleteSurvey(studyId, survey);
+        surveyService.deleteSurvey(survey);
         expireCache(surveyGuid, createdOnString);
         
         return okResult("Survey deleted.");
@@ -249,22 +249,6 @@ public class SurveyController extends BaseController {
         expireCache(surveyGuid, createdOnString);
         
         return okResult(new GuidCreatedOnVersionHolderImpl(survey));
-    }
-    
-    public Result closeSurvey(String surveyGuid, String createdOnString) throws Exception {
-        UserSession session = getAuthenticatedResearcherSession();
-        StudyIdentifier studyId = session.getStudyIdentifier();
-        
-        long createdOn = DateUtils.convertToMillisFromEpoch(createdOnString);
-        GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl(surveyGuid, createdOn);
-        
-        Survey survey = surveyService.getSurvey(keys);
-        verifySurveyIsInStudy(session, studyId, survey);
-        
-        surveyService.closeSurvey(survey);
-        expireCache(surveyGuid, createdOnString);
-        
-        return okResult("Survey closed.");
     }
     
     private void verifySurveyIsInStudy(UserSession session, StudyIdentifier studyIdentifier, List<Survey> surveys) {

--- a/app/org/sagebionetworks/bridge/services/SurveyService.java
+++ b/app/org/sagebionetworks/bridge/services/SurveyService.java
@@ -9,8 +9,8 @@ import org.sagebionetworks.bridge.models.surveys.Survey;
 public interface SurveyService {
 
     /**
-     * Get all versions of a specific survey, ordered by most recent version 
-     * first in the list.
+     * Get all versions of a specific survey, ordered by most recent version first in the list.
+     * 
      * @param studyIdentifier
      * @param guid
      * @return
@@ -18,8 +18,8 @@ public interface SurveyService {
     public List<Survey> getSurveyAllVersions(StudyIdentifier studyIdentifier, String guid);    
     
     /**
-     * Get the most recent version of a survey, regardless of whether it is published
-     * or not.
+     * Get the most recent version of a survey, regardless of whether it is published or not.
+     * 
      * @param studyIdentifier
      * @param guid
      * @return
@@ -36,7 +36,7 @@ public interface SurveyService {
     public Survey getSurveyMostRecentlyPublishedVersion(StudyIdentifier studyIdentifier, String guid);
     
     /**
-     * Get the most recently published version of a survey, using the identifier for the
+     * Get the most recently published version of a survey, using the identifier for the survey.
      * @param studyIdentifier
      * @param identifier
      * @return
@@ -44,7 +44,8 @@ public interface SurveyService {
     public Survey getSurveyMostRecentlyPublishedVersionByIdentifier(StudyIdentifier studyIdentifier, String identifier);
     
     /**
-     * Get the most recent version of each survey in the study, that has been published. 
+     * Get the most recent version of each survey in the study that has been published. If a survey has not 
+     * been published, nothing is returned. 
      * @param studyIdentifier
      * @return
      */
@@ -58,7 +59,8 @@ public interface SurveyService {
     public List<Survey> getAllSurveysMostRecentVersion(StudyIdentifier studyIdentifier);
     
     /**
-     * Get one instance of a survey. This call alone does not require the study's researcher role.
+     * Get one instance of a survey. This method will return a survey regardless of whether or not it has been 
+     * published. It will return a survey even if it has been deleted.
      * @param keys
      * @return
      */
@@ -79,32 +81,23 @@ public interface SurveyService {
     public Survey updateSurvey(Survey survey);
     
     /**
-     * Publish this survey. Although a non-published survey must still be accessible to users (in case 
-     * a schedule has been cached that references that survey), surveys should not be available for 
-     * assignment to schedules until they are published. 
+     * Make this version of this survey available for scheduling. One scheduled for publishing, 
+     * a survey version can no longer be changed (it can still be the source of a new version).  
+     * There can be more than one published version of a survey.
+     *  
      * @param keys
      * @return
      */
     public Survey publishSurvey(GuidCreatedOnVersionHolder keys);
     
     /**
-     * Delete a survey. A survey cannot be deleted unless 1) it is not published (either never was published 
-     * or was subsequently closed); 2) there are no survey responses created against this survey, and 3) 
-     * the survey is not referenced in any schedule plans. NOTE that the survey may still be referenced by 
-     * schedules that have been issued to clients (due to caching), so this action should still be done with 
-     * care. 
-     * @param studyIdentifier
+     * Delete this survey. Survey still exists in system and can be retrieved by direct reference
+     * (URLs that directly reference the GUID and createdOn timestamp of the survey), put cannot be 
+     * retrieved in any list of surveys, and is no longer considered when finding the most recently 
+     * published version of the survey. 
      * @param keys
      */
-    public void deleteSurvey(StudyIdentifier studyIdentifier, GuidCreatedOnVersionHolder keys);
-    
-    /**
-     * Un-publish a survey. Survey will still be accessible to any users who have schedules that point to the 
-     * survey, but the survey should not be available for further scheduling.
-     * @param keys
-     * @return
-     */
-    public Survey closeSurvey(GuidCreatedOnVersionHolder keys);
+    public void deleteSurvey(GuidCreatedOnVersionHolder keys);
     
     /**
      * Copy the survey and return a new version of it.

--- a/app/org/sagebionetworks/bridge/services/SurveyServiceImpl.java
+++ b/app/org/sagebionetworks/bridge/services/SurveyServiceImpl.java
@@ -69,14 +69,6 @@ public class SurveyServiceImpl implements SurveyService {
         
         return surveyDao.publishSurvey(keys);
     }
-
-    @Override
-    public Survey closeSurvey(GuidCreatedOnVersionHolder keys) {
-        checkArgument(StringUtils.isNotBlank(keys.getGuid()), "Survey GUID cannot be null/blank");
-        checkArgument(keys.getCreatedOn() != 0L, "Survey createdOn timestamp cannot be 0");
-        
-        return surveyDao.closeSurvey(keys);
-    }
     
     @Override
     public Survey versionSurvey(GuidCreatedOnVersionHolder keys) {
@@ -87,12 +79,11 @@ public class SurveyServiceImpl implements SurveyService {
     }
     
     @Override
-    public void deleteSurvey(StudyIdentifier studyIdentifier, GuidCreatedOnVersionHolder keys) {
-        checkNotNull(studyIdentifier, "study cannot be null");
+    public void deleteSurvey(GuidCreatedOnVersionHolder keys) {
         checkArgument(StringUtils.isNotBlank(keys.getGuid()), "Survey GUID cannot be null/blank");
         checkArgument(keys.getCreatedOn() != 0L, "Survey createdOn timestamp cannot be 0");
 
-        surveyDao.deleteSurvey(studyIdentifier, keys);
+        surveyDao.deleteSurvey(keys);
     }
 
     @Override

--- a/conf/routes
+++ b/conf/routes
@@ -63,7 +63,6 @@ GET    /researchers/v1/surveys/:surveyGuid/revisions/recent              @org.sa
 GET    /researchers/v1/surveys/:surveyGuid/revisions/published           @org.sagebionetworks.bridge.play.controllers.SurveyController.getSurveyMostRecentlyPublishedVersion(surveyGuid: String)
 POST   /researchers/v1/surveys/:surveyGuid/revisions/:createdOn/version  @org.sagebionetworks.bridge.play.controllers.SurveyController.versionSurvey(surveyGuid: String, createdOn: String)
 POST   /researchers/v1/surveys/:surveyGuid/revisions/:createdOn/publish  @org.sagebionetworks.bridge.play.controllers.SurveyController.publishSurvey(surveyGuid: String, createdOn: String)
-POST   /researchers/v1/surveys/:surveyGuid/revisions/:createdOn/close    @org.sagebionetworks.bridge.play.controllers.SurveyController.closeSurvey(surveyGuid: String, createdOn: String)
 GET    /researchers/v1/surveys/:surveyGuid/revisions/:createdOn          @org.sagebionetworks.bridge.play.controllers.SurveyController.getSurvey(surveyGuid: String, createdOn: String)
 POST   /researchers/v1/surveys/:surveyGuid/revisions/:createdOn          @org.sagebionetworks.bridge.play.controllers.SurveyController.updateSurvey(surveyGuid: String, createdOn: String)
 DELETE /researchers/v1/surveys/:surveyGuid/revisions/:createdOn          @org.sagebionetworks.bridge.play.controllers.SurveyController.deleteSurvey(surveyGuid: String, createdOn: String)

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoTest.java
@@ -464,4 +464,5 @@ public class DynamoSurveyDaoTest {
         // now you can delete this second version because you've created anotherversion.
         surveyDao.deleteSurvey(survey);
     }
+    
 }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyTest.java
@@ -57,8 +57,8 @@ public class DynamoSurveyTest {
         assertEquals(11, jsonMap.size());
         assertEquals("test-survey-guid", jsonMap.get("guid"));
         assertEquals(2, jsonMap.get("version"));
-        assertEquals("General Blood Pressure Survey", jsonMap.get("name"));
-        assertEquals("bloodpressure", jsonMap.get("identifier"));
+        assertEquals(survey.getName(), jsonMap.get("name"));
+        assertEquals(survey.getIdentifier(), jsonMap.get("identifier"));
         assertTrue((boolean) jsonMap.get("published"));
         assertTrue((boolean) jsonMap.get("deleted"));
         assertEquals(42, jsonMap.get("schemaRevision"));
@@ -82,8 +82,8 @@ public class DynamoSurveyTest {
         assertEquals(TEST_CREATED_ON_MILLIS, convertedSurvey.getCreatedOn());
         assertEquals(TEST_MODIFIED_ON_MILLIS, convertedSurvey.getModifiedOn());
         assertEquals(2, convertedSurvey.getVersion().longValue());
-        assertEquals("General Blood Pressure Survey", convertedSurvey.getName());
-        assertEquals("bloodpressure", convertedSurvey.getIdentifier());
+        assertEquals(survey.getName(), convertedSurvey.getName());
+        assertEquals(survey.getIdentifier(), convertedSurvey.getIdentifier());
         assertTrue(convertedSurvey.isPublished());
         assertEquals(42, convertedSurvey.getSchemaRevision().longValue());
         assertEquals(10, convertedSurvey.getElements().size());
@@ -120,8 +120,8 @@ public class DynamoSurveyTest {
         assertEquals(TEST_CREATED_ON_MILLIS, copy.getCreatedOn());
         assertEquals(TEST_MODIFIED_ON_MILLIS, copy.getModifiedOn());
         assertEquals(2, copy.getVersion().longValue());
-        assertEquals("General Blood Pressure Survey", copy.getName());
-        assertEquals("bloodpressure", copy.getIdentifier());
+        assertEquals(survey.getName(), copy.getName());
+        assertEquals(survey.getIdentifier(), copy.getIdentifier());
         assertTrue(copy.isPublished());
         assertEquals(42, copy.getSchemaRevision().longValue());
         assertEquals(9, copy.getElements().size());

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyTest.java
@@ -54,14 +54,16 @@ public class DynamoSurveyTest {
 
         // Convert JSON to map to validate JSON. Note that study ID is intentionally omitted, but type is added.
         Map<String, Object> jsonMap = BridgeObjectMapper.get().readValue(jsonText, JsonUtils.TYPE_REF_RAW_MAP);
-        assertEquals(10, jsonMap.size());
+        assertEquals(11, jsonMap.size());
         assertEquals("test-survey-guid", jsonMap.get("guid"));
         assertEquals(2, jsonMap.get("version"));
         assertEquals("General Blood Pressure Survey", jsonMap.get("name"));
         assertEquals("bloodpressure", jsonMap.get("identifier"));
         assertTrue((boolean) jsonMap.get("published"));
+        assertTrue((boolean) jsonMap.get("deleted"));
         assertEquals(42, jsonMap.get("schemaRevision"));
         assertEquals("Survey", jsonMap.get("type"));
+        
 
         // Timestamps are stored as long, but serialized as ISO timestamps. Convert them back to long millis so we
         // don't have to deal with timezones and formatting issues.
@@ -148,6 +150,8 @@ public class DynamoSurveyTest {
         survey.setGuid("test-survey-guid");
         survey.setCreatedOn(TEST_CREATED_ON_MILLIS);
         survey.setModifiedOn(TEST_MODIFIED_ON_MILLIS);
+        survey.setPublished(true);
+        survey.setDeleted(true);
         return survey;
     }
 }

--- a/test/org/sagebionetworks/bridge/models/surveys/TestSurvey.java
+++ b/test/org/sagebionetworks/bridge/models/surveys/TestSurvey.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.UUID;
 
 import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoSurvey;
 import org.sagebionetworks.bridge.dynamodb.DynamoSurveyQuestion;
 import org.sagebionetworks.bridge.json.DateUtils;
@@ -162,7 +163,7 @@ public class TestSurvey extends DynamoSurvey {
     public TestSurvey(boolean makeNew) {
         setGuid(UUID.randomUUID().toString());
         setName("General Blood Pressure Survey");
-        setIdentifier("bloodpressure");
+        setIdentifier(TestUtils.randomName());
         setModifiedOn(DateUtils.getCurrentMillisFromEpoch());
         setCreatedOn(DateUtils.getCurrentMillisFromEpoch());
         setVersion(2L);

--- a/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
@@ -368,7 +368,6 @@ public class SurveyControllerTest {
     
     @Test
     public void deleteSurvey() throws Exception {
-        StudyIdentifier studyId = new StudyIdentifierImpl("api");
         String guid = BridgeUtils.generateGuid();
         DateTime date = DateTime.now();
         Survey survey = getSurvey(false);
@@ -379,7 +378,7 @@ public class SurveyControllerTest {
         controller.deleteSurvey(guid, date.toString());
 
         verify(service).getSurvey(eq(keys));
-        verify(service).deleteSurvey(eq(studyId), eq(survey));
+        verify(service).deleteSurvey(eq(survey));
         verifyNoMoreInteractions(service);
     }
     
@@ -559,21 +558,7 @@ public class SurveyControllerTest {
     }
     
     @Test
-    public void closeSurvey() throws Exception {
-        Survey survey = getSurvey(false);
-        GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl(survey.getGuid(), survey.getCreatedOn());
-        setContext();
-        when(service.getSurvey(keys)).thenReturn(survey);
-        
-        controller.closeSurvey(keys.getGuid(), new DateTime(keys.getCreatedOn()).toString());
-        
-        verify(service).getSurvey(keys);
-        verify(service).closeSurvey(any(Survey.class));
-        verifyNoMoreInteractions(service);
-    }
-    
-    @Test
-    public void cannotCloseSurveyInOtherStudy() throws Exception {
+    public void cannotDeleteSurveyInOtherStudy() throws Exception {
         Survey survey = getSurvey(false);
         GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl(survey.getGuid(), survey.getCreatedOn());
         setContext();
@@ -581,7 +566,7 @@ public class SurveyControllerTest {
         setUserSession("secondstudy");
         
         try {
-            controller.closeSurvey(keys.getGuid(), new DateTime(keys.getCreatedOn()).toString());
+            controller.deleteSurvey(keys.getGuid(), new DateTime(keys.getCreatedOn()).toString());
             fail("Exception should have been thrown.");
         } catch(UnauthorizedException e) {
             verify(service).getSurvey(keys);

--- a/test/org/sagebionetworks/bridge/services/SurveyServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SurveyServiceTest.java
@@ -113,10 +113,10 @@ public class SurveyServiceTest {
         survey = surveyService.getSurvey(survey);
         assertEquals("Identifier has been changed", "newIdentifier", survey.getIdentifier());
         assertEquals("Be honest: do you have high blood pressue?", question.getPromptDetail());
-        surveyService.deleteSurvey(studyIdentifier, survey);
+        surveyService.deleteSurvey(survey);
 
         try {
-            survey = surveyService.getSurvey(survey);
+            surveyService.getSurveyMostRecentlyPublishedVersion(studyIdentifier, survey.getGuid()); 
             fail("Should have thrown an exception");
         } catch (EntityNotFoundException enfe) {
         }
@@ -144,9 +144,9 @@ public class SurveyServiceTest {
         assertEquals("Name can be updated", "C", survey.getName());
 
         // Now verify the nextVersion has not been changed
-        nextVersion = surveyService.getSurvey(nextVersion);
-        assertEquals("Next version has same identifier", "bloodpressure", nextVersion.getIdentifier());
-        assertEquals("Next name has not changed", "General Blood Pressure Survey", nextVersion.getName());
+        Survey finalVersion = surveyService.getSurvey(nextVersion);
+        assertEquals("Next version has same identifier", nextVersion.getIdentifier(), finalVersion.getIdentifier());
+        assertEquals("Next name has not changed", nextVersion.getName(), finalVersion.getName());
     }
 
     @Test
@@ -295,20 +295,6 @@ public class SurveyServiceTest {
                 version2.getCreatedOn());
     }
 
-    // CLOSE SURVEY
-
-    @Test
-    public void canClosePublishedSurvey() {
-        Survey survey = surveyService.createSurvey(testSurvey);
-        survey = surveyService.publishSurvey(survey);
-
-        survey = surveyService.closeSurvey(survey);
-        assertEquals("Survey no longer published", false, survey.isPublished());
-
-        survey = surveyService.getSurvey(survey);
-        assertEquals("Survey no longer published", false, survey.isPublished());
-    }
-
     // GET PUBLISHED SURVEY
 
     @Test
@@ -356,14 +342,6 @@ public class SurveyServiceTest {
     }
 
     // DELETE SURVEY
-
-    @Test(expected = PublishedSurveyException.class)
-    public void cannotDeleteAPublishedSurvey() {
-        Survey survey = surveyService.createSurvey(testSurvey);
-        surveyService.publishSurvey(survey);
-
-        surveyService.deleteSurvey(studyIdentifier, survey);
-    }
     
     @Test
     public void canRetrieveASurveyByIdentifier() {


### PR DESCRIPTION
- You can no longer unpublish a survey (close it), and once it is published, it cannot be updated.
- Delete sets a flag, and that record will not be returned from any API other than the API to retrieve a specific survey at a particular version
- You can delete a published survey. We no longer prevent this based on use of the survey. It shouldn't matter as the survey is still accessible. There two edge cases I know of:

1) Deleting the last published study would cause problems (going to address this before merging)

2) Deleting a published study can cause a "relative" reference to the most recently published study to change. Tasks resolve these references when they are created, but schedules do not, so clients using the list of schedules need to do this when a task with multiple parts, like a survey, is started, or the answers might look like they were answers to two different versions of a survey.
