### PR TITLE
Fixes based on audit of JSON produced during SDK integration tests

### DIFF
--- a/app/org/sagebionetworks/bridge/models/studies/Study.java
+++ b/app/org/sagebionetworks/bridge/models/studies/Study.java
@@ -22,7 +22,7 @@ public interface Study extends BridgeEntity, StudyIdentifier {
 
     public static final ObjectWriter STUDY_WRITER = new BridgeObjectMapper().writer(
         new SimpleFilterProvider().addFilter("filter", 
-        SimpleBeanPropertyFilter.serializeAllExcept("stormpathHref")));
+        SimpleBeanPropertyFilter.serializeAllExcept("stormpathHref", "active")));
 
     public static final ObjectWriter STUDY_LIST_WRITER = new BridgeObjectMapper().writer(
         new SimpleFilterProvider().addFilter("filter",

--- a/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
@@ -168,6 +168,10 @@ public abstract class BaseController extends Controller {
         return ok((JsonNode)mapper.valueToTree(new ResourceList<T>(list)));
     }
 
+    Result createdResult(String message) throws Exception {
+        return created(Json.toJson(new StatusMessage(message)));
+    }
+    
     Result createdResult(Object obj) throws Exception {
         return created((JsonNode)mapper.valueToTree(obj));
     }

--- a/app/org/sagebionetworks/bridge/play/controllers/UploadController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/UploadController.java
@@ -74,7 +74,7 @@ public class UploadController extends BaseController {
         // kick off upload validation
         uploadValidationService.validateUpload(session.getStudyIdentifier(), upload);
 
-        return ok("Upload " + uploadId + " complete!");
+        return okResult("Upload " + uploadId + " complete!");
     }
 
 }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
@@ -72,6 +72,10 @@ public class DynamoStudyTest {
         // You do need to create a new instance of the writer from a new mapper, SFAICT. This is stored as 
         // Study.STUDY_WRITER.
         json = Study.STUDY_WRITER.writeValueAsString(study);
+        node = BridgeObjectMapper.get().readTree(json);
+        assertNull(node.get("stormpathHref"));
+        assertNull(node.get("active"));
+        
         study = BridgeObjectMapper.get().readValue(json, DynamoStudy.class);
         assertNull(study.getStormpathHref());
         assertEquals("Study", node.get("type").asText());

--- a/test/org/sagebionetworks/bridge/play/controllers/UserManagementControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/UserManagementControllerTest.java
@@ -1,0 +1,78 @@
+package org.sagebionetworks.bridge.play.controllers;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.sagebionetworks.bridge.Roles.ADMIN;
+import static play.test.Helpers.contentAsString;
+
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.sagebionetworks.bridge.BridgeConstants;
+import org.sagebionetworks.bridge.TestUtils;
+import org.sagebionetworks.bridge.models.accounts.User;
+import org.sagebionetworks.bridge.models.accounts.UserSession;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
+import org.sagebionetworks.bridge.services.AuthenticationService;
+import org.sagebionetworks.bridge.services.StudyService;
+import org.sagebionetworks.bridge.services.UserAdminService;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+
+import play.mvc.Http;
+import play.mvc.Result;
+
+public class UserManagementControllerTest {
+
+    UserManagementController controller;
+    
+    @Before
+    public void before() throws Exception {
+        UserSession session = new UserSession();
+        User user = new User();
+        user.setHealthCode("BBB");
+        user.setStudyKey("api");
+        user.setRoles(Sets.newHashSet(ADMIN));
+        session.setUser(user);
+        session.setAuthenticated(true);
+        session.setStudyIdentifier(new StudyIdentifierImpl("api"));
+        
+        AuthenticationService authService = mock(AuthenticationService.class);
+        when(authService.getSession(any(String.class))).thenReturn(session);
+        StudyService studyService = mock(StudyService.class);
+        UserAdminService userAdminService = mock(UserAdminService.class);
+        
+        // We have to spy the controller, even though it's under test, because there's a reference
+        // to Cache which is a Play class with static methods, play framework is evil.
+        controller = spy(new UserManagementController());
+        controller.setStudyService(studyService);
+        controller.setUserAdminService(userAdminService);
+        controller.setAuthenticationService(authService);
+
+        Map<String,String[]> map = Maps.newHashMap();
+        map.put(BridgeConstants.SESSION_TOKEN_HEADER, new String[]{"AAA"});
+        
+        Http.Context context = TestUtils.mockPlayContextWithJson("{}");
+        Http.Request request = context.request();
+        when(request.headers()).thenReturn(map);
+        Http.Context.current.set(context);
+        doReturn(null).when(controller).getMetrics();
+    }
+    
+    @Test
+    public void createdResponseReturnsJSONPayload() throws Exception {
+        Result result = controller.createUser();
+        
+        JsonNode node = new ObjectMapper().readTree(contentAsString(result));
+        assertEquals("User created.", node.get("message").asText());
+    }
+    
+}

--- a/test/org/sagebionetworks/bridge/play/controllers/UserManagementControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/UserManagementControllerTest.java
@@ -50,8 +50,8 @@ public class UserManagementControllerTest {
         StudyService studyService = mock(StudyService.class);
         UserAdminService userAdminService = mock(UserAdminService.class);
         
-        // We have to spy the controller, even though it's under test, because there's a reference
-        // to Cache which is a Play class with static methods, play framework is evil.
+        // Using a spy on the controller, even though it's under test, because there's a reference
+        // to Cache in BaseController which is a Play class with a static method.
         controller = spy(new UserManagementController());
         controller.setStudyService(studyService);
         controller.setUserAdminService(userAdminService);
@@ -72,6 +72,8 @@ public class UserManagementControllerTest {
         Result result = controller.createUser();
         
         JsonNode node = new ObjectMapper().readTree(contentAsString(result));
+        
+        // This is the one assertion in this test... Play is hard to test.
         assertEquals("User created.", node.get("message").asText());
     }
     

--- a/test/org/sagebionetworks/bridge/play/interceptors/ExceptionInterceptorTest.java
+++ b/test/org/sagebionetworks/bridge/play/interceptors/ExceptionInterceptorTest.java
@@ -1,0 +1,105 @@
+package org.sagebionetworks.bridge.play.interceptors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static play.test.Helpers.contentAsString;
+
+import java.util.Map;
+
+import org.aopalliance.intercept.MethodInvocation;
+import org.junit.Before;
+import org.junit.Test;
+import org.sagebionetworks.bridge.config.Environment;
+import org.sagebionetworks.bridge.dao.ParticipantOption.SharingScope;
+import org.sagebionetworks.bridge.exceptions.ConsentRequiredException;
+import org.sagebionetworks.bridge.models.accounts.User;
+import org.sagebionetworks.bridge.models.accounts.UserSession;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.google.common.collect.Maps;
+
+import play.mvc.Http;
+import play.mvc.Result;
+
+public class ExceptionInterceptorTest {
+
+    private ExceptionInterceptor interceptor;
+    
+    @Before
+    public void before() throws Exception {
+        interceptor = new ExceptionInterceptor();
+        mockContext();
+    }
+    
+    private Map<String,String[]> map(String[] values) {
+        Map<String,String[]> map = Maps.newHashMap();
+        for (int i=0; i <= values.length-2; i+=2) {
+            map.put(values[i], new String[] { values[i+1] });
+        }
+        return map;
+    }
+    
+    private void mockContext(String... values) throws Exception {
+        Map<String,String[]> map = map(values);
+        
+        Http.Request request = mock(Http.Request.class);
+        when(request.queryString()).thenReturn(map);
+        
+        Http.Context context = mock(Http.Context.class);
+        when(context.request()).thenReturn(request);
+
+        Http.Context.current.set(context);
+    }
+    
+    
+    @Test
+    public void consentRequiredSessionSerializedCorrectly() throws Throwable {
+        User user = new User();
+        user.setConsent(false);
+        user.setEmail("email@email.com");
+        user.setFirstName("firstName");
+        user.setLastName("lastName");
+        user.setHealthCode("healthCode");
+        user.setId("userId");
+        user.setSharingScope(SharingScope.ALL_QUALIFIED_RESEARCHERS);
+        user.setSignedMostRecentConsent(false);
+        user.setStudyKey("test");
+        user.setUsername("username");
+        
+        UserSession session = new UserSession();
+        session.setAuthenticated(true);
+        session.setEnvironment(Environment.DEV);
+        session.setInternalSessionToken("internalToken");
+        session.setSessionToken("sessionToken");
+        session.setStudyIdentifier(new StudyIdentifierImpl("test"));
+        session.setUser(user);
+        
+        ConsentRequiredException exception = new ConsentRequiredException(session);
+        
+        MethodInvocation invocation = mock(MethodInvocation.class);
+        when(invocation.proceed()).thenThrow(exception);
+        
+        Result result = (Result)interceptor.invoke(invocation);
+        JsonNode node = new ObjectMapper().readTree(contentAsString(result));
+        
+        assertTrue(node.get("authenticated").asBoolean());
+        assertFalse(node.get("consented").asBoolean());
+        assertFalse(node.get("signedMostRecentConsent").asBoolean());
+        assertEquals("all_qualified_researchers", node.get("sharingScope").asText());
+        assertEquals("sessionToken", node.get("sessionToken").asText());
+        assertEquals("username", node.get("username").asText());
+        assertEquals("develop", node.get("environment").asText());
+        assertTrue(node.get("dataSharing").asBoolean());
+        assertEquals("UserSessionInfo", node.get("type").asText());
+        ArrayNode array = (ArrayNode)node.get("roles");
+        assertEquals(0, array.size());
+        // And no further properties
+        assertEquals(10, node.size());
+    }
+}    


### PR DESCRIPTION
Minor stuff:
- Some confirmation messages were being returned without the JSON message structure
- The session, when returned as part of a 412 response, was not serialized correctly
- Hiding active property from the study JSON

All the JSON responses were used to create example JSON for every object described in the API docs, and the documentation was adjusted where necessary to reflect what we are really returning from the API.
