### PR TITLE
survey schema fields should be optional by default

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDao.java
@@ -95,8 +95,10 @@ public class DynamoUploadSchemaDao implements UploadSchemaDao {
         for (SurveyQuestion oneQuestion : survey.getUnmodifiableQuestionList()) {
             String name = oneQuestion.getIdentifier();
             UploadFieldType type = getFieldTypeFromConstraints(oneQuestion.getConstraints());
+
+            // All survey questions are skippable, so mark the field as optional (not required)
             UploadFieldDefinition oneFieldDef = new DynamoUploadFieldDefinition.Builder().withName(name)
-                    .withType(type).build();
+                    .withType(type).withRequired(false).build();
             fieldDefList.add(oneFieldDef);
         }
 


### PR DESCRIPTION
Since survey questions are always skippable, we want auto-generated survey schemas to list their fields as optional (required=false).

Testing done:
- added unit test to verify fields are created as required=false - Added a separate unit test instead of adding to existing unit tests, so if we ever change this behavior, we only need to update one test.
- manually created and published a survey, verified schema fields have required=false
