### PR TITLE
change upload validation backfill to use upload IDs instead of record IDs

### DIFF
--- a/app/views/backfill.scala.html
+++ b/app/views/backfill.scala.html
@@ -12,7 +12,7 @@
   <script>
     $(function(){
       var data, xhr = new XMLHttpRequest();
-      xhr.open("POST", "/admin/v1/backfill/@name/start", true);
+      xhr.open("POST", "/v3/backfill/@name/start", true);
       xhr.seenBytes = 0;
       xhr.addEventListener("progress", function () {
         data = xhr.responseText.substr(xhr.seenBytes);


### PR DESCRIPTION
Most of this change is renaming "record" to "upload". There's also removing the step where we query Health Data Record for the Upload ID. I also fixed backfill.scala.html to point to the correct endpoint.

If it turns out we need both record ID and upload ID, we can split this into two separate backfills with shared code.

Testing done: Manual testing in local server.
