### PR TITLE
ClientInfo object added

### DIFF
--- a/app/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/app/org/sagebionetworks/bridge/BridgeConstants.java
@@ -13,6 +13,8 @@ public class BridgeConstants {
     public static final String BRIDGE_STUDY_HEADER = "Bridge-Study";
 
     public static final String BRIDGE_HOST_HEADER = "Bridge-Host";
+    
+    public static final String USER_AGENT_HEADER = "User-Agent";
 
     /** Used by Heroku to pass in the request ID */
     public static final String X_REQUEST_ID_HEADER = "X-Request-Id";

--- a/app/org/sagebionetworks/bridge/models/ClientInfo.java
+++ b/app/org/sagebionetworks/bridge/models/ClientInfo.java
@@ -6,6 +6,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
+import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -223,7 +224,7 @@ public final class ClientInfo {
                 return userAgents.get(userAgent);    
             } catch(ExecutionException e) {
                 // This should not happen, the CacheLoader doesn't throw exceptions
-                throw new RuntimeException(e);
+                throw new BridgeServiceException(e);
             }
         }
         return UNKNOWN_CLIENT;

--- a/app/org/sagebionetworks/bridge/models/ClientInfo.java
+++ b/app/org/sagebionetworks/bridge/models/ClientInfo.java
@@ -6,7 +6,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
+import org.sagebionetworks.bridge.dynamodb.DynamoInitializer;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -51,6 +54,8 @@ import com.google.common.cache.LoadingCache;
  *
  */
 public final class ClientInfo {
+
+    private static Logger logger = LoggerFactory.getLogger(ClientInfo.class);
 
     /**
      * A cache of ClientInfo objects that have already been parsed from user agent strings. 
@@ -224,7 +229,8 @@ public final class ClientInfo {
                 return userAgents.get(userAgent);    
             } catch(ExecutionException e) {
                 // This should not happen, the CacheLoader doesn't throw exceptions
-                throw new BridgeServiceException(e);
+                // Log it and return UNKNOWN_CLIENT
+                logger.error(e.getMessage(), e);
             }
         }
         return UNKNOWN_CLIENT;

--- a/app/org/sagebionetworks/bridge/models/ClientInfo.java
+++ b/app/org/sagebionetworks/bridge/models/ClientInfo.java
@@ -29,9 +29,9 @@ import com.google.common.cache.LoadingCache;
  * </p>
  * 
  * <ul>
- * 	<li>Asthma/26 (Unknown iPhone; iPhone OS 9.1) BridgeSDK/4</li>
- * 	<li>CardioHealth/1 (Unknown iPhone; iPhone OS 9.0.2) BridgeSDK/4</li>
- * 	<li>Unknown Client/14 BridgeJavaSDK/10</li>
+ *     <li>Asthma/26 (Unknown iPhone; iPhone OS 9.1) BridgeSDK/4</li>
+ *     <li>CardioHealth/1 (Unknown iPhone; iPhone OS 9.0.2) BridgeSDK/4</li>
+ *     <li>Unknown Client/14 BridgeJavaSDK/10</li>
  * </ul>
  * 
  * <p>
@@ -40,8 +40,8 @@ import com.google.common.cache.LoadingCache;
  * </p>
  * 
  * <ul>
- * 	<li>Amazon Route 53 Health Check Service; ref:c97cd53f-2272-49d6-a8cd-3cd658d9d020; report http://amzn.to/1vsZADi</li>
- * 	<li>Integration Tests (Linux/3.13.0-36-generic) BridgeJavaSDK/3</li>
+ *     <li>Amazon Route 53 Health Check Service; ref:c97cd53f-2272-49d6-a8cd-3cd658d9d020; report http://amzn.to/1vsZADi</li>
+ *     <li>Integration Tests (Linux/3.13.0-36-generic) BridgeJavaSDK/3</li>
  * </ul>
  * 
  * <p>
@@ -64,209 +64,209 @@ public final class ClientInfo {
     private static LoadingCache<String, ClientInfo> userAgents = CacheBuilder.newBuilder()
        .maximumSize(500)
        .build(new CacheLoader<String,ClientInfo>() {
-			@Override
-			public ClientInfo load(String userAgent) throws Exception {
-				return ClientInfo.parseUserAgentString(userAgent);
-			}
+            @Override
+            public ClientInfo load(String userAgent) throws Exception {
+                return ClientInfo.parseUserAgentString(userAgent);
+            }
        });
 
-	/**
-	 * A User-Agent string that does not follow our format is simply an unknown
-	 * client, and no filtering will be done for such a client. It is represented with 
-	 * a null object that is the ClientInfo object with all null fields. It is still
-	 * logged as we find it in the request.
-	 */
-	public static final ClientInfo UNKNOWN_CLIENT = new ClientInfo.Builder().build();
+    /**
+     * A User-Agent string that does not follow our format is simply an unknown
+     * client, and no filtering will be done for such a client. It is represented with 
+     * a null object that is the ClientInfo object with all null fields. It is still
+     * logged as we find it in the request.
+     */
+    public static final ClientInfo UNKNOWN_CLIENT = new ClientInfo.Builder().build();
 
-	/**
-	 * For example, "Unknown Client/14 BridgeJavaSDK/10".
-	 */
-	private static final Pattern SHORT_STRING = Pattern.compile("^([^/]+)\\/(\\d+)\\s([^/\\(]*)\\/(\\d+)($)");
-	/**
-	 * For example, "Asthma/26 (Unknown iPhone; iPhone OS 9.1) BridgeSDK/4".
-	 */
-	private static final Pattern LONG_STRING = Pattern
-			.compile("^([^/]+)\\/(\\d+)\\s\\(([^;]+);([^\\)]*)\\)\\s([^/]*)\\/(\\d+)($)");
+    /**
+     * For example, "Unknown Client/14 BridgeJavaSDK/10".
+     */
+    private static final Pattern SHORT_STRING = Pattern.compile("^([^/]+)\\/(\\d+)\\s([^/\\(]*)\\/(\\d+)($)");
+    /**
+     * For example, "Asthma/26 (Unknown iPhone; iPhone OS 9.1) BridgeSDK/4".
+     */
+    private static final Pattern LONG_STRING = Pattern
+            .compile("^([^/]+)\\/(\\d+)\\s\\(([^;]+);([^\\)]*)\\)\\s([^/]*)\\/(\\d+)($)");
 
-	private final String appName;
-	private final Integer appVersion;
-	private final String osName;
-	private final String osVersion;
-	private final String sdkName;
-	private final Integer sdkVersion;
+    private final String appName;
+    private final Integer appVersion;
+    private final String osName;
+    private final String osVersion;
+    private final String sdkName;
+    private final Integer sdkVersion;
 
-	private ClientInfo(String appName, Integer appVersion, String osName, String osVersion, String sdkName,
-			Integer sdkVersion) {
-		this.appName = appName;
-		this.appVersion = appVersion;
-		this.osName = osName;
-		this.osVersion = osVersion;
-		this.sdkName = sdkName;
-		this.sdkVersion = sdkVersion;
-	}
+    private ClientInfo(String appName, Integer appVersion, String osName, String osVersion, String sdkName,
+            Integer sdkVersion) {
+        this.appName = appName;
+        this.appVersion = appVersion;
+        this.osName = osName;
+        this.osVersion = osVersion;
+        this.sdkName = sdkName;
+        this.sdkVersion = sdkVersion;
+    }
 
-	public String getAppName() {
-		return appName;
-	}
+    public String getAppName() {
+        return appName;
+    }
 
-	public Integer getAppVersion() {
-		return appVersion;
-	}
+    public Integer getAppVersion() {
+        return appVersion;
+    }
 
-	public String getOsName() {
-		return osName;
-	}
+    public String getOsName() {
+        return osName;
+    }
 
-	public String getOsVersion() {
-		return osVersion;
-	}
+    public String getOsVersion() {
+        return osVersion;
+    }
 
-	public String getSdkName() {
-		return sdkName;
-	}
+    public String getSdkName() {
+        return sdkName;
+    }
 
-	public Integer getSdkVersion() {
-		return sdkVersion;
-	}
-	
-	public boolean isTargetedAppVersion(Integer minValue, Integer maxValue) {
-		// If there's no declared client version, it matches anything.
-		if (appVersion != null) {
-			// Otherwise we can't be outside of either range boundary if the boundary
-			// is declared.
-			if ((minValue != null && appVersion.intValue() < minValue.intValue()) || 
-		        (maxValue != null && appVersion.intValue() > maxValue.intValue())) {
-				return false;
-			}
-		}
-		return true;
-	}
+    public Integer getSdkVersion() {
+        return sdkVersion;
+    }
+    
+    public boolean isTargetedAppVersion(Integer minValue, Integer maxValue) {
+        // If there's no declared client version, it matches anything.
+        if (appVersion != null) {
+            // Otherwise we can't be outside of either range boundary if the boundary
+            // is declared.
+            if ((minValue != null && appVersion.intValue() < minValue.intValue()) || 
+                (maxValue != null && appVersion.intValue() > maxValue.intValue())) {
+                return false;
+            }
+        }
+        return true;
+    }
 
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + Objects.hashCode(appName);
-		result = prime * result + Objects.hashCode(appVersion);
-		result = prime * result + Objects.hashCode(osName);
-		result = prime * result + Objects.hashCode(osVersion);
-		result = prime * result + Objects.hashCode(sdkName);
-		result = prime * result + Objects.hashCode(sdkVersion);
-		return result;
-	}
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Objects.hashCode(appName);
+        result = prime * result + Objects.hashCode(appVersion);
+        result = prime * result + Objects.hashCode(osName);
+        result = prime * result + Objects.hashCode(osVersion);
+        result = prime * result + Objects.hashCode(sdkName);
+        result = prime * result + Objects.hashCode(sdkVersion);
+        return result;
+    }
 
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null || getClass() != obj.getClass())
-			return false;
-		ClientInfo other = (ClientInfo) obj;
-		return Objects.equals(appName, other.appName) && Objects.equals(appVersion, other.appVersion)
-				&& Objects.equals(osName, other.osName) && Objects.equals(osVersion, other.osVersion)
-				&& Objects.equals(sdkName, other.sdkName) && Objects.equals(sdkVersion, other.sdkVersion);
-	}
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null || getClass() != obj.getClass())
+            return false;
+        ClientInfo other = (ClientInfo) obj;
+        return Objects.equals(appName, other.appName) && Objects.equals(appVersion, other.appVersion)
+                && Objects.equals(osName, other.osName) && Objects.equals(osVersion, other.osVersion)
+                && Objects.equals(sdkName, other.sdkName) && Objects.equals(sdkVersion, other.sdkVersion);
+    }
 
