### PR TITLE
Upload Validation Strict Validation

### DIFF
--- a/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
+++ b/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
@@ -28,6 +28,7 @@ import org.sagebionetworks.bridge.upload.DecryptHandler;
 import org.sagebionetworks.bridge.upload.IosSchemaValidationHandler2;
 import org.sagebionetworks.bridge.upload.ParseJsonHandler;
 import org.sagebionetworks.bridge.upload.S3DownloadHandler;
+import org.sagebionetworks.bridge.upload.StrictValidationHandler;
 import org.sagebionetworks.bridge.upload.TranscribeConsentHandler;
 import org.sagebionetworks.bridge.upload.UnzipHandler;
 import org.sagebionetworks.bridge.upload.UploadArtifactsHandler;
@@ -287,10 +288,11 @@ public class BridgeSpringConfig {
     @Autowired
     public List<UploadValidationHandler> uploadValidationHandlerList(S3DownloadHandler s3DownloadHandler,
             DecryptHandler decryptHandler, UnzipHandler unzipHandler, ParseJsonHandler parseJsonHandler,
-            IosSchemaValidationHandler2 iosSchemaValidationHandler2, TranscribeConsentHandler transcribeConsentHandler,
-            UploadArtifactsHandler uploadArtifactsHandler) {
+            IosSchemaValidationHandler2 iosSchemaValidationHandler2, StrictValidationHandler strictValidationHandler,
+            TranscribeConsentHandler transcribeConsentHandler, UploadArtifactsHandler uploadArtifactsHandler) {
         return ImmutableList.of(s3DownloadHandler, decryptHandler, unzipHandler, parseJsonHandler,
-                iosSchemaValidationHandler2, transcribeConsentHandler, uploadArtifactsHandler);
+                iosSchemaValidationHandler2, strictValidationHandler, transcribeConsentHandler,
+                uploadArtifactsHandler);
     }
 
     @Bean(name = "uploadSchemaDdbMapper")

--- a/app/org/sagebionetworks/bridge/models/upload/UploadFieldType.java
+++ b/app/org/sagebionetworks/bridge/models/upload/UploadFieldType.java
@@ -1,5 +1,8 @@
 package org.sagebionetworks.bridge.models.upload;
 
+import java.util.EnumSet;
+import java.util.Set;
+
 /**
  * Represents field types in upload data. This is used for parsing the data from the upload buckets and to write the
  * data to the export data.
@@ -54,5 +57,10 @@ public enum UploadFieldType {
     STRING,
 
     /** A timestamp in ISO 8601 format (YYYY-MM-DDThhhh:mm:ss+/-zz:zz) */
-    TIMESTAMP,
+    TIMESTAMP;
+
+    /** A set of upload field types that are considered attachment types. */
+    public static final Set<UploadFieldType> ATTACHMENT_TYPE_SET = EnumSet.of(UploadFieldType.ATTACHMENT_BLOB,
+            UploadFieldType.ATTACHMENT_CSV, UploadFieldType.ATTACHMENT_JSON_BLOB,
+            UploadFieldType.ATTACHMENT_JSON_TABLE);
 }

--- a/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2.java
+++ b/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.bridge.upload;
 
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -57,10 +56,6 @@ import org.sagebionetworks.bridge.services.UploadSchemaService;
  */
 @Component
 public class IosSchemaValidationHandler2 implements UploadValidationHandler {
-    private static final Set<UploadFieldType> ATTACHMENT_TYPE_SET = EnumSet.of(UploadFieldType.ATTACHMENT_BLOB,
-            UploadFieldType.ATTACHMENT_CSV, UploadFieldType.ATTACHMENT_JSON_BLOB,
-            UploadFieldType.ATTACHMENT_JSON_TABLE);
-
     private static final String FILENAME_INFO_JSON = "info.json";
     private static final Pattern FILENAME_TIMESTAMP_PATTERN = Pattern.compile("-\\d{8,}");
     private static final String KEY_FILENAME = "filename";
@@ -291,7 +286,7 @@ public class IosSchemaValidationHandler2 implements UploadValidationHandler {
                 context.addMessage(String.format("upload ID %s filename %s has no timestamp", uploadId,
                         filename));
             } else {
-                DateTime timestamp = parseTimestampHelper(context, uploadId, filename, timestampNode.textValue());
+                DateTime timestamp = UploadUtil.parseIosTimestamp(timestampNode.textValue());
                 if (createdOn == null || timestamp.isAfter(createdOn)) {
                     createdOn = timestamp;
                 }
@@ -432,9 +427,6 @@ public class IosSchemaValidationHandler2 implements UploadValidationHandler {
             } else if (jsonFieldnameSet.contains(fieldName)) {
                 copyJsonField(context, uploadId, flattenedJsonDataMap.get(fieldName), oneFieldDef, dataMap,
                         attachmentMap);
-            } else if (oneFieldDef.isRequired()) {
-                // log a message only if the field is required (but missing)
-                context.addMessage(String.format("Upload ID %s is missing required field %s", uploadId, fieldName));
             }
         }
     }
