### PR TITLE
Updating AWS SDK for consistent read scans

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,10 +15,10 @@ libraryDependencies ++= Seq(
   filters,
   "org.jsoup" % "jsoup" % "1.8.2",
   // AWS
-  "com.amazonaws" % "aws-java-sdk-s3" % "1.10.2",
-  "com.amazonaws" % "aws-java-sdk-sts" % "1.10.2",
-  "com.amazonaws" % "aws-java-sdk-dynamodb" % "1.10.2",
-  "com.amazonaws" % "aws-java-sdk-ses" % "1.10.2",
+  "com.amazonaws" % "aws-java-sdk-s3" % "1.10.10",
+  "com.amazonaws" % "aws-java-sdk-sts" % "1.10.10",
+  "com.amazonaws" % "aws-java-sdk-dynamodb" % "1.10.10",
+  "com.amazonaws" % "aws-java-sdk-ses" % "1.10.10",
   // New Relic
   "com.newrelic.agent.java" % "newrelic-agent" % "3.18.0",
   // Spring

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyDaoTest.java
@@ -94,8 +94,6 @@ public class DynamoStudyDaoTest {
                 studyDao.deleteStudy(study);
             }
         }
-        // TODO: Investigating why tests fail often (not always) without this
-        Thread.sleep(5000);        
         List<Study> savedStudies = studyDao.getStudies();
         assertEquals("There should be only one study", 1, savedStudies.size());
         assertEquals("That should be the test study study", "api", savedStudies.get(0).getIdentifier());

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyResponseDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyResponseDaoTest.java
@@ -207,15 +207,6 @@ public class DynamoSurveyResponseDaoTest {
         surveyResponseDao.createSurveyResponse(survey, HEALTH_DATA_CODE, Lists.<SurveyAnswer>newArrayList(), targetIdentifier);
         surveyResponseDao.createSurveyResponse(survey, HEALTH_DATA_CODE, Lists.<SurveyAnswer>newArrayList(), BridgeUtils.generateGuid());
         
-        // This is *necessary* or this test cannot be made to fail by removing the relevant range query filter.
-        // This probably indicates other tests are not 100% accurate due to eventual consistency.
-        /*
-        try {
-            Thread.sleep(1000);    
-        } catch(InterruptedException e){
-            Thread.currentThread().interrupt();
-        }
-        */
         SurveyResponse response = surveyResponseDao.getSurveyResponse(HEALTH_DATA_CODE, targetIdentifier);
         assertEquals(targetIdentifier, response.getIdentifier());
     }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoUserConsentDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoUserConsentDaoTest.java
@@ -65,18 +65,15 @@ public class DynamoUserConsentDaoTest {
         for (int i=1; i < 6; i++) {
             userConsentDao.giveConsent(HEALTH_CODE+i, consent);
         }
-        Thread.sleep(3000);
         
         long count = userConsentDao.getNumberOfParticipants(STUDY_IDENTIFIER);
         assertEquals("Correct number of participants", 5, count);
         
         userConsentDao.withdrawConsent(HEALTH_CODE+"5", STUDY_IDENTIFIER);
-        Thread.sleep(3000);
         count = userConsentDao.getNumberOfParticipants(STUDY_IDENTIFIER);
         assertEquals("Correct number of participants", 4, count);
         
         userConsentDao.giveConsent(HEALTH_CODE+"5", consent);
-        Thread.sleep(3000);
         count = userConsentDao.getNumberOfParticipants(STUDY_IDENTIFIER);
         assertEquals("Correct number of participants", 5, count);
     }


### PR DESCRIPTION
Also removing Thread.sleep() in tests.

See: BRIDGE-691 with details on very recent changes to consistent read behavior with scans, supported in most recent version of the AWS SDK.