-	@Override
-	public String toString() {
-		return "ClientInfo [appName=" + appName + ", appVersion=" + appVersion + ", osName=" + osName + ", osVersion="
-				+ osVersion + ", sdkName=" + sdkName + ", sdkVersion=" + sdkVersion + "]";
-	}
+    @Override
+    public String toString() {
+        return "ClientInfo [appName=" + appName + ", appVersion=" + appVersion + ", osName=" + osName + ", osVersion="
+                + osVersion + ", sdkName=" + sdkName + ", sdkVersion=" + sdkVersion + "]";
+    }
 
-	public static class Builder {
-		private String appName;
-		private Integer appVersion;
-		private String osName;
-		private String osVersion;
-		private String sdkName;
-		private Integer sdkVersion;
+    public static class Builder {
+        private String appName;
+        private Integer appVersion;
+        private String osName;
+        private String osVersion;
+        private String sdkName;
+        private Integer sdkVersion;
 
-		public Builder withAppName(String appName) {
-			this.appName = appName;
-			return this;
-		}
-		public Builder withAppVersion(Integer appVersion) {
-			this.appVersion = appVersion;
-			return this;
-		}
-		public Builder withOsName(String osName) {
-			this.osName = osName;
-			return this;
-		}
-		public Builder withOsVersion(String osVersion) {
-			this.osVersion = osVersion;
-			return this;
-		}
-		public Builder withSdkName(String sdkName) {
-			this.sdkName = sdkName;
-			return this;
-		}
-		public Builder withSdkVersion(Integer sdkVersion) {
-			this.sdkVersion = sdkVersion;
-			return this;
-		}
-		/**
-		 * It's valid to have a client info object with no fields, if the
-		 * User-Agent header is not in our prescribed format.
-		 */
-		public ClientInfo build() {
-			return new ClientInfo(appName, appVersion, osName, osVersion, sdkName, sdkVersion);
-		}
+        public Builder withAppName(String appName) {
+            this.appName = appName;
+            return this;
+        }
+        public Builder withAppVersion(Integer appVersion) {
+            this.appVersion = appVersion;
+            return this;
+        }
+        public Builder withOsName(String osName) {
+            this.osName = osName;
+            return this;
+        }
+        public Builder withOsVersion(String osVersion) {
+            this.osVersion = osVersion;
+            return this;
+        }
+        public Builder withSdkName(String sdkName) {
+            this.sdkName = sdkName;
+            return this;
+        }
+        public Builder withSdkVersion(Integer sdkVersion) {
+            this.sdkVersion = sdkVersion;
+            return this;
+        }
+        /**
+         * It's valid to have a client info object with no fields, if the
+         * User-Agent header is not in our prescribed format.
+         */
+        public ClientInfo build() {
+            return new ClientInfo(appName, appVersion, osName, osVersion, sdkName, sdkVersion);
+        }
 
-	}
-	
-	/**
-	 * Get a ClientInfo object given a User-Agent header string. These values are cached and 
-	 * headers that are not in the prescribed format return an empty client info object.
-	 * @param userAgent
-	 * @return
-	 */
-	public static ClientInfo fromUserAgentCache(String userAgent) {
-		if (!StringUtils.isBlank(userAgent)) {
-			try {
-				return userAgents.get(userAgent);	
-			} catch(ExecutionException e) {
-				logger.debug(e.getMessage(), e);
-			}
-		}
-		return UNKNOWN_CLIENT;
-	}
-	
-	static ClientInfo parseUserAgentString(String ua) {
-		ClientInfo info = UNKNOWN_CLIENT;
-		if (!StringUtils.isBlank(ua)) {
-			info = parseLongUserAgent(ua);
-			if (info == UNKNOWN_CLIENT) {
-				info = parseShortUserAgent(ua);
-			}
-		}
-		return info;
-	}
+    }
+    
+    /**
+     * Get a ClientInfo object given a User-Agent header string. These values are cached and 
+     * headers that are not in the prescribed format return an empty client info object.
+     * @param userAgent
+     * @return
+     */
+    public static ClientInfo fromUserAgentCache(String userAgent) {
+        if (!StringUtils.isBlank(userAgent)) {
+            try {
+                return userAgents.get(userAgent);    
+            } catch(ExecutionException e) {
+                logger.debug(e.getMessage(), e);
+            }
+        }
+        return UNKNOWN_CLIENT;
+    }
+    
+    static ClientInfo parseUserAgentString(String ua) {
+        ClientInfo info = UNKNOWN_CLIENT;
+        if (!StringUtils.isBlank(ua)) {
+            info = parseLongUserAgent(ua);
+            if (info == UNKNOWN_CLIENT) {
+                info = parseShortUserAgent(ua);
+            }
+        }
+        return info;
+    }
 