@@ -468,7 +460,7 @@ public class IosSchemaValidationHandler2 implements UploadValidationHandler {
             return;
         }
 
-        if (ATTACHMENT_TYPE_SET.contains(fieldDef.getType())) {
+        if (UploadFieldType.ATTACHMENT_TYPE_SET.contains(fieldDef.getType())) {
             try {
                 attachmentMap.put(fieldName, BridgeObjectMapper.get().writeValueAsBytes(fieldValue));
             } catch (JsonProcessingException ex) {
@@ -478,37 +470,6 @@ public class IosSchemaValidationHandler2 implements UploadValidationHandler {
             }
         } else {
             dataMap.set(fieldName, fieldValue);
-        }
-    }
-
-    // For some reason, the iOS apps are sending timestamps in form "YYYY-MM-DD hh:mm:ss +ZZZZ", which is
-    // non-ISO-compliant and can't be parsed by JodaTime. We'll need to convert these to ISO format, generally
-    // "YYYY-MM-DDThh:mm:ss+ZZZZ".
-    // TODO: Remove this hack when it's no longer needed.
-    private static DateTime parseTimestampHelper(UploadValidationContext context, String uploadId, String filename,
-            String timestampStr) {
-        if (StringUtils.isBlank(timestampStr)) {
-            context.addMessage(String.format("upload ID %s filename %s has blank time stamp", uploadId,
-                    filename));
-            return null;
-        }
-
-        // Detect if this is iOS non-standard format by checking to see if the 10th char is a space.
-        if (timestampStr.charAt(10) == ' ') {
-            context.addMessage(String.format("upload ID %s filename %s has non-standard timestamp format %s",
-                    uploadId, filename, timestampStr));
-
-            // Attempt to convert this by replacing the 10th char with a T and then stripping out all spaces.
-            timestampStr = timestampStr.substring(0, 10) + 'T' + timestampStr.substring(11);
-            timestampStr = timestampStr.replaceAll("\\s+", "");
-        }
-
-        try {
-            return DateUtils.parseISODateTime(timestampStr);
-        } catch (RuntimeException ex) {
-            context.addMessage(String.format("upload ID %s filename %s has invalid timestamp %s", uploadId,
-                    filename, timestampStr));
-            return null;
         }
     }
 }

