### PR TITLE
Adding index; removing query by identifier

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/SurveyDao.java
+++ b/app/org/sagebionetworks/bridge/dao/SurveyDao.java
@@ -93,14 +93,6 @@ public interface SurveyDao {
     public Survey getSurveyMostRecentlyPublishedVersion(StudyIdentifier studyIdentifier, String guid);
     
     /**
-     * Get the most recently published version of a survey using its identifier.
-     * @param studyIdentifier
-     * @param identifier
-     * @return
-     */
-    public Survey getSurveyMostRecentlyPublishedVersionByIdentifier(StudyIdentifier studyIdentifier, String identifier);
-    
-    /**
      * Get the most recent version of each survey in the study, that has been published. 
      * @param studyIdentifier
      * @return

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoDBProjection.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoDBProjection.java
@@ -6,13 +6,13 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import com.amazonaws.services.dynamodbv2.model.ProjectionType;
+
 /**
  * An optional annotation for global indices, sets the projection type of 
  * the index. This annotation should go on the same method as the annotation 
- * for the index.
+ * for the index's hash key.
  */
-import com.amazonaws.services.dynamodbv2.model.ProjectionType;
-
 @Target({METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface DynamoDBProjection {

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurvey.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurvey.java
@@ -15,6 +15,7 @@ import org.sagebionetworks.bridge.models.surveys.SurveyQuestion;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIgnore;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIndexHashKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBVersionAttribute;
@@ -71,8 +72,9 @@ public class DynamoSurvey implements Survey {
     }
     
     @Override
-    @DynamoDBAttribute(attributeName = "studyKey")
     @JsonIgnore
+    @DynamoDBAttribute(attributeName = "studyKey")
+    @DynamoDBIndexHashKey(globalSecondaryIndexName = "studyKey-index")
     public String getStudyIdentifier() {
         return studyKey;
     }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurvey.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurvey.java
@@ -19,6 +19,7 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIndexHashKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBVersionAttribute;
+import com.amazonaws.services.dynamodbv2.model.ProjectionType;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -74,7 +75,8 @@ public class DynamoSurvey implements Survey {
     @Override
     @JsonIgnore
     @DynamoDBAttribute(attributeName = "studyKey")
-    @DynamoDBIndexHashKey(globalSecondaryIndexName = "studyKey-index")
+    @DynamoDBIndexHashKey(attributeName="studyKey", globalSecondaryIndexName = "studyKey-index")
+    @DynamoDBProjection(projectionType=ProjectionType.ALL, globalSecondaryIndexName = "studyKey-index")
     public String getStudyIdentifier() {
         return studyKey;
     }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
@@ -3,8 +3,6 @@ package org.sagebionetworks.bridge.dynamodb;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -31,7 +29,6 @@ import org.springframework.stereotype.Component;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper.FailedBatch;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBScanExpression;
 import com.amazonaws.services.dynamodbv2.datamodeling.QueryResultPage;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
@@ -43,23 +40,15 @@ import com.google.common.collect.Maps;
 @Component
 public class DynamoSurveyDao implements SurveyDao {
 
-    Comparator<DynamoSurvey> VERSIONED_ON_DESC_SORTER = new Comparator<DynamoSurvey>() {
-        @Override public int compare(DynamoSurvey o1, DynamoSurvey o2) {
-            return (int)(o2.getCreatedOn() - o1.getCreatedOn());
-        }
-    };
-    
     class QueryBuilder {
         
         private static final String PUBLISHED_PROPERTY = "published";
         private static final String DELETED_PROPERTY = "deleted";
         private static final String CREATED_ON_PROPERTY = "versionedOn";
         private static final String STUDY_KEY_PROPERTY = "studyKey";
-        private static final String IDENTIFIER_PROPERTY = "identifier";
         
         String surveyGuid;
         String studyIdentifier;
-        String identifier;
         long createdOn;
         boolean published;
         boolean notDeleted;
@@ -70,10 +59,6 @@ public class DynamoSurveyDao implements SurveyDao {
         }
         QueryBuilder setStudy(StudyIdentifier studyIdentifier) {
             this.studyIdentifier = studyIdentifier.getIdentifier();
-            return this;
-        }
-        QueryBuilder setIdentifier(String identifier) {
-            this.identifier = identifier;
             return this;
         }
         QueryBuilder setCreatedOn(long createdOn) {
@@ -113,7 +98,7 @@ public class DynamoSurveyDao implements SurveyDao {
         List<Survey> getAll(boolean exceptionIfEmpty) {
             List<DynamoSurvey> dynamoSurveys = null;
             if (surveyGuid == null) {
-                dynamoSurveys = scan();
+                dynamoSurveys = queryBySecondaryIndex();
             } else {
                 dynamoSurveys = query();
             }
@@ -154,7 +139,26 @@ public class DynamoSurveyDao implements SurveyDao {
             }
             return surveyMapper.queryPage(DynamoSurvey.class, query).getResults();
         }
-
+        
+        private List<DynamoSurvey> queryBySecondaryIndex() {
+            if (studyIdentifier == null) {
+                throw new IllegalStateException("Calculated the need to query by secondary index, but study identifier is not set");
+            }
+            DynamoSurvey hashKey = new DynamoSurvey();
+            hashKey.setStudyIdentifier(studyIdentifier);
+            
+            DynamoDBQueryExpression<DynamoSurvey> query = new DynamoDBQueryExpression<DynamoSurvey>();
+            query.withHashKeyValues(hashKey);
+            query.withConsistentRead(false);
+            if (published) {
+                query.withQueryFilterEntry(PUBLISHED_PROPERTY, equalsNumber("1"));
+            }
+            if (notDeleted) {
+                query.withQueryFilterEntry(DELETED_PROPERTY, equalsNumber("0"));
+            }
+            return surveyMapper.queryPage(DynamoSurvey.class, query).getResults();
+        }
+        /*
         private List<DynamoSurvey> scan() {
             DynamoDBScanExpression scan = new DynamoDBScanExpression();
             if (studyIdentifier != null) {
@@ -177,7 +181,7 @@ public class DynamoSurveyDao implements SurveyDao {
             Collections.sort(surveys, VERSIONED_ON_DESC_SORTER);
             return surveys;
         }
-
+        */
         private Condition equalsNumber(String equalTo) {
             Condition condition = new Condition();
             condition.withComparisonOperator(ComparisonOperator.EQ);
@@ -212,7 +216,7 @@ public class DynamoSurveyDao implements SurveyDao {
     private DynamoDBMapper surveyMapper;
     private DynamoDBMapper surveyElementMapper;
     private UploadSchemaDao uploadSchemaDao;
-
+    
     @Resource(name = "surveyMapper")
     public void setSurveyMapper(DynamoDBMapper surveyMapper) {
         this.surveyMapper = surveyMapper;
@@ -359,36 +363,18 @@ public class DynamoSurveyDao implements SurveyDao {
         return new QueryBuilder().setStudy(studyIdentifier).isPublished().setSurvey(guid).isNotDeleted().getOne(true);
     }
     
-    // SCAN
-    @Override
-    public Survey getSurveyMostRecentlyPublishedVersionByIdentifier(StudyIdentifier studyIdentifier, String identifier) {
-        return new QueryBuilder().setStudy(studyIdentifier).setIdentifier(identifier).isPublished().isNotDeleted().getOne(true);
-    }
-    
-    // SCAN
+    // secondary index query (not survey GUID) 
     @Override
     public List<Survey> getAllSurveysMostRecentlyPublishedVersion(StudyIdentifier studyIdentifier) {
-        return new QueryBuilder().setStudy(studyIdentifier).isPublished().isNotDeleted().getAll(false);
+        List<Survey> surveys = new QueryBuilder().setStudy(studyIdentifier).isPublished().isNotDeleted().getAll(false);
+        return findMostRecentVersions(surveys);
     }
     
-    // SCAN
+    // secondary index query (not survey GUID)
     @Override
     public List<Survey> getAllSurveysMostRecentVersion(StudyIdentifier studyIdentifier) {
         List<Survey> surveys = new QueryBuilder().setStudy(studyIdentifier).isNotDeleted().getAll(false);
-        if (surveys.isEmpty()) {
-            return surveys;
-        }
-        // If you knew the number of unique guids, you could iterate until you had found
-        // that many unique GUIDs, and stop, since they're ordered from largest timestamp 
-        // to smaller. This would be faster with many versions to go through.
-        Map<String, Survey> map = Maps.newLinkedHashMap();
-        for (Survey survey : surveys) {
-            Survey stored = map.get(survey.getGuid());
-            if (stored == null || survey.getCreatedOn() > stored.getCreatedOn()) {
-                map.put(survey.getGuid(), survey);
-            }
-        }
-        return new ArrayList<Survey>(map.values());
+        return findMostRecentVersions(surveys);
     }
     
     /**
@@ -399,6 +385,26 @@ public class DynamoSurveyDao implements SurveyDao {
     @Override
     public Survey getSurvey(GuidCreatedOnVersionHolder keys) {
         return new QueryBuilder().setSurvey(keys.getGuid()).setCreatedOn(keys.getCreatedOn()).getOne(true);
+    }
+    
+    /**
+     * This scan gets expensive when there are many revisions. We don't know the set of unique GUIDs, so 
+     * we also have to iterate over everything. 
+     * @param surveys
+     * @return
+     */
+    private List<Survey> findMostRecentVersions(List<Survey> surveys) {
+        if (surveys.isEmpty()) {
+            return surveys;
+        }
+        Map<String, Survey> map = Maps.newLinkedHashMap();
+        for (Survey survey : surveys) {
+            Survey stored = map.get(survey.getGuid());
+            if (stored == null || survey.getCreatedOn() > stored.getCreatedOn()) {
+                map.put(survey.getGuid(), survey);
+            }
+        }
+        return new ArrayList<Survey>(map.values());
     }
     
     private Survey saveSurvey(Survey survey) {

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
@@ -158,30 +158,7 @@ public class DynamoSurveyDao implements SurveyDao {
             }
             return surveyMapper.queryPage(DynamoSurvey.class, query).getResults();
         }
-        /*
-        private List<DynamoSurvey> scan() {
-            DynamoDBScanExpression scan = new DynamoDBScanExpression();
-            if (studyIdentifier != null) {
-                scan.addFilterCondition(STUDY_KEY_PROPERTY, equalsString(studyIdentifier));
-            }
-            if (createdOn != 0L) {
-                scan.addFilterCondition(CREATED_ON_PROPERTY, equalsNumber(Long.toString(createdOn)));
-            }
-            if (published) {
-                scan.addFilterCondition(PUBLISHED_PROPERTY, equalsNumber("1"));
-            }
-            if (identifier != null) {
-                scan.addFilterCondition(IDENTIFIER_PROPERTY, equalsString(identifier));
-            }
-            if (notDeleted) {
-                scan.addFilterCondition(DELETED_PROPERTY, equalsNumber("0"));
-            }
-            List<DynamoSurvey> surveys = Lists.newArrayList(surveyMapper.scan(DynamoSurvey.class, scan));
-            // Scans will not sort as queries do. Sort Manually. Probably a dog.
-            Collections.sort(surveys, VERSIONED_ON_DESC_SORTER);
-            return surveys;
-        }
-        */
+
         private Condition equalsNumber(String equalTo) {
             Condition condition = new Condition();
             condition.withComparisonOperator(ComparisonOperator.EQ);

--- a/app/org/sagebionetworks/bridge/play/controllers/SurveyController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/SurveyController.java
@@ -158,17 +158,6 @@ public class SurveyController extends BaseController {
         return ok(json).as(JSON_MIME_TYPE);
     }
     
-    public Result getMostRecentPublishedSurveyVersionByIdentifier(String identifier) throws Exception {
-        UserSession session = getAuthenticatedSession(DEVELOPER);
-        StudyIdentifier studyId = session.getStudyIdentifier();
-        
-        // Do not cache this. It's only used by researchers and without the GUID, you cannot
-        // cache it properly.
-        Survey survey = surveyService.getSurveyMostRecentlyPublishedVersionByIdentifier(studyId, identifier);
-        verifySurveyIsInStudy(session, studyId, survey);
-        return okResult(survey);
-    }
-    
     /**
      * Administrators can pass the ?physical=true flag to this endpoint to physicall delete a survey and all its 
      * survey elements, rather than only marking it deleted to maintain referential integrity. This should only be 

--- a/app/org/sagebionetworks/bridge/services/SurveyService.java
+++ b/app/org/sagebionetworks/bridge/services/SurveyService.java
@@ -36,14 +36,6 @@ public interface SurveyService {
     public Survey getSurveyMostRecentlyPublishedVersion(StudyIdentifier studyIdentifier, String guid);
     
     /**
-     * Get the most recently published version of a survey, using the identifier for the survey.
-     * @param studyIdentifier
-     * @param identifier
-     * @return
-     */
-    public Survey getSurveyMostRecentlyPublishedVersionByIdentifier(StudyIdentifier studyIdentifier, String identifier);
-    
-    /**
      * Get the most recent version of each survey in the study that has been published. If a survey has not 
      * been published, nothing is returned. 
      * @param studyIdentifier

--- a/app/org/sagebionetworks/bridge/services/SurveyServiceImpl.java
+++ b/app/org/sagebionetworks/bridge/services/SurveyServiceImpl.java
@@ -117,13 +117,6 @@ public class SurveyServiceImpl implements SurveyService {
 
         return surveyDao.getSurveyMostRecentlyPublishedVersion(studyIdentifier, guid);
     }
-    
-    @Override
-    public Survey getSurveyMostRecentlyPublishedVersionByIdentifier(StudyIdentifier studyIdentifier, String identifier) {
-        checkArgument(isNotBlank(identifier), Validate.CANNOT_BE_BLANK, "survey identifier");
-        
-        return surveyDao.getSurveyMostRecentlyPublishedVersionByIdentifier(studyIdentifier, identifier);
-    }
 
     @Override
     public List<Survey> getAllSurveysMostRecentlyPublishedVersion(StudyIdentifier studyIdentifier) {

--- a/conf/routes
+++ b/conf/routes
@@ -40,7 +40,6 @@ GET    /v3/surveys                                           @org.sagebionetwork
 POST   /v3/surveys                                           @org.sagebionetworks.bridge.play.controllers.SurveyController.createSurvey
 GET    /v3/surveys/recent                                    @org.sagebionetworks.bridge.play.controllers.SurveyController.getAllSurveysMostRecentVersion2
 GET    /v3/surveys/published                                 @org.sagebionetworks.bridge.play.controllers.SurveyController.getAllSurveysMostRecentlyPublishedVersion
-GET    /v3/surveys/:identifier                               @org.sagebionetworks.bridge.play.controllers.SurveyController.getMostRecentPublishedSurveyVersionByIdentifier(identifier: String)
 GET    /v3/surveys/:surveyGuid/revisions                     @org.sagebionetworks.bridge.play.controllers.SurveyController.getSurveyAllVersions(surveyGuid: String)
 GET    /v3/surveys/:surveyGuid/revisions/recent              @org.sagebionetworks.bridge.play.controllers.SurveyController.getSurveyMostRecentVersion(surveyGuid: String)
 GET    /v3/surveys/:surveyGuid/revisions/published           @org.sagebionetworks.bridge.play.controllers.SurveyController.getSurveyMostRecentlyPublishedVersion(surveyGuid: String)

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyDaoTest.java
@@ -9,7 +9,6 @@ import java.util.Set;
 
 import javax.annotation.Resource;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoTest.java
@@ -99,6 +99,14 @@ public class DynamoSurveyDaoTest {
         Survey publishedSurvey = surveyDao.publishSurvey(studyIdentifier, survey);
         return publishedSurvey;
     }
+
+    private class SimpleSurvey extends DynamoSurvey {
+        public SimpleSurvey(String name) {
+            setName(name);
+            setIdentifier("bloodpressure");
+            setStudyIdentifier(studyIdentifier.getIdentifier());
+        }
+    }
     
     // CREATE SURVEY
 
@@ -348,14 +356,6 @@ public class DynamoSurveyDaoTest {
     }
 
     // GET SURVEYS
-
-    private class SimpleSurvey extends DynamoSurvey {
-        public SimpleSurvey() {
-            setName("General Blood Pressure Survey");
-            setIdentifier("bloodpressure");
-            setStudyIdentifier(studyIdentifier.getIdentifier());
-        }
-    }
     
     @Test
     public void failToGetSurveysByBadStudyKey() {
@@ -366,9 +366,9 @@ public class DynamoSurveyDaoTest {
     @Test
     public void getSurveyAllVersions() {
         // Get a survey (one GUID), and no other surveys, all the versions, ordered most to least recent
-        createSurvey(new SimpleSurvey()); // spurious survey
+        createSurvey(new SimpleSurvey("First Survey")); // spurious survey
         
-        Survey versionedSurvey = createSurvey(new SimpleSurvey());
+        Survey versionedSurvey = createSurvey(new SimpleSurvey("Second Survey"));
         versionSurvey(versionedSurvey);
         versionSurvey(versionedSurvey);
         
@@ -389,7 +389,7 @@ public class DynamoSurveyDaoTest {
     public void getSurveyMostRecentVersion() {
         // Get one survey (with the GUID), the most recent version (unpublished or published)
         
-        Survey firstVersion = createSurvey(new SimpleSurvey());
+        Survey firstVersion = createSurvey(new SimpleSurvey("First Survey"));
         Survey middleVersion = versionSurvey(firstVersion);
         Survey finalVersion = versionSurvey(firstVersion);
 
@@ -404,7 +404,7 @@ public class DynamoSurveyDaoTest {
     public void getSurveyMostRecentlyPublishedVersion() {
         // Get one survey (with the GUID), the most recently published version
         
-        Survey firstVersion = createSurvey(new SimpleSurvey());
+        Survey firstVersion = createSurvey(new SimpleSurvey("First Survey"));
         Survey middleVersion = versionSurvey(firstVersion);
         versionSurvey(firstVersion);
         
@@ -417,65 +417,55 @@ public class DynamoSurveyDaoTest {
     
     @Test(expected = EntityNotFoundException.class)
     public void getSurveyMostRecentlyPublishedVersionThrowsException() {
-        Survey firstVersion = createSurvey(new SimpleSurvey());
+        Survey firstVersion = createSurvey(new SimpleSurvey("First Survey"));
         surveyDao.getSurveyMostRecentlyPublishedVersion(studyIdentifier, firstVersion.getGuid());
     }
     
     @Test
     public void getAllSurveysMostRecentlyPublishedVersion() {
         // Get all surveys (complete set of the GUIDS, most recently published (if never published, GUID isn't included)
-        Survey firstVersion = createSurvey(new SimpleSurvey());
-        versionSurvey(firstVersion);
-        versionSurvey(firstVersion);
-        publishSurvey(studyIdentifier, firstVersion);
+        Survey firstSurvey = createSurvey(new SimpleSurvey("First Survey"));
+        firstSurvey = versionSurvey(firstSurvey);
+        firstSurvey = versionSurvey(firstSurvey);
+        firstSurvey = publishSurvey(studyIdentifier, firstSurvey);
 
-        Survey nextVersion = createSurvey(new SimpleSurvey());
-        versionSurvey(nextVersion);
-        nextVersion = versionSurvey(nextVersion);
-        publishSurvey(studyIdentifier, nextVersion);
+        Survey secondSurvey = createSurvey(new SimpleSurvey("Second Survey"));
+        secondSurvey = versionSurvey(secondSurvey);
+        secondSurvey = versionSurvey(secondSurvey);
+        secondSurvey = publishSurvey(studyIdentifier, secondSurvey);
+        
+        // This version is later, and should be returned
+        secondSurvey = versionSurvey(secondSurvey);
+        secondSurvey = publishSurvey(studyIdentifier, secondSurvey);
 
         // This should include firstVersion and nextVersion.
         List<Survey> surveys = surveyDao.getAllSurveysMostRecentlyPublishedVersion(studyIdentifier);
-        boolean foundFirstVersion = false;
-        boolean foundNextVersion = false;
-        for (Survey oneSurvey : surveys) {
-            if (oneSurvey.keysEqual(firstVersion)) {
-                foundFirstVersion = true;
-            } else if (oneSurvey.keysEqual(nextVersion)) {
-                foundNextVersion = true;
-            }
-        }
-        assertTrue(foundFirstVersion);
-        assertTrue(foundNextVersion);
+
+        assertEquals(2, surveys.size());
+        assertTrue(secondSurvey.keysEqual(surveys.get(0)));
+        assertTrue(firstSurvey.keysEqual(surveys.get(1)));
     }
     
     @Test
     public void getAllSurveysMostRecentVersion() {
         // Get all surveys (complete set of the GUIDS, most recent (published or unpublished)
         // Get all surveys (complete set of the GUIDS, most recently published (if never published, GUID isn't included)
-        Survey firstVersion = createSurvey(new SimpleSurvey());
-        firstVersion = versionSurvey(firstVersion);
-        publishSurvey(studyIdentifier, firstVersion); // published is not the most recent
-        firstVersion = versionSurvey(firstVersion);
+        Survey firstSurvey = createSurvey(new SimpleSurvey("First Survey"));
+        firstSurvey = versionSurvey(firstSurvey);
+        firstSurvey = publishSurvey(studyIdentifier, firstSurvey); // published is not the most recent
+        firstSurvey = versionSurvey(firstSurvey);
 
-        Survey nextVersion = createSurvey(new SimpleSurvey());
-        nextVersion = versionSurvey(nextVersion);
-        publishSurvey(studyIdentifier, nextVersion); // published is again not the most recent.
-        nextVersion = versionSurvey(nextVersion);
+        Survey secondSurvey = createSurvey(new SimpleSurvey("Second Survey"));
+        secondSurvey = versionSurvey(secondSurvey);
+        secondSurvey = publishSurvey(studyIdentifier, secondSurvey); // published is again not the most recent.
+        secondSurvey = versionSurvey(secondSurvey);
 
         // This should include firstVersion and nextVersion.
         List<Survey> surveys = surveyDao.getAllSurveysMostRecentVersion(studyIdentifier);
-        boolean foundFirstVersion = false;
-        boolean foundNextVersion = false;
-        for (Survey oneSurvey : surveys) {
-            if (oneSurvey.keysEqual(firstVersion)) {
-                foundFirstVersion = true;
-            } else if (oneSurvey.keysEqual(nextVersion)) {
-                foundNextVersion = true;
-            }
-        }
-        assertTrue(foundFirstVersion);
-        assertTrue(foundNextVersion);
+        
+        assertEquals(2, surveys.size());
+        assertTrue(secondSurvey.keysEqual(surveys.get(0)));
+        assertTrue(firstSurvey.keysEqual(surveys.get(1)));
     }
 
     @Test
@@ -576,12 +566,6 @@ public class DynamoSurveyDaoTest {
         try {
             surveyDao.getSurveyMostRecentlyPublishedVersion(studyIdentifier, survey.getGuid());
             fail("Should have thrown exception [1].");
-        } catch(EntityNotFoundException e) {
-            assertEquals("Survey not found.", e.getMessage());
-        }
-        try {
-            surveyDao.getSurveyMostRecentlyPublishedVersionByIdentifier(studyIdentifier, survey.getIdentifier());
-            fail("Should have thrown exception [2].");
         } catch(EntityNotFoundException e) {
             assertEquals("Survey not found.", e.getMessage());
         }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoTest.java
@@ -42,6 +42,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import com.google.common.collect.Sets;
+
 @ContextConfiguration("classpath:test-context.xml")
 @RunWith(SpringJUnit4ClassRunner.class)
 public class DynamoSurveyDaoTest {
@@ -442,14 +444,12 @@ public class DynamoSurveyDaoTest {
         List<Survey> surveys = surveyDao.getAllSurveysMostRecentlyPublishedVersion(studyIdentifier);
 
         assertEquals(2, surveys.size());
-        assertTrue(secondSurvey.keysEqual(surveys.get(0)));
-        assertTrue(firstSurvey.keysEqual(surveys.get(1)));
+        assertEquals(Sets.newHashSet(surveys), Sets.newHashSet(firstSurvey, secondSurvey));
     }
     
     @Test
     public void getAllSurveysMostRecentVersion() {
         // Get all surveys (complete set of the GUIDS, most recent (published or unpublished)
-        // Get all surveys (complete set of the GUIDS, most recently published (if never published, GUID isn't included)
         Survey firstSurvey = createSurvey(new SimpleSurvey("First Survey"));
         firstSurvey = versionSurvey(firstSurvey);
         firstSurvey = publishSurvey(studyIdentifier, firstSurvey); // published is not the most recent
@@ -464,8 +464,7 @@ public class DynamoSurveyDaoTest {
         List<Survey> surveys = surveyDao.getAllSurveysMostRecentVersion(studyIdentifier);
         
         assertEquals(2, surveys.size());
-        assertTrue(secondSurvey.keysEqual(surveys.get(0)));
-        assertTrue(firstSurvey.keysEqual(surveys.get(1)));
+        assertEquals(Sets.newHashSet(surveys), Sets.newHashSet(firstSurvey, secondSurvey));
     }
 
     @Test

--- a/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
@@ -342,36 +342,6 @@ public class SurveyControllerTest {
     }
     
     @Test
-    public void getMostRecentPublishedSurveyVersionByIdentifier() throws Exception {
-        StudyIdentifier studyId = new StudyIdentifierImpl("api");
-        String identifier = BridgeUtils.generateGuid();
-        setContext();
-        when(service.getSurveyMostRecentlyPublishedVersionByIdentifier(eq(studyId), eq(identifier))).thenReturn(getSurvey(false));
-        
-        controller.getMostRecentPublishedSurveyVersionByIdentifier(identifier);
-        
-        verify(service).getSurveyMostRecentlyPublishedVersionByIdentifier(eq(studyId), eq(identifier));
-        verifyNoMoreInteractions(service);
-    }
-    
-    @Test
-    public void cannotGetMostRecentPublishedSurveyVersionByIdentifierFromOtherStudy() throws Exception {
-        StudyIdentifier studyId = new StudyIdentifierImpl("secondstudy");
-        String identifier = BridgeUtils.generateGuid();
-        setContext();
-        when(service.getSurveyMostRecentlyPublishedVersionByIdentifier(eq(studyId), eq(identifier))).thenReturn(getSurvey(false));
-        setUserSession("secondstudy");
-        
-        try {
-            controller.getMostRecentPublishedSurveyVersionByIdentifier(identifier);
-            fail("Should have thrown exception");
-        } catch(UnauthorizedException e) {
-            verify(service).getSurveyMostRecentlyPublishedVersionByIdentifier(eq(studyId), eq(identifier));
-            verifyNoMoreInteractions(service);
-        }
-    }
-    
-    @Test
     public void deleteSurveyAllowedForDeveloper() throws Exception {
         String guid = BridgeUtils.generateGuid();
         DateTime date = DateTime.now();

--- a/test/org/sagebionetworks/bridge/services/SurveyServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SurveyServiceTest.java
@@ -2,7 +2,6 @@ package org.sagebionetworks.bridge.services;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
@@ -18,7 +17,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoInitializer;
 import org.sagebionetworks.bridge.dynamodb.DynamoSurvey;
 import org.sagebionetworks.bridge.dynamodb.DynamoSurveyElement;
@@ -397,22 +395,6 @@ public class SurveyServiceTest {
     }
 
     // DELETE SURVEY
-
-    @Test
-    public void canRetrieveASurveyByIdentifier() {
-        String identifier = TestUtils.randomName();
-        Survey survey = new TestSurvey(true);
-        survey.setName("This is a different test name");
-        survey.setIdentifier(identifier);
-        
-        Survey createdSurvey = surveyService.createSurvey(survey);
-        surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(createdSurvey));
-        surveyService.publishSurvey(studyIdentifier, createdSurvey);
-
-        Survey found = surveyService.getSurveyMostRecentlyPublishedVersionByIdentifier(studyIdentifier, identifier);
-        assertNotNull(found);
-        assertEquals(survey.getName(), found.getName());
-    }
 
     @Test
     public void validationInfoScreen() {


### PR DESCRIPTION
- Removed the api to retrieve a survey by its identifier (this was a convenience for me and I know how we can do without it when we have a UI to manipulate surveys);
- Added global secondary index to the studyKey column, which allows a query to be used for these two calls:

getAllSurveysMostRecentlyPublishedVersion()
getAllSurveysMostRecentVersion()

Still iterating over all surveys in a study in the second case, looking for the latest update of each survey.

Numbers indicate it's a faster when running tests.
