### PR TITLE
Better surveyresponse api

### DIFF
--- a/app/org/sagebionetworks/bridge/models/accounts/IdentifierHolder.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/IdentifierHolder.java
@@ -1,5 +1,8 @@
 package org.sagebionetworks.bridge.models.accounts;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * Normally we would only return the version for an object that was identified
  * by a user-supplied string (an identifier). But at least survey responses allow
@@ -11,8 +14,9 @@ package org.sagebionetworks.bridge.models.accounts;
 public class IdentifierHolder {
 
     private final String identifier;
-    
-    public IdentifierHolder(String identifier) {
+
+    @JsonCreator
+    public IdentifierHolder(@JsonProperty("identifier") String identifier) {
         this.identifier = identifier;
     }
 

--- a/app/org/sagebionetworks/bridge/models/surveys/SurveyResponse.java
+++ b/app/org/sagebionetworks/bridge/models/surveys/SurveyResponse.java
@@ -13,7 +13,7 @@ public interface SurveyResponse extends BridgeEntity {
         IN_PROGRESS,
         FINISHED;
     }
-
+    
     public Long getVersion();
     public void setVersion(Long version);
     
@@ -32,7 +32,10 @@ public interface SurveyResponse extends BridgeEntity {
     public void setCompletedOn(Long completedOn);
 
     public String getSurveyGuid();
+    public void setSurveyGuid(String surveyGuid);
+    
     public long getSurveyCreatedOn();
+    public void setSurveyCreatedOn(long surveyCreatedOn);
     
     public List<SurveyAnswer> getAnswers();
     public void setAnswers(List<SurveyAnswer> answers);

--- a/app/org/sagebionetworks/bridge/play/controllers/SurveyResponseController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/SurveyResponseController.java
@@ -1,15 +1,10 @@
 package org.sagebionetworks.bridge.play.controllers;
 
-import java.io.IOException;
-import java.util.List;
-
 import org.sagebionetworks.bridge.dynamodb.DynamoSurveyResponse;
-import org.sagebionetworks.bridge.json.JsonUtils;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolder;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolderImpl;
 import org.sagebionetworks.bridge.models.accounts.IdentifierHolder;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
-import org.sagebionetworks.bridge.models.surveys.SurveyAnswer;
 import org.sagebionetworks.bridge.models.surveys.SurveyResponse;
 import org.sagebionetworks.bridge.models.surveys.SurveyResponseView;
 import org.sagebionetworks.bridge.services.SurveyResponseService;
@@ -19,9 +14,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 
 import play.mvc.Result;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 
 @Controller
 public class SurveyResponseController extends BaseController {
@@ -60,11 +52,6 @@ public class SurveyResponseController extends BaseController {
         
         responseService.appendSurveyAnswers(view.getResponse(), res.getAnswers());
         return okResult("Survey response updated.");
-    }
-
-    List<SurveyAnswer> deserializeSurveyAnswers() throws JsonProcessingException, IOException {
-        JsonNode node = requestToJSON(request());
-        return JsonUtils.asEntityList(node, SurveyAnswer.class);
     }
 
     SurveyResponseView getSurveyResponseIfAuthorized(String identifier) {

--- a/app/org/sagebionetworks/bridge/play/controllers/SurveyResponseController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/SurveyResponseController.java
@@ -3,9 +3,7 @@ package org.sagebionetworks.bridge.play.controllers;
 import java.io.IOException;
 import java.util.List;
 
-import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoSurveyResponse;
-import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.json.JsonUtils;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolder;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolderImpl;
@@ -15,6 +13,8 @@ import org.sagebionetworks.bridge.models.surveys.SurveyAnswer;
 import org.sagebionetworks.bridge.models.surveys.SurveyResponse;
 import org.sagebionetworks.bridge.models.surveys.SurveyResponseView;
 import org.sagebionetworks.bridge.services.SurveyResponseService;
+import org.sagebionetworks.bridge.validators.SurveyResponseValidator;
+import org.sagebionetworks.bridge.validators.Validate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 
@@ -32,85 +32,42 @@ public class SurveyResponseController extends BaseController {
     public void setSurveyResponseService(SurveyResponseService responseService) {
         this.responseService = responseService;
     }
-
-    // --- BETTER SURVEY RESPONSE API ---
     
-    public Result createSurveyResponseV4() throws Exception {
+    public Result createSurveyResponse() throws Exception {
         UserSession session = getAuthenticatedAndConsentedSession();
         
-        SurveyResponse res = parseJson(request(), DynamoSurveyResponse.class);
-        GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl(
-            res.getSurveyGuid(), res.getSurveyCreatedOn());
+        final SurveyResponse res = parseJson(request(), DynamoSurveyResponse.class);
+        Validate.entityThrowingException(new SurveyResponseValidator(), res);
         
-        String identifier = res.getIdentifier();
-        if (identifier == null) {
-            identifier = BridgeUtils.generateGuid();
-        }
+        GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl(res.getSurveyGuid(), res.getSurveyCreatedOn());
         
-        SurveyResponseView response = responseService.createSurveyResponse(
-            keys, session.getUser().getHealthCode(), res.getAnswers(), identifier);
+        SurveyResponseView view = responseService.createSurveyResponse(keys, 
+            session.getUser().getHealthCode(), res.getAnswers(), res.getIdentifier());
 
-        return createdResult(new IdentifierHolder(response.getIdentifier()));
+        return createdResult(new IdentifierHolder(view.getIdentifier()));
     }
     
-    public Result getSurveyResponseV4(String identifier) throws Exception {
-        SurveyResponseView response = getSurveyResponseIfAuthorized(identifier);
-        return okResult(response);
-    }
-    
-    public Result appendAnswersToSurveyResponseV4(String identifier) throws Exception {
-        SurveyResponseView response = getSurveyResponseIfAuthorized(identifier);
-        
-        SurveyResponse res = parseJson(request(), DynamoSurveyResponse.class);
-        responseService.appendSurveyAnswers(response.getResponse(), res.getAnswers());
-        return okResult("Survey response updated.");
-    }
-
-    // --- END BETTER SURVEY RESPONSE API ---
-    
-    public Result createSurveyResponse(String surveyGuid, String versionString) throws Exception {
-        UserSession session = getAuthenticatedAndConsentedSession();
-        List<SurveyAnswer> answers = deserializeSurveyAnswers();
-        Long version = DateUtils.convertToMillisFromEpoch(versionString);
-        
-        GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl(surveyGuid, version);
-        SurveyResponseView response = responseService
-                .createSurveyResponse(keys, session.getUser().getHealthCode(), answers);
-        return createdResult(new IdentifierHolder(response.getIdentifier()));
-    }
-    
-    public Result createSurveyResponseWithIdentifier(String surveyGuid, String versionString, String identifier)
-            throws Exception {
-        
-        UserSession session = getAuthenticatedAndConsentedSession();
-        List<SurveyAnswer> answers = deserializeSurveyAnswers();
-        Long version = DateUtils.convertToMillisFromEpoch(versionString);
-
-        GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl(surveyGuid, version);
-        SurveyResponseView response = responseService.createSurveyResponse(keys, 
-                session.getUser().getHealthCode(), answers, identifier);
-        return createdResult(new IdentifierHolder(response.getIdentifier()));
-    }
-
     public Result getSurveyResponse(String identifier) throws Exception {
-        SurveyResponseView response = getSurveyResponseIfAuthorized(identifier);
-        return okResult(response);
+        SurveyResponseView view = getSurveyResponseIfAuthorized(identifier);
+        return okResult(view);
     }
     
     public Result appendSurveyAnswers(String identifier) throws Exception {
-        SurveyResponseView response = getSurveyResponseIfAuthorized(identifier);
+        SurveyResponseView view = getSurveyResponseIfAuthorized(identifier);
+
+        // Get the answers. We have the survey keys, etc. given the identifier.
+        SurveyResponse res = parseJson(request(), DynamoSurveyResponse.class);
         
-        List<SurveyAnswer> answers = deserializeSurveyAnswers();
-        responseService.appendSurveyAnswers(response.getResponse(), answers);
+        responseService.appendSurveyAnswers(view.getResponse(), res.getAnswers());
         return okResult("Survey response updated.");
     }
 
-    private List<SurveyAnswer> deserializeSurveyAnswers() throws JsonProcessingException, IOException {
+    List<SurveyAnswer> deserializeSurveyAnswers() throws JsonProcessingException, IOException {
         JsonNode node = requestToJSON(request());
         return JsonUtils.asEntityList(node, SurveyAnswer.class);
     }
 
-    private SurveyResponseView getSurveyResponseIfAuthorized(String identifier) {
+    SurveyResponseView getSurveyResponseIfAuthorized(String identifier) {
         UserSession session = getAuthenticatedAndConsentedSession();
         String healthCode = session.getUser().getHealthCode(); 
         return responseService.getSurveyResponse(healthCode, identifier);

--- a/app/org/sagebionetworks/bridge/services/SurveyResponseService.java
+++ b/app/org/sagebionetworks/bridge/services/SurveyResponseService.java
@@ -10,9 +10,6 @@ import org.sagebionetworks.bridge.models.surveys.SurveyResponseView;
 public interface SurveyResponseService {
     
     public SurveyResponseView createSurveyResponse(GuidCreatedOnVersionHolder survey, String healthCode,
-            List<SurveyAnswer> answers);
-    
-    public SurveyResponseView createSurveyResponse(GuidCreatedOnVersionHolder survey, String healthCode,
             List<SurveyAnswer> answers, String identifier);
     
     public SurveyResponseView getSurveyResponse(String healthCode, String identifier);

--- a/app/org/sagebionetworks/bridge/services/SurveyResponseServiceImpl.java
+++ b/app/org/sagebionetworks/bridge/services/SurveyResponseServiceImpl.java
@@ -51,17 +51,14 @@ public class SurveyResponseServiceImpl implements SurveyResponseService {
     }
     
     @Override
-    public SurveyResponseView createSurveyResponse(GuidCreatedOnVersionHolder keys, String healthCode, List<SurveyAnswer> answers) {
-        return createSurveyResponse(keys, healthCode, answers, BridgeUtils.generateGuid());
-    }
-
-    @Override
     public SurveyResponseView createSurveyResponse(GuidCreatedOnVersionHolder keys, String healthCode,
             List<SurveyAnswer> answers, String identifier) {
+        if (identifier == null) {
+            identifier = BridgeUtils.generateGuid();
+        }
         checkNotNull(keys, CANNOT_BE_NULL, "keys");
         checkNotNull(answers, CANNOT_BE_NULL, "survey answers");
         checkArgument(isNotBlank(keys.getGuid()), CANNOT_BE_BLANK, "survey guid");
-        checkArgument(isNotBlank(identifier), CANNOT_BE_BLANK, "identifier");
         checkArgument(isNotBlank(healthCode), CANNOT_BE_BLANK, "health code");
         checkArgument(keys.getCreatedOn() != 0L, "Survey createdOn cannot be 0");
 

--- a/app/org/sagebionetworks/bridge/services/TaskService.java
+++ b/app/org/sagebionetworks/bridge/services/TaskService.java
@@ -182,7 +182,7 @@ public class TaskService {
         }   
         
         // Now create a response for that specific survey version
-        SurveyResponseView response = surveyResponseService.createSurveyResponse(keys, healthCode, EMPTY_ANSWERS);
+        SurveyResponseView response = surveyResponseService.createSurveyResponse(keys, healthCode, EMPTY_ANSWERS, null);
         
         // And reconstruct the activity with that survey instance as well as the new response object.
         return new Activity.Builder()

--- a/app/org/sagebionetworks/bridge/validators/SurveyResponseValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/SurveyResponseValidator.java
@@ -1,0 +1,32 @@
+package org.sagebionetworks.bridge.validators;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import org.sagebionetworks.bridge.models.surveys.SurveyResponse;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+
+/**
+ * This validates data sent to the server using the survey response payload, which is pretty sparse: 
+ * normally all we require are the survey key values, and an array of zero or more answers
+ */
+public class SurveyResponseValidator implements Validator {
+
+    @Override
+    public boolean supports(Class<?> clazz) {
+        return SurveyResponse.class.isAssignableFrom(clazz);
+    }
+    
+    @Override
+    public void validate(Object object, Errors errors) {
+        SurveyResponse response = (SurveyResponse)object;
+        
+        if (isBlank(response.getSurveyGuid())) {
+            errors.rejectValue("surveyGuid", "cannot be null or blank");
+        }
+        if (response.getSurveyCreatedOn() == 0L) {
+            errors.rejectValue("surveyCreatedOn", "cannot be null");
+        }
+    }
+    
+}

--- a/conf/routes
+++ b/conf/routes
@@ -51,15 +51,9 @@ POST   /v3/surveys/:surveyGuid/revisions/:createdOn          @org.sagebionetwork
 DELETE /v3/surveys/:surveyGuid/revisions/:createdOn          @org.sagebionetworks.bridge.play.controllers.SurveyController.deleteSurvey(surveyGuid: String, createdOn: String, physical: String ?= "false")
 
 # Survey responses
-GET    /v3/surveyresponses/:guid                                        @org.sagebionetworks.bridge.play.controllers.SurveyResponseController.getSurveyResponse(guid: String)
-POST   /v3/surveyresponses/:guid                                        @org.sagebionetworks.bridge.play.controllers.SurveyResponseController.appendSurveyAnswers(guid: String)
-POST   /v3/surveyresponses/:surveyGuid/revisions/:createdOn             @org.sagebionetworks.bridge.play.controllers.SurveyResponseController.createSurveyResponse(surveyGuid: String, createdOn: String)
-POST   /v3/surveyresponses/:surveyGuid/revisions/:createdOn/:identifier @org.sagebionetworks.bridge.play.controllers.SurveyResponseController.createSurveyResponseWithIdentifier(surveyGuid: String, createdOn: String, identifier: String)
-
-# Temporarily, an improved API
-POST   /v3/surveyresponses			@org.sagebionetworks.bridge.play.controllers.SurveyResponseController.createSurveyResponseV4
-GET    /v3/surveyresponses/:guid    @org.sagebionetworks.bridge.play.controllers.SurveyResponseController.getSurveyResponseV4(String identifier)
-POST   /v3/surveyresponses/:guid    @org.sagebionetworks.bridge.play.controllers.SurveyResponseController.appendAnswersToSurveyResponseV4(String identifier)
+POST   /v3/surveyresponses			   @org.sagebionetworks.bridge.play.controllers.SurveyResponseController.createSurveyResponse
+GET    /v3/surveyresponses/:identifier @org.sagebionetworks.bridge.play.controllers.SurveyResponseController.getSurveyResponse(identifier: String)
+POST   /v3/surveyresponses/:identifier @org.sagebionetworks.bridge.play.controllers.SurveyResponseController.appendSurveyAnswers(identifier: String)
 
 # Schedules
 GET    /v3/schedules   @org.sagebionetworks.bridge.play.controllers.ScheduleController.getSchedules
@@ -124,14 +118,6 @@ POST   /api/v1/profile                   @org.sagebionetworks.bridge.play.contro
 POST   /api/v1/profile/external-id       @org.sagebionetworks.bridge.play.controllers.UserProfileController.createExternalIdentifier
 POST   /api/v1/profile/unsubscribe       @org.sagebionetworks.bridge.play.controllers.EmailController.unsubscribeFromEmail
 GET    /api/v1/profile/unsubscribe       @org.sagebionetworks.bridge.play.controllers.EmailController.unsubscribeFromEmail
-
-# API - Surveys & Survey Response v2
-GET    /api/v2/surveyresponses/:guid                                @org.sagebionetworks.bridge.play.controllers.SurveyResponseController.getSurveyResponse(guid: String)
-POST   /api/v2/surveyresponses/:guid                                @org.sagebionetworks.bridge.play.controllers.SurveyResponseController.appendSurveyAnswers(guid: String)
-GET    /api/v2/surveys/:surveyGuid/revisions/published              @org.sagebionetworks.bridge.play.controllers.SurveyController.getSurveyMostRecentlyPublishedVersionForUser(surveyGuid: String)
-GET    /api/v2/surveys/:surveyGuid/revisions/:createdOn             @org.sagebionetworks.bridge.play.controllers.SurveyController.getSurveyForUser(surveyGuid: String, createdOn: String)
-POST   /api/v2/surveys/:surveyGuid/revisions/:createdOn             @org.sagebionetworks.bridge.play.controllers.SurveyResponseController.createSurveyResponse(surveyGuid: String, createdOn: String)
-POST   /api/v2/surveys/:surveyGuid/revisions/:createdOn/:identifier @org.sagebionetworks.bridge.play.controllers.SurveyResponseController.createSurveyResponseWithIdentifier(surveyGuid: String, createdOn: String, identifier: String)
 
 # API - Schedules
 GET    /api/v1/schedules   @org.sagebionetworks.bridge.play.controllers.ScheduleController.getSchedulesV1

--- a/conf/routes
+++ b/conf/routes
@@ -119,6 +119,10 @@ POST   /api/v1/profile/external-id       @org.sagebionetworks.bridge.play.contro
 POST   /api/v1/profile/unsubscribe       @org.sagebionetworks.bridge.play.controllers.EmailController.unsubscribeFromEmail
 GET    /api/v1/profile/unsubscribe       @org.sagebionetworks.bridge.play.controllers.EmailController.unsubscribeFromEmail
 
+# API - Surveys
+GET    /api/v2/surveys/:surveyGuid/revisions/published     @org.sagebionetworks.bridge.play.controllers.SurveyController.getSurveyMostRecentlyPublishedVersionForUser(surveyGuid: String)
+GET    /api/v2/surveys/:surveyGuid/revisions/:createdOn    @org.sagebionetworks.bridge.play.controllers.SurveyController.getSurveyForUser(surveyGuid: String, createdOn: String)
+
 # API - Schedules
 GET    /api/v1/schedules   @org.sagebionetworks.bridge.play.controllers.ScheduleController.getSchedulesV1
 

--- a/conf/routes
+++ b/conf/routes
@@ -56,6 +56,11 @@ POST   /v3/surveyresponses/:guid                                        @org.sag
 POST   /v3/surveyresponses/:surveyGuid/revisions/:createdOn             @org.sagebionetworks.bridge.play.controllers.SurveyResponseController.createSurveyResponse(surveyGuid: String, createdOn: String)
 POST   /v3/surveyresponses/:surveyGuid/revisions/:createdOn/:identifier @org.sagebionetworks.bridge.play.controllers.SurveyResponseController.createSurveyResponseWithIdentifier(surveyGuid: String, createdOn: String, identifier: String)
 
+# Temporarily, an improved API
+POST   /v3/surveyresponses			@org.sagebionetworks.bridge.play.controllers.SurveyResponseController.createSurveyResponseV4
+GET    /v3/surveyresponses/:guid    @org.sagebionetworks.bridge.play.controllers.SurveyResponseController.getSurveyResponseV4(String identifier)
+POST   /v3/surveyresponses/:guid    @org.sagebionetworks.bridge.play.controllers.SurveyResponseController.appendAnswersToSurveyResponseV4(String identifier)
+
 # Schedules
 GET    /v3/schedules   @org.sagebionetworks.bridge.play.controllers.ScheduleController.getSchedules
 

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyDaoTest.java
@@ -9,7 +9,6 @@ import java.util.Set;
 
 import javax.annotation.Resource;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyResponseTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyResponseTest.java
@@ -79,8 +79,6 @@ public class DynamoSurveyResponseTest {
         DynamoSurveyResponse newResponse = mapper.readValue(string, DynamoSurveyResponse.class);
         response.setSurveyKey(newResponse.getSurveyKey());
         
-        assertNull(newResponse.getSurveyGuid());
-        assertEquals(0, newResponse.getSurveyCreatedOn());
         assertNull(newResponse.getVersion());
         assertNull(newResponse.getHealthCode());
         

--- a/test/org/sagebionetworks/bridge/play/controllers/SurveyResponseControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SurveyResponseControllerTest.java
@@ -1,0 +1,177 @@
+package org.sagebionetworks.bridge.play.controllers;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.sagebionetworks.bridge.TestUtils;
+import org.sagebionetworks.bridge.dao.SurveyResponseDao;
+import org.sagebionetworks.bridge.dynamodb.DynamoSurveyResponse;
+import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolder;
+import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolderImpl;
+import org.sagebionetworks.bridge.models.accounts.IdentifierHolder;
+import org.sagebionetworks.bridge.models.accounts.User;
+import org.sagebionetworks.bridge.models.accounts.UserSession;
+import org.sagebionetworks.bridge.models.surveys.Survey;
+import org.sagebionetworks.bridge.models.surveys.SurveyAnswer;
+import org.sagebionetworks.bridge.models.surveys.SurveyResponse;
+import org.sagebionetworks.bridge.models.surveys.SurveyResponseView;
+import org.sagebionetworks.bridge.models.surveys.TestSurvey;
+import org.sagebionetworks.bridge.services.SurveyResponseService;
+
+import play.core.j.JavaResultExtractor;
+import play.mvc.Http;
+import play.mvc.Result;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.google.common.collect.Lists;
+
+public class SurveyResponseControllerTest {
+    
+    private static final String HEALTH_CODE = "BBB";
+    
+    private static final String SURVEY_RESPONSE_IDENTIFIER = "CCC";
+    
+    private static final GuidCreatedOnVersionHolder KEYS = new GuidCreatedOnVersionHolderImpl("AAA", 
+            DateTime.parse("2010-10-10").getMillis());
+    
+    private SurveyResponseService service;
+    
+    private SurveyResponseController controller;
+
+    @Before
+    public void before() {
+        UserSession session = new UserSession();
+        User user = new User();
+        user.setHealthCode(HEALTH_CODE);
+        session.setUser(user);
+        
+        service = mock(SurveyResponseService.class);
+        
+        controller = spy(new SurveyResponseController());
+        controller.setSurveyResponseService(service);
+        doReturn(session).when(controller).getAuthenticatedAndConsentedSession();
+    }
+    
+    private void setContext(Object object) throws Exception {
+        String json = BridgeObjectMapper.get().writeValueAsString(object);
+        Http.Context context = TestUtils.mockPlayContextWithJson(json);
+        Http.Context.current.set(context);
+    }
+    
+    private SurveyResponse mockSurveyResponse() {
+        DynamoSurveyResponse response = new DynamoSurveyResponse();
+        response.setSurveyKey(KEYS);
+        response.setIdentifier(SURVEY_RESPONSE_IDENTIFIER);
+        
+        SurveyAnswer answer = new SurveyAnswer();
+        answer.setQuestionGuid("DDD");
+        answer.setAnswers(Lists.newArrayList("A", "B"));
+        answer.setAnsweredOn(DateTime.parse("2010-10-09").getMillis());
+        answer.setClient("mobile");
+        response.getAnswers().add(answer);
+        
+        return response;
+    }
+    
+    private <T> T resultToType(Result result, Class<? extends T> clazz) throws Exception {
+        byte[] content = JavaResultExtractor.getBody(result, 0L);
+        return BridgeObjectMapper.get().readValue(content, clazz);
+    }
+    
+    private JsonNode resultToJSON(Result result) throws Exception {
+        byte[] content = JavaResultExtractor.getBody(result, 0L);
+        return BridgeObjectMapper.get().readTree(content);
+    }
+    
+    @Test
+    public void createSurveyResponse() throws Exception {
+        Survey survey = new TestSurvey(false);
+        SurveyResponse response = mockSurveyResponse();
+        SurveyResponseView view = new SurveyResponseView(response, survey);
+        setContext(response);
+        
+        when(service.createSurveyResponse(KEYS, HEALTH_CODE, response.getAnswers(), SURVEY_RESPONSE_IDENTIFIER)).thenReturn(view);
+        
+        Result result = controller.createSurveyResponse();
+        IdentifierHolder holder = resultToType(result, IdentifierHolder.class);
+
+        verify(service).createSurveyResponse(KEYS, HEALTH_CODE, response.getAnswers(), SURVEY_RESPONSE_IDENTIFIER);
+        assertEquals(SURVEY_RESPONSE_IDENTIFIER, holder.getIdentifier());
+        assertEquals(201, result.status()); // created
+    }
+    
+    @Test(expected = InvalidEntityException.class)
+    public void surveyResponseWithoutKeys() throws Exception {
+        SurveyResponse response = mockSurveyResponse();
+        response.setSurveyGuid(null);
+        setContext(response);
+        
+        controller.createSurveyResponse();
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void createSurveyResponseWithoutAnIdentifier() throws Exception {
+        Survey survey = new TestSurvey(false);
+        SurveyResponse response = mockSurveyResponse();
+        response.setIdentifier(null);
+        setContext(response);
+        
+        SurveyResponseView view = new SurveyResponseView(mockSurveyResponse(), survey);
+        when(service.createSurveyResponse(any(GuidCreatedOnVersionHolderImpl.class), anyString(), any(List.class), anyString())).thenReturn(view);
+        
+        Result result = controller.createSurveyResponse();
+        JsonNode node = resultToJSON(result);
+        
+        assertEquals(SURVEY_RESPONSE_IDENTIFIER, node.get("identifier").asText());
+    }
+    
+    @Test
+    public void getSurveyResponse() throws Exception {
+        Survey survey = new TestSurvey(false);
+        SurveyResponse response = mockSurveyResponse();
+        SurveyResponseView view = new SurveyResponseView(response, survey);
+        
+        when(service.getSurveyResponse(HEALTH_CODE, SURVEY_RESPONSE_IDENTIFIER)).thenReturn(view);
+        
+        Result result = controller.getSurveyResponse(SURVEY_RESPONSE_IDENTIFIER);
+        JsonNode node = resultToJSON(result); 
+        
+        assertEquals(SURVEY_RESPONSE_IDENTIFIER, node.get("identifier").asText());
+        assertEquals(1, ((ArrayNode)node.get("answers")).size());
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Test
+    public void appendAnswersToSurveyResponse() throws Exception {
+        Survey survey = new TestSurvey(false);
+        SurveyResponse response = mockSurveyResponse();
+        SurveyResponseView view = new SurveyResponseView(response, survey);
+        setContext(response);
+        
+        when(controller.getSurveyResponseIfAuthorized(SURVEY_RESPONSE_IDENTIFIER)).thenReturn(view);
+        
+        controller.appendSurveyAnswers(SURVEY_RESPONSE_IDENTIFIER);
+        
+        ArgumentCaptor<List> argument = ArgumentCaptor.forClass(List.class);
+        verify(service).appendSurveyAnswers(any(SurveyResponse.class), argument.capture());
+        
+        assertEquals(response.getAnswers().get(0), argument.getValue().get(0));
+    }
+
+}

--- a/test/org/sagebionetworks/bridge/play/controllers/SurveyResponseControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SurveyResponseControllerTest.java
@@ -16,7 +16,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.sagebionetworks.bridge.TestUtils;
-import org.sagebionetworks.bridge.dao.SurveyResponseDao;
 import org.sagebionetworks.bridge.dynamodb.DynamoSurveyResponse;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;

--- a/test/org/sagebionetworks/bridge/services/TaskServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/TaskServiceTest.java
@@ -98,7 +98,7 @@ public class TaskServiceTest {
         SurveyResponseView surveyResponse = new SurveyResponseView(response, survey);
         SurveyResponseService surveyResponseService = mock(SurveyResponseService.class);
         when(surveyResponseService.createSurveyResponse(
-            any(GuidCreatedOnVersionHolder.class), anyString(), any(List.class))).thenReturn(surveyResponse);
+            any(GuidCreatedOnVersionHolder.class), anyString(), any(List.class), anyString())).thenReturn(surveyResponse);
         
         service.setSchedulePlanService(schedulePlanService);
         service.setUserConsentDao(userConsentDao);


### PR DESCRIPTION
- This changes The survey responses API so it doesn't have survey keys in the URL, they are instead taken from a JSON payload, making the endpoints simpler (the payload is a simplified form of the SurveyResponse object).
- Can still create an identifier by providing it in the payload JSON.