--- a/app/org/sagebionetworks/bridge/upload/StrictValidationHandler.java
+++ b/app/org/sagebionetworks/bridge/upload/StrictValidationHandler.java
@@ -1,0 +1,235 @@
+package org.sagebionetworks.bridge.upload;
+
+import javax.annotation.Nonnull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Joiner;
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.sagebionetworks.bridge.json.DateUtils;
+import org.sagebionetworks.bridge.models.healthdata.HealthDataRecordBuilder;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
+import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
+import org.sagebionetworks.bridge.models.upload.UploadFieldType;
+import org.sagebionetworks.bridge.models.upload.UploadSchema;
+import org.sagebionetworks.bridge.services.UploadSchemaService;
+
+/**
+ * <p>
+ * Upload validation handler that handles strict schema validation. Specifically, it checks to make sure the record
+ * data contains all the fields marked as "required" are present. This guards against (a) apps sending "useless" data
+ * that's missing key fields and (b) apps changing filenames and fieldnames causing Bridge to no longer see the
+ * incoming data.
+ * </p>
+ * <p>
+ * This handler won't make any changes to the UploadValidationContext, but it will throw an UploadValidationException
+ * if the record data fails validation. Specifically, it will read data from
+ * {@link org.sagebionetworks.bridge.upload.UploadValidationContext#getHealthDataRecordBuilder} and
+ * {@link org.sagebionetworks.bridge.upload.UploadValidationContext#getAttachmentsByFieldName}.
+ * </p>
+ * <p>
+ * Because legacy studies don't have the concept of "required fields", Upload Validation was made lenient, to be able
+ * to still gather partial data. With strict validation, Bridge will still log warnings for all apps for reporting
+ * purposes, and failing strict validation can be configured on a per-study basis. Note that all new studies should be
+ * created with strict validation turned on.
+ * </p>
+ */
+@Component
+public class StrictValidationHandler implements UploadValidationHandler {
+    private static final Logger logger = LoggerFactory.getLogger(StrictValidationHandler.class);
+
+    private static final Joiner ERROR_MESSAGE_JOINER = Joiner.on("; ");
+
+    private UploadSchemaService uploadSchemaService;
+
+    /** Upload Schema Service, used to get the schema to validate against the upload. */
+    @Autowired
+    public final void setUploadSchemaService(UploadSchemaService uploadSchemaService) {
+        this.uploadSchemaService = uploadSchemaService;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void handle(@Nonnull UploadValidationContext context) throws UploadValidationException {
+        StudyIdentifier studyIdentifier = context.getStudy();
+
+        // get fields from record builder
+        HealthDataRecordBuilder recordBuilder = context.getHealthDataRecordBuilder();
+        JsonNode recordDataNode = recordBuilder.getData();
+        String schemaId = recordBuilder.getSchemaId();
+        int schemaRev = recordBuilder.getSchemaRevision();
+
+        // get attachment field names
+        Set<String> attachmentFieldNameSet = context.getAttachmentsByFieldName().keySet();
+
+        // get schema
+        UploadSchema schema = uploadSchemaService.getUploadSchemaByIdAndRev(studyIdentifier, schemaId, schemaRev);
+        List<UploadFieldDefinition> fieldDefList = schema.getFieldDefinitions();
+
+        List<String> errorList = validateAllFields(fieldDefList, attachmentFieldNameSet, recordDataNode);
+
+        handleErrors(context, errorList);
+    }
+
+    /**
+     * Handles validation errors. Specifically, this logs a warning in the logs, writes the message to the upload
+     * validation context, and (if shouldThrow is true) throws an UploadValidationException.
+     *
+     * @param context
+     *         upload validation context
+     * @param errorList
+     *         list of errors, may be empty if there are no errors
+     * @throws UploadValidationException
+     *         representing the error with the specified message, if shouldThrow is true
+     */
+    private void handleErrors(@Nonnull UploadValidationContext context, @Nonnull List<String> errorList)
+            throws UploadValidationException {
+        if (errorList.isEmpty()) {
+            // no errors, trivial return
+            return;
+        }
+
+        // copy to upload validation context messages
+        for (String oneError : errorList) {
+            context.addMessage(oneError);
+        }
+
+        // log warning
+        String combinedErrorMessage = "Strict upload validation error in study " + context.getStudy().getIdentifier()
+                + ", upload " + context.getUpload().getUploadId() + ": " + ERROR_MESSAGE_JOINER.join(errorList);
+        logger.warn(combinedErrorMessage);
+
+        // throw error, if configured to do so
+        if (shouldThrow(context.getStudy())) {
+            throw new UploadValidationException(combinedErrorMessage);
+        }
+    }
+
+    /**
+     * <p>
+     * Returns whether strict validation should throw exceptions, based on study configs.
+     * </p>
+     * <p>
+     * This is protected so that unit tests can mock this out. (Until we implement the actual study config lookup.)
+     * </p>
+     *
+     * @param studyIdentifier
+     *         study ID of the current data record we're validating
+     * @return true if we should throw an exception, false otherwise
+     */
+    // TODO: implement this
+    protected boolean shouldThrow(StudyIdentifier studyIdentifier) {
+        return false;
+    }
+
+    /**
+     * Given the schema, the attachments (all we need are names), and the JSON data nodes, we validate the data against
+     * the schema.
+     *
+     * @param fieldDefList
+     *         list of field definitions from the schema
+     * @param attachmentFieldNameSet
+     *         set of attachment field names that we have attachments for
+     * @param recordDataNode
+     *         JSON node of the parsed data to validate
+     * @return list of error messages, empty if there are no errors
+     */
+    private static List<String> validateAllFields(@Nonnull List<UploadFieldDefinition> fieldDefList,
+            @Nonnull Set<String> attachmentFieldNameSet, @Nonnull JsonNode recordDataNode) {
+        // walk the field definitions and validate fields
+        List<String> errorList = new ArrayList<>();
+        for (UploadFieldDefinition oneFieldDef : fieldDefList) {
+            String fieldName = oneFieldDef.getName();
+            UploadFieldType fieldType = oneFieldDef.getType();
+            boolean isRequired = oneFieldDef.isRequired();
+
+            if (UploadFieldType.ATTACHMENT_TYPE_SET.contains(fieldType)) {
+                // For attachment types, since they just get exported as raw files, we only need to check if it's
+                // required and present. Specifically, if it's required and it's not present, then that's an error.
+                if (isRequired && !attachmentFieldNameSet.contains(fieldName)) {
+                    errorList.add("Required attachment field " + fieldName + " missing");
+                }
+            } else {
+                JsonNode fieldValueNode = recordDataNode.get(fieldName);
+
+                if (fieldValueNode != null && !fieldValueNode.isNull()) {
+                    boolean isValid = validateJsonField(fieldType, fieldValueNode);
+                    if (!isValid) {
+                        errorList.add("Expected field " + fieldName + " to be " + fieldType.name() +
+                                ", but was instead JSON type " + fieldValueNode.getNodeType().name());
+                    }
+                } else if (isRequired) {
+                    errorList.add("Required field " + fieldName + " missing");
+                }
+            }
+        }
+
+        return errorList;
+    }
+
+    /**
+     * Given the expected field type and the field value JSON node, this validates the we have the correct type,
+     * returning true of the value is valid and false otherwise. Note that because attachment fields live in the
+     * attachments map and not in JSON, this will always return false for attachment types.
+     *
+     * @param fieldType
+     *         expected field type
+     * @param fieldValueNode
+     *         field value JSON node to validate
+     * @return true if valid, false otherwise
+     */
+    private static boolean validateJsonField(@Nonnull UploadFieldType fieldType, @Nonnull JsonNode fieldValueNode) {
+        switch (fieldType) {
+            case BOOLEAN:
+                return fieldValueNode.isBoolean();
+            case CALENDAR_DATE:
+                // We expect a string. Also, the string should be parseable by Joda LocalDate.
+                if (!fieldValueNode.isTextual()) {
+                    return false;
+                }
+
+                try {
+                    // DateUtils calls through to Joda parseLocalDate(), which is documented as
+                    // never returning null. So we don't need to null check here.
+                    DateUtils.parseCalendarDate(fieldValueNode.textValue());
+                    return true;
+                } catch (RuntimeException ex) {
+                    return false;
+                }
+            case FLOAT:
+            case INT:
+                // Research Kit doesn't distinguish between floats and ints, so neither should we. Just
+                // accept any number type.
+                return fieldValueNode.isNumber();
+            case INLINE_JSON_BLOB:
+                // JSON blobs are always JSON blobs. We don't need to do any special validation.
+                return true;
+            case STRING:
+                return fieldValueNode.isTextual();
+            case TIMESTAMP:
+                // either it's a string in ISO format, or it's a long in epoch milliseconds
+                if (fieldValueNode.isTextual()) {
+                    DateTime dateTime = UploadUtil.parseIosTimestamp(fieldValueNode.textValue());
+                    return dateTime != null;
+                } else if (fieldValueNode.isIntegralNumber()) {
+                    // any integral value can be converted to an epoch milliseconds, so this is good no
+                    // matter what
+                    return true;
+                } else {
+                    return false;
+                }
+            default:
+                // This should never happen, but just in case we add a new field to UploadFieldType
+                // but forget to upload this switch.
+                return false;
+        }
+    }
+}

--- a/app/org/sagebionetworks/bridge/upload/StrictValidationHandler.java
+++ b/app/org/sagebionetworks/bridge/upload/StrictValidationHandler.java
@@ -98,9 +98,7 @@ public class StrictValidationHandler implements UploadValidationHandler {
         }
 
         // copy to upload validation context messages
-        for (String oneError : errorList) {
-            context.addMessage(oneError);
-        }
+        errorList.forEach(context::addMessage);
 
         // log warning
         String combinedErrorMessage = "Strict upload validation error in study " + context.getStudy().getIdentifier()

--- a/app/org/sagebionetworks/bridge/upload/UploadUtil.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadUtil.java
@@ -2,11 +2,15 @@ package org.sagebionetworks.bridge.upload;
 
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.sagebionetworks.bridge.json.DateUtils;
 
 /** Utility class that contains static utility methods for handling uploads. */
 public class UploadUtil {
+    private static final Logger logger = LoggerFactory.getLogger(UploadUtil.class);
+
     /**
      * For some reason, the iOS apps are sometimes sending timestamps in form "YYYY-MM-DD hh:mm:ss +ZZZZ", which is
      * non-ISO-compliant and can't be parsed by JodaTime. We'll need to convert these to ISO format, generally
@@ -18,7 +22,8 @@ public class UploadUtil {
      */
     // TODO: Remove this hack when it's no longer needed.
     public static DateTime parseIosTimestamp(String timestampStr) {
-        if (StringUtils.isBlank(timestampStr)) {
+        // Timestamps must have at least 11 chars to represent the date, at minimum.
+        if (StringUtils.isBlank(timestampStr) || timestampStr.length() < 11) {
             return null;
         }
 
@@ -27,6 +32,9 @@ public class UploadUtil {
             // Attempt to convert this by replacing the 10th char with a T and then stripping out all spaces.
             timestampStr = timestampStr.substring(0, 10) + 'T' + timestampStr.substring(11);
             timestampStr = timestampStr.replaceAll("\\s+", "");
+
+            // Log something, so we can keep track of how often this happens.
+            logger.info("Non-standard timestamp in upload data: " + timestampStr);
         }
 
         try {

--- a/app/org/sagebionetworks/bridge/upload/UploadUtil.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadUtil.java
@@ -29,17 +29,18 @@ public class UploadUtil {
 
         // Detect if this is iOS non-standard format by checking to see if the 10th char is a space.
         if (timestampStr.charAt(10) == ' ') {
+            // Log something, so we can keep track of how often this happens.
+            logger.warn("Non-standard timestamp in upload data: " + timestampStr);
+
             // Attempt to convert this by replacing the 10th char with a T and then stripping out all spaces.
             timestampStr = timestampStr.substring(0, 10) + 'T' + timestampStr.substring(11);
             timestampStr = timestampStr.replaceAll("\\s+", "");
-
-            // Log something, so we can keep track of how often this happens.
-            logger.info("Non-standard timestamp in upload data: " + timestampStr);
         }
 
         try {
             return DateUtils.parseISODateTime(timestampStr);
         } catch (RuntimeException ex) {
+            logger.warn("Malformatted timestamp in upload data: " + timestampStr);
             return null;
         }
     }

--- a/app/org/sagebionetworks/bridge/upload/UploadUtil.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadUtil.java
@@ -1,0 +1,38 @@
+package org.sagebionetworks.bridge.upload;
+
+import org.apache.commons.lang3.StringUtils;
+import org.joda.time.DateTime;
+
+import org.sagebionetworks.bridge.json.DateUtils;
+
+/** Utility class that contains static utility methods for handling uploads. */
+public class UploadUtil {
+    /**
+     * For some reason, the iOS apps are sometimes sending timestamps in form "YYYY-MM-DD hh:mm:ss +ZZZZ", which is
+     * non-ISO-compliant and can't be parsed by JodaTime. We'll need to convert these to ISO format, generally
+     * "YYYY-MM-DDThh:mm:ss+ZZZZ".
+     *
+     * @param timestampStr
+     *         raw timestamp string
+     * @return parsed DateTime, or null if it couldn't be parsed
+     */
+    // TODO: Remove this hack when it's no longer needed.
+    public static DateTime parseIosTimestamp(String timestampStr) {
+        if (StringUtils.isBlank(timestampStr)) {
+            return null;
+        }
+
+        // Detect if this is iOS non-standard format by checking to see if the 10th char is a space.
+        if (timestampStr.charAt(10) == ' ') {
+            // Attempt to convert this by replacing the 10th char with a T and then stripping out all spaces.
+            timestampStr = timestampStr.substring(0, 10) + 'T' + timestampStr.substring(11);
+            timestampStr = timestampStr.replaceAll("\\s+", "");
+        }
+
+        try {
+            return DateUtils.parseISODateTime(timestampStr);
+        } catch (RuntimeException ex) {
+            return null;
+        }
+    }
+}

--- a/test/org/sagebionetworks/bridge/upload/StrictValidationHandlerTest.java
+++ b/test/org/sagebionetworks/bridge/upload/StrictValidationHandlerTest.java
@@ -1,0 +1,134 @@
+package org.sagebionetworks.bridge.upload;
+
+import static org.mockito.Matchers.notNull;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.dynamodb.DynamoUpload2;
+import org.sagebionetworks.bridge.dynamodb.DynamoUploadFieldDefinition;
+import org.sagebionetworks.bridge.dynamodb.DynamoUploadSchema;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
+import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
+import org.sagebionetworks.bridge.models.upload.UploadFieldType;
+import org.sagebionetworks.bridge.services.UploadSchemaService;
+
+public class StrictValidationHandlerTest {
+    private final static byte[] DUMMY_ATTACHMENT = new byte[0];
+
+    private UploadValidationContext context;
+    private StrictValidationHandler handler;
+
+    @Before
+    public void setup() {
+        // Mock out shouldThrow to always return true. This forces strict validation in tests, which is what we want.
+        // TODO: replace this when we implement per-study config lookup
+        handler = spy(new StrictValidationHandler());
+        doReturn(true).when(handler).shouldThrow(notNull(StudyIdentifier.class));
+
+        // Set up common context attributes.
+        context.setStudy(TestConstants.TEST_STUDY);
+
+        DynamoUpload2 upload = new DynamoUpload2();
+        upload.setUploadId("test-upload");
+        context.setUpload(upload);
+    }
+
+    // happy case
+    //   missing/present optional attachment
+    //   missing/present optional JSON field
+    @Test
+    public void happyCase() {
+        // Schema for test. All that matters is field def list.
+        // Test one of each type.
+        DynamoUploadSchema testSchema = new DynamoUploadSchema();
+        testSchema.setFieldDefinitions(ImmutableList.<UploadFieldDefinition>of(
+                new DynamoUploadFieldDefinition.Builder().withName("attachment blob")
+                        .withType(UploadFieldType.ATTACHMENT_BLOB).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("attachment csv")
+                        .withType(UploadFieldType.ATTACHMENT_CSV).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("attachment json blob")
+                        .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("attachment json table")
+                        .withType(UploadFieldType.ATTACHMENT_JSON_TABLE).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("boolean")
+                        .withType(UploadFieldType.BOOLEAN).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("calendar date")
+                        .withType(UploadFieldType.CALENDAR_DATE).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("float")
+                        .withType(UploadFieldType.FLOAT).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("float with int value")
+                        .withType(UploadFieldType.FLOAT).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("inline json blob")
+                        .withType(UploadFieldType.INLINE_JSON_BLOB).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("int")
+                        .withType(UploadFieldType.INT).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("int with float value")
+                        .withType(UploadFieldType.INT).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("string")
+                        .withType(UploadFieldType.STRING).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("string timestamp")
+                        .withType(UploadFieldType.TIMESTAMP).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("long timestamp")
+                        .withType(UploadFieldType.TIMESTAMP).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("missing optional attachment")
+                        .withType(UploadFieldType.ATTACHMENT_BLOB).withRequired(false).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("present optional attachment")
+                        .withType(UploadFieldType.ATTACHMENT_BLOB).withRequired(false).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("missing optional json")
+                        .withType(UploadFieldType.STRING).withRequired(false).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("present optional json")
+                        .withType(UploadFieldType.STRING).withRequired(false).build()));
+
+        // mock schema service
+        UploadSchemaService mockSchemaService = mock(UploadSchemaService.class);
+        when(mockSchemaService.getUploadSchemaByIdAndRev(TestConstants.TEST_STUDY, "test-study", 1)).thenReturn(
+                testSchema);
+
+        // set up attachments map
+        Map<String, byte[]> attachmentsMap = ImmutableMap.of(
+                "attachment blob", DUMMY_ATTACHMENT,
+                "attachment csv", DUMMY_ATTACHMENT,
+                "attachment json blob", DUMMY_ATTACHMENT,
+                "attachment json table", DUMMY_ATTACHMENT,
+                "present optional attachment", DUMMY_ATTACHMENT);
+
+        // set up JSON data
+        String jsonString = "{\n" +
+                "   \"boolean\":true,\n" +
+                "   \"calendar date\":\"2015-07-24\",\n" +
+                "   \"float\":3.14,\n" +
+                "   \"float with int value\":13,\n" +
+                "   \"inline json blob\":[\"inline\", \"json\", \"blob\"],\n" +
+                "   \"int\":42,\n" +
+                "   \"int with float value\":2.78,\n" +
+                "   \"string\":\"This is a string\",\n" +
+                "   \"string timestamp\":\"2015-07-24T18:49:54-07:00\",\n" +
+                "   \"long timestamp\":1437787098066,\n" +
+                "   \"present optional json\":\"optional, but present\"\n" +
+                "}";
+    }
+
+    // missing required attachment
+    // missing required field
+    // optional field still gets validated
+    // JSON null required field
+    // invalid boolean
+    // non-string calendar date
+    // malformatted calendar date
+    // invalid float
+    // invalid int
+    // invalid string
+    // malformatted timestamp
+    // wrong type timestamp
+    // multiple validation errors
+}

--- a/test/org/sagebionetworks/bridge/upload/UploadUtilTest.java
+++ b/test/org/sagebionetworks/bridge/upload/UploadUtilTest.java
@@ -1,0 +1,63 @@
+package org.sagebionetworks.bridge.upload;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+// This file exists to support a hack, but we should still test it anyway.
+public class UploadUtilTest {
+    @Test
+    public void nullTimestamp() {
+        assertNull(UploadUtil.parseIosTimestamp(null));
+    }
+
+    @Test
+    public void emptyTimestamp() {
+        assertNull(UploadUtil.parseIosTimestamp(""));
+    }
+
+    @Test
+    public void blankTimestamp() {
+        assertNull(UploadUtil.parseIosTimestamp("   "));
+    }
+
+    @Test
+    public void calendarDate() {
+        assertNull(UploadUtil.parseIosTimestamp("2015-08-26"));
+    }
+
+    @Test
+    public void shortMalformedTimestamp() {
+        assertNull(UploadUtil.parseIosTimestamp("foo"));
+    }
+
+    @Test
+    public void longMalformedTimestamp() {
+        assertNull(UploadUtil.parseIosTimestamp("August 26, 2015 @ 4:54:04pm PDT"));
+    }
+
+    @Test
+    public void properTimestampUtc() {
+        String timestampStr = "2015-08-26T23:54:04Z";
+        long expectedMillis = DateTime.parse(timestampStr).getMillis();
+        DateTime parsedTimestamp = UploadUtil.parseIosTimestamp(timestampStr);
+        assertEquals(expectedMillis, parsedTimestamp.getMillis());
+    }
+
+    @Test
+    public void properTimestampWithTimezone() {
+        String timestampStr = "2015-08-26T16:54:04-07:00";
+        long expectedMillis = DateTime.parse(timestampStr).getMillis();
+        DateTime parsedTimestamp = UploadUtil.parseIosTimestamp(timestampStr);
+        assertEquals(expectedMillis, parsedTimestamp.getMillis());
+    }
+
+    @Test
+    public void iosTimestamp() {
+        long expectedMillis = DateTime.parse("2015-08-26T16:54:04-07:00").getMillis();
+        DateTime parsedTimestamp = UploadUtil.parseIosTimestamp("2015-08-26 16:54:04 -0700");
+        assertEquals(expectedMillis, parsedTimestamp.getMillis());
+    }
+}


### PR DESCRIPTION
Reviving and refactoring the Strict Validation code to fit in with our upload validation handler chain. Added unit tests.

If a field has the wrong type or if a required field is missing, this will log a warning. In the future, or for new studies, we could configure this to fail upload validation.

Testing done:
- relevant unit tests
- manually tested upload validation
- ran integration tests to make sure existing Upload behavior wasn't broken
