### PR TITLE
Adding developer role

### DIFF
--- a/app/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/app/org/sagebionetworks/bridge/BridgeConstants.java
@@ -24,10 +24,6 @@ public class BridgeConstants {
     public static final String CUSTOM_DATA_CONSENT_SIGNATURE_SUFFIX = "_consent_signature";
 
     public static final String CUSTOM_DATA_VERSION = "version";
-
-    public static final String ADMIN_GROUP = "admin";
-
-    public static final String TEST_USERS_GROUP = "test_users";
     
     public static final String STUDY_PROPERTY = "study";
 
@@ -48,4 +44,5 @@ public class BridgeConstants {
 
     /** Per-request metrics expires in the cache after 120 seconds. */
     public static final int METRICS_EXPIRE_SECONDS = 2 * 60;
+    
 }

--- a/app/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/app/org/sagebionetworks/bridge/BridgeUtils.java
@@ -15,6 +15,8 @@ import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
 import org.sagebionetworks.bridge.json.BridgeTypeName;
 import org.sagebionetworks.bridge.models.BridgeEntity;
 import org.sagebionetworks.bridge.models.schedules.Task;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.AnnotationUtils;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper.FailedBatch;
@@ -26,6 +28,8 @@ import com.stormpath.sdk.group.Group;
 import com.stormpath.sdk.group.GroupList;
 
 public class BridgeUtils {
+
+    private static Logger logger = LoggerFactory.getLogger(BridgeUtils.class);
     
     /**
      * A simple means of providing template variables in template strings, in the format <code>${variableName}</code>.
@@ -135,7 +139,8 @@ public class BridgeUtils {
                 try {
                     roleSet.add(Roles.valueOf(group.getName().toUpperCase()));
                 } catch(IllegalArgumentException e) {
-                    // probably api_researcher
+                    // probably api_researcher.
+                    logger.info("Found an invalid role: " + group.getName().toUpperCase());
                 }
             }
         }

--- a/app/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/app/org/sagebionetworks/bridge/BridgeUtils.java
@@ -3,8 +3,10 @@ package org.sagebionetworks.bridge;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import org.joda.time.DateTime;
@@ -20,6 +22,8 @@ import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.stormpath.sdk.group.Group;
+import com.stormpath.sdk.group.GroupList;
 
 public class BridgeUtils {
     
@@ -122,5 +126,19 @@ public class BridgeUtils {
 
     public static String toString(Long datetime) {
         return (datetime == null) ? null : new DateTime(datetime).toString();
+    }
+    
+    public static Set<Roles> convertRolesQuietly(GroupList groups) {
+        Set<Roles> roleSet = new HashSet<>();
+        if (groups != null) {
+            for (Group group : groups) {
+                try {
+                    roleSet.add(Roles.valueOf(group.getName().toUpperCase()));
+                } catch(IllegalArgumentException e) {
+                    // probably api_researcher
+                }
+            }
+        }
+        return roleSet;
     }
 }

--- a/app/org/sagebionetworks/bridge/DefaultStudyBootstrapper.java
+++ b/app/org/sagebionetworks/bridge/DefaultStudyBootstrapper.java
@@ -30,7 +30,6 @@ public class DefaultStudyBootstrapper {
             study.setIdentifier("api");
             study.setSponsorName("Sage Bionetworks");
             study.setMinAgeOfConsent(18);
-            study.setResearcherRole("api_researcher");
             study.setConsentNotificationEmail("bridge-testing+consent@sagebase.org");
             study.setTechnicalEmail("bridge-testing+technical@sagebase.org");
             study.setSupportEmail("support@sagebridge.org");

--- a/app/org/sagebionetworks/bridge/Roles.java
+++ b/app/org/sagebionetworks/bridge/Roles.java
@@ -1,0 +1,8 @@
+package org.sagebionetworks.bridge;
+
+public enum Roles {
+    DEVELOPER,
+    RESEARCHER,
+    ADMIN,
+    TEST_USERS
+}

--- a/app/org/sagebionetworks/bridge/dao/DirectoryDao.java
+++ b/app/org/sagebionetworks/bridge/dao/DirectoryDao.java
@@ -3,7 +3,6 @@ package org.sagebionetworks.bridge.dao;
 import org.sagebionetworks.bridge.models.studies.Study;
 
 import com.stormpath.sdk.directory.Directory;
-import com.stormpath.sdk.group.Group;
 
 public interface DirectoryDao {
 
@@ -14,7 +13,5 @@ public interface DirectoryDao {
     public Directory getDirectoryForStudy(String identifier);
 
     public void deleteDirectoryForStudy(String identifier);
-
-    public Group getGroup(String name);
 
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
@@ -28,7 +28,6 @@ public final class DynamoStudy implements Study {
     private String name;
     private String sponsorName;
     private String identifier;
-    private String researcherRole;
     private String stormpathHref;
     private String supportEmail;
     private String technicalEmail;
@@ -95,15 +94,6 @@ public final class DynamoStudy implements Study {
     }
     public void setVersion(Long version) {
         this.version = version;
-    }
-    /** {@inheritDoc} */
-    @Override
-    public String getResearcherRole() {
-        return researcherRole;
-    }
-    @Override
-    public void setResearcherRole(String role) {
-        this.researcherRole = role;
     }
     /** {@inheritDoc} */
     @Override
@@ -218,7 +208,6 @@ public final class DynamoStudy implements Study {
         result = prime * result + Objects.hashCode(minAgeOfConsent);
         result = prime * result + Objects.hashCode(name);
         result = prime * result + Objects.hashCode(sponsorName);
-        result = prime * result + Objects.hashCode(researcherRole);
         result = prime * result + Objects.hashCode(supportEmail);
         result = prime * result + Objects.hashCode(technicalEmail);
         result = prime * result + Objects.hashCode(consentNotificationEmail);
@@ -243,7 +232,7 @@ public final class DynamoStudy implements Study {
         return (Objects.equals(identifier, other.identifier) && Objects.equals(supportEmail, other.supportEmail) &&
             Objects.equals(maxNumOfParticipants, other.maxNumOfParticipants) && 
             Objects.equals(minAgeOfConsent, other.minAgeOfConsent) && Objects.equals(name, other.name) && 
-            Objects.equals(researcherRole, other.researcherRole) && Objects.equals(stormpathHref, other.stormpathHref) &&
+            Objects.equals(stormpathHref, other.stormpathHref) &&
             Objects.equals(passwordPolicy, other.passwordPolicy) && Objects.equals(active, other.active)) && 
             Objects.equals(verifyEmailTemplate, other.verifyEmailTemplate) && 
             Objects.equals(consentNotificationEmail, other.consentNotificationEmail) && 
@@ -254,12 +243,13 @@ public final class DynamoStudy implements Study {
 
     @Override
     public String toString() {
-        return String.format("DynamoStudy [name=%s, active=%s, sponsorName=%s, identifier=%s, researcherRole=%s, stormpathHref=%s, "
-            + "minAgeOfConsent=%s, maxNumOfParticipants=%s, supportEmail=%s, technicalEmail=%s, consentNotificationEmail=%s, "
-            + "version=%s, userProfileAttributes=%s, passwordPolicy=%s, verifyEmailTemplate=%s, resetPasswordTemplate=%s]",
-            name, active, sponsorName, identifier, researcherRole, stormpathHref, minAgeOfConsent, maxNumOfParticipants,
-            supportEmail, technicalEmail, consentNotificationEmail, version, profileAttributes, passwordPolicy,
-            verifyEmailTemplate, resetPasswordTemplate);        
+        return String.format(
+            "DynamoStudy [name=%s, active=%s, sponsorName=%s, identifier=%s, stormpathHref=%s, minAgeOfConsent=%s, " 
+                + "maxNumOfParticipants=%s, supportEmail=%s, technicalEmail=%s, consentNotificationEmail=%s, "
+                + "version=%s, userProfileAttributes=%s, passwordPolicy=%s, verifyEmailTemplate=%s, resetPasswordTemplate=%s]",
+                name, active, sponsorName, identifier, stormpathHref, minAgeOfConsent, maxNumOfParticipants,
+                supportEmail, technicalEmail, consentNotificationEmail, version, profileAttributes,
+                passwordPolicy, verifyEmailTemplate, resetPasswordTemplate);
     }
     
 }

--- a/app/org/sagebionetworks/bridge/json/JsonUtils.java
+++ b/app/org/sagebionetworks/bridge/json/JsonUtils.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.models.surveys.Constraints;
 import org.sagebionetworks.bridge.models.surveys.DataType;
@@ -172,6 +173,22 @@ public class JsonUtils {
             ArrayNode array = (ArrayNode)parent.get(property);
             for (int i = 0; i < array.size(); i++) {
                 results.add(array.get(i).asText());
+            }
+        }
+        return results;
+    }
+    
+    public static Set<Roles> asRolesSet(JsonNode parent, String property) {
+        Set<Roles> results = new HashSet<>();
+        if (parent != null && parent.hasNonNull(property)) {
+            ArrayNode array = (ArrayNode)parent.get(property);
+            for (int i = 0; i < array.size(); i++) {
+                try {
+                    Roles role = Roles.valueOf(array.get(i).asText().toUpperCase());
+                    results.add(role);    
+                } catch(IllegalArgumentException e) {
+                    // Almost certainly "api_researcher"
+                }
             }
         }
         return results;

--- a/app/org/sagebionetworks/bridge/json/JsonUtils.java
+++ b/app/org/sagebionetworks/bridge/json/JsonUtils.java
@@ -6,10 +6,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.models.surveys.Constraints;
 import org.sagebionetworks.bridge.models.surveys.DataType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -27,6 +30,8 @@ import com.google.common.collect.Lists;
  * type casting as well. Hence these utility methods.
  */
 public class JsonUtils {
+
+    private static Logger logger = LoggerFactory.getLogger(JsonUtils.class);
 
     private static final String DATA_TYPE_PROPERTY = "dataType";
     private static final String ENUM_PROPERTY = "enumeration";
@@ -183,11 +188,12 @@ public class JsonUtils {
         if (parent != null && parent.hasNonNull(property)) {
             ArrayNode array = (ArrayNode)parent.get(property);
             for (int i = 0; i < array.size(); i++) {
+                String name = array.get(i).asText().toUpperCase();
                 try {
-                    Roles role = Roles.valueOf(array.get(i).asText().toUpperCase());
-                    results.add(role);    
+                    results.add(Roles.valueOf(name));    
                 } catch(IllegalArgumentException e) {
-                    // Almost certainly "api_researcher"
+                    // probably api_researcher.
+                    logger.info("Found an invalid role: " + name);
                 }
             }
         }

--- a/app/org/sagebionetworks/bridge/models/accounts/Account.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/Account.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge.models.accounts;
 
 import java.util.Set;
 
+import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.models.BridgeEntity;
 import org.sagebionetworks.bridge.models.studies.ConsentSignature;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
@@ -35,7 +36,7 @@ public interface Account extends BridgeEntity {
 
     public StudyIdentifier getStudyIdentifier();
     
-    public Set<String> getRoles();
+    public Set<Roles> getRoles();
 
     /**
      * This is the store-specific identifier for the account (in the case of 

--- a/app/org/sagebionetworks/bridge/models/accounts/SignUp.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/SignUp.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge.models.accounts;
 
 import java.util.Set;
 
+import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.json.JsonUtils;
 import org.sagebionetworks.bridge.models.BridgeEntity;
 
@@ -18,9 +19,9 @@ public class SignUp implements BridgeEntity {
     private final String username;
     private final String email;
     private final String password;
-    private final Set<String> roles;
+    private final Set<Roles> roles;
 
-    public SignUp(String username, String email, String password, Set<String> roles) {
+    public SignUp(String username, String email, String password, Set<Roles> roles) {
         this.username = username;
         this.email = email;
         this.password = password;
@@ -34,7 +35,7 @@ public class SignUp implements BridgeEntity {
         String username = JsonUtils.asText(node, USERNAME_FIELD);
         String email = JsonUtils.asText(node, EMAIL_FIELD);
         String password = JsonUtils.asText(node, PASSWORD_FIELD);
-        Set<String> roles = (allowRoles) ? JsonUtils.asStringSet(node, ROLES_FIELD) : null;
+        Set<Roles> roles = (allowRoles) ? JsonUtils.asRolesSet(node, ROLES_FIELD) : null;
         return new SignUp(username, email, password, roles);
     }
 
@@ -50,14 +51,13 @@ public class SignUp implements BridgeEntity {
         return password;
     }
 
-    public Set<String> getRoles() {
+    public Set<Roles> getRoles() {
         return roles;
     }
 
     @Override
     public String toString() {
-        return "SignUp [username=" + username + ", email=" + email + ", password=" + password + ", roles=" + roles
-                + "]";
+        return "SignUp [username=" + username + ", email=" + email + ", password=" + password + ", roles=" + roles + "]";
     }
 
 }

--- a/app/org/sagebionetworks/bridge/models/accounts/User.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/User.java
@@ -1,7 +1,9 @@
 package org.sagebionetworks.bridge.models.accounts;
 
+import java.util.HashSet;
 import java.util.Set;
 
+import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 import org.sagebionetworks.bridge.crypto.AesGcmEncryptor;
 import org.sagebionetworks.bridge.crypto.Encryptor;
@@ -28,7 +30,7 @@ public class User implements BridgeEntity {
     private boolean consent;
     private boolean signedMostRecentConsent;
     private SharingScope sharingScope;
-    private Set<String> roles = Sets.newHashSet();
+    private Set<Roles> roles = Sets.newHashSet();
 
     public User() {
     }
@@ -39,7 +41,7 @@ public class User implements BridgeEntity {
         this.firstName = account.getFirstName();
         this.lastName = account.getLastName();
         this.id = account.getId();
-        this.roles = account.getRoles();
+        this.roles = new HashSet<>(account.getRoles());
     }
 
     public User(String id, String email) {
@@ -113,11 +115,11 @@ public class User implements BridgeEntity {
         this.studyKey = studyKey;
     }
 
-    public Set<String> getRoles() {
+    public Set<Roles> getRoles() {
         return roles;
     }
 
-    public void setRoles(Set<String> roles) {
+    public void setRoles(Set<Roles> roles) {
         this.roles = roles;
     }
 
@@ -155,7 +157,7 @@ public class User implements BridgeEntity {
         this.sharingScope = sharingScope;
     }
 
-    public boolean isInRole(String role) {
+    public boolean isInRole(Roles role) {
         return this.roles.contains(role);
     }
 

--- a/app/org/sagebionetworks/bridge/models/accounts/UserSessionInfo.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/UserSessionInfo.java
@@ -1,8 +1,11 @@
 package org.sagebionetworks.bridge.models.accounts;
 
 import java.util.HashMap;
-import java.util.Map;
 
+import java.util.Map;
+import java.util.Set;
+
+import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.config.Environment;
 import org.sagebionetworks.bridge.dao.ParticipantOption.SharingScope;
 
@@ -28,6 +31,7 @@ public class UserSessionInfo {
     private final String sessionToken;
     private final String username;
     private final String environment;
+    private final Set<Roles> roles;
 
     public UserSessionInfo(UserSession session) {
         this.authenticated = session.isAuthenticated();
@@ -36,6 +40,7 @@ public class UserSessionInfo {
         this.consented = session.getUser().doesConsent();
         this.sharingScope = session.getUser().getSharingScope();
         this.username = session.getUser().getUsername();
+        this.roles = session.getUser().getRoles();
         this.environment = ENVIRONMENTS.get(session.getEnvironment());
     }
 
@@ -62,5 +67,8 @@ public class UserSessionInfo {
     }
     public String getEnvironment() {
         return environment;
+    }
+    public Set<Roles> getRoles() {
+        return roles;
     }
 }

--- a/app/org/sagebionetworks/bridge/models/studies/Study.java
+++ b/app/org/sagebionetworks/bridge/models/studies/Study.java
@@ -22,7 +22,7 @@ public interface Study extends BridgeEntity, StudyIdentifier {
 
     public static final ObjectWriter STUDY_WRITER = new BridgeObjectMapper().writer(
         new SimpleFilterProvider().addFilter("filter", 
-        SimpleBeanPropertyFilter.serializeAllExcept("researcherRole", "stormpathHref")));
+        SimpleBeanPropertyFilter.serializeAllExcept("stormpathHref")));
 
     public static final ObjectWriter STUDY_LIST_WRITER = new BridgeObjectMapper().writer(
         new SimpleFilterProvider().addFilter("filter",
@@ -63,12 +63,6 @@ public interface Study extends BridgeEntity, StudyIdentifier {
      */
     public Long getVersion();
     public void setVersion(Long version);
-    
-    /**
-     * The role assigned to participants who have researcher privileges in the study.
-     */
-    public String getResearcherRole();
-    public void setResearcherRole(String role);
     
     /**
      * User must confirm that they are at least this many years old in order to 

--- a/app/org/sagebionetworks/bridge/models/studies/StudyIdentifier.java
+++ b/app/org/sagebionetworks/bridge/models/studies/StudyIdentifier.java
@@ -5,14 +5,12 @@ import org.sagebionetworks.bridge.json.BridgeTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 /**
- * Significant fields from the study object that are used throughout our code base, 
- * but that don't require loading the full Study object.
+ * Type-safe object representing the study identifier token.
  */
 @JsonDeserialize(as=StudyIdentifierImpl.class)
 @BridgeTypeName("StudyIdentifier")
 public interface StudyIdentifier {
     
     public String getIdentifier();
-    public String getResearcherRole();
 
 }

--- a/app/org/sagebionetworks/bridge/models/studies/StudyIdentifierImpl.java
+++ b/app/org/sagebionetworks/bridge/models/studies/StudyIdentifierImpl.java
@@ -20,10 +20,6 @@ public final class StudyIdentifierImpl implements StudyIdentifier {
     public String getIdentifier() {
         return identifier;
     }
-    
-    public String getResearcherRole() {
-        return identifier + "_researcher";
-    }
 
     @Override
     public int hashCode() {
@@ -45,7 +41,6 @@ public final class StudyIdentifierImpl implements StudyIdentifier {
 
     @Override
     public String toString() {
-        return String.format("StudyIdentifierImpl [identifier=%s, researcherRole=%s]", 
-            getIdentifier(), getResearcherRole());
+        return String.format("StudyIdentifierImpl [identifier=%s]", identifier);
     }
 }

--- a/app/org/sagebionetworks/bridge/play/controllers/BackfillController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/BackfillController.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.bridge.play.controllers;
 
+import static org.sagebionetworks.bridge.Roles.ADMIN;
+
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.services.backfill.BackfillService;
 import org.slf4j.Logger;
@@ -42,7 +44,7 @@ public class BackfillController extends BaseController implements ApplicationCon
     }
 
     private String checkUser() throws Exception {
-        UserSession session = getAuthenticatedAdminSession();
+        UserSession session = getAuthenticatedSession(ADMIN);
         return session.getUser().getEmail();
     }
 }

--- a/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
@@ -135,10 +135,6 @@ public abstract class BaseController extends Controller {
         checkNotNull(role);
         
         UserSession session = getAuthenticatedSession();
-        
-        logger.info("LOOKING FOR ROLE: " + role.toString());
-        logger.info("USER'S ROLES: " + session.getUser().getRoles().toString());
-        
         if (!session.getUser().isInRole(role)) {
             throw new UnauthorizedException();
         }

--- a/app/org/sagebionetworks/bridge/play/controllers/CacheAdminController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/CacheAdminController.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.bridge.play.controllers;
 
+import static org.sagebionetworks.bridge.Roles.ADMIN;
+
 import java.util.Set;
 
 import org.sagebionetworks.bridge.services.CacheAdminService;
@@ -19,14 +21,14 @@ public class CacheAdminController extends BaseController {
     }
     
     public Result listItems() throws Exception {
-        getAuthenticatedAdminSession();
+        getAuthenticatedSession(ADMIN);
         
         Set<String> keys = cacheAdminService.listItems();
         return okResult(keys);
     }
     
     public Result removeItem(String cacheKey) {
-        getAuthenticatedAdminSession();
+        getAuthenticatedSession(ADMIN);
         
         cacheAdminService.removeItem(cacheKey);
         return ok("Item removed from cache.");

--- a/app/org/sagebionetworks/bridge/play/controllers/SchedulePlanController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/SchedulePlanController.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.bridge.play.controllers;
 
+import static org.sagebionetworks.bridge.Roles.DEVELOPER;
+
 import java.util.List;
 
 import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
@@ -24,7 +26,7 @@ public class SchedulePlanController extends BaseController {
     }
     
     public Result getSchedulePlans() throws Exception {
-        UserSession session = getAuthenticatedResearcherSession();
+        UserSession session = getAuthenticatedSession(DEVELOPER);
         StudyIdentifier studyId = session.getStudyIdentifier();
 
         List<SchedulePlan> plans =  schedulePlanService.getSchedulePlans(studyId);
@@ -32,7 +34,7 @@ public class SchedulePlanController extends BaseController {
     }
 
     public Result createSchedulePlan() throws Exception {
-        UserSession session = getAuthenticatedResearcherSession();
+        UserSession session = getAuthenticatedSession(DEVELOPER);
         StudyIdentifier studyId = session.getStudyIdentifier();
 
         DynamoSchedulePlan planForm = DynamoSchedulePlan.fromJson(requestToJSON(request()));
@@ -42,7 +44,7 @@ public class SchedulePlanController extends BaseController {
     }
 
     public Result getSchedulePlan(String guid) throws Exception {
-        UserSession session = getAuthenticatedResearcherSession();
+        UserSession session = getAuthenticatedSession(DEVELOPER);
         StudyIdentifier studyId = session.getStudyIdentifier();
         
         SchedulePlan plan = schedulePlanService.getSchedulePlan(studyId, guid);
@@ -50,7 +52,7 @@ public class SchedulePlanController extends BaseController {
     }
 
     public Result updateSchedulePlan(String guid) throws Exception {
-        UserSession session = getAuthenticatedResearcherSession();
+        UserSession session = getAuthenticatedSession(DEVELOPER);
         StudyIdentifier studyId = session.getStudyIdentifier();
 
         DynamoSchedulePlan planForm = DynamoSchedulePlan.fromJson(requestToJSON(request()));
@@ -61,7 +63,7 @@ public class SchedulePlanController extends BaseController {
     }
 
     public Result deleteSchedulePlan(String guid) {
-        UserSession session = getAuthenticatedResearcherSession();
+        UserSession session = getAuthenticatedSession(DEVELOPER);
         StudyIdentifier studyId = session.getStudyIdentifier();
 
         schedulePlanService.deleteSchedulePlan(studyId, guid);

--- a/app/org/sagebionetworks/bridge/play/controllers/StudyConsentController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/StudyConsentController.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.bridge.play.controllers;
 
+import static org.sagebionetworks.bridge.Roles.RESEARCHER;
+
 import java.util.List;
 
 import org.sagebionetworks.bridge.json.DateUtils;
@@ -25,28 +27,28 @@ public class StudyConsentController extends BaseController {
     }
 
     public Result getAllConsents() throws Exception {
-        UserSession session = getAuthenticatedResearcherSession();
+        UserSession session = getAuthenticatedSession(RESEARCHER);
         StudyIdentifier studyId = session.getStudyIdentifier();
         List<StudyConsent> consents = studyConsentService.getAllConsents(studyId);
         return okResult(consents);
     }
 
     public Result getActiveConsent() throws Exception {
-        UserSession session = getAuthenticatedResearcherSession();
+        UserSession session = getAuthenticatedSession(RESEARCHER);
         StudyIdentifier studyId = session.getStudyIdentifier();
         StudyConsentView consent = studyConsentService.getActiveConsent(studyId);
         return okResult(consent);
     }
     
     public Result getMostRecentConsent() throws Exception {
-        UserSession session = getAuthenticatedResearcherSession();
+        UserSession session = getAuthenticatedSession(RESEARCHER);
         StudyIdentifier studyId = session.getStudyIdentifier();
         StudyConsentView consent = studyConsentService.getMostRecentConsent(studyId);
         return okResult(consent);
     }
 
     public Result getConsent(String createdOn) throws Exception {
-        UserSession session = getAuthenticatedResearcherSession();
+        UserSession session = getAuthenticatedSession(RESEARCHER);
         StudyIdentifier studyId = session.getStudyIdentifier();
         long timestamp = DateUtils.convertToMillisFromEpoch(createdOn);
         StudyConsentView consent = studyConsentService.getConsent(studyId, timestamp);
@@ -54,7 +56,7 @@ public class StudyConsentController extends BaseController {
     }
     
     public Result addConsent() throws Exception {
-        UserSession session = getAuthenticatedResearcherSession();
+        UserSession session = getAuthenticatedSession(RESEARCHER);
         StudyIdentifier studyId = session.getStudyIdentifier();
         StudyConsentForm form = parseJson(request(), StudyConsentForm.class);
         StudyConsentView studyConsent = studyConsentService.addConsent(studyId, form);
@@ -62,7 +64,7 @@ public class StudyConsentController extends BaseController {
     }
 
     public Result setActiveConsent(String createdOn) throws Exception {
-        UserSession session = getAuthenticatedResearcherSession();
+        UserSession session = getAuthenticatedSession(RESEARCHER);
         StudyIdentifier studyId = session.getStudyIdentifier();
         long timestamp = DateUtils.convertToMillisFromEpoch(createdOn);
         studyConsentService.activateConsent(studyId, timestamp);

--- a/app/org/sagebionetworks/bridge/play/controllers/SurveyController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/SurveyController.java
@@ -3,7 +3,6 @@ package org.sagebionetworks.bridge.play.controllers;
 import static org.sagebionetworks.bridge.BridgeConstants.JSON_MIME_TYPE;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
-import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 
 import java.util.List;
 
@@ -254,7 +253,7 @@ public class SurveyController extends BaseController {
     }
     
     public Result closeSurvey(String surveyGuid, String createdOnString) throws Exception {
-        UserSession session = getAuthenticatedSession(RESEARCHER);
+        UserSession session = getAuthenticatedSession(DEVELOPER);
         StudyIdentifier studyId = session.getStudyIdentifier();
         
         long createdOn = DateUtils.convertToMillisFromEpoch(createdOnString);

--- a/app/org/sagebionetworks/bridge/play/controllers/SurveyController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/SurveyController.java
@@ -1,10 +1,12 @@
 package org.sagebionetworks.bridge.play.controllers;
 
 import static org.sagebionetworks.bridge.BridgeConstants.JSON_MIME_TYPE;
+import static org.sagebionetworks.bridge.Roles.ADMIN;
+import static org.sagebionetworks.bridge.Roles.DEVELOPER;
+import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 
 import java.util.List;
 
-import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.cache.ViewCache;
 import org.sagebionetworks.bridge.cache.ViewCache.ViewCacheKey;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
@@ -42,7 +44,7 @@ public class SurveyController extends BaseController {
     }
     
     public Result getAllSurveysMostRecentVersion() throws Exception {
-        UserSession session = getAuthenticatedResearcherSession();
+        UserSession session = getAuthenticatedSession(DEVELOPER);
         StudyIdentifier studyId = session.getStudyIdentifier();
 
         List<Survey> surveys = surveyService.getAllSurveysMostRecentVersion(studyId);
@@ -51,7 +53,7 @@ public class SurveyController extends BaseController {
     }
     
     public Result getAllSurveysMostRecentVersion2() throws Exception {
-        UserSession session = getAuthenticatedResearcherSession();
+        UserSession session = getAuthenticatedSession(DEVELOPER);
         StudyIdentifier studyId = session.getStudyIdentifier();
 
         List<Survey> surveys = surveyService.getAllSurveysMostRecentVersion(studyId);
@@ -60,7 +62,7 @@ public class SurveyController extends BaseController {
     }
     
     public Result getAllSurveysMostRecentlyPublishedVersion() throws Exception {
-        UserSession session = getAuthenticatedResearcherSession();
+        UserSession session = getAuthenticatedSession(DEVELOPER);
         StudyIdentifier studyId = session.getStudyIdentifier();
 
         List<Survey> surveys = surveyService.getAllSurveysMostRecentlyPublishedVersion(studyId);
@@ -103,7 +105,7 @@ public class SurveyController extends BaseController {
     
     // Otherwise you don't need consent but you must be a researcher or an administrator
     public Result getSurvey(final String surveyGuid, final String createdOnString) throws Exception {
-        final UserSession session = getAuthenticatedResearcherSession();
+        final UserSession session = getAuthenticatedSession(DEVELOPER);
         final StudyIdentifier studyId = session.getStudyIdentifier();
         
         ViewCacheKey<Survey> cacheKey = viewCache.getCacheKey(Survey.class, surveyGuid, createdOnString); 
@@ -120,7 +122,7 @@ public class SurveyController extends BaseController {
     }
     
     public Result getSurveyMostRecentVersion(final String surveyGuid) throws Exception {
-        final UserSession session = getAuthenticatedResearcherSession();
+        final UserSession session = getAuthenticatedSession(DEVELOPER);
         final StudyIdentifier studyId = session.getStudyIdentifier();
         
         ViewCacheKey<Survey> cacheKey = viewCache.getCacheKey(Survey.class, surveyGuid, MOSTRECENT_KEY);
@@ -135,7 +137,7 @@ public class SurveyController extends BaseController {
     }
     
     public Result getSurveyMostRecentlyPublishedVersion(final String surveyGuid) throws Exception {
-        final UserSession session = getAuthenticatedResearcherSession();
+        final UserSession session = getAuthenticatedSession(DEVELOPER);
         final StudyIdentifier studyId = session.getStudyIdentifier();
         
         ViewCacheKey<Survey> cacheKey = viewCache.getCacheKey(Survey.class, surveyGuid, PUBLISHED_KEY);
@@ -150,7 +152,7 @@ public class SurveyController extends BaseController {
     }
     
     public Result getMostRecentPublishedSurveyVersionByIdentifier(String identifier) throws Exception {
-        UserSession session = getAuthenticatedResearcherSession();
+        UserSession session = getAuthenticatedSession(DEVELOPER);
         StudyIdentifier studyId = session.getStudyIdentifier();
         
         // Do not cache this. It's only used by researchers and without the GUID, you cannot
@@ -161,7 +163,7 @@ public class SurveyController extends BaseController {
     }
     
     public Result deleteSurvey(String surveyGuid, String createdOnString) throws Exception {
-        UserSession session = getAuthenticatedResearcherSession();
+        UserSession session = getAuthenticatedSession(DEVELOPER);
         StudyIdentifier studyId = session.getStudyIdentifier();
         
         long createdOn = DateUtils.convertToMillisFromEpoch(createdOnString);
@@ -177,7 +179,7 @@ public class SurveyController extends BaseController {
     }
     
     public Result getSurveyAllVersions(String surveyGuid) throws Exception {
-        UserSession session = getAuthenticatedResearcherSession();
+        UserSession session = getAuthenticatedSession(DEVELOPER);
         StudyIdentifier studyId = session.getStudyIdentifier();
         
         List<Survey> surveys = surveyService.getSurveyAllVersions(studyId, surveyGuid);
@@ -186,7 +188,7 @@ public class SurveyController extends BaseController {
     }
     
     public Result createSurvey() throws Exception {
-        UserSession session = getAuthenticatedResearcherSession();
+        UserSession session = getAuthenticatedSession(DEVELOPER);
         StudyIdentifier studyId = session.getStudyIdentifier();
         
         Survey survey = parseJson(request(), Survey.class);
@@ -197,7 +199,7 @@ public class SurveyController extends BaseController {
     }
     
     public Result versionSurvey(String surveyGuid, String createdOnString) throws Exception {
-        UserSession session = getAuthenticatedResearcherSession();
+        UserSession session = getAuthenticatedSession(DEVELOPER);
         StudyIdentifier studyId = session.getStudyIdentifier();
         
         long createdOn = DateUtils.convertToMillisFromEpoch(createdOnString);
@@ -213,7 +215,7 @@ public class SurveyController extends BaseController {
     }
     
     public Result updateSurvey(String surveyGuid, String createdOnString) throws Exception {
-        UserSession session = getAuthenticatedResearcherSession();
+        UserSession session = getAuthenticatedSession(DEVELOPER);
         StudyIdentifier studyId = session.getStudyIdentifier();
         
         long createdOn = DateUtils.convertToMillisFromEpoch(createdOnString);
@@ -236,7 +238,7 @@ public class SurveyController extends BaseController {
     }
     
     public Result publishSurvey(String surveyGuid, String createdOnString) throws Exception {
-        UserSession session = getAuthenticatedResearcherSession();
+        UserSession session = getAuthenticatedSession(DEVELOPER);
         StudyIdentifier studyId = session.getStudyIdentifier();
          
         long createdOn = DateUtils.convertToMillisFromEpoch(createdOnString);
@@ -252,7 +254,7 @@ public class SurveyController extends BaseController {
     }
     
     public Result closeSurvey(String surveyGuid, String createdOnString) throws Exception {
-        UserSession session = getAuthenticatedResearcherSession();
+        UserSession session = getAuthenticatedSession(RESEARCHER);
         StudyIdentifier studyId = session.getStudyIdentifier();
         
         long createdOn = DateUtils.convertToMillisFromEpoch(createdOnString);
@@ -274,7 +276,7 @@ public class SurveyController extends BaseController {
     }
     
     private void verifySurveyIsInStudy(UserSession session, StudyIdentifier studyIdentifier, Survey survey) {
-        if (!session.getUser().isInRole(BridgeConstants.ADMIN_GROUP) && 
+        if (!session.getUser().isInRole(ADMIN) && 
             !survey.getStudyIdentifier().equals(studyIdentifier.getIdentifier())) {
             throw new UnauthorizedException();
         }

--- a/app/org/sagebionetworks/bridge/play/controllers/UploadSchemaController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/UploadSchemaController.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.bridge.play.controllers;
 
+import static org.sagebionetworks.bridge.Roles.DEVELOPER;
+
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,7 +33,7 @@ public class UploadSchemaController extends BaseController {
      * @return Play result, with the created or updated schema in JSON format
      */
     public Result createOrUpdateUploadSchema() {
-        UserSession session = getAuthenticatedResearcherSession();
+        UserSession session = getAuthenticatedSession(DEVELOPER);
         StudyIdentifier studyId = session.getStudyIdentifier();
         
         UploadSchema uploadSchema = parseJson(request(), UploadSchema.class);
@@ -50,7 +52,7 @@ public class UploadSchemaController extends BaseController {
      * @return Play result with the OK message
      */
     public Result deleteUploadSchemaByIdAndRev(String schemaId, int rev) {
-        UserSession session = getAuthenticatedResearcherSession();
+        UserSession session = getAuthenticatedSession(DEVELOPER);
         StudyIdentifier studyIdentifier = session.getStudyIdentifier();
 
         uploadSchemaService.deleteUploadSchemaByIdAndRev(studyIdentifier, schemaId, rev);
@@ -67,7 +69,7 @@ public class UploadSchemaController extends BaseController {
      * @return Play result with the OK message
      */
     public Result deleteUploadSchemaById(String schemaId) {
-        UserSession session = getAuthenticatedResearcherSession();
+        UserSession session = getAuthenticatedSession(DEVELOPER);
         StudyIdentifier studyIdentifier = session.getStudyIdentifier();
 
         uploadSchemaService.deleteUploadSchemaById(studyIdentifier, schemaId);
@@ -84,7 +86,7 @@ public class UploadSchemaController extends BaseController {
      * @return Play result with the fetched schema in JSON format
      */
     public Result getUploadSchema(String schemaId) {
-        UserSession session = getAuthenticatedResearcherSession();
+        UserSession session = getAuthenticatedSession(DEVELOPER);
         StudyIdentifier studyId = session.getStudyIdentifier();
         
         UploadSchema uploadSchema = uploadSchemaService.getUploadSchema(studyId, schemaId);
@@ -94,10 +96,11 @@ public class UploadSchemaController extends BaseController {
     /**
      * Play controller for GET /researcher/v1/uploadSchema/forStudy. This API fetches all revisions of all upload
      * schemas in the current study. This is generally used by worker apps to validate uploads against schemas.
+     * 
      * @return Play result with list of schemas for this study
      */
     public Result getUploadSchemasForStudy() throws Exception {
-        UserSession session = getAuthenticatedResearcherSession();
+        UserSession session = getAuthenticatedSession(DEVELOPER);
         StudyIdentifier studyId = session.getStudyIdentifier();
 
         List<UploadSchema> schemaList = uploadSchemaService.getUploadSchemasForStudy(studyId);

--- a/app/org/sagebionetworks/bridge/play/controllers/UserManagementController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/UserManagementController.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.bridge.play.controllers;
 
+import static org.sagebionetworks.bridge.Roles.ADMIN;
+
 import org.sagebionetworks.bridge.json.JsonUtils;
 import org.sagebionetworks.bridge.models.accounts.SignUp;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
@@ -25,7 +27,7 @@ public class UserManagementController extends BaseController {
     }
 
     public Result createUser() throws Exception {
-        UserSession session = getAuthenticatedAdminSession();
+        UserSession session = getAuthenticatedSession(ADMIN);
         Study study = studyService.getStudy(session.getStudyIdentifier());
 
         JsonNode node = requestToJSON(request());
@@ -39,7 +41,7 @@ public class UserManagementController extends BaseController {
     }
 
     public Result deleteUser(String email) throws Exception {
-        UserSession session = getAuthenticatedAdminSession();
+        UserSession session = getAuthenticatedSession(ADMIN);
         Study study = studyService.getStudy(session.getStudyIdentifier());
         
         userAdminService.deleteUser(study, email);

--- a/app/org/sagebionetworks/bridge/services/AuthenticationServiceImpl.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationServiceImpl.java
@@ -1,8 +1,10 @@
 package org.sagebionetworks.bridge.services;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.sagebionetworks.bridge.Roles.ADMIN;
+import static org.sagebionetworks.bridge.Roles.DEVELOPER;
+import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 
-import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.config.BridgeConfig;
@@ -230,7 +232,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         // And now for some exceptions...
         // All administrators and all researchers are assumed to consent when using any API.
         // This is needed so they can sign in without facing a 412 exception.
-        if (user.isInRole(BridgeConstants.ADMIN_GROUP) || user.isInRole(study.getResearcherRole())) {
+        if (user.isInRole(ADMIN) || user.isInRole(RESEARCHER) || user.isInRole(DEVELOPER)) {
             user.setConsent(true);
         }
         // And then we set *any* account that has the admin email to be consented as well

--- a/app/org/sagebionetworks/bridge/services/StudyServiceImpl.java
+++ b/app/org/sagebionetworks/bridge/services/StudyServiceImpl.java
@@ -157,7 +157,6 @@ public class StudyServiceImpl implements StudyService {
             studyConsentService.activateConsent(study.getStudyIdentifier(), view.getCreatedOn());
             
             study.setActive(true);
-            study.setResearcherRole(study.getIdentifier() + "_researcher");
 
             String directory = directoryDao.createDirectoryForStudy(study);
             study.setStormpathHref(directory);
@@ -199,7 +198,6 @@ public class StudyServiceImpl implements StudyService {
         // These cannot be set through the API and will be null here, so they are set on update
         Study originalStudy = studyDao.getStudy(study.getIdentifier());
         study.setStormpathHref(originalStudy.getStormpathHref());
-        study.setResearcherRole(originalStudy.getResearcherRole());
         study.setActive(true);
         // study.setActive(originalStudy.isActive());
         // And this cannot be set unless you're an administrator.

--- a/app/org/sagebionetworks/bridge/services/UserAdminService.java
+++ b/app/org/sagebionetworks/bridge/services/UserAdminService.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.services;
 
+import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.models.accounts.SignUp;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
@@ -35,10 +36,10 @@ public interface UserAdminService {
     public void deleteUser(Study study, String email);
     
     /**
-     * Deletes all all users in the "test users" group in Stormpath.
+     * Deletes all all users with a given role (used to remove TEST_USERS).
      *
      * @throws BridgeServiceException
      */
-    public void deleteAllUsers(String role) throws BridgeServiceException;
+    public void deleteAllUsers(Roles role);
 
 }

--- a/app/org/sagebionetworks/bridge/services/UserAdminServiceImpl.java
+++ b/app/org/sagebionetworks/bridge/services/UserAdminServiceImpl.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.Iterator;
 
 import org.apache.commons.lang3.StringUtils;
+import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dao.DistributedLockDao;
@@ -146,7 +147,7 @@ public class UserAdminServiceImpl implements UserAdminService {
     }
 
     @Override
-    public void deleteAllUsers(String role) {
+    public void deleteAllUsers(Roles role) {
         Iterator<Account> iterator = accountDao.getAllAccounts();
         while(iterator.hasNext()) {
             Account account = iterator.next();

--- a/app/org/sagebionetworks/bridge/stormpath/StormpathAccount.java
+++ b/app/org/sagebionetworks/bridge/stormpath/StormpathAccount.java
@@ -7,6 +7,8 @@ import java.io.IOException;
 import java.util.Set;
 import java.util.SortedMap;
 
+import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.crypto.Encryptor;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.json.BridgeTypeName;
@@ -16,8 +18,6 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Sets;
-import com.stormpath.sdk.group.Group;
 
 /**
  * Account values are decrypted with the appropriate Encryptor implementation based on the version 
@@ -51,7 +51,7 @@ class StormpathAccount implements Account {
     private final String consentSignatureKey;
     private final String oldHealthIdVersionKey;
     private final String oldConsentSignatureKey;
-    private final Set<String> roles;
+    private final Set<Roles> roles;
     
     StormpathAccount(StudyIdentifier studyIdentifier, com.stormpath.sdk.account.Account acct,
             SortedMap<Integer, Encryptor> encryptors) {
@@ -68,12 +68,7 @@ class StormpathAccount implements Account {
         this.consentSignatureKey = studyId + CONSENT_SIGNATURE_SUFFIX;
         this.oldHealthIdVersionKey = studyId + OLD_VERSION_SUFFIX;
         this.oldConsentSignatureKey = studyId + CONSENT_SIGNATURE_SUFFIX;
-        this.roles = Sets.newHashSet();
-        if (acct.getGroups() != null) {
-            for (Group group : acct.getGroups()) {
-                this.roles.add(group.getName());
-            }
-        }
+        this.roles = BridgeUtils.convertRolesQuietly(acct.getGroups());
     }
     
     com.stormpath.sdk.account.Account getAccount() {
@@ -151,7 +146,7 @@ class StormpathAccount implements Account {
         return studyIdentifier;
     }
     @Override
-    public Set<String> getRoles() {
+    public Set<Roles> getRoles() {
         return this.roles;
     }
     @Override

--- a/app/org/sagebionetworks/bridge/stormpath/StormpathAccountDao.java
+++ b/app/org/sagebionetworks/bridge/stormpath/StormpathAccountDao.java
@@ -11,6 +11,7 @@ import java.util.SortedMap;
 
 import javax.annotation.Resource;
 
+import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.crypto.Encryptor;
 import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
@@ -213,7 +214,7 @@ public class StormpathAccountDao implements AccountDao {
         account.setLastName(StormpathAccount.PLACEHOLDER_STRING);
         acct.setPassword(signUp.getPassword());
         if (signUp.getRoles() != null) {
-            account.getRoles().addAll(signUp.getRoles());    
+            account.getRoles().addAll(signUp.getRoles());
         }
         try {
             Directory directory = client.getResource(study.getStormpathHref(), Directory.class);
@@ -286,7 +287,10 @@ public class StormpathAccountDao implements AccountDao {
     }
     
     private void updateGroups(Directory directory, Account account) {
-        Set<String> roles = Sets.newHashSet(account.getRoles());
+        Set<String> roles = Sets.newHashSet();
+        for (Roles role : account.getRoles()) {
+            roles.add(role.name().toLowerCase());
+        }
         com.stormpath.sdk.account.Account acct = ((StormpathAccount)account).getAccount();
         
         // Remove any memberships that don't match a role

--- a/conf/routes
+++ b/conf/routes
@@ -85,9 +85,9 @@ POST   /researcher/v1/consents/active/:timestamp    @org.sagebionetworks.bridge.
 
 # Researchers - Studies
 GET    /researcher/v1/studies            @org.sagebionetworks.bridge.play.controllers.StudyController.getStudyList
-GET    /researcher/v1/study              @org.sagebionetworks.bridge.play.controllers.StudyController.getStudyForResearcher
+GET    /researcher/v1/study              @org.sagebionetworks.bridge.play.controllers.StudyController.getStudyForDeveloper
 POST   /researcher/v1/study/participants @org.sagebionetworks.bridge.play.controllers.StudyController.sendStudyParticipantsRoster          
-POST   /researcher/v1/study              @org.sagebionetworks.bridge.play.controllers.StudyController.updateStudyForResearcher
+POST   /researcher/v1/study              @org.sagebionetworks.bridge.play.controllers.StudyController.updateStudyForDeveloper
 
 # Researchers - Upload Schemas
 GET    /researcher/v1/uploadSchemas                           @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getUploadSchemasForStudy

--- a/test/org/sagebionetworks/bridge/DefaultStudyBootstrapperTest.java
+++ b/test/org/sagebionetworks/bridge/DefaultStudyBootstrapperTest.java
@@ -37,7 +37,6 @@ public class DefaultStudyBootstrapperTest {
         assertEquals("api", study.getIdentifier());
         assertEquals("Sage Bionetworks", study.getSponsorName());
         assertEquals(18, study.getMinAgeOfConsent());
-        assertEquals("api_researcher", study.getResearcherRole());
         assertEquals("bridge-testing+consent@sagebase.org", study.getConsentNotificationEmail());
         assertEquals("bridge-testing+technical@sagebase.org", study.getTechnicalEmail());
         assertEquals("support@sagebridge.org", study.getSupportEmail());

--- a/test/org/sagebionetworks/bridge/ManualCleanupTest.java
+++ b/test/org/sagebionetworks/bridge/ManualCleanupTest.java
@@ -1,10 +1,11 @@
 package org.sagebionetworks.bridge;
 
+import static org.sagebionetworks.bridge.Roles.TEST_USERS;
+
 import javax.annotation.Resource;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.services.UserAdminService;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -18,6 +19,6 @@ public class ManualCleanupTest {
 
     @Test
     public void deleteAllRemainingTestUsers() {
-        userAdminService.deleteAllUsers(BridgeConstants.TEST_USERS_GROUP);
+        userAdminService.deleteAllUsers(TEST_USERS);
     }
 }

--- a/test/org/sagebionetworks/bridge/TestUserAdminHelper.java
+++ b/test/org/sagebionetworks/bridge/TestUserAdminHelper.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.sagebionetworks.bridge.Roles.TEST_USERS;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 
 import java.util.Set;
@@ -39,18 +40,18 @@ public class TestUserAdminHelper {
         private final String username;
         private final String email;
         private final String password;
-        private final Set<String> roles;
+        private final Set<Roles> roles;
         private final Study study;
         private final UserSession session;
 
-        public TestUser(String username, String email, String password, Set<String> roleList, Study study, UserSession session) {
+        public TestUser(String username, String email, String password, Set<Roles> roleList, Study study, UserSession session) {
             this.username = username;
             this.email = email;
             this.password = password;
             this.study = study;
             this.session = session;
-            this.roles = (roleList == null) ? Sets.<String>newHashSet() : roleList;
-            this.roles.add(BridgeConstants.TEST_USERS_GROUP);
+            this.roles = (roleList == null) ? Sets.<Roles>newHashSet() : roleList;
+            this.roles.add(TEST_USERS);
         }
         public SignUp getSignUp() {
             return new SignUp(username, email, password, roles);
@@ -107,13 +108,13 @@ public class TestUserAdminHelper {
         return createUser(cls, null);
     }
 
-    public TestUser createUser(Class<?> cls, Set<String> roles) {
+    public TestUser createUser(Class<?> cls, Set<Roles> roles) {
         checkNotNull(cls, "Class must not be null");
 
         return createUser(cls, true, true, roles);
     }
 
-    public TestUser createUser(Class<?> cls, boolean signIn, boolean consent, Set<String> roles) {
+    public TestUser createUser(Class<?> cls, boolean signIn, boolean consent, Set<Roles> roles) {
         checkNotNull(cls, "Class must not be null");
 
         String name = makeRandomUserName(cls);
@@ -132,7 +133,7 @@ public class TestUserAdminHelper {
         return new TestUser(signUp.getUsername(), signUp.getEmail(), signUp.getPassword(), signUp.getRoles(), study, session);
     }
 
-    public TestUser createUser(Class<?> cls, Study study, boolean consent, Set<String> roles) {
+    public TestUser createUser(Class<?> cls, Study study, boolean consent, Set<Roles> roles) {
         checkNotNull(cls, "Class must not be null");
         checkNotNull(study);
 

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -154,7 +154,6 @@ public class TestUtils {
         study.setMinAgeOfConsent(18);
         study.setMaxNumOfParticipants(200);
         study.setStormpathHref("http://enterprise.stormpath.io/directories/asdf");
-        study.setResearcherRole(study.getIdentifier() + "_researcher");
         study.setSponsorName("The Council on Test Studies");
         study.setConsentNotificationEmail("bridge-testing+consent@sagebase.org");
         study.setTechnicalEmail("bridge-testing+technical@sagebase.org");

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
@@ -50,7 +50,6 @@ public class DynamoStudyTest {
         assertEquals(study.getMinAgeOfConsent(), node.get("minAgeOfConsent").asInt());
         assertEquals(study.getMaxNumOfParticipants(), node.get("maxNumOfParticipants").asInt());
         assertEquals(study.getStormpathHref(), node.get("stormpathHref").asText());
-        assertEquals(study.getResearcherRole(), node.get("researcherRole").asText());
         assertEquals(study.getPasswordPolicy(), JsonUtils.asEntity(node, "passwordPolicy", PasswordPolicy.class));
         assertEquals(study.getVerifyEmailTemplate(), JsonUtils.asEntity(node, "verifyEmailTemplate", EmailTemplate.class));
         assertEquals(study.getResetPasswordTemplate(), JsonUtils.asEntity(node, "resetPasswordTemplate", EmailTemplate.class));
@@ -64,7 +63,6 @@ public class DynamoStudyTest {
         // Study.STUDY_WRITER.
         json = Study.STUDY_WRITER.writeValueAsString(study);
         study = BridgeObjectMapper.get().readValue(json, DynamoStudy.class);
-        assertNull(study.getResearcherRole());
         assertNull(study.getStormpathHref());
         assertEquals("Study", node.get("type").asText());
     }

--- a/test/org/sagebionetworks/bridge/json/JsonUtilsTest.java
+++ b/test/org/sagebionetworks/bridge/json/JsonUtilsTest.java
@@ -3,11 +3,15 @@ package org.sagebionetworks.bridge.json;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.sagebionetworks.bridge.Roles.ADMIN;
+import static org.sagebionetworks.bridge.Roles.RESEARCHER;
+import static org.sagebionetworks.bridge.Roles.TEST_USERS;
 
 import java.util.Set;
 
 import org.joda.time.DateTime;
 import org.junit.Test;
+import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.models.schedules.ActivityType;
 import org.sagebionetworks.bridge.models.schedules.ScheduleType;
 import org.sagebionetworks.bridge.models.surveys.Image;
@@ -193,6 +197,17 @@ public class JsonUtilsTest {
         assertEquals(Sets.newHashSet(), JsonUtils.asStringSet(node, null));
         assertEquals(Sets.newHashSet(), JsonUtils.asStringSet(node, "badProp"));
         assertEquals(set, JsonUtils.asStringSet(node, "key"));
+    }
+
+    @Test
+    public void asRolesSet() throws Exception {
+        Set<Roles> set = Sets.newHashSet(ADMIN, RESEARCHER, TEST_USERS);
+        
+        JsonNode node = mapper.readTree(esc("{'key':['admin','researcher','test_users', 'junk']}"));
+        
+        assertEquals(Sets.newHashSet(), JsonUtils.asRolesSet(node, null));
+        assertEquals(Sets.newHashSet(), JsonUtils.asRolesSet(node, "badProp"));
+        assertEquals(set, JsonUtils.asRolesSet(node, "key"));
     }
 
 }

--- a/test/org/sagebionetworks/bridge/models/accounts/UserSessionInfoTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/UserSessionInfoTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.models.accounts;
 
 import static org.junit.Assert.*;
+import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 
 import org.junit.Test;
 import org.sagebionetworks.bridge.config.Environment;
@@ -9,7 +10,6 @@ import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.collect.Sets;
 
 public class UserSessionInfoTest {
 
@@ -22,7 +22,7 @@ public class UserSessionInfoTest {
         user.setLastName("last name");
         user.setHealthCode("healthCode");
         user.setId("user-identifier");
-        user.setRoles(Sets.newHashSet("test_role"));
+        user.getRoles().add(RESEARCHER);
         user.setSharingScope(SharingScope.ALL_QUALIFIED_RESEARCHERS);
         user.setSignedMostRecentConsent(false);
         user.setStudyKey("study-identifier");
@@ -47,11 +47,12 @@ public class UserSessionInfoTest {
         assertEquals(user.getSharingScope().name(), node.get("sharingScope").asText().toUpperCase());
         assertEquals(session.getSessionToken(), node.get("sessionToken").asText());
         assertEquals(user.getUsername(), node.get("username").asText());
+        assertEquals("researcher", node.get("roles").get(0).asText());
         assertEquals("staging", node.get("environment").asText());
         assertEquals("UserSessionInfo", node.get("type").asText());
         
         // ... and no things that shouldn't be there
-        assertEquals(9, node.size());
+        assertEquals(10, node.size());
     }
     
 }

--- a/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 
 import java.util.List;
 import java.util.Map;
@@ -21,6 +22,7 @@ import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.cache.ViewCache;
@@ -120,12 +122,11 @@ public class SurveyControllerTest {
         User user = new User();
         user.setHealthCode("BBB");
         user.setStudyKey(studyIdentifier);
-        user.setRoles(Sets.newHashSet("api_researcher"));
+        user.setRoles(Sets.newHashSet(RESEARCHER));
         session.setUser(user);
         session.setStudyIdentifier(new StudyIdentifierImpl(studyIdentifier));
         doReturn(session).when(controller).getAuthenticatedAndConsentedSession();
-        doReturn(session).when(controller).getAuthenticatedSession();
-        doReturn(session).when(controller).getAuthenticatedResearcherSession();
+        doReturn(session).when(controller).getAuthenticatedSession(any(Roles.class));
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/play/controllers/UploadSchemaControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/UploadSchemaControllerTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.play.controllers;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -18,6 +19,7 @@ import play.mvc.Http;
 import play.mvc.Result;
 import play.test.Helpers;
 
+import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
@@ -61,7 +63,7 @@ public class UploadSchemaControllerTest {
         // spy controller
         UploadSchemaController controller = spy(new UploadSchemaController());
         controller.setUploadSchemaService(mockSvc);
-        doReturn(mockSession).when(controller).getAuthenticatedResearcherSession();
+        doReturn(mockSession).when(controller).getAuthenticatedSession(any(Roles.class));
 
         // execute and validate
         Result result = controller.createOrUpdateUploadSchema();
@@ -90,7 +92,7 @@ public class UploadSchemaControllerTest {
         // spy controller
         UploadSchemaController controller = spy(new UploadSchemaController());
         controller.setUploadSchemaService(mockSvc);
-        doReturn(mockSession).when(controller).getAuthenticatedResearcherSession();
+        doReturn(mockSession).when(controller).getAuthenticatedSession(any(Roles.class));
 
         // execute and validate
         Result result = controller.deleteUploadSchemaByIdAndRev("delete-schema", 1);
@@ -111,7 +113,7 @@ public class UploadSchemaControllerTest {
         // spy controller
         UploadSchemaController controller = spy(new UploadSchemaController());
         controller.setUploadSchemaService(mockSvc);
-        doReturn(mockSession).when(controller).getAuthenticatedResearcherSession();
+        doReturn(mockSession).when(controller).getAuthenticatedSession(any(Roles.class));
 
         // execute and validate
         Result result = controller.deleteUploadSchemaById("delete-schema");
@@ -133,7 +135,7 @@ public class UploadSchemaControllerTest {
         // spy controller
         UploadSchemaController controller = spy(new UploadSchemaController());
         controller.setUploadSchemaService(mockSvc);
-        doReturn(mockSession).when(controller).getAuthenticatedResearcherSession();
+        doReturn(mockSession).when(controller).getAuthenticatedSession(any(Roles.class));
 
         // execute and validate
         Result result = controller.getUploadSchema(TEST_SCHEMA_ID);
@@ -159,7 +161,7 @@ public class UploadSchemaControllerTest {
         // spy controller
         UploadSchemaController controller = spy(new UploadSchemaController());
         controller.setUploadSchemaService(mockSvc);
-        doReturn(mockSession).when(controller).getAuthenticatedResearcherSession();
+        doReturn(mockSession).when(controller).getAuthenticatedSession(any(Roles.class));
 
         // execute and validate
         Result result = controller.getUploadSchemasForStudy();

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceImplTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceImplTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.sagebionetworks.bridge.Roles.ADMIN;
+import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 
 import javax.annotation.Resource;
 
@@ -12,8 +14,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.sagebionetworks.bridge.BridgeConstants;
-import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUserAdminHelper;
 import org.sagebionetworks.bridge.TestUserAdminHelper.TestUser;
 import org.sagebionetworks.bridge.TestUtils;
@@ -159,9 +159,8 @@ public class AuthenticationServiceImplTest {
 
     @Test
     public void createResearcherAndSignInWithoutConsentError() {
-        Study study = studyService.getStudy(TestConstants.TEST_STUDY_IDENTIFIER);
         TestUser researcher = helper.createUser(AuthenticationServiceImplTest.class, false, false,
-                Sets.newHashSet(study.getResearcherRole()));
+                Sets.newHashSet(RESEARCHER));
         try {
             authService.signIn(researcher.getStudy(), researcher.getSignIn());
             // no exception should have been thrown.
@@ -173,7 +172,7 @@ public class AuthenticationServiceImplTest {
     @Test
     public void createAdminAndSignInWithoutConsentError() {
         TestUser researcher = helper.createUser(AuthenticationServiceImplTest.class, false, false,
-                Sets.newHashSet(BridgeConstants.ADMIN_GROUP));
+                        Sets.newHashSet(ADMIN));
         try {
             authService.signIn(researcher.getStudy(), researcher.getSignIn());
             // no exception should have been thrown.

--- a/test/org/sagebionetworks/bridge/services/StudyServiceImplTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceImplTest.java
@@ -111,7 +111,6 @@ public class StudyServiceImplTest {
         assertEquals(200, study.getMaxNumOfParticipants());
         assertEquals(18, study.getMinAgeOfConsent());
         // these should have been changed
-        assertEquals(identifier+"_researcher", study.getResearcherRole());
         assertNotEquals("http://local-test-junk", study.getStormpathHref());
         verify(cache).getStudy(study.getIdentifier());
         verify(cache).setStudy(study);

--- a/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoTest.java
+++ b/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.sagebionetworks.bridge.Roles.TEST_USERS;
 
 import java.util.Iterator;
 
@@ -86,7 +87,7 @@ public class StormpathAccountDaoTest {
         Account account = null;
         
         try {
-            SignUp signUp = new SignUp(random, email, PASSWORD, Sets.newHashSet("test_users"));
+            SignUp signUp = new SignUp(random, email, PASSWORD, Sets.newHashSet(TEST_USERS));
             accountDao.signUp(study, signUp, false);
             
             account = accountDao.authenticate(study, new SignIn(email, PASSWORD));
@@ -102,7 +103,7 @@ public class StormpathAccountDaoTest {
         String random = RandomStringUtils.randomAlphabetic(5);
         String email = "bridge-testing+"+random+"@sagebridge.org";
         try {
-            SignUp signUp = new SignUp(random, email, PASSWORD, Sets.newHashSet("test_users"));
+            SignUp signUp = new SignUp(random, email, PASSWORD, Sets.newHashSet(TEST_USERS));
             accountDao.signUp(study, signUp, false);
             
             try {
@@ -129,7 +130,7 @@ public class StormpathAccountDaoTest {
         try {
             ConsentSignature sig = ConsentSignature.create("Test Test", "1970-01-01", null, null);
             
-            SignUp signUp = new SignUp(random, email, PASSWORD, Sets.newHashSet("test_users"));
+            SignUp signUp = new SignUp(random, email, PASSWORD, Sets.newHashSet(TEST_USERS));
             
             accountDao.signUp(study, signUp, false);
             account = accountDao.getAccount(study, signUp.getEmail());
@@ -160,7 +161,7 @@ public class StormpathAccountDaoTest {
 
             // Just remove a group... this gets into verifying and avoiding saving the underlying
             // Stormpath account. 
-            account.getRoles().remove("test_users");
+            account.getRoles().remove(TEST_USERS);
             accountDao.updateAccount(study, account);
             
             newAccount = accountDao.getAccount(study, newAccount.getEmail());

--- a/test/org/sagebionetworks/bridge/stormpath/StormpathAccountTest.java
+++ b/test/org/sagebionetworks/bridge/stormpath/StormpathAccountTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -227,9 +228,9 @@ public class StormpathAccountTest {
     
     @Test
     public void canSetAndGetRoles() {
-        acct.getRoles().add("aRole");
+        acct.getRoles().add(DEVELOPER);
         
         assertEquals(1, acct.getRoles().size());
-        assertEquals("aRole", acct.getRoles().iterator().next());
+        assertEquals(DEVELOPER, acct.getRoles().iterator().next());
     }
 }

--- a/test/org/sagebionetworks/bridge/stormpath/StormpathDirectoryDaoTest.java
+++ b/test/org/sagebionetworks/bridge/stormpath/StormpathDirectoryDaoTest.java
@@ -3,6 +3,10 @@ package org.sagebionetworks.bridge.stormpath;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.sagebionetworks.bridge.Roles.ADMIN;
+import static org.sagebionetworks.bridge.Roles.DEVELOPER;
+import static org.sagebionetworks.bridge.Roles.RESEARCHER;
+import static org.sagebionetworks.bridge.Roles.TEST_USERS;
 
 import javax.annotation.Resource;
 
@@ -15,6 +19,7 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.config.BridgeConfig;
 import org.sagebionetworks.bridge.config.BridgeConfigFactory;
@@ -69,7 +74,10 @@ public class StormpathDirectoryDaoTest {
         
         assertEquals("Name is the right one", identifier + " ("+config.getEnvironment().name().toLowerCase()+")", directory.getName());
         assertTrue("Mapping exists for new directory in the right application", containsMapping(stormpathHref));
-        assertTrue("The researcher group was created", researcherGroupExists(directory, identifier));
+        assertTrue("The researcher group was created", groupExists(directory, RESEARCHER));
+        assertTrue("The developer group was created", groupExists(directory, DEVELOPER));
+        assertTrue("The admin group was created", groupExists(directory, ADMIN));
+        assertTrue("The test_users group was created", groupExists(directory, TEST_USERS));
         
         Directory newDirectory = directoryDao.getDirectoryForStudy(identifier);
         assertDirectoriesAreEqual(study, "subject", "subject", directory, newDirectory);
@@ -152,9 +160,9 @@ public class StormpathDirectoryDaoTest {
         assertTrue(templateJSON.get("defaultModel").get("linkBaseUrl").asText().contains("/mobile/verifyEmail.html?study="));
     }
     
-    private boolean researcherGroupExists(Directory directory, String name) {
+    private boolean groupExists(Directory directory, Roles role) {
         for (Group group : directory.getGroups()) {
-            if (group.getName().equals(name+"_researcher")) {
+            if (group.getName().equals(role.name().toLowerCase())) {
                 return true;
             }
         }


### PR DESCRIPTION
- Researcher role split into a developer role (administration of a study) and a researcher role (access to consent and to participant information).
- Because users are scoped to a study now, and cannot cross it, there is no need for studies and roles to be associated in any way. This was removed from study and a simple enum of roles was put in its place
- String representations of roles were refactored to use the enumeration.
- About a billion classes were altered by this