-	private static ClientInfo parseLongUserAgent(String ua) {
-		Matcher matcher = LONG_STRING.matcher(ua);
-		if (matcher.matches()) {
-			return new ClientInfo.Builder()
-					.withAppName(matcher.group(1).trim())
-					.withAppVersion(Integer.parseInt(matcher.group(2).trim()))
-					.withOsName(matcher.group(3).trim())
-					.withOsVersion(matcher.group(4).trim())
-					.withSdkName(matcher.group(5).trim())
-					.withSdkVersion(Integer.parseInt(matcher.group(6).trim())).build();
-		}
-		return UNKNOWN_CLIENT;
-	}
+    private static ClientInfo parseLongUserAgent(String ua) {
+        Matcher matcher = LONG_STRING.matcher(ua);
+        if (matcher.matches()) {
+            return new ClientInfo.Builder()
+                .withAppName(matcher.group(1).trim())
+                .withAppVersion(Integer.parseInt(matcher.group(2).trim()))
+                .withOsName(matcher.group(3).trim())
+                .withOsVersion(matcher.group(4).trim())
+                .withSdkName(matcher.group(5).trim())
+                .withSdkVersion(Integer.parseInt(matcher.group(6).trim())).build();
+        }
+        return UNKNOWN_CLIENT;
+    }
 
-	private static ClientInfo parseShortUserAgent(String ua) {
-		Matcher matcher = SHORT_STRING.matcher(ua);
-		if (matcher.matches()) {
-			return new ClientInfo.Builder()
-					.withAppName(matcher.group(1).trim())
-					.withAppVersion(Integer.parseInt(matcher.group(2).trim()))
-					.withSdkName(matcher.group(3).trim())
-					.withSdkVersion(Integer.parseInt(matcher.group(4).trim())).build();
-		}
-		return UNKNOWN_CLIENT;
-	}
+    private static ClientInfo parseShortUserAgent(String ua) {
+        Matcher matcher = SHORT_STRING.matcher(ua);
+        if (matcher.matches()) {
+            return new ClientInfo.Builder()
+                .withAppName(matcher.group(1).trim())
+                .withAppVersion(Integer.parseInt(matcher.group(2).trim()))
+                .withSdkName(matcher.group(3).trim())
+                .withSdkVersion(Integer.parseInt(matcher.group(4).trim())).build();
+        }
+        return UNKNOWN_CLIENT;
+    }
 
 }

