### PR TITLE
Optimization: Changing survey text without changing types shouldn't change the schema

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadFieldDefinition.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadFieldDefinition.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge.dynamodb;
 import javax.annotation.Nonnull;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.base.Objects;
 
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
@@ -15,7 +16,7 @@ import org.sagebionetworks.bridge.validators.Validate;
  * class exists to distinguish itself from potential other implementations.
  */
 @JsonDeserialize(builder = DynamoUploadFieldDefinition.Builder.class)
-public class DynamoUploadFieldDefinition implements UploadFieldDefinition {
+public final class DynamoUploadFieldDefinition implements UploadFieldDefinition {
     private final @Nonnull String name;
     private final boolean required;
     private final @Nonnull UploadFieldType type;
@@ -43,6 +44,27 @@ public class DynamoUploadFieldDefinition implements UploadFieldDefinition {
     @Override
     public @Nonnull UploadFieldType getType() {
         return type;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DynamoUploadFieldDefinition that = (DynamoUploadFieldDefinition) o;
+        return Objects.equal(required, that.required) &&
+                Objects.equal(name, that.name) &&
+                Objects.equal(type, that.type);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(name, required, type);
     }
 
     /** Builder for DynamoUploadFieldDefinition */

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDao.java
@@ -104,7 +104,7 @@ public class DynamoUploadSchemaDao implements UploadSchemaDao {
         String studyId = studyIdentifier.getIdentifier();
         String schemaId = survey.getIdentifier();
         DynamoUploadSchema oldUploadSchema = getUploadSchemaNoThrow(studyId, schemaId);
-        int oldRev;
+        int oldRev = 0;
         if (oldUploadSchema != null) {
             oldRev = oldUploadSchema.getRevision();
 
@@ -118,8 +118,6 @@ public class DynamoUploadSchemaDao implements UploadSchemaDao {
             if (oldFieldDefSet.equals(newFieldDefSet)) {
                 return oldUploadSchema;
             }
-        } else {
-            oldRev = 0;
         }
 
         // Create schema.

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDao.java
@@ -4,12 +4,14 @@ import javax.annotation.Nonnull;
 import javax.annotation.Resource;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBSaveExpression;
 import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException;
 import com.amazonaws.services.dynamodbv2.model.ExpectedAttributeValue;
+import com.google.common.collect.ImmutableSet;
 import org.springframework.stereotype.Component;
 
 import org.sagebionetworks.bridge.BridgeUtils;
@@ -101,7 +103,24 @@ public class DynamoUploadSchemaDao implements UploadSchemaDao {
         // Get the current rev.
         String studyId = studyIdentifier.getIdentifier();
         String schemaId = survey.getIdentifier();
-        int oldRev = getCurrentSchemaRevision(studyId, schemaId);
+        DynamoUploadSchema oldUploadSchema = getUploadSchemaNoThrow(studyId, schemaId);
+        int oldRev;
+        if (oldUploadSchema != null) {
+            oldRev = oldUploadSchema.getRevision();
+
+            // Optimization: If the new schema and the old schema have the same fields, return the old schema instead
+            // of creating a new one.
+            //
+            // Dump the fieldDefLists into a set, because if we have the same fields in a different order, the schemas
+            // are compatible, and we should use the old schema too.
+            Set<UploadFieldDefinition> oldFieldDefSet = ImmutableSet.copyOf(oldUploadSchema.getFieldDefinitions());
+            Set<UploadFieldDefinition> newFieldDefSet = ImmutableSet.copyOf(fieldDefList);
+            if (oldFieldDefSet.equals(newFieldDefSet)) {
+                return oldUploadSchema;
+            }
+        } else {
+            oldRev = 0;
+        }
 
         // Create schema.
         DynamoUploadSchema schema = new DynamoUploadSchema();

--- a/test/org/sagebionetworks/bridge/models/upload/UploadFieldDefinitionTest.java
+++ b/test/org/sagebionetworks/bridge/models/upload/UploadFieldDefinitionTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.HashMap;
 import java.util.Map;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 import org.springframework.validation.MapBindingResult;
 
@@ -119,5 +120,10 @@ public class UploadFieldDefinitionTest {
         assertEquals("test-field", jsonMap.get("name"));
         assertFalse((boolean) jsonMap.get("required"));
         assertEquals("int", jsonMap.get("type"));
+    }
+
+    @Test
+    public void equalsVerifier() {
+        EqualsVerifier.forClass(DynamoUploadFieldDefinition.class).allFieldsShouldBeUsed().verify();
     }
 }


### PR DESCRIPTION
This is for https://sagebionetworks.jira.com/browse/BRIDGE-706

This allows researchers to change survey question text or re-order survey questions without having to create a new Upload Schema or a new Synapse table.

Testing done:
- relevant unit tests
- manual tests: create new survey, update survey with same fields in different order, update survey with new fields
- TODO: Integration tests
