### PR TITLE
Admin roles (developer, researcher, admin) do not get consent exception

### DIFF
--- a/app/org/sagebionetworks/bridge/Roles.java
+++ b/app/org/sagebionetworks/bridge/Roles.java
@@ -1,8 +1,13 @@
 package org.sagebionetworks.bridge;
 
+import java.util.EnumSet;
+import java.util.Set;
+
 public enum Roles {
     DEVELOPER,
     RESEARCHER,
     ADMIN,
-    TEST_USERS
+    TEST_USERS;
+    
+    public static final Set<Roles> ADMINISTRATIVE_ROLES = EnumSet.of(Roles.DEVELOPER, Roles.RESEARCHER, Roles.ADMIN);
 }

--- a/app/org/sagebionetworks/bridge/models/accounts/User.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/User.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.models.accounts;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -158,7 +159,11 @@ public class User implements BridgeEntity {
     }
 
     public boolean isInRole(Roles role) {
-        return this.roles.contains(role);
+        return (role != null && this.roles.contains(role));
+    }
+    
+    public boolean isInRole(Set<Roles> roleSet) {
+        return roleSet != null && !Collections.disjoint(roles, roleSet);
     }
 
     @Override

--- a/test/org/sagebionetworks/bridge/TestConstants.java
+++ b/test/org/sagebionetworks/bridge/TestConstants.java
@@ -17,6 +17,7 @@ public class TestConstants {
     public static final String SIGN_OUT_URL = API_URL + "/auth/signOut";
     public static final String SIGN_IN_URL = API_URL + "/auth/signIn";
     public static final String SCHEDULES_API = API_URL + "/schedules";
+    public static final String SCHEDULED_ACTIVITIES_API = API_URL + "/activities";
 
     public static final String APPLICATION_JSON = "application/json";
     public static final String USERNAME = "username";

--- a/test/org/sagebionetworks/bridge/models/accounts/UserTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/UserTest.java
@@ -3,11 +3,16 @@ package org.sagebionetworks.bridge.models.accounts;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.util.Set;
 
 import org.junit.Test;
+import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+import com.google.common.collect.Sets;
 
 public class UserTest {
 
@@ -24,5 +29,19 @@ public class UserTest {
         User userDe = BridgeObjectMapper.get().readValue(userSer, User.class);
         assertNotNull(userDe);
         assertEquals("123abc", userDe.getHealthCode());
+    }
+    
+    @Test
+    public void userIsInRole() {
+        User user = new User();
+        user.setRoles(Sets.newHashSet(Roles.ADMIN, Roles.DEVELOPER));
+
+        assertTrue(user.isInRole(Roles.DEVELOPER));
+        assertTrue(user.isInRole(Roles.ADMINISTRATIVE_ROLES));
+        assertFalse(user.isInRole((Roles)null));
+        
+        user = new User();
+        assertFalse(user.isInRole(Roles.ADMINISTRATIVE_ROLES));
+        assertFalse(user.isInRole((Set<Roles>)null));
     }
 }

--- a/test/org/sagebionetworks/bridge/models/accounts/UserTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/UserTest.java
@@ -37,11 +37,17 @@ public class UserTest {
         user.setRoles(Sets.newHashSet(Roles.ADMIN, Roles.DEVELOPER));
 
         assertTrue(user.isInRole(Roles.DEVELOPER));
-        assertTrue(user.isInRole(Roles.ADMINISTRATIVE_ROLES));
         assertFalse(user.isInRole((Roles)null));
+    }
+    
+    @Test
+    public void userIsInRoleSet() {
+        User user = new User();
+        user.setRoles(Sets.newHashSet(Roles.ADMIN, Roles.DEVELOPER));
+        assertTrue(user.isInRole(Roles.ADMINISTRATIVE_ROLES));
+        assertFalse(user.isInRole((Set<Roles>)null));
         
         user = new User();
         assertFalse(user.isInRole(Roles.ADMINISTRATIVE_ROLES));
-        assertFalse(user.isInRole((Set<Roles>)null));
     }
 }

--- a/test/org/sagebionetworks/bridge/play/controllers/ScheduledActivityControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ScheduledActivityControllerTest.java
@@ -46,7 +46,7 @@ public class ScheduledActivityControllerTest {
     private ScheduledActivityController controller;
     
     private ClientInfo clientInfo;
-    
+
     ArgumentCaptor<ScheduleContext> argument = ArgumentCaptor.forClass(ScheduleContext.class);
     
     @Before


### PR DESCRIPTION
When signing in users with "administrative" roles do not get a consent exception. But the individual APIs do check for consent and return a 412 for these users. This should remove the weirdness around such researchers utilizing participant APIs, as they will have normal consent workflow happen before doing this.