--- a/app/org/sagebionetworks/bridge/models/ClientInfo.java
+++ b/app/org/sagebionetworks/bridge/models/ClientInfo.java
@@ -6,8 +6,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -52,8 +50,6 @@ import com.google.common.cache.LoadingCache;
  *
  */
 public final class ClientInfo {
-
-    private static Logger logger = LoggerFactory.getLogger(ClientInfo.class);
 
     /**
      * A cache of ClientInfo objects that have already been parsed from user agent strings. 
@@ -173,7 +169,7 @@ public final class ClientInfo {
                 + osVersion + ", sdkName=" + sdkName + ", sdkVersion=" + sdkVersion + "]";
     }
 
-    public static class Builder {
+    static class Builder {
         private String appName;
         private Integer appVersion;
         private String osName;
@@ -226,7 +222,8 @@ public final class ClientInfo {
             try {
                 return userAgents.get(userAgent);    
             } catch(ExecutionException e) {
-                logger.debug(e.getMessage(), e);
+                // This should not happen, the CacheLoader doesn't throw exceptions
+                throw new RuntimeException(e);
             }
         }
         return UNKNOWN_CLIENT;

--- a/app/org/sagebionetworks/bridge/models/ClientInfo.java
+++ b/app/org/sagebionetworks/bridge/models/ClientInfo.java
@@ -1,0 +1,272 @@
+package org.sagebionetworks.bridge.models;
+
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+
+/**
+ * <p>
+ * Parsed representation of the User-Agent header provided by the client, when
+ * it is in our prescribed format:
+ * </p>
+ * 
+ * <p>
+ * appName/appVersion (osName; osVersion) sdkName/sdkVersion
+ * </p>
+ * 
+ * <p>
+ * osName and osVersion are optional, and punctuation is removed when they are
+ * not present. Some examples:
+ * </p>
+ * 
+ * <ul>
+ * 	<li>Asthma/26 (Unknown iPhone; iPhone OS 9.1) BridgeSDK/4</li>
+ * 	<li>CardioHealth/1 (Unknown iPhone; iPhone OS 9.0.2) BridgeSDK/4</li>
+ * 	<li>Unknown Client/14 BridgeJavaSDK/10</li>
+ * </ul>
+ * 
+ * <p>
+ * Other clients with more typical browser user agent strings will be represented by ClientInfo that 
+ * have all empty fields. Some examples of these headers, from our logs:
+ * </p>
+ * 
+ * <ul>
+ * 	<li>Amazon Route 53 Health Check Service; ref:c97cd53f-2272-49d6-a8cd-3cd658d9d020; report http://amzn.to/1vsZADi</li>
+ * 	<li>Integration Tests (Linux/3.13.0-36-generic) BridgeJavaSDK/3</li>
+ * </ul>
+ * 
+ * <p>
+ * ClientInfo is not the end result of a generic user agent string parser. Those are very complicated and we 
+ * do not need all this information (we log the user agent string from the client but only use these strings from 
+ * when they are in a given format in order to filter some API responses).
+ * </p>
+ *
+ */
+public final class ClientInfo {
+
+    private static Logger logger = LoggerFactory.getLogger(ClientInfo.class);
+
+    /**
+     * A cache of ClientInfo objects that have already been parsed from user agent strings. 
+     * We're using this, rather than ConcurrentHashMap, because external clients submit this string, 
+     * and thus could create an infinite number of them, starving the server. The cache will protect 
+     * against this with its size limit.
+     */
+    private static LoadingCache<String, ClientInfo> userAgents = CacheBuilder.newBuilder()
+       .maximumSize(500)
+       .build(new CacheLoader<String,ClientInfo>() {
+			@Override
+			public ClientInfo load(String userAgent) throws Exception {
+				return ClientInfo.parseUserAgentString(userAgent);
+			}
+       });
+
+	/**
+	 * A User-Agent string that does not follow our format is simply an unknown
+	 * client, and no filtering will be done for such a client. It is represented with 
+	 * a null object that is the ClientInfo object with all null fields. It is still
+	 * logged as we find it in the request.
+	 */
+	public static final ClientInfo UNKNOWN_CLIENT = new ClientInfo.Builder().build();
+
+	/**
+	 * For example, "Unknown Client/14 BridgeJavaSDK/10".
+	 */
+	private static final Pattern SHORT_STRING = Pattern.compile("^([^/]+)\\/(\\d+)\\s([^/\\(]*)\\/(\\d+)($)");
+	/**
+	 * For example, "Asthma/26 (Unknown iPhone; iPhone OS 9.1) BridgeSDK/4".
+	 */
+	private static final Pattern LONG_STRING = Pattern
+			.compile("^([^/]+)\\/(\\d+)\\s\\(([^;]+);([^\\)]*)\\)\\s([^/]*)\\/(\\d+)($)");
+
+	private final String appName;
+	private final Integer appVersion;
+	private final String osName;
+	private final String osVersion;
+	private final String sdkName;
+	private final Integer sdkVersion;
+
+	private ClientInfo(String appName, Integer appVersion, String osName, String osVersion, String sdkName,
+			Integer sdkVersion) {
+		this.appName = appName;
+		this.appVersion = appVersion;
+		this.osName = osName;
+		this.osVersion = osVersion;
+		this.sdkName = sdkName;
+		this.sdkVersion = sdkVersion;
+	}
+
+	public String getAppName() {
+		return appName;
+	}
+
+	public Integer getAppVersion() {
+		return appVersion;
+	}
+
+	public String getOsName() {
+		return osName;
+	}
+
+	public String getOsVersion() {
+		return osVersion;
+	}
+
+	public String getSdkName() {
+		return sdkName;
+	}
+
+	public Integer getSdkVersion() {
+		return sdkVersion;
+	}
+	
+	public boolean isTargetedAppVersion(Integer minValue, Integer maxValue) {
+		// If there's no declared client version, it matches anything.
+		if (appVersion != null) {
+			// Otherwise we can't be outside of either range boundary if the boundary
+			// is declared.
+			if ((minValue != null && appVersion.intValue() < minValue.intValue()) || 
+		        (maxValue != null && appVersion.intValue() > maxValue.intValue())) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + Objects.hashCode(appName);
+		result = prime * result + Objects.hashCode(appVersion);
+		result = prime * result + Objects.hashCode(osName);
+		result = prime * result + Objects.hashCode(osVersion);
+		result = prime * result + Objects.hashCode(sdkName);
+		result = prime * result + Objects.hashCode(sdkVersion);
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null || getClass() != obj.getClass())
+			return false;
+		ClientInfo other = (ClientInfo) obj;
+		return Objects.equals(appName, other.appName) && Objects.equals(appVersion, other.appVersion)
+				&& Objects.equals(osName, other.osName) && Objects.equals(osVersion, other.osVersion)
+				&& Objects.equals(sdkName, other.sdkName) && Objects.equals(sdkVersion, other.sdkVersion);
+	}
+
+	@Override
+	public String toString() {
+		return "ClientInfo [appName=" + appName + ", appVersion=" + appVersion + ", osName=" + osName + ", osVersion="
+				+ osVersion + ", sdkName=" + sdkName + ", sdkVersion=" + sdkVersion + "]";
+	}
+
+	public static class Builder {
+		private String appName;
+		private Integer appVersion;
+		private String osName;
+		private String osVersion;
+		private String sdkName;
+		private Integer sdkVersion;
+
+		public Builder withAppName(String appName) {
+			this.appName = appName;
+			return this;
+		}
+		public Builder withAppVersion(Integer appVersion) {
+			this.appVersion = appVersion;
+			return this;
+		}
+		public Builder withOsName(String osName) {
+			this.osName = osName;
+			return this;
+		}
+		public Builder withOsVersion(String osVersion) {
+			this.osVersion = osVersion;
+			return this;
+		}
+		public Builder withSdkName(String sdkName) {
+			this.sdkName = sdkName;
+			return this;
+		}
+		public Builder withSdkVersion(Integer sdkVersion) {
+			this.sdkVersion = sdkVersion;
+			return this;
+		}
+		/**
+		 * It's valid to have a client info object with no fields, if the
+		 * User-Agent header is not in our prescribed format.
+		 */
+		public ClientInfo build() {
+			return new ClientInfo(appName, appVersion, osName, osVersion, sdkName, sdkVersion);
+		}
+
+	}
+	
+	/**
+	 * Get a ClientInfo object given a User-Agent header string. These values are cached and 
+	 * headers that are not in the prescribed format return an empty client info object.
+	 * @param userAgent
+	 * @return
+	 */
+	public static ClientInfo fromUserAgentCache(String userAgent) {
+		if (!StringUtils.isBlank(userAgent)) {
+			try {
+				return userAgents.get(userAgent);	
+			} catch(ExecutionException e) {
+				logger.debug(e.getMessage(), e);
+			}
+		}
+		return UNKNOWN_CLIENT;
+	}
+	
+	static ClientInfo parseUserAgentString(String ua) {
+		ClientInfo info = UNKNOWN_CLIENT;
+		if (!StringUtils.isBlank(ua)) {
+			info = parseLongUserAgent(ua);
+			if (info == UNKNOWN_CLIENT) {
+				info = parseShortUserAgent(ua);
+			}
+		}
+		return info;
+	}
+
+	private static ClientInfo parseLongUserAgent(String ua) {
+		Matcher matcher = LONG_STRING.matcher(ua);
+		if (matcher.matches()) {
+			return new ClientInfo.Builder()
+					.withAppName(matcher.group(1).trim())
+					.withAppVersion(Integer.parseInt(matcher.group(2).trim()))
+					.withOsName(matcher.group(3).trim())
+					.withOsVersion(matcher.group(4).trim())
+					.withSdkName(matcher.group(5).trim())
+					.withSdkVersion(Integer.parseInt(matcher.group(6).trim())).build();
+		}
+		return UNKNOWN_CLIENT;
+	}
+
+	private static ClientInfo parseShortUserAgent(String ua) {
+		Matcher matcher = SHORT_STRING.matcher(ua);
+		if (matcher.matches()) {
+			return new ClientInfo.Builder()
+					.withAppName(matcher.group(1).trim())
+					.withAppVersion(Integer.parseInt(matcher.group(2).trim()))
+					.withSdkName(matcher.group(3).trim())
+					.withSdkVersion(Integer.parseInt(matcher.group(4).trim())).build();
+		}
+		return UNKNOWN_CLIENT;
+	}
+
+}

--- a/app/org/sagebionetworks/bridge/models/schedules/TaskScheduler.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/TaskScheduler.java
@@ -8,7 +8,6 @@ import java.util.List;
 import org.joda.time.DateTime;
 import org.joda.time.LocalTime;
 import org.sagebionetworks.bridge.BridgeUtils;
-import org.sagebionetworks.bridge.dynamodb.DynamoTask;
 
 public abstract class TaskScheduler {
 

--- a/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
@@ -28,6 +28,7 @@ import org.sagebionetworks.bridge.services.AuthenticationService;
 import org.sagebionetworks.bridge.services.StudyService;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import play.Logger;
 import play.cache.Cache;
 import play.libs.Json;
 import play.mvc.Controller;
@@ -160,8 +161,11 @@ public abstract class BaseController extends Controller {
     }
 
     ClientInfo getClientInfoFromUserAgentHeader() {
-    	return ClientInfo.fromUserAgentCache(
-			request().getHeader(BridgeConstants.USER_AGENT_HEADER));
+        String userAgentHeader = request().getHeader(BridgeConstants.USER_AGENT_HEADER);
+        ClientInfo info = ClientInfo.fromUserAgentCache(userAgentHeader);
+        
+        Logger.debug("User agent: '"+userAgentHeader+"' converted to " + info);
+    	return info;
     }
     
     Result okResult(String message) {

--- a/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
@@ -7,6 +7,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.List;
 
 import javax.annotation.Nonnull;
+
+import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.config.BridgeConfig;
@@ -15,6 +17,7 @@ import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.exceptions.NotAuthenticatedException;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.Metrics;
 import org.sagebionetworks.bridge.models.ResourceList;
 import org.sagebionetworks.bridge.models.StatusMessage;
@@ -156,6 +159,12 @@ public abstract class BaseController extends Controller {
         return session[0];
     }
 
+    ClientInfo getUserAgent() {
+    	System.out.println(request().getHeader(BridgeConstants.USER_AGENT_HEADER));
+    	return ClientInfo.fromUserAgentCache(
+			request().getHeader(BridgeConstants.USER_AGENT_HEADER));
+    }
+    
     Result okResult(String message) {
         return ok(Json.toJson(new StatusMessage(message)));
     }

--- a/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
@@ -159,8 +159,7 @@ public abstract class BaseController extends Controller {
         return session[0];
     }
 
-    ClientInfo getUserAgent() {
-    	System.out.println(request().getHeader(BridgeConstants.USER_AGENT_HEADER));
+    ClientInfo getClientInfoFromUserAgentHeader() {
     	return ClientInfo.fromUserAgentCache(
 			request().getHeader(BridgeConstants.USER_AGENT_HEADER));
     }

--- a/app/org/sagebionetworks/bridge/play/controllers/ScheduleController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ScheduleController.java
@@ -37,7 +37,7 @@ public class ScheduleController extends BaseController {
         UserSession session = getAuthenticatedAndConsentedSession();
         StudyIdentifier studyId = session.getStudyIdentifier();
         Study study = studyService.getStudy(studyId);
-        ClientInfo clientInfo = getUserAgent();
+        ClientInfo clientInfo = getClientInfoFromUserAgentHeader();
         
         List<SchedulePlan> plans = schedulePlanService.getSchedulePlans(studyId);
         List<Schedule> schedules = Lists.newArrayListWithCapacity(plans.size());

--- a/app/org/sagebionetworks/bridge/play/controllers/ScheduleController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ScheduleController.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge.play.controllers;
 import java.util.Collections;
 import java.util.List;
 
+import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.schedules.Schedule;
 import org.sagebionetworks.bridge.models.schedules.SchedulePlan;
@@ -36,6 +37,7 @@ public class ScheduleController extends BaseController {
         UserSession session = getAuthenticatedAndConsentedSession();
         StudyIdentifier studyId = session.getStudyIdentifier();
         Study study = studyService.getStudy(studyId);
+        ClientInfo clientInfo = getUserAgent();
         
         List<SchedulePlan> plans = schedulePlanService.getSchedulePlans(studyId);
         List<Schedule> schedules = Lists.newArrayListWithCapacity(plans.size());

--- a/app/org/sagebionetworks/bridge/play/controllers/TaskController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/TaskController.java
@@ -9,6 +9,7 @@ import org.joda.time.DateTimeZone;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.json.DateUtils;
+import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.schedules.ScheduleContext;
 import org.sagebionetworks.bridge.models.schedules.Task;
@@ -53,6 +54,8 @@ public class TaskController extends BaseController {
         } else {
             throw new BadRequestException("Supply either 'until' parameter, or 'daysAhead' and 'offset' parameters.");
         }
+        // The ClientInfo will be added to the scheduling context.
+        ClientInfo clientInfo = getUserAgent();
         ScheduleContext context = new ScheduleContext.Builder()
             .withStudyIdentifier(session.getStudyIdentifier())
             .withTimeZone(zone)

--- a/app/org/sagebionetworks/bridge/play/controllers/TaskController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/TaskController.java
@@ -55,7 +55,7 @@ public class TaskController extends BaseController {
             throw new BadRequestException("Supply either 'until' parameter, or 'daysAhead' and 'offset' parameters.");
         }
         // The ClientInfo will be added to the scheduling context.
-        ClientInfo clientInfo = getUserAgent();
+        ClientInfo clientInfo = getClientInfoFromUserAgentHeader();
         ScheduleContext context = new ScheduleContext.Builder()
             .withStudyIdentifier(session.getStudyIdentifier())
             .withTimeZone(zone)

--- a/build.sbt
+++ b/build.sbt
@@ -66,3 +66,10 @@ lazy val root = (project in file(".")).enablePlugins(PlayJava)
 routesGenerator := InjectedRoutesGenerator
 
 testOptions += Tests.Argument(TestFrameworks.JUnit, "-a")
+
+// Compile before generating eclipse files
+EclipseKeys.preTasks := Seq(compile in Compile)
+// Java project files only
+EclipseKeys.projectFlavor := EclipseProjectFlavor.Java
+EclipseKeys.createSrc := EclipseCreateSrc.ValueSet(EclipseCreateSrc.ManagedClasses, EclipseCreateSrc.ManagedResources)  // Use .class files instead 
+

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoTaskDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoTaskDaoMockTest.java
@@ -20,7 +20,6 @@ import org.joda.time.DateTimeUtils;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDateTime;
 import org.joda.time.Period;
-import org.joda.time.format.ISODateTimeFormat;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/test/org/sagebionetworks/bridge/models/ClientInfoTest.java
+++ b/test/org/sagebionetworks/bridge/models/ClientInfoTest.java
@@ -16,6 +16,7 @@ public class ClientInfoTest {
     private static final String INVALID_UA_1 = "Amazon Route 53 Health Check Service; ref:c97cd53f-2272-49d6-a8cd-3cd658d9d020; report http://amzn.to/1vsZADi";
     private static final String INVALID_UA_2 = "Integration Tests (Linux/3.13.0-36-generic) BridgeJavaSDK/3";
     private static final String INVALID_UA_3 = "Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2224.3 Safari/537.36";
+    private static final String INVALID_UA_4 = "Mozilla/5 (Windows NT 5.1) Safari/537"; // Purposefully very ambiguous; still fails.
     
     @Test
     public void hashEquals() {
@@ -48,6 +49,7 @@ public class ClientInfoTest {
         assertSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.parseUserAgentString(INVALID_UA_1));
         assertSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.parseUserAgentString(INVALID_UA_2));
         assertSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.parseUserAgentString(INVALID_UA_3));
+        assertSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.parseUserAgentString(INVALID_UA_4));
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/models/ClientInfoTest.java
+++ b/test/org/sagebionetworks/bridge/models/ClientInfoTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.*;
 import org.junit.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
-import nl.jqno.equalsverifier.Warning;
 
 public class ClientInfoTest {
 
@@ -20,7 +19,7 @@ public class ClientInfoTest {
     
     @Test
     public void hashEquals() {
-        EqualsVerifier.forClass(ClientInfo.class).suppress(Warning.NONFINAL_FIELDS).allFieldsShouldBeUsed().verify();
+        EqualsVerifier.forClass(ClientInfo.class).allFieldsShouldBeUsed().verify();
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/models/ClientInfoTest.java
+++ b/test/org/sagebionetworks/bridge/models/ClientInfoTest.java
@@ -1,0 +1,139 @@
+package org.sagebionetworks.bridge.models;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+
+public class ClientInfoTest {
+
+	private static final String VALID_UA_1 = "Asthma/26 (Unknown iPhone; iPhone OS 9.1) BridgeSDK/4";
+	private static final String VALID_UA_2 = "Cardio Health/1 (Unknown iPhone; iPhone OS 9.0.2) BridgeSDK/4";
+	private static final String VALID_UA_3 = "Unknown Client/14 BridgeJavaSDK/10";
+	
+	private static final String INVALID_UA_1 = "Amazon Route 53 Health Check Service; ref:c97cd53f-2272-49d6-a8cd-3cd658d9d020; report http://amzn.to/1vsZADi";
+	private static final String INVALID_UA_2 = "Integration Tests (Linux/3.13.0-36-generic) BridgeJavaSDK/3";
+	private static final String INVALID_UA_3 = "Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2224.3 Safari/537.36";
+	
+	@Test
+	public void hashEquals() {
+        EqualsVerifier.forClass(ClientInfo.class).suppress(Warning.NONFINAL_FIELDS).allFieldsShouldBeUsed().verify();
+	}
+	
+	@Test
+	public void allFieldsCorrect() {
+		ClientInfo info = new ClientInfo.Builder()
+				.withAppName("AppName")
+				.withAppVersion(1)
+				.withOsName("OsName")
+				.withOsVersion("Version1")
+				.withSdkVersion(4).build();
+		assertEquals("AppName", info.getAppName());
+		assertEquals(1, info.getAppVersion().intValue());
+		assertEquals("OsName", info.getOsName());
+		assertEquals("Version1", info.getOsVersion());
+		assertEquals(4, info.getSdkVersion().intValue());
+	}
+	
+	@Test
+	public void missingUserAgentReturnsEmptyClientInf() {
+		assertSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.parseUserAgentString(null));
+		assertSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.parseUserAgentString("   \t"));
+	}
+	
+	@Test
+	public void incorrectFormatsReturnEmptyClientInfo() {
+		assertSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.parseUserAgentString(INVALID_UA_1));
+		assertSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.parseUserAgentString(INVALID_UA_2));
+		assertSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.parseUserAgentString(INVALID_UA_3));
+	}
+	
+	@Test
+	public void correctFormatReturnsClientInfo() {
+		assertNotSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.parseUserAgentString(VALID_UA_1));
+		assertNotSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.parseUserAgentString(VALID_UA_2));
+	}
+	
+	@Test
+	public void correctFormatWithoutOsReturnsClientInfo() {
+		assertNotSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.parseUserAgentString(VALID_UA_3));
+	}
+	
+	@Test
+	public void shortFormCorrectlyParsed() {
+		ClientInfo info = ClientInfo.parseUserAgentString(VALID_UA_3);
+		assertEquals("Unknown Client", info.getAppName());
+		assertEquals(14, info.getAppVersion().intValue());
+		assertNull(info.getOsName());
+		assertNull(info.getOsVersion());
+		assertEquals("BridgeJavaSDK", info.getSdkName());
+		assertEquals(10, info.getSdkVersion().intValue());
+	}
+	
+	@Test
+	public void longFormCorrectlyParsed() {
+		ClientInfo info = ClientInfo.parseUserAgentString(VALID_UA_1);
+		assertEquals("Asthma", info.getAppName());
+		assertEquals(26, info.getAppVersion().intValue());
+		assertEquals("Unknown iPhone", info.getOsName());
+		assertEquals("iPhone OS 9.1", info.getOsVersion());
+		assertEquals("BridgeSDK", info.getSdkName());
+		assertEquals(4, info.getSdkVersion().intValue());
+		
+		info = ClientInfo.parseUserAgentString(VALID_UA_2);
+		assertEquals("Cardio Health", info.getAppName());
+		assertEquals(1, info.getAppVersion().intValue());
+		assertEquals("Unknown iPhone", info.getOsName());
+		assertEquals("iPhone OS 9.0.2", info.getOsVersion());
+		assertEquals("BridgeSDK", info.getSdkName());
+		assertEquals(4, info.getSdkVersion().intValue());
+	}
+	
+	@Test
+	public void cacheWorks() {
+		ClientInfo info1 = ClientInfo.fromUserAgentCache(VALID_UA_1);
+		ClientInfo info2 = ClientInfo.fromUserAgentCache(VALID_UA_1);
+		
+		assertSame(info1, info2);
+	}
+	
+	@Test
+	public void cacheWorksWithBadValues() {
+		assertSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.fromUserAgentCache(null));
+		assertSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.fromUserAgentCache("   \n"));
+	}
+	
+	@Test
+	public void clientWithoutVersionMatchesAnyRange() {
+		ClientInfo info = ClientInfo.parseUserAgentString(INVALID_UA_1);
+		assertTrue(info.isTargetedAppVersion(3, 3));
+	}
+	
+	@Test
+	public void clientWithVersionInRangeSucceeds() {
+		ClientInfo info = ClientInfo.parseUserAgentString(VALID_UA_1);
+		assertTrue(info.isTargetedAppVersion(24, 26));
+		assertTrue(info.isTargetedAppVersion(26, 27));
+	}
+	
+	@Test
+	public void clientWithVersionFilteredOnLowEnd() {
+		ClientInfo info = ClientInfo.parseUserAgentString(VALID_UA_1);
+		assertFalse(info.isTargetedAppVersion(27, null));
+	}
+	
+	@Test
+	public void clientWithVersionFilteredOnHighEnd() {
+		ClientInfo info = ClientInfo.parseUserAgentString(VALID_UA_1);
+		assertFalse(info.isTargetedAppVersion(null, 13));
+	}
+	
+	@Test
+	public void clientWithVersionFilteredWithZeroes() {
+		ClientInfo info = ClientInfo.parseUserAgentString(VALID_UA_1);
+		assertTrue(info.isTargetedAppVersion(0, 100));
+	}
+	
+}

