### PR TITLE
get schema by id and rev, updated schema rev logic in upload validation and added schemaRevision flag

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/UploadSchemaDao.java
+++ b/app/org/sagebionetworks/bridge/dao/UploadSchemaDao.java
@@ -74,6 +74,21 @@ public interface UploadSchemaDao {
     @Nonnull UploadSchema getUploadSchema(@Nonnull String studyId, @Nonnull String schemaId);
 
     /**
+     * Fetches the upload schema for the specified study, schema ID, and revision. If no schema is found, this API
+     * throws an EntityNotFoundException
+     *
+     * @param studyIdentifier
+     *         study to fetch the schema from, must be non-null
+     * @param schemaId
+     *         ID of the schema to fetch, must be non-null and non-empty
+     * @param schemaRev
+     *         revision number of the schema to fetch, must be positive
+     * @return the fetched schema, will be non-null
+     */
+    @Nonnull UploadSchema getUploadSchemaByIdAndRev(@Nonnull StudyIdentifier studyIdentifier, @Nonnull String schemaId,
+            int schemaRev);
+
+    /**
      * DAO method for fetching all revisions of all upload schemas in a given study. This is used by upload unpacking
      * and validation to match up the data to the schema.
      *

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDao.java
@@ -233,6 +233,25 @@ public class DynamoUploadSchemaDao implements UploadSchemaDao {
         return uploadSchema;
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public @Nonnull UploadSchema getUploadSchemaByIdAndRev(@Nonnull StudyIdentifier studyIdentifier,
+            @Nonnull String schemaId, int schemaRev) {
+        String studyId = studyIdentifier.getIdentifier();
+
+        DynamoUploadSchema key = new DynamoUploadSchema();
+        key.setStudyId(studyId);
+        key.setSchemaId(schemaId);
+        key.setRevision(schemaRev);
+
+        DynamoUploadSchema schema = mapper.load(key);
+        if (schema == null) {
+            throw new EntityNotFoundException(UploadSchema.class, String.format(
+                    "Upload schema not found for study %s, schema ID %s, revision %d", studyId, schemaId, schemaRev));
+        }
+        return schema;
+    }
+
     /**
      * Private helper function, which gets a schema from DDB. This is used by the get (which validates afterwards) and
      * the put (which needs to check for concurrent modification exceptions). The return value of this helper method

--- a/app/org/sagebionetworks/bridge/play/controllers/UploadSchemaController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/UploadSchemaController.java
@@ -94,6 +94,24 @@ public class UploadSchemaController extends BaseController {
     }
 
     /**
+     * Fetches the upload schema for the specified study, schema ID, and revision. If no schema is found, this API
+     * throws a 404 exception.
+     *
+     * @param schemaId
+     *         schema ID to fetch
+     * @param rev
+     *         revision number of the schema to fetch, must be positive
+     * @return Play result with the fetched schema in JSON format
+     */
+    public Result getUploadSchemaByIdAndRev(String schemaId, int rev) {
+        UserSession session = getAuthenticatedSession(DEVELOPER);
+        StudyIdentifier studyId = session.getStudyIdentifier();
+
+        UploadSchema uploadSchema = uploadSchemaService.getUploadSchemaByIdAndRev(studyId, schemaId, rev);
+        return okResult(uploadSchema);
+    }
+
+    /**
      * Play controller for GET /researcher/v1/uploadSchema/forStudy. This API fetches all revisions of all upload
      * schemas in the current study. This is generally used by worker apps to validate uploads against schemas.
      * 

--- a/app/org/sagebionetworks/bridge/services/UploadSchemaService.java
+++ b/app/org/sagebionetworks/bridge/services/UploadSchemaService.java
@@ -124,6 +124,33 @@ public class UploadSchemaService {
 
     /**
      * <p>
+     * Fetches the upload schema for the specified study, schema ID, and revision. If no schema is found, this API
+     * throws an EntityNotFoundException
+     * </p>
+     * <p>
+     * This method validates the schema ID and rev. However, it does not validate the study, as that is not user input.
+     * </p>
+     *
+     * @param studyIdentifier
+     *         study to fetch the schema from, provided by the controller
+     * @param schemaId
+     *         ID of the schema to fetch, must be non-null and non-empty
+     * @param schemaRev
+     *         revision number of the schema to fetch, must be positive
+     * @return the fetched schema, will be non-null
+     */
+    public UploadSchema getUploadSchemaByIdAndRev(StudyIdentifier studyIdentifier, String schemaId, int schemaRev) {
+        if (StringUtils.isBlank(schemaId)) {
+            throw new BadRequestException(String.format("Invalid schema ID %s", schemaId));
+        }
+        if (schemaRev <= 0) {
+            throw new BadRequestException(String.format("Invalid schema revision %d", schemaRev));
+        }
+        return uploadSchemaDao.getUploadSchemaByIdAndRev(studyIdentifier, schemaId, schemaRev);
+    }
+
+    /**
+     * <p>
      * Service handler for fetching all revisions of all upload schemas in a study. This is used by upload unpacking
      * and validation to match up the data to the schema.
      * </p>

--- a/conf/application-context.xml
+++ b/conf/application-context.xml
@@ -18,6 +18,55 @@
         <ref bean="healthCodeEncryptor"/>
     </util:list>
 
+    <!--
+        Normally, Upload Validation defaults to rev 1. However, some schemas had to be bumped up to higher versions,
+        but the apps weren't sending schemaRevision yet. So we need this legacy map to track those exceptions where we
+        default to a different revision.
+
+        Hopefully as these schemas and app versions get phased out, we can eventually remove this map.
+    -->
+    <util:map id="defaultSchemaRevisionMap" key-type="java.lang.String" value-type="java.util.Map">
+        <entry key="api">
+            <map key-type="java.lang.String" value-type="java.lang.Integer">
+                <entry key="schema-rev-test" value="2" />
+            </map>
+        </entry>
+        <entry key="asthma">
+            <map key-type="java.lang.String" value-type="java.lang.Integer">
+                <entry key="Air Quality Report" value="4" />
+                <entry key="NonIdentifiableDemographicsTask" value="2" />
+            </map>
+        </entry>
+        <entry key="breastcancer">
+            <map key-type="java.lang.String" value-type="java.lang.Integer">
+                <entry key="Journal" value="3"/>
+                <entry key="My Journal" value="3"/>
+                <entry key="NonIdentifiableDemographicsTask" value="2"/>
+            </map>
+        </entry>
+        <entry key="cardiovascular">
+            <map key-type="java.lang.String" value-type="java.lang.Integer">
+                <entry key="2-APHHeartAge-7259AC18-D711-47A6-ADBD-6CFCECDED1DF" value="2" />
+                <entry key="6-Minute Walk Test" value="3" />
+                <entry key="NonIdentifiableDemographicsTask" value="2" />
+            </map>
+        </entry>
+        <entry key="diabetes">
+            <map key-type="java.lang.String" value-type="java.lang.Integer">
+                <entry key="NonIdentifiableDemographicsTask" value="2" />
+                <entry key="glucoseLogEntryStep" value="2" />
+            </map>
+        </entry>
+        <entry key="parkinson">
+            <map key-type="java.lang.String" value-type="java.lang.Integer">
+                <entry key="NonIdentifiableDemographicsTask" value="2" />
+                <entry key="Tapping Activity" value="6" />
+                <entry key="Voice Activity" value="3" />
+                <entry key="Walking Activity" value="5" />
+            </map>
+        </entry>
+    </util:map>
+
     <bean id="proxiedController" class="org.springframework.aop.framework.ProxyFactoryBean">
         <property name="proxyTargetClass" value="true"/>
         <property name="interceptorNames">

--- a/conf/routes
+++ b/conf/routes
@@ -72,6 +72,7 @@ GET    /v3/uploadstatuses/:uploadId    @org.sagebionetworks.bridge.play.controll
 GET    /v3/uploadschemas                           @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getUploadSchemasForStudy
 POST   /v3/uploadschemas                           @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.createOrUpdateUploadSchema
 GET    /v3/uploadschemas/:schemaId                 @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getUploadSchema(schemaId: String)
+GET    /v3/uploadschemas/:schemaId/revisions/:rev  @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getUploadSchemaByIdAndRev(schemaId: String, rev: Int)
 DELETE /v3/uploadschemas/:schemaId                 @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.deleteUploadSchemaById(schemaId: String)
 DELETE /v3/uploadschemas/:schemaId/revisions/:rev  @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.deleteUploadSchemaByIdAndRev(schemaId: String, rev: Int)
 

--- a/test/org/sagebionetworks/bridge/play/controllers/UploadSchemaControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/UploadSchemaControllerTest.java
@@ -26,7 +26,6 @@ import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.upload.UploadSchema;
-import org.sagebionetworks.bridge.play.controllers.UploadSchemaController;
 import org.sagebionetworks.bridge.services.UploadSchemaService;
 
 public class UploadSchemaControllerTest {
@@ -139,6 +138,32 @@ public class UploadSchemaControllerTest {
 
         // execute and validate
         Result result = controller.getUploadSchema(TEST_SCHEMA_ID);
+        assertEquals(200, result.status());
+
+        // JSON validation is already tested, so just check obvious things like schema
+        String resultJson = Helpers.contentAsString(result);
+        UploadSchema resultSchema = BridgeObjectMapper.get().readValue(resultJson, UploadSchema.class);
+        assertEquals(TEST_SCHEMA_ID, resultSchema.getSchemaId());
+    }
+
+    @Test
+    public void getSchemaByIdAndRev() throws Exception {
+        // mock session
+        StudyIdentifier studyIdentifier = new StudyIdentifierImpl("get-schema-study");
+        UserSession mockSession = new UserSession();
+        mockSession.setStudyIdentifier(studyIdentifier);
+
+        // mock UploadSchemaService
+        UploadSchemaService mockSvc = mock(UploadSchemaService.class);
+        when(mockSvc.getUploadSchemaByIdAndRev(studyIdentifier, TEST_SCHEMA_ID, 1)).thenReturn(makeUploadSchema());
+
+        // spy controller
+        UploadSchemaController controller = spy(new UploadSchemaController());
+        controller.setUploadSchemaService(mockSvc);
+        doReturn(mockSession).when(controller).getAuthenticatedSession(any(Roles.class));
+
+        // execute and validate
+        Result result = controller.getUploadSchemaByIdAndRev(TEST_SCHEMA_ID, 1);
         assertEquals(200, result.status());
 
         // JSON validation is already tested, so just check obvious things like schema

--- a/test/org/sagebionetworks/bridge/services/UploadSchemaServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/UploadSchemaServiceTest.java
@@ -160,6 +160,46 @@ public class UploadSchemaServiceTest {
         assertSame(daoRetVal, svcRetVal);
     }
 
+    @Test(expected = BadRequestException.class)
+    public void getByIdAndRevNullId() {
+        new UploadSchemaService().getUploadSchemaByIdAndRev(makeTestStudy(), null, 1);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void getByIdAndRevEmptyId() {
+        new UploadSchemaService().getUploadSchemaByIdAndRev(makeTestStudy(), "", 1);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void getByIdAndRevBlankId() {
+        new UploadSchemaService().getUploadSchemaByIdAndRev(makeTestStudy(), "   ", 1);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void getByIdAndRevNegativeRev() {
+        new UploadSchemaService().getUploadSchemaByIdAndRev(makeTestStudy(), "test-schema-rev", -1);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void getByIdAndRevZeroRev() {
+        new UploadSchemaService().getUploadSchemaByIdAndRev(makeTestStudy(), "test-schema-rev", 0);
+    }
+
+    @Test
+    public void getByIdAndRevSuccess() {
+        // mock dao
+        StudyIdentifier studyIdentifier = makeTestStudy();
+        UploadSchema daoRetVal = new DynamoUploadSchema();
+        UploadSchemaDao mockDao = mock(UploadSchemaDao.class);
+        when(mockDao.getUploadSchemaByIdAndRev(studyIdentifier, "test-schema-rev", 1)).thenReturn(daoRetVal);
+
+        // execute and validate
+        UploadSchemaService svc = new UploadSchemaService();
+        svc.setUploadSchemaDao(mockDao);
+        UploadSchema svcRetVal = svc.getUploadSchemaByIdAndRev(makeTestStudy(), "test-schema-rev", 1);
+        assertSame(daoRetVal, svcRetVal);
+    }
+
     @Test
     public void getSchemasForStudy() {
         // mock dao

--- a/test/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2GetSchemaTest.java
+++ b/test/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2GetSchemaTest.java
@@ -1,0 +1,227 @@
+package org.sagebionetworks.bridge.upload;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.dynamodb.DynamoUploadSchema;
+import org.sagebionetworks.bridge.exceptions.BadRequestException;
+import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.upload.UploadSchema;
+import org.sagebionetworks.bridge.services.UploadSchemaService;
+
+@SuppressWarnings("unchecked")
+public class IosSchemaValidationHandler2GetSchemaTest {
+    private static final Map<String, Map<String, Integer>> DEFAULT_SCHEMA_REV_MAP =
+            ImmutableMap.<String, Map<String, Integer>>of(TestConstants.TEST_STUDY_IDENTIFIER,
+                    ImmutableMap.of("schema-rev-test", 2));
+
+    @Test
+    public void itemWithDefaultRev() throws Exception {
+        // mock upload schema service
+        UploadSchema dummySchema = new DynamoUploadSchema();
+        UploadSchemaService mockSchemaSvc = mock(UploadSchemaService.class);
+        when(mockSchemaSvc.getUploadSchemaByIdAndRev(TestConstants.TEST_STUDY, "test-schema", 1)).thenReturn(
+                dummySchema);
+
+        // set up test handler
+        IosSchemaValidationHandler2 handler = new IosSchemaValidationHandler2();
+        handler.setDefaultSchemaRevisionMap(DEFAULT_SCHEMA_REV_MAP);
+        handler.setUploadSchemaService(mockSchemaSvc);
+
+        // make input
+        ObjectNode infoJson = BridgeObjectMapper.get().createObjectNode();
+        infoJson.put("item", "test-schema");
+
+        // execute and validate
+        UploadSchema retVal = handler.getUploadSchema(TestConstants.TEST_STUDY, infoJson);
+        assertSame(dummySchema, retVal);
+    }
+
+    @Test
+    public void itemWithLegacyMapRev() throws Exception {
+        // mock upload schema service
+        UploadSchema dummySchema = new DynamoUploadSchema();
+        UploadSchemaService mockSchemaSvc = mock(UploadSchemaService.class);
+        when(mockSchemaSvc.getUploadSchemaByIdAndRev(TestConstants.TEST_STUDY, "schema-rev-test", 2)).thenReturn(
+                dummySchema);
+
+        // set up test handler
+        IosSchemaValidationHandler2 handler = new IosSchemaValidationHandler2();
+        handler.setDefaultSchemaRevisionMap(DEFAULT_SCHEMA_REV_MAP);
+        handler.setUploadSchemaService(mockSchemaSvc);
+
+        // make input
+        ObjectNode infoJson = BridgeObjectMapper.get().createObjectNode();
+        infoJson.put("item", "schema-rev-test");
+
+        // execute and validate
+        UploadSchema retVal = handler.getUploadSchema(TestConstants.TEST_STUDY, infoJson);
+        assertSame(dummySchema, retVal);
+    }
+
+    @Test
+    public void itemWithRev() throws Exception {
+        // mock upload schema service
+        UploadSchema dummySchema = new DynamoUploadSchema();
+        UploadSchemaService mockSchemaSvc = mock(UploadSchemaService.class);
+        when(mockSchemaSvc.getUploadSchemaByIdAndRev(TestConstants.TEST_STUDY, "schema-rev-test", 3)).thenReturn(
+                dummySchema);
+
+        // set up test handler
+        IosSchemaValidationHandler2 handler = new IosSchemaValidationHandler2();
+        handler.setDefaultSchemaRevisionMap(DEFAULT_SCHEMA_REV_MAP);
+        handler.setUploadSchemaService(mockSchemaSvc);
+
+        // make input
+        ObjectNode infoJson = BridgeObjectMapper.get().createObjectNode();
+        infoJson.put("item", "schema-rev-test");
+        infoJson.put("schemaRevision", 3);
+
+        // execute and validate
+        UploadSchema retVal = handler.getUploadSchema(TestConstants.TEST_STUDY, infoJson);
+        assertSame(dummySchema, retVal);
+    }
+
+    @Test
+    public void fallbackToIdentifier() throws Exception {
+        // mock upload schema service
+        UploadSchema dummySchema = new DynamoUploadSchema();
+        UploadSchemaService mockSchemaSvc = mock(UploadSchemaService.class);
+        when(mockSchemaSvc.getUploadSchemaByIdAndRev(TestConstants.TEST_STUDY, "test-schema", 1)).thenReturn(
+                dummySchema);
+
+        // set up test handler
+        IosSchemaValidationHandler2 handler = new IosSchemaValidationHandler2();
+        handler.setDefaultSchemaRevisionMap(DEFAULT_SCHEMA_REV_MAP);
+        handler.setUploadSchemaService(mockSchemaSvc);
+
+        // make input
+        ObjectNode infoJson = BridgeObjectMapper.get().createObjectNode();
+        infoJson.put("identifier", "test-schema");
+
+        // execute and validate
+        UploadSchema retVal = handler.getUploadSchema(TestConstants.TEST_STUDY, infoJson);
+        assertSame(dummySchema, retVal);
+    }
+
+    @Test(expected = UploadValidationException.class)
+    public void missingItem() throws Exception {
+        new IosSchemaValidationHandler2().getUploadSchema(TestConstants.TEST_STUDY,
+                BridgeObjectMapper.get().createObjectNode());
+    }
+
+    @Test(expected = UploadValidationException.class)
+    public void nullItem() throws Exception {
+        ObjectNode infoJson = BridgeObjectMapper.get().createObjectNode();
+        infoJson.putNull("item");
+
+        new IosSchemaValidationHandler2().getUploadSchema(TestConstants.TEST_STUDY, infoJson);
+    }
+
+    @Test(expected = UploadValidationException.class)
+    public void itemInvalidType() throws Exception {
+        ObjectNode infoJson = BridgeObjectMapper.get().createObjectNode();
+        infoJson.put("item", 42);
+
+        new IosSchemaValidationHandler2().getUploadSchema(TestConstants.TEST_STUDY, infoJson);
+    }
+
+    @Test(expected = UploadValidationException.class)
+    public void emptyItem() throws Exception {
+        ObjectNode infoJson = BridgeObjectMapper.get().createObjectNode();
+        infoJson.put("item", "");
+
+        new IosSchemaValidationHandler2().getUploadSchema(TestConstants.TEST_STUDY, infoJson);
+    }
+
+    @Test(expected = UploadValidationException.class)
+    public void blankItem() throws Exception {
+        ObjectNode infoJson = BridgeObjectMapper.get().createObjectNode();
+        infoJson.put("item", "   ");
+
+        new IosSchemaValidationHandler2().getUploadSchema(TestConstants.TEST_STUDY, infoJson);
+    }
+
+    @Test(expected = UploadValidationException.class)
+    public void nullSchemaRev() throws Exception {
+        ObjectNode infoJson = BridgeObjectMapper.get().createObjectNode();
+        infoJson.put("item", "test-schema");
+        infoJson.putNull("schemaRevision");
+
+        new IosSchemaValidationHandler2().getUploadSchema(TestConstants.TEST_STUDY, infoJson);
+    }
+
+    @Test(expected = UploadValidationException.class)
+    public void schemaRevInvalidType() throws Exception {
+        ObjectNode infoJson = BridgeObjectMapper.get().createObjectNode();
+        infoJson.put("item", "test-schema");
+        infoJson.put("schemaRevision", "not an int");
+
+        new IosSchemaValidationHandler2().getUploadSchema(TestConstants.TEST_STUDY, infoJson);
+    }
+
+    @Test
+    public void badRequestException() throws Exception {
+        // BadRequestExceptions happen if the inputs are invalid (like null or empty schema IDs or non-positive schema
+        // revs). The only way this is possible through our code is a non-positive schema rev. So we can use a real
+        // UploadSchemaService and pass it a negative rev to trigger this.
+
+        // set up test handler
+        IosSchemaValidationHandler2 handler = new IosSchemaValidationHandler2();
+        handler.setDefaultSchemaRevisionMap(DEFAULT_SCHEMA_REV_MAP);
+        handler.setUploadSchemaService(new UploadSchemaService());
+
+        // make input
+        ObjectNode infoJson = BridgeObjectMapper.get().createObjectNode();
+        infoJson.put("item", "test-schema");
+        infoJson.put("schemaRevision", -1);
+
+        // execute and validate
+        Exception thrownEx = null;
+        try {
+            handler.getUploadSchema(TestConstants.TEST_STUDY, infoJson);
+            fail();
+        } catch (UploadValidationException ex) {
+            thrownEx = ex;
+        }
+        assertTrue(thrownEx.getCause() instanceof BadRequestException);
+    }
+
+    @Test
+    public void entityNotFoundException() throws Exception {
+        // mock upload schema service
+        UploadSchemaService mockSchemaSvc = mock(UploadSchemaService.class);
+        when(mockSchemaSvc.getUploadSchemaByIdAndRev(TestConstants.TEST_STUDY, "not-found-schema", 1)).thenThrow(
+                EntityNotFoundException.class);
+
+        // set up test handler
+        IosSchemaValidationHandler2 handler = new IosSchemaValidationHandler2();
+        handler.setDefaultSchemaRevisionMap(DEFAULT_SCHEMA_REV_MAP);
+        handler.setUploadSchemaService(mockSchemaSvc);
+
+        // make input
+        ObjectNode infoJson = BridgeObjectMapper.get().createObjectNode();
+        infoJson.put("item", "not-found-schema");
+
+        // execute and validate
+        Exception thrownEx = null;
+        try {
+            handler.getUploadSchema(TestConstants.TEST_STUDY, infoJson);
+            fail();
+        } catch (UploadValidationException ex) {
+            thrownEx = ex;
+        }
+        assertTrue(thrownEx.getCause() instanceof EntityNotFoundException);
+    }
+}


### PR DESCRIPTION
Three changes here:
1. Added getSchemaByIdAndRev API. It was weird that there was no way to get a specific schema rev. This is mostly used to support upload validation getting any arbitrary schema rev, but it could be useful in the researcher portal as well. (We might also want to add a list schemas API in the future.)
2. Currently, Upload Validation always uses the latest schema revision. This might cause problems with older clients when schema revisions are bumped up. So we're changing this to default to schema rev 1. One problem that we have is that many schemas had their revs bumped up already (many of which had this happen before launch), so in order to support these, we have a legacy map of default schema revs.
3. Added schemaRevision flag to Upload Validation. We need this in place before clients start using it, and we want clients to start using it.

Testing done:
- unit tests
- manual tests:
  *\* created schema-rev-test schemas rev 2 and rev 3 and tested getSchemaByIdAndRev on both
  *\* manually tested uploads schema-rev-test with the legacy map (rev 2) and with an explicit rev (rev 3)
- Upload integration tests
- TODO: write new integration tests
