### PR TITLE
Removing tests for a non-existent role on Stormpath

### DIFF
--- a/app/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/app/org/sagebionetworks/bridge/BridgeUtils.java
@@ -28,8 +28,6 @@ import com.stormpath.sdk.group.Group;
 import com.stormpath.sdk.group.GroupList;
 
 public class BridgeUtils {
-
-    private static Logger logger = LoggerFactory.getLogger(BridgeUtils.class);
     
     /**
      * A simple means of providing template variables in template strings, in the format <code>${variableName}</code>.
@@ -136,12 +134,7 @@ public class BridgeUtils {
         Set<Roles> roleSet = new HashSet<>();
         if (groups != null) {
             for (Group group : groups) {
-                try {
-                    roleSet.add(Roles.valueOf(group.getName().toUpperCase()));
-                } catch(IllegalArgumentException e) {
-                    // probably api_researcher.
-                    logger.info("Found an invalid role: " + group.getName().toUpperCase());
-                }
+                roleSet.add(Roles.valueOf(group.getName().toUpperCase()));
             }
         }
         return roleSet;

--- a/app/org/sagebionetworks/bridge/json/JsonUtils.java
+++ b/app/org/sagebionetworks/bridge/json/JsonUtils.java
@@ -189,12 +189,7 @@ public class JsonUtils {
             ArrayNode array = (ArrayNode)parent.get(property);
             for (int i = 0; i < array.size(); i++) {
                 String name = array.get(i).asText().toUpperCase();
-                try {
-                    results.add(Roles.valueOf(name));    
-                } catch(IllegalArgumentException e) {
-                    // probably api_researcher.
-                    logger.info("Found an invalid role: " + name);
-                }
+                results.add(Roles.valueOf(name));
             }
         }
         return results;

--- a/test/org/sagebionetworks/bridge/json/JsonUtilsTest.java
+++ b/test/org/sagebionetworks/bridge/json/JsonUtilsTest.java
@@ -203,7 +203,7 @@ public class JsonUtilsTest {
     public void asRolesSet() throws Exception {
         Set<Roles> set = Sets.newHashSet(ADMIN, RESEARCHER, TEST_USERS);
         
-        JsonNode node = mapper.readTree(esc("{'key':['admin','researcher','test_users', 'junk']}"));
+        JsonNode node = mapper.readTree(esc("{'key':['admin','researcher','test_users']}"));
         
         assertEquals(Sets.newHashSet(), JsonUtils.asRolesSet(node, null));
         assertEquals(Sets.newHashSet(), JsonUtils.asRolesSet(node, "badProp"));


### PR DESCRIPTION
These methods should throw an exception if they encounter an unknown role, and now they do. Older Groups were removed from Stormpath.