--- a/test/org/sagebionetworks/bridge/models/ClientInfoTest.java
+++ b/test/org/sagebionetworks/bridge/models/ClientInfoTest.java
@@ -9,131 +9,131 @@ import nl.jqno.equalsverifier.Warning;
 
 public class ClientInfoTest {
 
-	private static final String VALID_UA_1 = "Asthma/26 (Unknown iPhone; iPhone OS 9.1) BridgeSDK/4";
-	private static final String VALID_UA_2 = "Cardio Health/1 (Unknown iPhone; iPhone OS 9.0.2) BridgeSDK/4";
-	private static final String VALID_UA_3 = "Unknown Client/14 BridgeJavaSDK/10";
-	
-	private static final String INVALID_UA_1 = "Amazon Route 53 Health Check Service; ref:c97cd53f-2272-49d6-a8cd-3cd658d9d020; report http://amzn.to/1vsZADi";
-	private static final String INVALID_UA_2 = "Integration Tests (Linux/3.13.0-36-generic) BridgeJavaSDK/3";
-	private static final String INVALID_UA_3 = "Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2224.3 Safari/537.36";
-	
-	@Test
-	public void hashEquals() {
+    private static final String VALID_UA_1 = "Asthma/26 (Unknown iPhone; iPhone OS 9.1) BridgeSDK/4";
+    private static final String VALID_UA_2 = "Cardio Health/1 (Unknown iPhone; iPhone OS 9.0.2) BridgeSDK/4";
+    private static final String VALID_UA_3 = "Unknown Client/14 BridgeJavaSDK/10";
+    
+    private static final String INVALID_UA_1 = "Amazon Route 53 Health Check Service; ref:c97cd53f-2272-49d6-a8cd-3cd658d9d020; report http://amzn.to/1vsZADi";
+    private static final String INVALID_UA_2 = "Integration Tests (Linux/3.13.0-36-generic) BridgeJavaSDK/3";
+    private static final String INVALID_UA_3 = "Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2224.3 Safari/537.36";
+    
+    @Test
+    public void hashEquals() {
         EqualsVerifier.forClass(ClientInfo.class).suppress(Warning.NONFINAL_FIELDS).allFieldsShouldBeUsed().verify();
-	}
-	
-	@Test
-	public void allFieldsCorrect() {
-		ClientInfo info = new ClientInfo.Builder()
-				.withAppName("AppName")
-				.withAppVersion(1)
-				.withOsName("OsName")
-				.withOsVersion("Version1")
-				.withSdkVersion(4).build();
-		assertEquals("AppName", info.getAppName());
-		assertEquals(1, info.getAppVersion().intValue());
-		assertEquals("OsName", info.getOsName());
-		assertEquals("Version1", info.getOsVersion());
-		assertEquals(4, info.getSdkVersion().intValue());
-	}
-	
-	@Test
-	public void missingUserAgentReturnsEmptyClientInf() {
-		assertSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.parseUserAgentString(null));
-		assertSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.parseUserAgentString("   \t"));
-	}
-	
-	@Test
-	public void incorrectFormatsReturnEmptyClientInfo() {
-		assertSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.parseUserAgentString(INVALID_UA_1));
-		assertSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.parseUserAgentString(INVALID_UA_2));
-		assertSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.parseUserAgentString(INVALID_UA_3));
-	}
-	
-	@Test
-	public void correctFormatReturnsClientInfo() {
-		assertNotSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.parseUserAgentString(VALID_UA_1));
-		assertNotSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.parseUserAgentString(VALID_UA_2));
-	}
-	
-	@Test
-	public void correctFormatWithoutOsReturnsClientInfo() {
-		assertNotSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.parseUserAgentString(VALID_UA_3));
-	}
-	
-	@Test
-	public void shortFormCorrectlyParsed() {
-		ClientInfo info = ClientInfo.parseUserAgentString(VALID_UA_3);
-		assertEquals("Unknown Client", info.getAppName());
-		assertEquals(14, info.getAppVersion().intValue());
-		assertNull(info.getOsName());
-		assertNull(info.getOsVersion());
-		assertEquals("BridgeJavaSDK", info.getSdkName());
-		assertEquals(10, info.getSdkVersion().intValue());
-	}
-	
-	@Test
-	public void longFormCorrectlyParsed() {
-		ClientInfo info = ClientInfo.parseUserAgentString(VALID_UA_1);
-		assertEquals("Asthma", info.getAppName());
-		assertEquals(26, info.getAppVersion().intValue());
-		assertEquals("Unknown iPhone", info.getOsName());
-		assertEquals("iPhone OS 9.1", info.getOsVersion());
-		assertEquals("BridgeSDK", info.getSdkName());
-		assertEquals(4, info.getSdkVersion().intValue());
-		
-		info = ClientInfo.parseUserAgentString(VALID_UA_2);
-		assertEquals("Cardio Health", info.getAppName());
-		assertEquals(1, info.getAppVersion().intValue());
-		assertEquals("Unknown iPhone", info.getOsName());
-		assertEquals("iPhone OS 9.0.2", info.getOsVersion());
-		assertEquals("BridgeSDK", info.getSdkName());
-		assertEquals(4, info.getSdkVersion().intValue());
-	}
-	
-	@Test
-	public void cacheWorks() {
-		ClientInfo info1 = ClientInfo.fromUserAgentCache(VALID_UA_1);
-		ClientInfo info2 = ClientInfo.fromUserAgentCache(VALID_UA_1);
-		
-		assertSame(info1, info2);
-	}
-	
-	@Test
-	public void cacheWorksWithBadValues() {
-		assertSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.fromUserAgentCache(null));
-		assertSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.fromUserAgentCache("   \n"));
-	}
-	
-	@Test
-	public void clientWithoutVersionMatchesAnyRange() {
-		ClientInfo info = ClientInfo.parseUserAgentString(INVALID_UA_1);
-		assertTrue(info.isTargetedAppVersion(3, 3));
-	}
-	
-	@Test
-	public void clientWithVersionInRangeSucceeds() {
-		ClientInfo info = ClientInfo.parseUserAgentString(VALID_UA_1);
-		assertTrue(info.isTargetedAppVersion(24, 26));
-		assertTrue(info.isTargetedAppVersion(26, 27));
-	}
-	
-	@Test
-	public void clientWithVersionFilteredOnLowEnd() {
-		ClientInfo info = ClientInfo.parseUserAgentString(VALID_UA_1);
-		assertFalse(info.isTargetedAppVersion(27, null));
-	}
-	
-	@Test
-	public void clientWithVersionFilteredOnHighEnd() {
-		ClientInfo info = ClientInfo.parseUserAgentString(VALID_UA_1);
-		assertFalse(info.isTargetedAppVersion(null, 13));
-	}
-	
-	@Test
-	public void clientWithVersionFilteredWithZeroes() {
-		ClientInfo info = ClientInfo.parseUserAgentString(VALID_UA_1);
-		assertTrue(info.isTargetedAppVersion(0, 100));
-	}
-	
+    }
+    
+    @Test
+    public void allFieldsCorrect() {
+        ClientInfo info = new ClientInfo.Builder()
+                .withAppName("AppName")
+                .withAppVersion(1)
+                .withOsName("OsName")
+                .withOsVersion("Version1")
+                .withSdkVersion(4).build();
+        assertEquals("AppName", info.getAppName());
+        assertEquals(1, info.getAppVersion().intValue());
+        assertEquals("OsName", info.getOsName());
+        assertEquals("Version1", info.getOsVersion());
+        assertEquals(4, info.getSdkVersion().intValue());
+    }
+    
+    @Test
+    public void missingUserAgentReturnsEmptyClientInf() {
+        assertSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.parseUserAgentString(null));
+        assertSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.parseUserAgentString("   \t"));
+    }
+    
+    @Test
+    public void incorrectFormatsReturnEmptyClientInfo() {
+        assertSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.parseUserAgentString(INVALID_UA_1));
+        assertSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.parseUserAgentString(INVALID_UA_2));
+        assertSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.parseUserAgentString(INVALID_UA_3));
+    }
+    
+    @Test
+    public void correctFormatReturnsClientInfo() {
+        assertNotSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.parseUserAgentString(VALID_UA_1));
+        assertNotSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.parseUserAgentString(VALID_UA_2));
+    }
+    
+    @Test
+    public void correctFormatWithoutOsReturnsClientInfo() {
+        assertNotSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.parseUserAgentString(VALID_UA_3));
+    }
+    
+    @Test
+    public void shortFormCorrectlyParsed() {
+        ClientInfo info = ClientInfo.parseUserAgentString(VALID_UA_3);
+        assertEquals("Unknown Client", info.getAppName());
+        assertEquals(14, info.getAppVersion().intValue());
+        assertNull(info.getOsName());
+        assertNull(info.getOsVersion());
+        assertEquals("BridgeJavaSDK", info.getSdkName());
+        assertEquals(10, info.getSdkVersion().intValue());
+    }
+    
+    @Test
+    public void longFormCorrectlyParsed() {
+        ClientInfo info = ClientInfo.parseUserAgentString(VALID_UA_1);
+        assertEquals("Asthma", info.getAppName());
+        assertEquals(26, info.getAppVersion().intValue());
+        assertEquals("Unknown iPhone", info.getOsName());
+        assertEquals("iPhone OS 9.1", info.getOsVersion());
+        assertEquals("BridgeSDK", info.getSdkName());
+        assertEquals(4, info.getSdkVersion().intValue());
+        
+        info = ClientInfo.parseUserAgentString(VALID_UA_2);
+        assertEquals("Cardio Health", info.getAppName());
+        assertEquals(1, info.getAppVersion().intValue());
+        assertEquals("Unknown iPhone", info.getOsName());
+        assertEquals("iPhone OS 9.0.2", info.getOsVersion());
+        assertEquals("BridgeSDK", info.getSdkName());
+        assertEquals(4, info.getSdkVersion().intValue());
+    }
+    
+    @Test
+    public void cacheWorks() {
+        ClientInfo info1 = ClientInfo.fromUserAgentCache(VALID_UA_1);
+        ClientInfo info2 = ClientInfo.fromUserAgentCache(VALID_UA_1);
+        
+        assertSame(info1, info2);
+    }
+    
+    @Test
+    public void cacheWorksWithBadValues() {
+        assertSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.fromUserAgentCache(null));
+        assertSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.fromUserAgentCache("   \n"));
+    }
+    
+    @Test
+    public void clientWithoutVersionMatchesAnyRange() {
+        ClientInfo info = ClientInfo.parseUserAgentString(INVALID_UA_1);
+        assertTrue(info.isTargetedAppVersion(3, 3));
+    }
+    
+    @Test
+    public void clientWithVersionInRangeSucceeds() {
+        ClientInfo info = ClientInfo.parseUserAgentString(VALID_UA_1);
+        assertTrue(info.isTargetedAppVersion(24, 26));
+        assertTrue(info.isTargetedAppVersion(26, 27));
+    }
+    
+    @Test
+    public void clientWithVersionFilteredOnLowEnd() {
+        ClientInfo info = ClientInfo.parseUserAgentString(VALID_UA_1);
+        assertFalse(info.isTargetedAppVersion(27, null));
+    }
+    
+    @Test
+    public void clientWithVersionFilteredOnHighEnd() {
+        ClientInfo info = ClientInfo.parseUserAgentString(VALID_UA_1);
+        assertFalse(info.isTargetedAppVersion(null, 13));
+    }
+    
+    @Test
+    public void clientWithVersionFilteredWithZeroes() {
+        ClientInfo info = ClientInfo.parseUserAgentString(VALID_UA_1);
+        assertTrue(info.isTargetedAppVersion(0, 100));
+    }
+    
 }

