### PR TITLE
Upload Validation parse Survey Guid and CreatedOn

### DIFF
--- a/test/org/sagebionetworks/bridge/json/DateUtilsTest.java
+++ b/test/org/sagebionetworks/bridge/json/DateUtilsTest.java
@@ -47,6 +47,17 @@ public class DateUtilsTest {
         assertEquals(16, date.getDayOfMonth());
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void parseCalendarDateMalformattedString() {
+        DateUtils.parseCalendarDate("February 16, 2014");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void parseCalendarDateShortInt() {
+        // Make sure we don't do something dumb, like parse this as year 42.
+        DateUtils.parseCalendarDate("42");
+    }
+
     @Test
     public void getISODateTime() {
         String dateString = DateUtils.getISODateTime(getDateTime());
@@ -70,6 +81,17 @@ public class DateUtilsTest {
 
         DateTime dateTime = DateUtils.parseISODateTime("2014-02-17T23:00-0800");
         assertEquals(expectedMillis, dateTime.getMillis());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void parseISODateTimeMalformattedString() {
+        DateUtils.parseISODateTime("February 17, 2014 at 11:00:00pm");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void parseISODateTimeShortInt() {
+        // Make sure we don't do something dumb, like parse this as year 42.
+        DateUtils.parseISODateTime("42");
     }
 
     @Test
@@ -97,5 +119,22 @@ public class DateUtilsTest {
 
         long millis = DateUtils.convertToMillisFromEpoch("2014-02-17T23:00-0800");
         assertEquals(expectedMillis, millis);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void convertToMillisFromMalformattedDate() {
+        // We detect dates as being 10 chars long.
+        DateUtils.convertToMillisFromEpoch("1234567890");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void convertToMillisFromMalformattedString() {
+        DateUtils.convertToMillisFromEpoch("February 17, 2014 at 11:00:00pm");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void convertToMillisFromShortInt() {
+        // Make sure we don't do something dumb, like parse this as year 42.
+        DateUtils.convertToMillisFromEpoch("42");
     }
 }


### PR DESCRIPTION
This is needed so that apps can tell the server what version of the survey they are answering.

I also noticed an obscure edge case in DateUtils, where if you pass in an int with 4 digits or less (like 42), it'll parse that int as the year, and you end up with something dumb, like midnight Jan 1 in year 42. So that obscure edge case has been patched.

Testing done:
- relevant unit tests
- manually tested upload with survey Guid and CreatedOn in info.json
- ran UploadTest integration test to verify Upload still works
