### PR TITLE
Preventing account enumeration when verifying email, reseting password

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
@@ -62,7 +62,7 @@ public class AuthenticationController extends BaseController {
         Email email = parseJson(request(), Email.class);
         StudyIdentifier studyIdentifier = getStudyIdentifierOrThrowException(json);
         authenticationService.resendEmailVerification(studyIdentifier, email);
-        return okResult("A request to verify an email address was re-sent.");
+        return okResult("If registered with the study, we'll email you instructions on how to verify your account.");
     }
 
     public Result requestResetPassword() throws Exception {
@@ -70,7 +70,7 @@ public class AuthenticationController extends BaseController {
         Email email = parseJson(request(), Email.class);
         Study study = getStudyOrThrowException(json);
         authenticationService.requestResetPassword(study, email);
-        return okResult("An email has been sent allowing you to set a new password.");
+        return okResult("If registered with the study, we'll email you instructions on how to change your password.");
     }
 
     public Result resetPassword() throws Exception {

--- a/app/org/sagebionetworks/bridge/services/AuthenticationServiceImpl.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationServiceImpl.java
@@ -163,12 +163,14 @@ public class AuthenticationServiceImpl implements AuthenticationService {
             }
             accountDao.signUp(study, signUp, isAnonSignUp);
         } catch(EntityAlreadyExistsException e) {
-            // Suppress this. Otherwise it reveals if the account does not exist
-            // Non-anonymous sign ups (sign ups done by admins on behalf of users) still get a 404
+            // Suppress this. Otherwise it the response reveals that the email has already been taken, 
+            // and you can infer who is in the study from the response. Instead send a reset password 
+            // request to the email address in case user has forgotten password and is trying to sign 
+            // up again. Non-anonymous sign ups (sign ups done by admins on behalf of users) still get a 404
             if (isAnonSignUp) {
                 Email email = new Email(study.getIdentifier(), signUp.getEmail());
                 requestResetPassword(study, email);
-                logger.info("Sign up attempt for existing account: "+study.getIdentifier()+" "+email.getEmail());
+                logger.info("Sign up attempt for existing email address in study '"+study.getIdentifier()+"'");
             } else {
                 throw e;
             }
@@ -203,7 +205,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
             accountDao.resendEmailVerificationToken(studyIdentifier, email);    
         } catch(EntityNotFoundException e) {
             // Suppress this. Otherwise it reveals if the account does not exist
-            logger.info("Resend email verification attempt using address: "+studyIdentifier.getIdentifier()+" "+email.getEmail());
+            logger.info("Resend email verification for unregistered email in study '"+studyIdentifier.getIdentifier()+"'");
         }
     }
 
@@ -217,7 +219,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
             accountDao.requestResetPassword(study, email);    
         } catch(EntityNotFoundException e) {
             // Suppress this. Otherwise it reveals if the account does not exist
-            logger.info("Request reset password attempt using address: "+study.getIdentifier()+" "+email.getEmail());
+            logger.info("Request reset password request for unregistered email in study '"+study.getIdentifier()+"'");
         }
     }
 

--- a/app/org/sagebionetworks/bridge/services/AuthenticationServiceImpl.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationServiceImpl.java
@@ -163,13 +163,12 @@ public class AuthenticationServiceImpl implements AuthenticationService {
             }
             accountDao.signUp(study, signUp, isAnonSignUp);
         } catch(EntityAlreadyExistsException e) {
-            // Do not indicate to the end user that this email address has already been taken, as this 
-            // leaks information about who is in the study. Instead send a reset password request to the 
-            // email address in case user has forgotten password and is trying to sign up again.
+            // Suppress this. Otherwise it reveals if the account does not exist
+            // Non-anonymous sign ups (sign ups done by admins on behalf of users) still get a 404
             if (isAnonSignUp) {
-                logger.info(String.format("Sign up attempt for existing account: %s, %s", study.getIdentifier(), signUp.getEmail()));
                 Email email = new Email(study.getIdentifier(), signUp.getEmail());
                 requestResetPassword(study, email);
+                logger.info("Sign up attempt for existing account: "+study.getIdentifier()+" "+email.getEmail());
             } else {
                 throw e;
             }
@@ -200,8 +199,12 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         checkNotNull(email, "Email object cannnot be null");
         
         Validate.entityThrowingException(emailValidator, email);
-        
-        accountDao.resendEmailVerificationToken(studyIdentifier, email);
+        try {
+            accountDao.resendEmailVerificationToken(studyIdentifier, email);    
+        } catch(EntityNotFoundException e) {
+            // Suppress this. Otherwise it reveals if the account does not exist
+            logger.info("Resend email verification attempt using address: "+studyIdentifier.getIdentifier()+" "+email.getEmail());
+        }
     }
 
     @Override
@@ -210,8 +213,12 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         checkNotNull(email);
         
         Validate.entityThrowingException(emailValidator, email);
-
-        accountDao.requestResetPassword(study, email);
+        try {
+            accountDao.requestResetPassword(study, email);    
+        } catch(EntityNotFoundException e) {
+            // Suppress this. Otherwise it reveals if the account does not exist
+            logger.info("Request reset password attempt using address: "+study.getIdentifier()+" "+email.getEmail());
+        }
     }
 
     @Override

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceImplTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceImplTest.java
@@ -130,9 +130,9 @@ public class AuthenticationServiceImplTest {
         authService.requestResetPassword(testUser.getStudy(), email);
     }
     
-    @Test(expected = BridgeServiceException.class)
+    @Test(expected = EntityNotFoundException.class)
     public void resetPasswordWithBadTokenFails() throws Exception {
-        authService.resetPassword(new PasswordReset("foo", "newpassword"));
+        authService.resetPassword(new PasswordReset("newpassword", "foo"));
     }
 
     @Test
@@ -154,7 +154,18 @@ public class AuthenticationServiceImplTest {
         try {
             Email email = new Email(testUser.getStudyIdentifier(), user.getEmail());
             authService.resendEmailVerification(user.getStudyIdentifier(), email);
-        } catch (ConsentRequiredException e) {
+        } finally {
+            helper.deleteUser(user);
+        }
+    }
+    
+    @Test
+    public void resendEmailVerificationLooksSuccessfulWhenNoAccount() throws Exception {
+        // In particular, it must not throw an EntityNotFoundException
+        TestUser user = helper.createUser(AuthenticationServiceImplTest.class, false, false, null);
+        try {
+            Email email = new Email(testUser.getStudyIdentifier(), "notarealaccount@sagebase.org");
+            authService.resendEmailVerification(user.getStudyIdentifier(), email);
         } finally {
             helper.deleteUser(user);
         }


### PR DESCRIPTION
There are a few other calls that will return 404s to unauthenticated users, if the email address used is not currently known to Stormpath. These are now changed in the service layer to return as if they had been successful (as is now done with the signUp endpoint).