--- a/test/org/sagebionetworks/bridge/play/controllers/BaseControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/BaseControllerTest.java
@@ -79,37 +79,37 @@ public class BaseControllerTest {
     public void canRetrieveClientInfoObject() throws Exception {
         Http.Request mockRequest = mock(Http.Request.class);
         when(mockRequest.getHeader(BridgeConstants.USER_AGENT_HEADER))
-        	.thenReturn("Asthma/26 (Unknown iPhone; iPhone OS 9.0.2) BridgeSDK/4");
+            .thenReturn("Asthma/26 (Unknown iPhone; iPhone OS 9.0.2) BridgeSDK/4");
         
-    	Http.Context context = mockPlayContext();
-    	when(context.request()).thenReturn(mockRequest);
-    	Http.Context.current.set(context);
-    	
+        Http.Context context = mockPlayContext();
+        when(context.request()).thenReturn(mockRequest);
+        Http.Context.current.set(context);
+        
         ClientInfo info = new SchedulePlanController().getUserAgent();
-		assertEquals("Asthma", info.getAppName());
-		assertEquals(26, info.getAppVersion().intValue());
-		assertEquals("Unknown iPhone", info.getOsName());
-		assertEquals("iPhone OS 9.0.2", info.getOsVersion());
-		assertEquals("BridgeSDK", info.getSdkName());
-		assertEquals(4, info.getSdkVersion().intValue());
+        assertEquals("Asthma", info.getAppName());
+        assertEquals(26, info.getAppVersion().intValue());
+        assertEquals("Unknown iPhone", info.getOsName());
+        assertEquals("iPhone OS 9.0.2", info.getOsVersion());
+        assertEquals("BridgeSDK", info.getSdkName());
+        assertEquals(4, info.getSdkVersion().intValue());
     }
     
     @Test
     public void doesNotThrowErrorWhenUserAgentStringInvalid() throws Exception {
         Http.Request mockRequest = mock(Http.Request.class);
         when(mockRequest.getHeader(BridgeConstants.USER_AGENT_HEADER))
-        	.thenReturn("Amazon Route 53 Health Check Service; ref:c97cd53f-2272-49d6-a8cd-3cd658d9d020; report http://amzn.to/1vsZADi");
+            .thenReturn("Amazon Route 53 Health Check Service; ref:c97cd53f-2272-49d6-a8cd-3cd658d9d020; report http://amzn.to/1vsZADi");
         
-    	Http.Context context = mockPlayContext();
-    	when(context.request()).thenReturn(mockRequest);
-    	Http.Context.current.set(context);
-    	
+        Http.Context context = mockPlayContext();
+        when(context.request()).thenReturn(mockRequest);
+        Http.Context.current.set(context);
+        
         ClientInfo info = new SchedulePlanController().getUserAgent();
-		assertNull(info.getAppName());
-		assertNull(info.getAppVersion());
-		assertNull(info.getOsName());
-		assertNull(info.getOsVersion());
-		assertNull(info.getSdkName());
-		assertNull(info.getSdkVersion());
+        assertNull(info.getAppName());
+        assertNull(info.getAppVersion());
+        assertNull(info.getOsName());
+        assertNull(info.getOsVersion());
+        assertNull(info.getSdkName());
+        assertNull(info.getSdkVersion());
     }
 }

