### PR TITLE
Upload schema apis changes

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/UploadSchemaDao.java
+++ b/app/org/sagebionetworks/bridge/dao/UploadSchemaDao.java
@@ -74,6 +74,16 @@ public interface UploadSchemaDao {
     @Nonnull UploadSchema getUploadSchema(@Nonnull String studyId, @Nonnull String schemaId);
 
     /**
+     * Fetch all revisions of a single upload schema. Throws EntityNotFoundException if no records are found. 
+     * @param studyIdentifier
+     *         study to fetch the schema from, must be non-null and non-empty
+     * @param schemaId
+     *         ID of the schema to fetch, must be non-null and non-empty
+     * @return a list of all revisions of a schema
+     */
+    @Nonnull List<UploadSchema> getUploadSchemaAllRevisions(@Nonnull StudyIdentifier studyIdentifier, @Nonnull String schemaId);
+    
+    /**
      * Fetches the upload schema for the specified study, schema ID, and revision. If no schema is found, this API
      * throws an EntityNotFoundException
      *

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDao.java
@@ -352,6 +352,6 @@ public class DynamoUploadSchemaDao implements UploadSchemaDao {
             }
         }
         // Do we care if it's sorted? What would it be sorted by?
-        return new ArrayList<>(schemaMap.values());
+        return ImmutableList.copyOf(schemaMap.values());
     }
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDao.java
@@ -14,6 +14,7 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBSaveExpression;
 import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException;
 import com.amazonaws.services.dynamodbv2.model.ExpectedAttributeValue;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import org.springframework.stereotype.Component;
@@ -270,11 +271,7 @@ public class DynamoUploadSchemaDao implements UploadSchemaDao {
             throw new EntityNotFoundException(UploadSchema.class, String.format(
                 "Upload schema not found for study %s, schema ID %s", studyIdentifier.getIdentifier(), schemaId));
         }
-        List<UploadSchema> schemas = new ArrayList<>();
-        for (DynamoUploadSchema schema : uploadSchemas) {
-            schemas.add(schema);
-        }
-        return schemas;
+        return ImmutableList.<UploadSchema>copyOf(uploadSchemas);
     }
 
     /** {@inheritDoc} */

--- a/app/org/sagebionetworks/bridge/play/controllers/UploadSchemaController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/UploadSchemaController.java
@@ -127,7 +127,7 @@ public class UploadSchemaController extends BaseController {
     }
 
     /**
-     * Play controller for GET /m3/uploadschemas. This API fetches the most recent revision of all upload 
+     * Play controller for GET /v3/uploadschemas. This API fetches the most recent revision of all upload 
      * schemas for the current study. 
      * 
      * @return Play result with list of schemas for this study

--- a/app/org/sagebionetworks/bridge/play/controllers/UploadSchemaController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/UploadSchemaController.java
@@ -112,8 +112,8 @@ public class UploadSchemaController extends BaseController {
     }
 
     /**
-     * Play controller for GET /researcher/v1/uploadSchema/forStudy. This API fetches all revisions of all upload
-     * schemas in the current study. This is generally used by worker apps to validate uploads against schemas.
+     * Play controller for GET /m3/uploadschemas. This API fetches the most recent revision of all upload 
+     * schemas for the current study. 
      * 
      * @return Play result with list of schemas for this study
      */

--- a/app/org/sagebionetworks/bridge/play/controllers/UploadSchemaController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/UploadSchemaController.java
@@ -92,6 +92,21 @@ public class UploadSchemaController extends BaseController {
         UploadSchema uploadSchema = uploadSchemaService.getUploadSchema(studyId, schemaId);
         return okResult(uploadSchema);
     }
+    
+    /**
+     * Play controller for GET /v3/uploadschemas/:schemaId. Returns all revisions of this upload schema. If the 
+     * schema doesn't exist, this API throws a 404 exception.
+     * @param schemaId
+     *         schema ID to fetch
+     * @return Play result with an array of all revisions of the fetched schema in JSON format
+     */
+    public Result getUploadSchemaAllRevisions(String schemaId) {
+        UserSession session = getAuthenticatedSession(DEVELOPER);
+        StudyIdentifier studyId = session.getStudyIdentifier();
+        
+        List<UploadSchema> uploadSchemas = uploadSchemaService.getUploadSchemaAllRevisions(studyId, schemaId);
+        return okResult(uploadSchemas);
+    }
 
     /**
      * Fetches the upload schema for the specified study, schema ID, and revision. If no schema is found, this API

--- a/app/org/sagebionetworks/bridge/services/UploadSchemaService.java
+++ b/app/org/sagebionetworks/bridge/services/UploadSchemaService.java
@@ -124,6 +124,28 @@ public class UploadSchemaService {
 
     /**
      * <p>
+     * Service handler for fetching upload schemas. This method fetches all revisions of an an upload schema for 
+     * the specified study and schema ID. If the schema doesn't exist, this handler throws an InvalidEntityException.
+     * </p>
+     * <p>
+     * This method validates the schema ID. However, it does not validate the study, as that is not user input.
+     * </p>
+     *
+     * @param studyIdentifier
+     *         study to fetch the schema from, provided by the controller
+     * @param schemaId
+     *         ID of the schema to fetch, must be non-null and non-empty
+     * @return the fetched schema, will be non-null
+     */
+    public List<UploadSchema> getUploadSchemaAllRevisions(StudyIdentifier studyIdentifier, String schemaId) {
+        if (StringUtils.isBlank(schemaId)) {
+            throw new BadRequestException(String.format("Invalid schema ID %s", schemaId));
+        }
+        return uploadSchemaDao.getUploadSchemaAllRevisions(studyIdentifier, schemaId);
+    }
+    
+    /**
+     * <p>
      * Fetches the upload schema for the specified study, schema ID, and revision. If no schema is found, this API
      * throws an EntityNotFoundException
      * </p>

--- a/app/org/sagebionetworks/bridge/services/UploadSchemaService.java
+++ b/app/org/sagebionetworks/bridge/services/UploadSchemaService.java
@@ -151,8 +151,8 @@ public class UploadSchemaService {
 
     /**
      * <p>
-     * Service handler for fetching all revisions of all upload schemas in a study. This is used by upload unpacking
-     * and validation to match up the data to the schema.
+     * Service handler for fetching the most recent revision of all upload schemas in a study. This is used by 
+     * upload unpacking and validation to match up the data to the schema.
      * </p>
      * <p>
      * This method does not validate the study ID, as that is not user input.

--- a/conf/routes
+++ b/conf/routes
@@ -75,6 +75,12 @@ GET    /v3/uploadschemas/:schemaId/revisions/:rev  @org.sagebionetworks.bridge.p
 DELETE /v3/uploadschemas/:schemaId                 @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.deleteUploadSchemaById(schemaId: String)
 DELETE /v3/uploadschemas/:schemaId/revisions/:rev  @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.deleteUploadSchemaByIdAndRev(schemaId: String, rev: Int)
 
+# New APIs... the middle one will have changed however.
+# GET    /v3/uploadschemas/recent                    @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getMostRecentUploadSchemas
+# GET    /v3/uploadschemas/:schemaId                 @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getUploadSchemaAllRevisions(schemaId: String)
+# GET    /v3/uploadschemas/:schemaId/recent          @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getUploadSchema(schemaId: String)
+
+
 # Schedule Plans
 GET    /v3/scheduleplans           @org.sagebionetworks.bridge.play.controllers.SchedulePlanController.getSchedulePlans
 POST   /v3/scheduleplans           @org.sagebionetworks.bridge.play.controllers.SchedulePlanController.createSchedulePlan

--- a/conf/routes
+++ b/conf/routes
@@ -70,16 +70,11 @@ GET    /v3/uploadstatuses/:uploadId    @org.sagebionetworks.bridge.play.controll
 # Upload Schemas
 GET    /v3/uploadschemas                           @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getUploadSchemasForStudy
 POST   /v3/uploadschemas                           @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.createOrUpdateUploadSchema
-GET    /v3/uploadschemas/:schemaId                 @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getUploadSchema(schemaId: String)
+GET    /v3/uploadschemas/:schemaId                 @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getUploadSchemaAllRevisions(schemaId: String)
+GET    /v3/uploadschemas/:schemaId/recent          @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getUploadSchema(schemaId: String)
 GET    /v3/uploadschemas/:schemaId/revisions/:rev  @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getUploadSchemaByIdAndRev(schemaId: String, rev: Int)
 DELETE /v3/uploadschemas/:schemaId                 @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.deleteUploadSchemaById(schemaId: String)
 DELETE /v3/uploadschemas/:schemaId/revisions/:rev  @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.deleteUploadSchemaByIdAndRev(schemaId: String, rev: Int)
-
-# New APIs... the middle one will have changed however.
-# GET    /v3/uploadschemas/recent                    @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getMostRecentUploadSchemas
-# GET    /v3/uploadschemas/:schemaId                 @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getUploadSchemaAllRevisions(schemaId: String)
-# GET    /v3/uploadschemas/:schemaId/recent          @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getUploadSchema(schemaId: String)
-
 
 # Schedule Plans
 GET    /v3/scheduleplans           @org.sagebionetworks.bridge.play.controllers.SchedulePlanController.getSchedulePlans

--- a/test/org/sagebionetworks/bridge/play/controllers/UploadSchemaControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/UploadSchemaControllerTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableList;
 
 import org.junit.Test;
@@ -203,8 +204,54 @@ public class UploadSchemaControllerTest {
         UploadSchema resultSchema = BridgeObjectMapper.get().treeToValue(itemListNode.get(0), UploadSchema.class);
         assertEquals(TEST_SCHEMA_ID, resultSchema.getSchemaId());
     }
+    
+    @Test
+    public void getAllRevisionsOfASchema() throws Exception {
+        String schemaId = "controller-test-schema";
+        
+        // mock session
+        StudyIdentifier studyIdentifier = new StudyIdentifierImpl("get-schema-study");
+        UserSession mockSession = new UserSession();
+        mockSession.setStudyIdentifier(studyIdentifier);
+
+        // Create a couple of revisions
+        UploadSchema schema1 = makeUploadSchema(1);
+        UploadSchema schema2 = makeUploadSchema(2);
+        UploadSchema schema3 = makeUploadSchema(3);
+        
+        // mock UploadSchemaService
+        UploadSchemaService mockSvc = mock(UploadSchemaService.class);
+        when(mockSvc.getUploadSchemaAllRevisions(studyIdentifier, schemaId)).thenReturn(ImmutableList.of(schema3, schema2, schema1));
+
+        // spy controller
+        UploadSchemaController controller = spy(new UploadSchemaController());
+        controller.setUploadSchemaService(mockSvc);
+        doReturn(mockSession).when(controller).getAuthenticatedSession(any(Roles.class));
+
+        // execute and validate
+        Result result = controller.getUploadSchemaAllRevisions(schemaId);
+        assertEquals(200, result.status());
+
+        String resultJson = Helpers.contentAsString(result);
+        JsonNode resultNode = BridgeObjectMapper.get().readTree(resultJson);
+        assertEquals("ResourceList", resultNode.get("type").textValue());
+        assertEquals(3, resultNode.get("total").intValue());
+
+        JsonNode itemsNode = resultNode.get("items");
+        assertEquals(3, itemsNode.size());
+
+        assertEquals(3, itemsNode.get(0).get("revision").asInt());
+        assertEquals(2, itemsNode.get(1).get("revision").asInt());
+        assertEquals(1, itemsNode.get(2).get("revision").asInt());
+    }
 
     private static UploadSchema makeUploadSchema() throws Exception {
-        return BridgeObjectMapper.get().readValue(TEST_SCHEMA_JSON, UploadSchema.class);
+        return makeUploadSchema(3);
+    }
+    
+    private static UploadSchema makeUploadSchema(int revision) throws Exception {
+        ObjectNode node = (ObjectNode)BridgeObjectMapper.get().readTree(TEST_SCHEMA_JSON);
+        node.put("revision", revision);
+        return BridgeObjectMapper.get().convertValue(node, UploadSchema.class);
     }
 }

--- a/test/org/sagebionetworks/bridge/services/UploadSchemaServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/UploadSchemaServiceTest.java
@@ -215,6 +215,31 @@ public class UploadSchemaServiceTest {
         List<UploadSchema> svcRetVal = svc.getUploadSchemasForStudy(studyIdentifier);
         assertSame(daoRetVal, svcRetVal);
     }
+    
+    @Test
+    public void getSchemaAllRevisions() {
+        String schemaId = "test-schema";
+        
+        // mock dao
+        StudyIdentifier studyIdentifier = makeTestStudy();
+        
+        DynamoUploadSchema schema1 = new DynamoUploadSchema();
+        schema1.setRevision(3);
+        DynamoUploadSchema schema2 = new DynamoUploadSchema();
+        schema1.setRevision(2);
+        DynamoUploadSchema schema3 = new DynamoUploadSchema();
+        schema1.setRevision(1);
+        
+        List<UploadSchema> daoRetVal = ImmutableList.<UploadSchema>of(schema1, schema2, schema3);
+        UploadSchemaDao mockDao = mock(UploadSchemaDao.class);
+        when(mockDao.getUploadSchemaAllRevisions(studyIdentifier, schemaId)).thenReturn(daoRetVal);
+
+        // execute and validate
+        UploadSchemaService svc = new UploadSchemaService();
+        svc.setUploadSchemaDao(mockDao);
+        List<UploadSchema> svcRetVal = svc.getUploadSchemaAllRevisions(studyIdentifier, schemaId);
+        assertSame(daoRetVal, svcRetVal);
+    }
 
     private static StudyIdentifier makeTestStudy() {
         return new StudyIdentifierImpl("test-study");

--- a/test/org/sagebionetworks/bridge/services/UploadSchemaServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/UploadSchemaServiceTest.java
@@ -204,6 +204,7 @@ public class UploadSchemaServiceTest {
     public void getSchemasForStudy() {
         // mock dao
         StudyIdentifier studyIdentifier = makeTestStudy();
+        
         List<UploadSchema> daoRetVal = ImmutableList.<UploadSchema>of(new DynamoUploadSchema());
         UploadSchemaDao mockDao = mock(UploadSchemaDao.class);
         when(mockDao.getUploadSchemasForStudy(studyIdentifier)).thenReturn(daoRetVal);


### PR DESCRIPTION
GET /v3/uploadschemas
- This now returns the most recent version of each schema

GET /v3/uploadschemas/:schemaId
- This now returns all revisions of a single schema, most recent revision first

GET /v3/uploadschemas/:schemaId/recent
- The returns the most recent version of a single schema
