### PR TITLE
Allow surveys to be permanently deleted (through API)

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
@@ -172,8 +172,8 @@ public class DynamoSurveyDao implements SurveyDao {
             if (notDeleted) {
                 scan.addFilterCondition(DELETED_PROPERTY, equalsNumber("0"));
             }
-            // Scans will not sort as queries do. Sort Manually.
-            List<DynamoSurvey> surveys = Lists.newArrayList(surveyMapper.scan(DynamoSurvey.class, scan));
+            List<DynamoSurvey> surveys = Lists.newArrayList(surveyMapper.scanPage(DynamoSurvey.class, scan).getResults());
+            // Scans will not sort as queries do. Sort Manually. Probably a dog.
             Collections.sort(surveys, VERSIONED_ON_DESC_SORTER);
             return surveys;
         }
@@ -351,16 +351,19 @@ public class DynamoSurveyDao implements SurveyDao {
         return new QueryBuilder().setStudy(studyIdentifier).isPublished().setSurvey(guid).isNotDeleted().getOne(true);
     }
     
+    // SCAN
     @Override
     public Survey getSurveyMostRecentlyPublishedVersionByIdentifier(StudyIdentifier studyIdentifier, String identifier) {
         return new QueryBuilder().setStudy(studyIdentifier).setIdentifier(identifier).isPublished().isNotDeleted().getOne(true);
     }
     
+    // SCAN
     @Override
     public List<Survey> getAllSurveysMostRecentlyPublishedVersion(StudyIdentifier studyIdentifier) {
         return new QueryBuilder().setStudy(studyIdentifier).isPublished().isNotDeleted().getAll(false);
     }
     
