### PR TITLE
Filter the persisted tasks by the endsOn timestamp

### DIFF
--- a/app/org/sagebionetworks/bridge/services/TaskService.java
+++ b/app/org/sagebionetworks/bridge/services/TaskService.java
@@ -118,9 +118,8 @@ public class TaskService {
         
         // Now read back the tasks from the database to pick up persisted startedOn, finishedOn values, 
         // but filter based on the endsOn time from the query. If the client dynamically adjusts the 
-        // lookahead window from a large number of days to a small number of days, the client will still 
-        // get back all the tasks scheduled into the longer time period. This is counter-intuitive, 
-        // so hide them.
+        // lookahead window from a large number of days to a small number of days, the client would 
+        // still get back all the tasks scheduled into the longer time period, so we filter these.
         return taskDao.getTasks(context).stream().filter(task -> {
             return !task.getScheduledOn().isAfter(context.getEndsOn());
         }).collect(Collectors.toList());

--- a/app/org/sagebionetworks/bridge/services/TaskService.java
+++ b/app/org/sagebionetworks/bridge/services/TaskService.java
@@ -119,7 +119,7 @@ public class TaskService {
         // Now read back the tasks from the database to pick up persisted startedOn, finishedOn values, 
         // but filter based on the endsOn time from the query. If the client dynamically adjusts the 
         // lookahead window from a large number of days to a small number of days, the client will still 
-        // get back all the tasks scheduled into the longer time period. This is counter-intuitive , 
+        // get back all the tasks scheduled into the longer time period. This is counter-intuitive, 
         // so hide them.
         return taskDao.getTasks(context).stream().filter(task -> {
             return (task.getScheduledOn().isBefore(context.getEndsOn()) || 

--- a/app/org/sagebionetworks/bridge/services/TaskService.java
+++ b/app/org/sagebionetworks/bridge/services/TaskService.java
@@ -6,6 +6,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.joda.time.DateTime;
 import org.sagebionetworks.bridge.dao.TaskDao;
@@ -115,8 +116,15 @@ public class TaskService {
         // Finally, save these new tasks
         taskDao.saveTasks(tasksToSave);
         
-        // Now read back the tasks from the database to pick up persisted startedOn, finishedOn values
-        return taskDao.getTasks(context);
+        // Now read back the tasks from the database to pick up persisted startedOn, finishedOn values, 
+        // but filter based on the endsOn time from the query. If the client dynamically adjusts the 
+        // lookahead window from a large number of days to a small number of days, the client will still 
+        // get back all the tasks scheduled into the longer time period. This is counter-intuitive , 
+        // so hide them.
+        return taskDao.getTasks(context).stream().filter(task -> {
+            return (task.getScheduledOn().isBefore(context.getEndsOn()) || 
+                    task.getScheduledOn().isEqual(context.getEndsOn()));
+        }).collect(Collectors.toList());
     }
     
     public void updateTasks(String healthCode, List<Task> tasks) {

--- a/app/org/sagebionetworks/bridge/services/TaskService.java
+++ b/app/org/sagebionetworks/bridge/services/TaskService.java
@@ -122,8 +122,7 @@ public class TaskService {
         // get back all the tasks scheduled into the longer time period. This is counter-intuitive, 
         // so hide them.
         return taskDao.getTasks(context).stream().filter(task -> {
-            return (task.getScheduledOn().isBefore(context.getEndsOn()) || 
-                    task.getScheduledOn().isEqual(context.getEndsOn()));
+            return !task.getScheduledOn().isAfter(context.getEndsOn());
         }).collect(Collectors.toList());
     }
     

--- a/test/org/sagebionetworks/bridge/models/ClientInfoTest.java
+++ b/test/org/sagebionetworks/bridge/models/ClientInfoTest.java
@@ -13,6 +13,7 @@ public class ClientInfoTest {
     private static final String VALID_MEDIUM_UA_1 = "Unknown Client/14 BridgeJavaSDK/10";
     private static final String VALID_LONG_UA_1 = "Asthma/26 (Unknown iPhone; iPhone OS 9.1) BridgeSDK/4";
     private static final String VALID_LONG_UA_2 = "Cardio Health/1 (Unknown iPhone; iPhone OS 9.0.2) BridgeSDK/4";
+    private static final String VALID_LONG_UA_3 = "Belgium/2 (Motorola Flip-Phone; Android 14) BridgeJavaSDK/10";
     
     private static final String INVALID_UA_1 = "Amazon Route 53 Health Check Service; ref:c97cd53f-2272-49d6-a8cd-3cd658d9d020; report http://amzn.to/1vsZADi";
     private static final String INVALID_UA_2 = "Integration Tests (Linux/3.13.0-36-generic) BridgeJavaSDK/3";
@@ -118,6 +119,14 @@ public class ClientInfoTest {
         assertEquals("iPhone OS 9.0.2", info.getOsVersion());
         assertEquals("BridgeSDK", info.getSdkName());
         assertEquals(4, info.getSdkVersion().intValue());
+        
+        info = ClientInfo.parseUserAgentString(VALID_LONG_UA_3);
+        assertEquals("Belgium", info.getAppName());
+        assertEquals(2, info.getAppVersion().intValue());
+        assertEquals("Motorola Flip-Phone", info.getOsName());
+        assertEquals("Android 14", info.getOsVersion());
+        assertEquals("BridgeJavaSDK", info.getSdkName());
+        assertEquals(10, info.getSdkVersion().intValue());
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/services/TaskServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/TaskServiceTest.java
@@ -128,13 +128,12 @@ public class TaskServiceTest {
         // Dave teleports to California, where it's still the prior day. He gets 4 tasks 
         // (yesterday, today in Russia, tomorrow and the next day). One task was created beyond
         // the window, over in Moscow... that is not returned because although it exists, we 
-        // filter it out from the tasks retrieved from the db.
+        // filter it out from the persisted tasks retrieved from the db.
         tasks = service.getTasks(testUser.getUser(), getContext(PST));
         assertEquals(3, tasks.size());
         assertEquals(pst1+"T10:00:00.000-07:00", tasks.get(0).getScheduledOn().toString());
         assertEquals(pst2+"T10:00:00.000-07:00", tasks.get(1).getScheduledOn().toString());
         assertEquals(pst3+"T10:00:00.000-07:00", tasks.get(2).getScheduledOn().toString());
-        //assertEquals(pst4+"T10:00:00.000-07:00", tasks.get(3).getScheduledOn().toString());
         
         // Dave returns to the Moscow and we move time forward a day.
         DateTimeUtils.setCurrentMillisFixed(DateTime.parse((year+1)+"-09-24T03:39:57.779+03:00").getMillis());

--- a/test/org/sagebionetworks/bridge/services/TaskServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/TaskServiceTest.java
@@ -117,7 +117,7 @@ public class TaskServiceTest {
         // Hi, I'm dave, I'm in Moscow, what am I supposed to do for the next two days?
         // You get the schedule from yesterday that hasn't expired just yet (22nd), plus the 
         // 23rd, 24th and 25th
-        ScheduleContext context = getContext(MSK);
+        ScheduleContext context = getContextWith2DayWindow(MSK);
         List<Task> tasks = service.getTasks(testUser.getUser(), context);
         assertEquals(4, tasks.size());
         assertEquals(msk0+"T10:00:00.000+03:00", tasks.get(0).getScheduledOn().toString());
@@ -129,7 +129,7 @@ public class TaskServiceTest {
         // (yesterday, today in Russia, tomorrow and the next day). One task was created beyond
         // the window, over in Moscow... that is not returned because although it exists, we 
         // filter it out from the persisted tasks retrieved from the db.
-        tasks = service.getTasks(testUser.getUser(), getContext(PST));
+        tasks = service.getTasks(testUser.getUser(), getContextWith2DayWindow(PST));
         assertEquals(3, tasks.size());
         assertEquals(pst1+"T10:00:00.000-07:00", tasks.get(0).getScheduledOn().toString());
         assertEquals(pst2+"T10:00:00.000-07:00", tasks.get(1).getScheduledOn().toString());
@@ -140,7 +140,7 @@ public class TaskServiceTest {
         
         // He hasn't finished any tasks. The 22nd expires but it's too early in the day 
         // for the 23rd to expire (earlier than 10am), so, 4 tasks, but with different dates.
-        tasks = service.getTasks(testUser.getUser(), getContext(MSK));
+        tasks = service.getTasks(testUser.getUser(), getContextWith2DayWindow(MSK));
         assertEquals(4, tasks.size());
         assertEquals(msk1+"T10:00:00.000+03:00", tasks.get(0).getScheduledOn().toString());
         assertEquals(msk2+"T10:00:00.000+03:00", tasks.get(1).getScheduledOn().toString());
@@ -153,7 +153,7 @@ public class TaskServiceTest {
         service.updateTasks(testUser.getUser().getHealthCode(), tasks);
         
         // This is easy, Dave has the later tasks and that's it, at this point.
-        tasks = service.getTasks(testUser.getUser(), getContext(MSK));
+        tasks = service.getTasks(testUser.getUser(), getContextWith2DayWindow(MSK));
         assertEquals(2, tasks.size());
         assertEquals(msk3+"T10:00:00.000+03:00", tasks.get(0).getScheduledOn().toString());
         assertEquals(msk4+"T10:00:00.000+03:00", tasks.get(1).getScheduledOn().toString());
@@ -162,7 +162,7 @@ public class TaskServiceTest {
     @Test
     public void tasksAreFilteredBasedOnAppVersion() throws Exception {
         ScheduleContext context = new ScheduleContext.Builder()
-                .withContext(getContext(DateTimeZone.UTC))
+                .withContext(getContextWith2DayWindow(DateTimeZone.UTC))
                 .withClientInfo(ClientInfo.fromUserAgentCache("app/5")).build();
         
         // Ask for version 5, nothing is created
@@ -194,10 +194,8 @@ public class TaskServiceTest {
         assertTrue(tasks2.size() < tasks.size());
     }
     
-    private ScheduleContext getContext(DateTimeZone zone) {
-        // Setting the endsOn value to the end of the day, as we do in the controller.
-        DateTime endsOn = DateTime.now(zone).plusDays(2);
-        return getContext(zone, endsOn);
+    private ScheduleContext getContextWith2DayWindow(DateTimeZone zone) {
+        return getContext(zone, DateTime.now(zone).plusDays(2));
     }
     
     private ScheduleContext getContext(DateTimeZone zone, DateTime endsOn) {
@@ -206,6 +204,7 @@ public class TaskServiceTest {
             .withStudyIdentifier(TEST_STUDY)
             .withClientInfo(ClientInfo.UNKNOWN_CLIENT)
             .withTimeZone(zone)
+            // Setting the endsOn value to the end of the day, as we do in the controller.
             .withEndsOn(endsOn.withHourOfDay(23).withMinuteOfHour(59).withSecondOfMinute(59))
             .withHealthCode(testUser.getUser().getHealthCode()).build();
     }


### PR DESCRIPTION
Erin built a demo app where you can change the daysAhead value when getting tasks. If you ask for a larger number of days followed by a smaller number of days, we just return all the persisted tasks for the larger number, which is okay (a real app probably won't do this), but counter-intuitive. Filter the persisted tasks using the endsOn value.
