### PR TITLE
tweak SingleChoice survey schema types

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDao.java
@@ -126,15 +126,22 @@ public class DynamoUploadSchemaDao implements UploadSchemaDao {
             return UploadFieldType.INLINE_JSON_BLOB;
         }
 
-        if (constraints instanceof MultiValueConstraints
-                && ((MultiValueConstraints) constraints).getAllowMultiple()) {
-            if (constraints.getDataType() == DataType.STRING) {
-                // Multiple choice string answers frequently become longer than the 100-char limit. This will have
-                // to be a JSON attachment.
-                return UploadFieldType.ATTACHMENT_JSON_BLOB;
+        if (constraints instanceof MultiValueConstraints) {
+            MultiValueConstraints multiValueConstraints = (MultiValueConstraints) constraints;
+
+            if (multiValueConstraints.getAllowMultiple()) {
+                if (constraints.getDataType() == DataType.STRING) {
+                    // Multiple choice string answers frequently become longer than the 100-char limit. This will have
+                    // to be a JSON attachment.
+                    return UploadFieldType.ATTACHMENT_JSON_BLOB;
+                } else {
+                    // Multiple choice non-string answers (frequently ints) tend to be very short, so this can fit in
+                    // an inline_json_blob.
+                    return UploadFieldType.INLINE_JSON_BLOB;
+                }
             } else {
-                // Multiple choice non-string answers (frequently ints) tend to be very short, so this can fit in
-                // an inline_json_blob.
+                // iOS always returns a JSON array with a single element, so we treat this as an INLINE_JSON_BLOB.
+                // TODO: revisit this in the new upload data format
                 return UploadFieldType.INLINE_JSON_BLOB;
             }
         } else {

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDaoTest.java
@@ -133,6 +133,18 @@ public class DynamoUploadSchemaDaoTest {
             surveyElementList.add(q);
         }
 
+        // multi value string don't allow multiple
+        {
+            MultiValueConstraints constraints = new MultiValueConstraints();
+            constraints.setDataType(DataType.STRING);
+            constraints.setAllowMultiple(false);
+
+            SurveyQuestion q = new DynamoSurveyQuestion();
+            q.setIdentifier("multi-value-single-choice-string");
+            q.setConstraints(constraints);
+            surveyElementList.add(q);
+        }
+
         // multi value int don't allow multiple
         {
             MultiValueConstraints constraints = new MultiValueConstraints();
@@ -140,7 +152,7 @@ public class DynamoUploadSchemaDaoTest {
             constraints.setAllowMultiple(false);
 
             SurveyQuestion q = new DynamoSurveyQuestion();
-            q.setIdentifier("multi-value-single-choice");
+            q.setIdentifier("multi-value-single-choice-int");
             q.setConstraints(constraints);
             surveyElementList.add(q);
         }
@@ -257,7 +269,7 @@ public class DynamoUploadSchemaDaoTest {
         assertEquals("survey-study", createdSchema.getStudyId());
 
         List<UploadFieldDefinition> fieldDefList = createdSchema.getFieldDefinitions();
-        assertEquals(14, fieldDefList.size());
+        assertEquals(15, fieldDefList.size());
 
         assertEquals("no-constraints", fieldDefList.get(0).getName());
         assertEquals(UploadFieldType.INLINE_JSON_BLOB, fieldDefList.get(0).getType());
@@ -268,38 +280,41 @@ public class DynamoUploadSchemaDaoTest {
         assertEquals("multi-value-int", fieldDefList.get(2).getName());
         assertEquals(UploadFieldType.INLINE_JSON_BLOB, fieldDefList.get(2).getType());
 
-        assertEquals("multi-value-single-choice", fieldDefList.get(3).getName());
-        assertEquals(UploadFieldType.INT, fieldDefList.get(3).getType());
+        assertEquals("multi-value-single-choice-string", fieldDefList.get(3).getName());
+        assertEquals(UploadFieldType.INLINE_JSON_BLOB, fieldDefList.get(3).getType());
 
-        assertEquals("duration", fieldDefList.get(4).getName());
-        assertEquals(UploadFieldType.STRING, fieldDefList.get(4).getType());
+        assertEquals("multi-value-single-choice-int", fieldDefList.get(4).getName());
+        assertEquals(UploadFieldType.INLINE_JSON_BLOB, fieldDefList.get(4).getType());
 
-        assertEquals("unbounded-string", fieldDefList.get(5).getName());
-        assertEquals(UploadFieldType.ATTACHMENT_BLOB, fieldDefList.get(5).getType());
+        assertEquals("duration", fieldDefList.get(5).getName());
+        assertEquals(UploadFieldType.STRING, fieldDefList.get(5).getType());
 
-        assertEquals("long-string", fieldDefList.get(6).getName());
+        assertEquals("unbounded-string", fieldDefList.get(6).getName());
         assertEquals(UploadFieldType.ATTACHMENT_BLOB, fieldDefList.get(6).getType());
 
-        assertEquals("short-string", fieldDefList.get(7).getName());
-        assertEquals(UploadFieldType.STRING, fieldDefList.get(7).getType());
+        assertEquals("long-string", fieldDefList.get(7).getName());
+        assertEquals(UploadFieldType.ATTACHMENT_BLOB, fieldDefList.get(7).getType());
 
-        assertEquals("int", fieldDefList.get(8).getName());
-        assertEquals(UploadFieldType.INT, fieldDefList.get(8).getType());
+        assertEquals("short-string", fieldDefList.get(8).getName());
+        assertEquals(UploadFieldType.STRING, fieldDefList.get(8).getType());
 
-        assertEquals("decimal", fieldDefList.get(9).getName());
-        assertEquals(UploadFieldType.FLOAT, fieldDefList.get(9).getType());
+        assertEquals("int", fieldDefList.get(9).getName());
+        assertEquals(UploadFieldType.INT, fieldDefList.get(9).getType());
 
-        assertEquals("boolean", fieldDefList.get(10).getName());
-        assertEquals(UploadFieldType.BOOLEAN, fieldDefList.get(10).getType());
+        assertEquals("decimal", fieldDefList.get(10).getName());
+        assertEquals(UploadFieldType.FLOAT, fieldDefList.get(10).getType());
 
-        assertEquals("calendar-date", fieldDefList.get(11).getName());
-        assertEquals(UploadFieldType.CALENDAR_DATE, fieldDefList.get(11).getType());
+        assertEquals("boolean", fieldDefList.get(11).getName());
+        assertEquals(UploadFieldType.BOOLEAN, fieldDefList.get(11).getType());
 
-        assertEquals("local-time", fieldDefList.get(12).getName());
-        assertEquals(UploadFieldType.STRING, fieldDefList.get(12).getType());
+        assertEquals("calendar-date", fieldDefList.get(12).getName());
+        assertEquals(UploadFieldType.CALENDAR_DATE, fieldDefList.get(12).getType());
 
-        assertEquals("timestamp", fieldDefList.get(13).getName());
-        assertEquals(UploadFieldType.TIMESTAMP, fieldDefList.get(13).getType());
+        assertEquals("local-time", fieldDefList.get(13).getName());
+        assertEquals(UploadFieldType.STRING, fieldDefList.get(13).getType());
+
+        assertEquals("timestamp", fieldDefList.get(14).getName());
+        assertEquals(UploadFieldType.TIMESTAMP, fieldDefList.get(14).getType());
 
         // Validate call to DDB - make sure returned schema same as the one sent to DDB.
         ArgumentCaptor<DynamoUploadSchema> arg = ArgumentCaptor.forClass(DynamoUploadSchema.class);


### PR DESCRIPTION
In iOS, SingleChoice types are represented by an array with one element, rather than just that element itself. So we need to tweak survey schemas to do the same.

(Note: We should revisit this when we design Data Format v2.)