+    // SCAN
     @Override
     public List<Survey> getAllSurveysMostRecentVersion(StudyIdentifier studyIdentifier) {
         List<Survey> surveys = new QueryBuilder().setStudy(studyIdentifier).isNotDeleted().getAll(false);
@@ -424,8 +427,8 @@ public class DynamoSurveyDao implements SurveyDao {
         DynamoDBQueryExpression<DynamoSurveyElement> query = new DynamoDBQueryExpression<DynamoSurveyElement>();
         query.withHashKeyValues(template);
         
-        QueryResultPage<DynamoSurveyElement> page = surveyElementMapper.queryPage(DynamoSurveyElement.class, query);
-        List<FailedBatch> failures = surveyElementMapper.batchDelete(page.getResults());
+        List<DynamoSurveyElement> page = surveyElementMapper.query(DynamoSurveyElement.class, query);
+        List<FailedBatch> failures = surveyElementMapper.batchDelete(page);
         BridgeUtils.ifFailuresThrowException(failures);
     }
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
@@ -413,6 +413,8 @@ public class DynamoSurveyDao implements SurveyDao {
         try {
             surveyMapper.save(survey);
         } catch(ConditionalCheckFailedException throwable) {
+            // At this point, delete the elements you just created... compensating transaction
+            deleteAllElements(survey.getGuid(), survey.getCreatedOn());
             throw new ConcurrentModificationException(survey);
         } catch(Throwable t) {
             throw new BridgeServiceException(t);

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
@@ -172,7 +172,7 @@ public class DynamoSurveyDao implements SurveyDao {
             if (notDeleted) {
                 scan.addFilterCondition(DELETED_PROPERTY, equalsNumber("0"));
             }
-            List<DynamoSurvey> surveys = Lists.newArrayList(surveyMapper.scanPage(DynamoSurvey.class, scan).getResults());
+            List<DynamoSurvey> surveys = Lists.newArrayList(surveyMapper.scan(DynamoSurvey.class, scan));
             // Scans will not sort as queries do. Sort Manually. Probably a dog.
             Collections.sort(surveys, VERSIONED_ON_DESC_SORTER);
             return surveys;
@@ -338,8 +338,7 @@ public class DynamoSurveyDao implements SurveyDao {
         // Delete the schemas as well, or they accumulate.
         try {
             StudyIdentifier studyId = new StudyIdentifierImpl(existing.getStudyIdentifier());
-            String schemaId = existing.getStudyIdentifier() + ":" + existing.getIdentifier();
-            uploadSchemaDao.deleteUploadSchemaById(studyId, schemaId);
+            uploadSchemaDao.deleteUploadSchemaById(studyId, existing.getIdentifier());
         } catch(EntityNotFoundException e) {
             // This is OK. Just means this survey wasn't published.
         }

--- a/conf/routes
+++ b/conf/routes
@@ -48,7 +48,7 @@ POST   /v3/surveys/:surveyGuid/revisions/:createdOn/version  @org.sagebionetwork
 POST   /v3/surveys/:surveyGuid/revisions/:createdOn/publish  @org.sagebionetworks.bridge.play.controllers.SurveyController.publishSurvey(surveyGuid: String, createdOn: String)
 GET    /v3/surveys/:surveyGuid/revisions/:createdOn          @org.sagebionetworks.bridge.play.controllers.SurveyController.getSurvey(surveyGuid: String, createdOn: String)
 POST   /v3/surveys/:surveyGuid/revisions/:createdOn          @org.sagebionetworks.bridge.play.controllers.SurveyController.updateSurvey(surveyGuid: String, createdOn: String)
-DELETE /v3/surveys/:surveyGuid/revisions/:createdOn          @org.sagebionetworks.bridge.play.controllers.SurveyController.deleteSurvey(surveyGuid: String, createdOn: String)
+DELETE /v3/surveys/:surveyGuid/revisions/:createdOn          @org.sagebionetworks.bridge.play.controllers.SurveyController.deleteSurvey(surveyGuid: String, createdOn: String, physical: String ?= "false")
 
 # Survey responses
 GET    /v3/surveyresponses/:guid                                        @org.sagebionetworks.bridge.play.controllers.SurveyResponseController.getSurveyResponse(guid: String)

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyDaoTest.java
@@ -89,7 +89,7 @@ public class DynamoStudyDaoTest {
             
             List<Study> savedStudies = studyDao.getStudies();
             // The five studies, plus the API study we refuse to delete...
-            assertEquals("There are six studies", 3, savedStudies.size());
+            assertEquals("There are three studies", 3, savedStudies.size());
         } finally {
             for (Study study : studies) {
                 studyDao.deleteStudy(study);

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyDaoTest.java
@@ -9,7 +9,9 @@ import java.util.Set;
 
 import javax.annotation.Resource;
 
+import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.sagebionetworks.bridge.TestUtils;
@@ -31,9 +33,13 @@ public class DynamoStudyDaoTest {
     @Resource
     DynamoStudyDao studyDao;
 
+    @BeforeClass
+    public static void beforeClass() {
+        DynamoInitializer.init(DynamoStudy.class);
+    }
+    
     @Before
     public void before() {
-        DynamoInitializer.init(DynamoStudy.class);
         // We need to leave the test study in the database.
         List<Study> studies = studyDao.getStudies();
         for (Study study : studies) {
@@ -80,20 +86,17 @@ public class DynamoStudyDaoTest {
         try {
             studies.add(studyDao.createStudy(TestUtils.getValidStudy()));
             studies.add(studyDao.createStudy(TestUtils.getValidStudy()));
-            studies.add(studyDao.createStudy(TestUtils.getValidStudy()));
-            studies.add(studyDao.createStudy(TestUtils.getValidStudy()));
-            studies.add(studyDao.createStudy(TestUtils.getValidStudy()));
-
+            
             List<Study> savedStudies = studyDao.getStudies();
             // The five studies, plus the API study we refuse to delete...
-            assertEquals("There are six studies", 6, savedStudies.size());
-
+            assertEquals("There are six studies", 3, savedStudies.size());
         } finally {
             for (Study study : studies) {
                 studyDao.deleteStudy(study);
             }
-            Thread.sleep(2000);
         }
+        // TODO: Investigating why tests fail often (not always) without this
+        Thread.sleep(5000);
         List<Study> savedStudies = studyDao.getStudies();
         assertEquals("There should be only one study", 1, savedStudies.size());
         assertEquals("That should be the test study study", "api", savedStudies.get(0).getIdentifier());

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoTest.java
@@ -122,8 +122,7 @@ public class DynamoSurveyDaoTest {
 
     @Test(expected = BridgeServiceException.class)
     public void createPreventsRecreatingASurvey() {
-        Survey survey = createSurvey(testSurvey);
-
+        createSurvey(testSurvey);
         surveyDao.createSurvey(testSurvey);
     }
 
@@ -219,8 +218,6 @@ public class DynamoSurveyDaoTest {
 
         assertEquals("Survey has one less question", count-1, survey.getElements().size());
         
-        // TODO: So this doesn't work, from a concrete parent class to sub-interface.
-        // BUT: getting closer.
         SurveyQuestion restored = (SurveyQuestion)survey.getElements().get(6);
         MultiValueConstraints mvc = (MultiValueConstraints)restored.getConstraints();
         

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoTest.java
@@ -56,8 +56,7 @@ public class DynamoSurveyDaoTest {
 
     private final StudyIdentifier studyIdentifier = new StudyIdentifierImpl(TEST_STUDY_IDENTIFIER);
     private TestSurvey testSurvey;
-    private Set<GuidCreatedOnVersionHolder> surveysToDelete;
-    private Set<String> schemaIdsToDelete;
+    private Set<GuidCreatedOnVersionHolderImpl> surveysToDelete;
 
     @BeforeClass
     public static void beforeClass() {
@@ -68,7 +67,6 @@ public class DynamoSurveyDaoTest {
     public void before() {
         testSurvey = new TestSurvey(true);
         surveysToDelete = new HashSet<>();
-        schemaIdsToDelete = new HashSet<>();
     }
 
     @After
@@ -77,14 +75,6 @@ public class DynamoSurveyDaoTest {
         for (GuidCreatedOnVersionHolder oneSurvey : surveysToDelete) {
             try {
                 surveyDao.deleteSurveyPermanently(oneSurvey);
-            } catch (Exception ex) {
-                logger.error(ex.getMessage(), ex);
-            }
-        }
-        // clean up schemas
-        for (String oneSchemaId : schemaIdsToDelete) {
-            try {
-                uploadSchemaDao.deleteUploadSchemaById(studyIdentifier, oneSchemaId);
             } catch (Exception ex) {
                 logger.error(ex.getMessage(), ex);
             }
@@ -107,7 +97,6 @@ public class DynamoSurveyDaoTest {
     
     private Survey publishSurvey(StudyIdentifier studyIdentifier, Survey survey) {
         Survey publishedSurvey = surveyDao.publishSurvey(studyIdentifier, survey);
-        schemaIdsToDelete.add(publishedSurvey.getIdentifier());
         return publishedSurvey;
     }
     
@@ -491,11 +480,11 @@ public class DynamoSurveyDaoTest {
 
     @Test
     public void canGetAllSurveys() {
-        Set<GuidCreatedOnVersionHolder> mostRecentVersionSurveys = new HashSet<>();
-        mostRecentVersionSurveys.add(createSurvey(new TestSurvey(true)));
-        mostRecentVersionSurveys.add(createSurvey(new TestSurvey(true)));
-        mostRecentVersionSurveys.add(createSurvey(new TestSurvey(true)));
-        mostRecentVersionSurveys.add(createSurvey(new TestSurvey(true)));
+        Set<GuidCreatedOnVersionHolderImpl> mostRecentVersionSurveys = new HashSet<>();
+        mostRecentVersionSurveys.add(new GuidCreatedOnVersionHolderImpl(createSurvey(new TestSurvey(true))));
+        mostRecentVersionSurveys.add(new GuidCreatedOnVersionHolderImpl(createSurvey(new TestSurvey(true))));
+        mostRecentVersionSurveys.add(new GuidCreatedOnVersionHolderImpl(createSurvey(new TestSurvey(true))));
+        mostRecentVersionSurveys.add(new GuidCreatedOnVersionHolderImpl(createSurvey(new TestSurvey(true))));
 
         Survey survey = createSurvey(new TestSurvey(true));
 
@@ -606,7 +595,7 @@ public class DynamoSurveyDaoTest {
         assertNotNull(survey);
     }
 
-    private static void assertContainsAllKeys(Set<GuidCreatedOnVersionHolder> expected, List<Survey> actual) {
+    private static void assertContainsAllKeys(Set<GuidCreatedOnVersionHolderImpl> expected, List<Survey> actual) {
         for (GuidCreatedOnVersionHolder oneExpected : expected) {
             boolean found = false;
             for (Survey oneActual : actual) {

--- a/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
@@ -387,6 +387,39 @@ public class SurveyControllerTest {
         verifyNoMoreInteractions(service);
     }
     
+    @Test
+    public void physicalDeleteOfSurveyNotAllowedForDeveloper() throws Exception {
+        String guid = BridgeUtils.generateGuid();
+        DateTime date = DateTime.now();
+        Survey survey = getSurvey(false);
+        GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl(guid, date.getMillis());
+        when(service.getSurvey(eq(keys))).thenReturn(survey);
+        setContext();
+        
+        controller.deleteSurvey(guid, date.toString(), "true");
+        
+        verify(service).getSurvey(eq(keys));
+        verify(service).deleteSurvey(eq(survey));
+        verifyNoMoreInteractions(service);
+    }
+    
+    @Test
+    public void physicalDeleteAllowedForAdmin() throws Exception {
+        String guid = BridgeUtils.generateGuid();
+        DateTime date = DateTime.now();
+        Survey survey = getSurvey(false);
+        GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl(guid, date.getMillis());
+        when(service.getSurvey(eq(keys))).thenReturn(survey);
+        setContext();
+        
+        session.getUser().getRoles().add(ADMIN);
+        controller.deleteSurvey(guid, date.toString(), "true");
+        
+        verify(service).getSurvey(eq(keys));
+        verify(service).deleteSurveyPermanently(eq(survey));
+        verifyNoMoreInteractions(service);
+    }
+    
     @Test(expected = EntityNotFoundException.class)
     public void deleteSurveyThrowsGoodExceptionIfSurveyDoesntExist() throws Exception {
         String guid = BridgeUtils.generateGuid();

--- a/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
@@ -380,7 +380,7 @@ public class SurveyControllerTest {
         when(service.getSurvey(eq(keys))).thenReturn(survey);
         setContext();
         
-        controller.deleteSurvey(guid, date.toString());
+        controller.deleteSurvey(guid, date.toString(), "false");
 
         verify(service).getSurvey(eq(keys));
         verify(service).deleteSurvey(eq(survey));
@@ -395,7 +395,7 @@ public class SurveyControllerTest {
         when(service.getSurvey(eq(keys))).thenThrow(new EntityNotFoundException(Survey.class));
         setContext();
         
-        controller.deleteSurvey(guid, date.toString());
+        controller.deleteSurvey(guid, date.toString(), "false");
     }
     
     @Test
@@ -409,7 +409,7 @@ public class SurveyControllerTest {
         setUserSession("secondstudy");
         
         try {
-            controller.deleteSurvey(guid, date.toString());
+            controller.deleteSurvey(guid, date.toString(), "false");
             fail("Should have thrown exception");
         } catch(UnauthorizedException e) {
             verify(service).getSurvey(eq(keys));
@@ -571,7 +571,7 @@ public class SurveyControllerTest {
         setUserSession("secondstudy");
         
         try {
-            controller.deleteSurvey(keys.getGuid(), new DateTime(keys.getCreatedOn()).toString());
+            controller.deleteSurvey(keys.getGuid(), new DateTime(keys.getCreatedOn()).toString(), "false");
             fail("Exception should have been thrown.");
         } catch(UnauthorizedException e) {
             verify(service).getSurvey(keys);

--- a/test/org/sagebionetworks/bridge/services/SurveyServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SurveyServiceTest.java
@@ -40,12 +40,17 @@ import org.sagebionetworks.bridge.models.surveys.Survey;
 import org.sagebionetworks.bridge.models.surveys.SurveyQuestion;
 import org.sagebionetworks.bridge.models.surveys.TestSurvey;
 import org.sagebionetworks.bridge.models.surveys.UIHint;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 @ContextConfiguration("classpath:test-context.xml")
 @RunWith(SpringJUnit4ClassRunner.class)
 public class SurveyServiceTest {
+
+    private static Logger logger = LoggerFactory.getLogger(SurveyServiceTest.class);
+    
     @Resource
     UploadSchemaService schemaService;
 
@@ -77,7 +82,7 @@ public class SurveyServiceTest {
             try {
                 surveyService.deleteSurveyPermanently(oneSurvey);
             } catch (Exception ex) {
-                // suppress exception
+                logger.error(ex.getMessage(), ex);
             }
         }
 
@@ -86,7 +91,7 @@ public class SurveyServiceTest {
             try {
                 schemaService.deleteUploadSchemaById(studyIdentifier, oneSchemaId);
             } catch (Exception ex) {
-                // suppress exception
+                logger.error(ex.getMessage(), ex);
             }
         }
     }

--- a/test/org/sagebionetworks/bridge/services/SurveyServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SurveyServiceTest.java
@@ -61,7 +61,6 @@ public class SurveyServiceTest {
 
     private TestSurvey testSurvey;
     private Set<GuidCreatedOnVersionHolderImpl> surveysToDelete;
-    private Set<String> schemaIdsToDelete;
 
     @BeforeClass
     public static void beforeClass() {
@@ -72,7 +71,6 @@ public class SurveyServiceTest {
     public void before() {
         testSurvey = new TestSurvey(true);
         surveysToDelete = new HashSet<>();
-        schemaIdsToDelete = new HashSet<>();
     }
 
     @After
@@ -81,15 +79,6 @@ public class SurveyServiceTest {
         for (GuidCreatedOnVersionHolder oneSurvey : surveysToDelete) {
             try {
                 surveyService.deleteSurveyPermanently(oneSurvey);
-            } catch (Exception ex) {
-                logger.error(ex.getMessage(), ex);
-            }
-        }
-
-        // clean up schemas
-        for (String oneSchemaId : schemaIdsToDelete) {
-            try {
-                schemaService.deleteUploadSchemaById(studyIdentifier, oneSchemaId);
             } catch (Exception ex) {
                 logger.error(ex.getMessage(), ex);
             }
@@ -222,7 +211,6 @@ public class SurveyServiceTest {
         Survey survey = surveyService.createSurvey(testSurvey);
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(survey));
         surveyService.publishSurvey(studyIdentifier, survey);
-        schemaIdsToDelete.add(survey.getIdentifier());
 
         survey.setName("This is a new name");
         surveyService.updateSurvey(survey);
@@ -235,7 +223,6 @@ public class SurveyServiceTest {
         Survey survey = surveyService.createSurvey(testSurvey);
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(survey));
         surveyService.publishSurvey(studyIdentifier, survey);
-        schemaIdsToDelete.add(survey.getIdentifier());
 
         Long originalVersion = survey.getCreatedOn();
         survey = surveyService.versionSurvey(survey);
@@ -270,7 +257,6 @@ public class SurveyServiceTest {
         Survey survey = surveyService.createSurvey(testSurvey);
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(survey));
         survey = surveyService.publishSurvey(studyIdentifier, survey);
-        schemaIdsToDelete.add(survey.getIdentifier());
 
         assertTrue("Survey is marked published", survey.isPublished());
 
@@ -293,7 +279,6 @@ public class SurveyServiceTest {
         Survey survey = surveyService.createSurvey(testSurvey);
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(survey));
         survey = surveyService.publishSurvey(studyIdentifier, survey);
-        schemaIdsToDelete.add(survey.getIdentifier());
 
         Survey laterSurvey = surveyService.versionSurvey(survey);
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(laterSurvey));
@@ -365,7 +350,6 @@ public class SurveyServiceTest {
 
         // Publish one version
         surveyService.publishSurvey(studyIdentifier, survey1);
-        schemaIdsToDelete.add(survey1.getIdentifier());
 
         // Find the survey that we created and make sure it's the published version (survey1)
         List<Survey> surveys = surveyService.getAllSurveysMostRecentlyPublishedVersion(studyIdentifier);
@@ -398,17 +382,14 @@ public class SurveyServiceTest {
         Survey survey1 = surveyService.createSurvey(new TestSurvey(true));
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(survey1));
         surveyService.publishSurvey(studyIdentifier, survey1);
-        schemaIdsToDelete.add(survey1.getIdentifier());
 
         Survey survey2 = surveyService.createSurvey(new TestSurvey(true));
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(survey2));
         surveyService.publishSurvey(studyIdentifier, survey2);
-        schemaIdsToDelete.add(survey2.getIdentifier());
 
         Survey survey3 = surveyService.createSurvey(new TestSurvey(true));
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(survey3));
         surveyService.publishSurvey(studyIdentifier, survey3);
-        schemaIdsToDelete.add(survey3.getIdentifier());
 
         // Make sure this returns all surveys that we created
         List<Survey> published = surveyService.getAllSurveysMostRecentlyPublishedVersion(studyIdentifier);
@@ -427,7 +408,6 @@ public class SurveyServiceTest {
         Survey createdSurvey = surveyService.createSurvey(survey);
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(createdSurvey));
         surveyService.publishSurvey(studyIdentifier, createdSurvey);
-        schemaIdsToDelete.add(survey.getIdentifier());
 
         Survey found = surveyService.getSurveyMostRecentlyPublishedVersionByIdentifier(studyIdentifier, identifier);
         assertNotNull(found);


### PR DESCRIPTION
Adding the ability to permanently delete a survey to the DELETE /v3/surveys/... endpoint. You must be an admin and specifically request a physical delete rather than the logical delete.

Verified after running tests that there are no surveys or survey elements left in DDB. Will now wire up to SDK tests as well.
