### PR TITLE
Switching from use of directory name, to directory HREF

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/DirectoryDao.java
+++ b/app/org/sagebionetworks/bridge/dao/DirectoryDao.java
@@ -10,8 +10,8 @@ public interface DirectoryDao {
 
     public void updateDirectoryForStudy(Study study);
     
-    public Directory getDirectoryForStudy(String identifier);
+    public Directory getDirectoryForStudy(Study study);
 
-    public void deleteDirectoryForStudy(String identifier);
+    public void deleteDirectoryForStudy(Study study);
 
 }

--- a/app/org/sagebionetworks/bridge/json/JsonUtils.java
+++ b/app/org/sagebionetworks/bridge/json/JsonUtils.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.models.surveys.Constraints;

--- a/app/org/sagebionetworks/bridge/services/StudyServiceImpl.java
+++ b/app/org/sagebionetworks/bridge/services/StudyServiceImpl.java
@@ -235,7 +235,7 @@ public class StudyServiceImpl implements StudyService {
             lockId = lockDao.acquireLock(Study.class, identifier);
             studyDao.deleteStudy(existing);
             studyConsentDao.deleteAllConsents(existing.getStudyIdentifier());
-            directoryDao.deleteDirectoryForStudy(identifier);
+            directoryDao.deleteDirectoryForStudy(existing);
             cacheProvider.removeStudy(identifier);
         } finally {
             lockDao.releaseLock(Study.class, identifier, lockId);

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -153,7 +153,6 @@ public class TestUtils {
         study.setIdentifier(TestUtils.randomName());
         study.setMinAgeOfConsent(18);
         study.setMaxNumOfParticipants(200);
-        study.setStormpathHref("http://enterprise.stormpath.io/directories/asdf");
         study.setSponsorName("The Council on Test Studies");
         study.setConsentNotificationEmail("bridge-testing+consent@sagebase.org");
         study.setTechnicalEmail("bridge-testing+technical@sagebase.org");

--- a/test/org/sagebionetworks/bridge/stormpath/StormpathDirectoryDaoTest.java
+++ b/test/org/sagebionetworks/bridge/stormpath/StormpathDirectoryDaoTest.java
@@ -50,28 +50,29 @@ public class StormpathDirectoryDaoTest {
     @Resource
     Client client;
     
-    private String identifier;
+    private DynamoStudy study;
     
     @After
     public void after() {
-        if (identifier != null) {
-            directoryDao.deleteDirectoryForStudy(identifier);
+        if (study != null) {
+            directoryDao.deleteDirectoryForStudy(study);
         }
     }
     
     @Test
     public void crudDirectory() throws Exception {
-        identifier = TestUtils.randomName();
+        String identifier = TestUtils.randomName();
         
-        DynamoStudy study = TestUtils.getValidStudy();
+        study = TestUtils.getValidStudy();
         study.setIdentifier(identifier);
         
         String stormpathHref = directoryDao.createDirectoryForStudy(study);
+        study.setStormpathHref(stormpathHref);
         BridgeConfig config = BridgeConfigFactory.getConfig();
         
         // Verify the directory and mapping were created
         Directory directory = getDirectory(stormpathHref);
-        
+
         assertEquals("Name is the right one", identifier + " ("+config.getEnvironment().name().toLowerCase()+")", directory.getName());
         assertTrue("Mapping exists for new directory in the right application", containsMapping(stormpathHref));
         assertTrue("The researcher group was created", groupExists(directory, RESEARCHER));
@@ -79,7 +80,7 @@ public class StormpathDirectoryDaoTest {
         assertTrue("The admin group was created", groupExists(directory, ADMIN));
         assertTrue("The test_users group was created", groupExists(directory, TEST_USERS));
         
-        Directory newDirectory = directoryDao.getDirectoryForStudy(identifier);
+        Directory newDirectory = directoryDao.getDirectoryForStudy(study);
         assertDirectoriesAreEqual(study, "subject", "subject", directory, newDirectory);
         
         // Verify that we can update the directory.
@@ -89,14 +90,14 @@ public class StormpathDirectoryDaoTest {
         
         directoryDao.updateDirectoryForStudy(study);
         
-        newDirectory = directoryDao.getDirectoryForStudy(identifier);
+        newDirectory = directoryDao.getDirectoryForStudy(study);
         assertDirectoriesAreEqual(study, "new rp subject", "new ve subject", directory, newDirectory);
         
-        directoryDao.deleteDirectoryForStudy(study.getIdentifier());
-        newDirectory = directoryDao.getDirectoryForStudy(identifier);
+        directoryDao.deleteDirectoryForStudy(study);
+        newDirectory = directoryDao.getDirectoryForStudy(study);
         assertNull("Directory has been deleted", newDirectory);
         
-        identifier = null;
+        study = null;
     }
 
     private void assertDirectoriesAreEqual(DynamoStudy study, String rpSubject, String veSubject, Directory directory, Directory newDirectory) throws Exception {


### PR DESCRIPTION
Up until now, we were retrieving a directory based on a calculation of the directory's name and then a search. This was inefficient and frankly, dumb. This change uses the href which is the recommended way of retrieving a Stormpath resource.

This was _necessary_ to have two studies share the same directory, and some day we may need to do this. But we hope not to do it now (though this was the original motive of this fix).