--- a/test/org/sagebionetworks/bridge/play/controllers/BaseControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/BaseControllerTest.java
@@ -85,7 +85,7 @@ public class BaseControllerTest {
         when(context.request()).thenReturn(mockRequest);
         Http.Context.current.set(context);
         
-        ClientInfo info = new SchedulePlanController().getUserAgent();
+        ClientInfo info = new SchedulePlanController().getClientInfoFromUserAgentHeader();
         assertEquals("Asthma", info.getAppName());
         assertEquals(26, info.getAppVersion().intValue());
         assertEquals("Unknown iPhone", info.getOsName());
@@ -104,7 +104,7 @@ public class BaseControllerTest {
         when(context.request()).thenReturn(mockRequest);
         Http.Context.current.set(context);
         
-        ClientInfo info = new SchedulePlanController().getUserAgent();
+        ClientInfo info = new SchedulePlanController().getClientInfoFromUserAgentHeader();
         assertNull(info.getAppName());
         assertNull(info.getAppVersion());
         assertNull(info.getOsName());

--- a/test/org/sagebionetworks/bridge/play/controllers/BaseControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/BaseControllerTest.java
@@ -1,8 +1,10 @@
 package org.sagebionetworks.bridge.play.controllers;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.sagebionetworks.bridge.TestUtils.mockPlayContext;
 
 import java.util.Map;
 
@@ -10,8 +12,10 @@ import org.junit.Test;
 
 import play.mvc.Http;
 
+import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.play.controllers.BaseController;
 
 /** Test class for basic utility functions in BaseController. */
@@ -69,5 +73,43 @@ public class BaseControllerTest {
 
         // execute and validate
         BaseController.parseJson(mockRequest, Map.class);
+    }
+    
+    @Test
+    public void canRetrieveClientInfoObject() throws Exception {
+        Http.Request mockRequest = mock(Http.Request.class);
+        when(mockRequest.getHeader(BridgeConstants.USER_AGENT_HEADER))
+        	.thenReturn("Asthma/26 (Unknown iPhone; iPhone OS 9.0.2) BridgeSDK/4");
+        
+    	Http.Context context = mockPlayContext();
+    	when(context.request()).thenReturn(mockRequest);
+    	Http.Context.current.set(context);
+    	
+        ClientInfo info = new SchedulePlanController().getUserAgent();
+		assertEquals("Asthma", info.getAppName());
+		assertEquals(26, info.getAppVersion().intValue());
+		assertEquals("Unknown iPhone", info.getOsName());
+		assertEquals("iPhone OS 9.0.2", info.getOsVersion());
+		assertEquals("BridgeSDK", info.getSdkName());
+		assertEquals(4, info.getSdkVersion().intValue());
+    }
+    
+    @Test
+    public void doesNotThrowErrorWhenUserAgentStringInvalid() throws Exception {
+        Http.Request mockRequest = mock(Http.Request.class);
+        when(mockRequest.getHeader(BridgeConstants.USER_AGENT_HEADER))
+        	.thenReturn("Amazon Route 53 Health Check Service; ref:c97cd53f-2272-49d6-a8cd-3cd658d9d020; report http://amzn.to/1vsZADi");
+        
+    	Http.Context context = mockPlayContext();
+    	when(context.request()).thenReturn(mockRequest);
+    	Http.Context.current.set(context);
+    	
+        ClientInfo info = new SchedulePlanController().getUserAgent();
+		assertNull(info.getAppName());
+		assertNull(info.getAppVersion());
+		assertNull(info.getOsName());
+		assertNull(info.getOsVersion());
+		assertNull(info.getSdkName());
+		assertNull(info.getSdkVersion());
     }
 }


### PR DESCRIPTION
Adding a ClientInfo object, as well as code to parse it from a User-Agent header, and to retrieve it from a controller. ClientInfo objects are also cached in memory, they are highly redundant between requests.
