### PR TITLE
configure DDB max retries

### DIFF
--- a/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
+++ b/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
@@ -7,6 +7,8 @@ import java.util.concurrent.Executors;
 
 import javax.annotation.Resource;
 
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.PredefinedClientConfigurations;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient;
@@ -129,8 +131,8 @@ public class BridgeSpringConfig {
     }
 
     @Bean(name = "awsCredentials")
-    @Resource(name = "bridgeConfig")
-    public BasicAWSCredentials awsCredentials(BridgeConfig bridgeConfig) {
+    public BasicAWSCredentials awsCredentials() {
+        BridgeConfig bridgeConfig = bridgeConfig();
         return new BasicAWSCredentials(bridgeConfig.getProperty("aws.key"),
                 bridgeConfig.getProperty("aws.secret.key"));
     }
@@ -150,9 +152,11 @@ public class BridgeSpringConfig {
     }
 
     @Bean(name = "dynamoDbClient")
-    @Resource(name = "awsCredentials")
-    public AmazonDynamoDBClient dynamoDbClient(BasicAWSCredentials awsCredentials) {
-        return new AmazonDynamoDBClient(awsCredentials);
+    public AmazonDynamoDBClient dynamoDbClient() {
+        int maxRetries = bridgeConfig().getPropertyAsInt("ddb.max.retries");
+        ClientConfiguration awsClientConfig = PredefinedClientConfigurations.dynamoDefault()
+                .withMaxErrorRetry(maxRetries);
+        return new AmazonDynamoDBClient(awsCredentials(), awsClientConfig);
     }
 
     @Bean(name = "s3Client")

--- a/conf/bridge-server.conf
+++ b/conf/bridge-server.conf
@@ -1,6 +1,9 @@
 aws.key = dummy-value
 aws.secret.key = dummy-value
 
+# Excludes the original try. For example, if this is set to 1, DDB will try a total of twice (one try, one retry)
+ddb.max.retries = 1
+
 # 10 is max number of connections allowed on the free-tier RedisCloud
 # so this default value 10 supports one host using the free-tier Redis
 redis.max.total = 10


### PR DESCRIPTION
By default, DDB retries 10 times. This seems a little excessive, and it causes throttling to spiral very quickly out of control. This change sets the max retries to 1 (2 tries: 1 initial try, 1 retry), and makes it configurable with bridge-server.conf.

This also updates relevant BridgeSpringConfig entries to a new style that's less cumbersome to update.

Testing done: Started up local server. Ran a subset of the integration tests just to verify major scenarios still work.
