### PR TITLE
Adding UserConsent3 table with different keys and a withdrawal date

### DIFF
--- a/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
+++ b/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
@@ -52,6 +52,8 @@ import org.sagebionetworks.bridge.dynamodb.DynamoScheduledActivity;
 import org.sagebionetworks.bridge.dynamodb.DynamoActivityEvent;
 import org.sagebionetworks.bridge.dynamodb.DynamoUpload2;
 import org.sagebionetworks.bridge.dynamodb.DynamoUploadSchema;
+import org.sagebionetworks.bridge.dynamodb.DynamoUserConsent2;
+import org.sagebionetworks.bridge.dynamodb.DynamoUserConsent3;
 import org.sagebionetworks.bridge.dynamodb.DynamoUtils;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.redis.JedisOps;
@@ -338,7 +340,19 @@ public class BridgeSpringConfig {
     public DynamoDBMapper surveyResponseDdbMapper(final BridgeConfig bridgeConfig, final AmazonDynamoDB client) {
         return DynamoUtils.getMapper(DynamoSurveyResponse.class, bridgeConfig, client);
     }
-
+    
+    @Bean(name = "userConsentDdbMapper2")
+    @Autowired
+    public DynamoDBMapper userConsentDdbMapperV2(final BridgeConfig bridgeConfig, final AmazonDynamoDB client) {
+        return DynamoUtils.getMapper(DynamoUserConsent2.class, bridgeConfig, client);
+    }
+    
+    @Bean(name = "userConsentDdbMapper3")
+    @Autowired
+    public DynamoDBMapper userConsentDdbMapperV3(final BridgeConfig bridgeConfig, final AmazonDynamoDB client) {
+        return DynamoUtils.getMapper(DynamoUserConsent3.class, bridgeConfig, client);
+    }
+    
     @Bean(name = "uploadSchemaStudyIdIndex")
     @Autowired
     public DynamoIndexHelper uploadSchemaStudyIdIndex(final BridgeConfig bridgeConfig, final AmazonDynamoDB client) {

--- a/app/org/sagebionetworks/bridge/dao/UserConsentDao.java
+++ b/app/org/sagebionetworks/bridge/dao/UserConsentDao.java
@@ -44,4 +44,17 @@ public interface UserConsentDao {
      * @return
      */
     long getNumberOfParticipants(StudyIdentifier studyIdentifier);
+    
+    /**
+     * Delete all consent records for a user, in order to clean up after tests. If withdrawing a user, 
+     * call <code>withDrawConsent()</code> instead.
+     */
+    void deleteConsentRecords(String healthCode, StudyIdentifier studyIdentifier);
+    
+    /**
+     * Copy existing consent record over from consent 2 table to consent 3 table.
+     * @param healthCode
+     * @param studyIdentifier
+     */
+    boolean migrateConsent(String healthCode, StudyIdentifier studyIdentifier);
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUserConsent2.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUserConsent2.java
@@ -7,6 +7,7 @@ import org.sagebionetworks.bridge.models.accounts.UserConsent;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIgnore;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBVersionAttribute;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -98,6 +99,7 @@ public class DynamoUserConsent2 implements UserConsent {
         this.studyKey = studyKey;
     }
     @Override
+    @DynamoDBIgnore
     public String getStudyIdentifier() {
         return studyKey;
     }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUserConsent2.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUserConsent2.java
@@ -4,7 +4,6 @@ import org.sagebionetworks.bridge.json.BridgeTypeName;
 import org.sagebionetworks.bridge.json.DateTimeToPrimitiveLongDeserializer;
 import org.sagebionetworks.bridge.json.DateTimeToLongSerializer;
 import org.sagebionetworks.bridge.models.accounts.UserConsent;
-import org.sagebionetworks.bridge.models.studies.StudyConsent;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
@@ -39,13 +38,6 @@ public class DynamoUserConsent2 implements UserConsent {
         healthCodeStudy = healthCode + ":" + studyKey;
     }
 
-    // Constructor to create a hash-key object
-    DynamoUserConsent2(String healthCode, StudyConsent consent) {
-        this(healthCode, consent.getStudyKey());
-        consentCreatedOn = consent.getCreatedOn();
-    }
-
-    // Copy constructor
     DynamoUserConsent2(DynamoUserConsent2 consent) {
         healthCodeStudy = consent.healthCodeStudy;
         signedOn = consent.signedOn;
@@ -53,6 +45,14 @@ public class DynamoUserConsent2 implements UserConsent {
         healthCode = consent.healthCode;
         studyKey = consent.studyKey;
         consentCreatedOn = consent.consentCreatedOn;
+    }
+
+    // We're not going to use this value until after we migrate to UserConsent3, 
+    // so it does not need to be implemented, except so that UserConsent2 and 
+    // UserConsent3 share the same interface.
+    @Override
+    public Long getWithdrewOn() {
+        return null;
     }
 
     @DynamoDBHashKey
@@ -96,6 +96,13 @@ public class DynamoUserConsent2 implements UserConsent {
     }
     public void setStudyKey(String studyKey) {
         this.studyKey = studyKey;
+    }
+    @Override
+    public String getStudyIdentifier() {
+        return studyKey;
+    }
+    public void setStudyIdentifier(String studyIdentifier) {
+        this.studyKey = studyIdentifier;
     }
 
     @DynamoDBAttribute

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUserConsent3.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUserConsent3.java
@@ -7,11 +7,10 @@ import org.sagebionetworks.bridge.models.accounts.UserConsent;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIgnore;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBVersionAttribute;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 /**
  * This version of the consent will accept a withdrewOn timestamp, and the range key is set to the signedOn 
@@ -19,17 +18,20 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
  *
  */
 @DynamoDBTable(tableName = "UserConsent3")
-@BridgeTypeName("UserConsent")
 public class DynamoUserConsent3 implements UserConsent {
 
     // The only timestamp that can be null is withdrewOn.
     private String healthCodeStudy;
-    private String healthCode;
-    private String studyIdentifier;
     private long consentCreatedOn;
     private long signedOn;
     private Long withdrewOn;
     private Long version;
+    
+    public DynamoUserConsent3() {}
+    
+    public DynamoUserConsent3(String healthCode, String studyIdentifier) {
+        setHealthCodeStudy(healthCode + ":" + studyIdentifier);
+    }
     
     @DynamoDBHashKey
     public String getHealthCodeStudy() {
@@ -38,47 +40,33 @@ public class DynamoUserConsent3 implements UserConsent {
     public void setHealthCodeStudy(String healthCodeStudy) {
         this.healthCodeStudy = healthCodeStudy;
     }
-    public void setHealthCodeStudy(String healthCode, String studyIdentifier) {
-        this.healthCode = healthCode;
-        this.studyIdentifier = studyIdentifier;
-        this.healthCodeStudy = healthCode + ":" + studyIdentifier;
-    }
-    
-    @DynamoDBAttribute
+    @DynamoDBIgnore
     public String getHealthCode() {
-        return healthCode;
+        return getValue(0);
     }
-    public void setHealthCode(String healthCode) {
-        setHealthCodeStudy(healthCode, getStudyIdentifier());
-    }
-
     @Override
-    @DynamoDBAttribute
+    @DynamoDBIgnore
     public String getStudyIdentifier() {
-        return studyIdentifier;
+        return getValue(1);
     }
-    public void setStudyIdentifier(String studyIdentifier) {
-        setHealthCodeStudy(getHealthCode(), studyIdentifier);
+    private String getValue(int index) {
+        return (healthCodeStudy != null && healthCodeStudy.contains(":")) ?
+                healthCodeStudy.split(":")[index] : null;
     }
-
     @Override
     @DynamoDBAttribute
-    @JsonSerialize(using = DateTimeToLongSerializer.class)
     public long getConsentCreatedOn() {
         return consentCreatedOn;
     }
-    @JsonDeserialize(using = DateTimeToPrimitiveLongDeserializer.class)
     public void setConsentCreatedOn(long consentCreatedOn) {
         this.consentCreatedOn = consentCreatedOn;
     }
 
     @Override
     @DynamoDBRangeKey
-    @JsonSerialize(using = DateTimeToLongSerializer.class)
     public long getSignedOn() {
         return signedOn;
     }
-    @JsonDeserialize(using = DateTimeToPrimitiveLongDeserializer.class)
     public void setSignedOn(long signedOn) {
         this.signedOn = signedOn;
     }
@@ -102,8 +90,8 @@ public class DynamoUserConsent3 implements UserConsent {
     
     @Override
     public String toString() {
-        return String.format("DynamoUserConsent3 [healthCode=%s, studyIdentifier=%s, consentCreatedOn=%s, version=%s, signedOn=%s, withdrewOn=%s]",
-                healthCode, studyIdentifier, consentCreatedOn, version, signedOn, withdrewOn);
+        return String.format("DynamoUserConsent3 [healthCodeStudy=%s, consentCreatedOn=%s, version=%s, signedOn=%s, withdrewOn=%s]",
+                healthCodeStudy, consentCreatedOn, version, signedOn, withdrewOn);
     }
     
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUserConsent3.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUserConsent3.java
@@ -1,0 +1,109 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import org.sagebionetworks.bridge.json.BridgeTypeName;
+import org.sagebionetworks.bridge.json.DateTimeToLongSerializer;
+import org.sagebionetworks.bridge.json.DateTimeToPrimitiveLongDeserializer;
+import org.sagebionetworks.bridge.models.accounts.UserConsent;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBVersionAttribute;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * This version of the consent will accept a withdrewOn timestamp, and the range key is set to the signedOn 
+ * value so there can be multiple records, returned in the order they were created by participant.
+ *
+ */
+@DynamoDBTable(tableName = "UserConsent3")
+@BridgeTypeName("UserConsent")
+public class DynamoUserConsent3 implements UserConsent {
+
+    // The only timestamp that can be null is withdrewOn.
+    private String healthCodeStudy;
+    private String healthCode;
+    private String studyIdentifier;
+    private long consentCreatedOn;
+    private long signedOn;
+    private Long withdrewOn;
+    private Long version;
+    
+    @DynamoDBHashKey
+    public String getHealthCodeStudy() {
+        return healthCodeStudy;
+    }
+    public void setHealthCodeStudy(String healthCodeStudy) {
+        this.healthCodeStudy = healthCodeStudy;
+    }
+    public void setHealthCodeStudy(String healthCode, String studyIdentifier) {
+        this.healthCode = healthCode;
+        this.studyIdentifier = studyIdentifier;
+        this.healthCodeStudy = healthCode + ":" + studyIdentifier;
+    }
+    
+    @DynamoDBAttribute
+    public String getHealthCode() {
+        return healthCode;
+    }
+    public void setHealthCode(String healthCode) {
+        setHealthCodeStudy(healthCode, getStudyIdentifier());
+    }
+
+    @Override
+    @DynamoDBAttribute
+    public String getStudyIdentifier() {
+        return studyIdentifier;
+    }
+    public void setStudyIdentifier(String studyIdentifier) {
+        setHealthCodeStudy(getHealthCode(), studyIdentifier);
+    }
+
+    @Override
+    @DynamoDBAttribute
+    @JsonSerialize(using = DateTimeToLongSerializer.class)
+    public long getConsentCreatedOn() {
+        return consentCreatedOn;
+    }
+    @JsonDeserialize(using = DateTimeToPrimitiveLongDeserializer.class)
+    public void setConsentCreatedOn(long consentCreatedOn) {
+        this.consentCreatedOn = consentCreatedOn;
+    }
+
+    @Override
+    @DynamoDBRangeKey
+    @JsonSerialize(using = DateTimeToLongSerializer.class)
+    public long getSignedOn() {
+        return signedOn;
+    }
+    @JsonDeserialize(using = DateTimeToPrimitiveLongDeserializer.class)
+    public void setSignedOn(long signedOn) {
+        this.signedOn = signedOn;
+    }
+    
+    @Override
+    @DynamoDBAttribute
+    public Long getWithdrewOn() {
+        return withdrewOn;
+    }
+    public void setWithdrewOn(Long withdrewOn) {
+        this.withdrewOn = withdrewOn;
+    }
+    
+    @DynamoDBVersionAttribute
+    public Long getVersion() {
+        return version;
+    }
+    public void setVersion(Long version) {
+        this.version = version;
+    }
+    
+    @Override
+    public String toString() {
+        return String.format("DynamoUserConsent3 [healthCode=%s, studyIdentifier=%s, consentCreatedOn=%s, version=%s, signedOn=%s, withdrewOn=%s]",
+                healthCode, studyIdentifier, consentCreatedOn, version, signedOn, withdrewOn);
+    }
+    
+}

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUserConsent3.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUserConsent3.java
@@ -41,7 +41,8 @@ public class DynamoUserConsent3 implements UserConsent {
     }
     @DynamoDBIgnore
     public String getHealthCode() {
-        return getValue(0);
+        return (healthCodeStudy != null && healthCodeStudy.contains(":")) ?
+                healthCodeStudy.split(":")[0] : null;
     }
     @Override
     @DynamoDBAttribute
@@ -50,10 +51,6 @@ public class DynamoUserConsent3 implements UserConsent {
     }
     public void setStudyIdentifier(String studyIdentifier) {
         this.studyIdentifier = studyIdentifier;
-    }
-    private String getValue(int index) {
-        return (healthCodeStudy != null && healthCodeStudy.contains(":")) ?
-                healthCodeStudy.split(":")[index] : null;
     }
     @Override
     @DynamoDBAttribute

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUserConsent3.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUserConsent3.java
@@ -1,8 +1,5 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import org.sagebionetworks.bridge.json.BridgeTypeName;
-import org.sagebionetworks.bridge.json.DateTimeToLongSerializer;
-import org.sagebionetworks.bridge.json.DateTimeToPrimitiveLongDeserializer;
 import org.sagebionetworks.bridge.models.accounts.UserConsent;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUserConsent3.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUserConsent3.java
@@ -19,6 +19,7 @@ public class DynamoUserConsent3 implements UserConsent {
 
     // The only timestamp that can be null is withdrewOn.
     private String healthCodeStudy;
+    private String studyIdentifier;
     private long consentCreatedOn;
     private long signedOn;
     private Long withdrewOn;
@@ -28,6 +29,7 @@ public class DynamoUserConsent3 implements UserConsent {
     
     public DynamoUserConsent3(String healthCode, String studyIdentifier) {
         setHealthCodeStudy(healthCode + ":" + studyIdentifier);
+        this.studyIdentifier = studyIdentifier;
     }
     
     @DynamoDBHashKey
@@ -42,9 +44,12 @@ public class DynamoUserConsent3 implements UserConsent {
         return getValue(0);
     }
     @Override
-    @DynamoDBIgnore
+    @DynamoDBAttribute
     public String getStudyIdentifier() {
-        return getValue(1);
+        return studyIdentifier;
+    }
+    public void setStudyIdentifier(String studyIdentifier) {
+        this.studyIdentifier = studyIdentifier;
     }
     private String getValue(int index) {
         return (healthCodeStudy != null && healthCodeStudy.contains(":")) ?
@@ -87,8 +92,8 @@ public class DynamoUserConsent3 implements UserConsent {
     
     @Override
     public String toString() {
-        return String.format("DynamoUserConsent3 [healthCodeStudy=%s, consentCreatedOn=%s, version=%s, signedOn=%s, withdrewOn=%s]",
-                healthCodeStudy, consentCreatedOn, version, signedOn, withdrewOn);
+        return String.format("DynamoUserConsent3 [healthCodeStudy=%s, studyIdentifier=%s, consentCreatedOn=%s, version=%s, signedOn=%s, withdrewOn=%s]",
+                healthCodeStudy, studyIdentifier, consentCreatedOn, version, signedOn, withdrewOn);
     }
     
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUserConsentDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUserConsentDao.java
@@ -64,7 +64,7 @@ public class DynamoUserConsentDao implements UserConsentDao {
         // consent record if it exists. Throw an exception if it does.
         DynamoUserConsent2 consent2 = getUserConsent2(healthCode, studyConsent.getStudyKey());
         if (consent2 != null) {
-            throw new EntityAlreadyExistsException(consent2);
+            throw new EntityAlreadyExistsException(null, "Consent already exists.");
         }
         
         // save 3 then do 2, undo 3 if 2 fails
@@ -201,7 +201,10 @@ public class DynamoUserConsentDao implements UserConsentDao {
     private List<DynamoUserConsent3> getAllUserConsentRecords3(String healthCode, String studyIdentifier) {
         DynamoUserConsent3 hashKey = new DynamoUserConsent3(healthCode, studyIdentifier);
 
+        // Currently this is only one record. In the next phase of migration, remove scanIndexForward (maybe) and the limit.
         DynamoDBQueryExpression<DynamoUserConsent3> query = new DynamoDBQueryExpression<DynamoUserConsent3>()
+                .withScanIndexForward(false)
+                .withLimit(1)
                 .withHashKeyValues(hashKey);
 
         return mapperV3.query(DynamoUserConsent3.class, query);

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUserConsentDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUserConsentDao.java
@@ -9,9 +9,10 @@ import java.util.Set;
 
 import javax.annotation.Resource;
 
+import org.apache.http.HttpStatus;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.dao.UserConsentDao;
-import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
+import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.models.accounts.UserConsent;
 import org.sagebionetworks.bridge.models.studies.StudyConsent;
@@ -56,7 +57,7 @@ public class DynamoUserConsentDao implements UserConsentDao {
         // if a record exists.
         UserConsent existingConsent = getUserConsent(healthCode, new StudyIdentifierImpl(studyConsent.getStudyKey()));
         if (existingConsent != null) {
-            throw new EntityAlreadyExistsException(null, "Consent already exists.");
+            throw new BridgeServiceException("Consent already exists.", HttpStatus.SC_CONFLICT);
         }
         
         DynamoUserConsent3 consent = new DynamoUserConsent3(healthCode, studyConsent.getStudyKey());

--- a/app/org/sagebionetworks/bridge/exceptions/ConcurrentModificationException.java
+++ b/app/org/sagebionetworks/bridge/exceptions/ConcurrentModificationException.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.bridge.exceptions;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import org.apache.http.HttpStatus;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.models.BridgeEntity;
@@ -11,12 +13,12 @@ public class ConcurrentModificationException extends BridgeServiceException {
     
     public ConcurrentModificationException(BridgeEntity entity) {
         super(BridgeUtils.getTypeName(entity.getClass()) + " has the wrong version number; it may have been saved in the background.", HttpStatus.SC_CONFLICT);
-        this.entity = entity;
+        this.entity = checkNotNull(entity);
     }
     
     public ConcurrentModificationException(BridgeEntity entity, String message) {
         super(message, HttpStatus.SC_CONFLICT);
-        this.entity = entity;
+        this.entity = checkNotNull(entity);
     }
     
     public ConcurrentModificationException(String message) {

--- a/app/org/sagebionetworks/bridge/exceptions/EntityAlreadyExistsException.java
+++ b/app/org/sagebionetworks/bridge/exceptions/EntityAlreadyExistsException.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.bridge.exceptions;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import org.apache.http.HttpStatus;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.models.BridgeEntity;
@@ -16,7 +18,7 @@ public class EntityAlreadyExistsException extends BridgeServiceException {
     
     public EntityAlreadyExistsException(BridgeEntity entity, String message) {
         super(message, HttpStatus.SC_CONFLICT);
-        this.entity = entity;
+        this.entity = checkNotNull(entity);
     }
     
     public Class<? extends BridgeEntity> getEntityClass() {

--- a/app/org/sagebionetworks/bridge/exceptions/EntityNotFoundException.java
+++ b/app/org/sagebionetworks/bridge/exceptions/EntityNotFoundException.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.bridge.exceptions;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import org.apache.http.HttpStatus;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.models.BridgeEntity;
@@ -8,19 +10,19 @@ import org.sagebionetworks.bridge.models.BridgeEntity;
 @NoStackTraceException
 public class EntityNotFoundException extends BridgeServiceException {
     
-    private Class<? extends BridgeEntity> clazz; 
+    private Class<? extends BridgeEntity> entity; 
     
-    public EntityNotFoundException(Class<? extends BridgeEntity> clazz) {
-        this(clazz, BridgeUtils.getTypeName(clazz) + " not found.");
+    public EntityNotFoundException(Class<? extends BridgeEntity> entity) {
+        this(entity, BridgeUtils.getTypeName(entity) + " not found.");
     }
     
-    public EntityNotFoundException(Class<? extends BridgeEntity> clazz, String message) {
+    public EntityNotFoundException(Class<? extends BridgeEntity> entity, String message) {
         super(message, HttpStatus.SC_NOT_FOUND);
-        this.clazz = clazz;
+        this.entity = checkNotNull(entity);
     }
     
     public Class<? extends BridgeEntity> getEntityClass() {
-        return clazz;
+        return entity;
     }
 
 }

--- a/app/org/sagebionetworks/bridge/exceptions/InvalidEntityException.java
+++ b/app/org/sagebionetworks/bridge/exceptions/InvalidEntityException.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.bridge.exceptions;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.List;
 import java.util.Map;
 
@@ -20,12 +22,12 @@ public class InvalidEntityException extends BridgeServiceException {
     
     public InvalidEntityException(BridgeEntity entity, String message) {
         super(message, HttpStatus.SC_BAD_REQUEST);
-        this.entity = entity;
+        this.entity = checkNotNull(entity);
     }
     
     public InvalidEntityException(BridgeEntity entity, String message, Map<String,List<String>> errors) {
         super(message, HttpStatus.SC_BAD_REQUEST);
-        this.entity = entity;
+        this.entity = checkNotNull(entity);
         this.errors = errors;
     }
     

--- a/app/org/sagebionetworks/bridge/models/accounts/UserConsent.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/UserConsent.java
@@ -4,10 +4,12 @@ import org.sagebionetworks.bridge.models.BridgeEntity;
 
 public interface UserConsent extends BridgeEntity {
     
-    public long getSignedOn();
-
-    public String getStudyKey();
+    public String getStudyIdentifier();
 
     public long getConsentCreatedOn();
+    
+    public long getSignedOn();
+    
+    public Long getWithdrewOn();
 
 }

--- a/app/org/sagebionetworks/bridge/services/backfill/UserConsentBackfill.java
+++ b/app/org/sagebionetworks/bridge/services/backfill/UserConsentBackfill.java
@@ -27,7 +27,7 @@ public class UserConsentBackfill extends AsyncBackfillTemplate {
         this.userConsentDao = userConsentDao;
     }
     @Autowired
-    public void setHealthCodeService(HealthCodeService healthCodeService) {
+    public final void setHealthCodeService(HealthCodeService healthCodeService) {
         this.healthCodeService = healthCodeService;
     }
     

--- a/app/org/sagebionetworks/bridge/services/backfill/UserConsentBackfill.java
+++ b/app/org/sagebionetworks/bridge/services/backfill/UserConsentBackfill.java
@@ -1,0 +1,64 @@
+package org.sagebionetworks.bridge.services.backfill;
+
+import java.util.Iterator;
+
+import org.sagebionetworks.bridge.dao.AccountDao;
+import org.sagebionetworks.bridge.dao.UserConsentDao;
+import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.HealthId;
+import org.sagebionetworks.bridge.models.backfill.BackfillTask;
+import org.sagebionetworks.bridge.services.HealthCodeService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component("userConsentEventBackfill")
+public class UserConsentBackfill extends AsyncBackfillTemplate {
+
+    private AccountDao accountDao;
+    private UserConsentDao userConsentDao;
+    private HealthCodeService healthCodeService;
+    
+    @Autowired
+    private final void setAccountDao(AccountDao accountDao) {
+        this.accountDao = accountDao;
+    }
+    @Autowired
+    private final void setUserConsentDao(UserConsentDao userConsentDao) {
+        this.userConsentDao = userConsentDao;
+    }
+    @Autowired
+    public void setHealthCodeService(HealthCodeService healthCodeService) {
+        this.healthCodeService = healthCodeService;
+    }
+    
+    @Override
+    int getLockExpireInSeconds() {
+        return 30 * 60;
+    }
+
+    @Override
+    void doBackfill(BackfillTask task, BackfillCallback callback) {
+        callback.newRecords(getBackfillRecordFactory().createOnly(task, "Starting to examine accounts"));
+        
+        Iterator<Account> i = accountDao.getAllAccounts();
+        while (i.hasNext()) {
+            Account account = i.next();
+            
+            callback.newRecords(getBackfillRecordFactory().createOnly(task, "Examining account: " + account.getId()));
+            
+            HealthId mapping = healthCodeService.getMapping(account.getHealthId());
+            if (mapping != null) {
+                String healthCode = mapping.getCode();
+                boolean success = userConsentDao.migrateConsent(healthCode, account.getStudyIdentifier());
+                if (success) {
+                    callback.newRecords(getBackfillRecordFactory().createOnly(task, "Consent record migrated"));
+                } else {
+                    callback.newRecords(getBackfillRecordFactory().createOnly(task, "Could not migrate consent record"));
+                }
+            }  else {
+                callback.newRecords(getBackfillRecordFactory().createOnly(task, "Health code not found"));
+            }
+        }
+    }
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-sts" % "1.10.20",
   "com.amazonaws" % "aws-java-sdk-dynamodb" % "1.10.20",
   "com.amazonaws" % "aws-java-sdk-ses" % "1.10.20",
+  
   // New Relic
   "com.newrelic.agent.java" % "newrelic-agent" % "3.18.0",
   // Spring

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoUserConsent3Test.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoUserConsent3Test.java
@@ -10,24 +10,11 @@ public class DynamoUserConsent3Test {
         String healthCode = "123";
         String studyKey = "456";
         
-        DynamoUserConsent3 userConsent = new DynamoUserConsent3();
-        // This is the only unusual setter in the class.
-        userConsent.setHealthCodeStudy(healthCode, studyKey);
+        DynamoUserConsent3 userConsent = new DynamoUserConsent3(healthCode, studyKey);
         
         assertEquals(healthCode + ":" + studyKey, userConsent.getHealthCodeStudy());
         assertEquals(healthCode, userConsent.getHealthCode());
         assertEquals(studyKey, userConsent.getStudyIdentifier());
-        
-        // These do update the compound key (it doesn't work the other way).
-        userConsent.setHealthCode("BBB");
-        assertEquals("BBB:" + studyKey, userConsent.getHealthCodeStudy());
-        assertEquals("BBB", userConsent.getHealthCode());
-        assertEquals(studyKey, userConsent.getStudyIdentifier());
-        
-        userConsent.setStudyIdentifier("CCC");
-        assertEquals("BBB:CCC", userConsent.getHealthCodeStudy());
-        assertEquals("BBB", userConsent.getHealthCode());
-        assertEquals("CCC", userConsent.getStudyIdentifier());
     }
 
 }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoUserConsent3Test.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoUserConsent3Test.java
@@ -1,0 +1,33 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class DynamoUserConsent3Test {
+    @Test
+    public void test() {
+        String healthCode = "123";
+        String studyKey = "456";
+        
+        DynamoUserConsent3 userConsent = new DynamoUserConsent3();
+        // This is the only unusual setter in the class.
+        userConsent.setHealthCodeStudy(healthCode, studyKey);
+        
+        assertEquals(healthCode + ":" + studyKey, userConsent.getHealthCodeStudy());
+        assertEquals(healthCode, userConsent.getHealthCode());
+        assertEquals(studyKey, userConsent.getStudyIdentifier());
+        
+        // These do update the compound key (it doesn't work the other way).
+        userConsent.setHealthCode("BBB");
+        assertEquals("BBB:" + studyKey, userConsent.getHealthCodeStudy());
+        assertEquals("BBB", userConsent.getHealthCode());
+        assertEquals(studyKey, userConsent.getStudyIdentifier());
+        
+        userConsent.setStudyIdentifier("CCC");
+        assertEquals("BBB:CCC", userConsent.getHealthCodeStudy());
+        assertEquals("BBB", userConsent.getHealthCode());
+        assertEquals("CCC", userConsent.getStudyIdentifier());
+    }
+
+}

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoUserConsentDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoUserConsentDaoMockTest.java
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.ConcurrentModificationException;
-import java.util.List;
 import java.util.stream.Stream;
 
 import org.joda.time.DateTime;
@@ -31,6 +30,7 @@ import com.amazonaws.services.dynamodbv2.datamodeling.PaginatedQueryList;
 
 public class DynamoUserConsentDaoMockTest {
 
+    private static final String HEALTH_CODE = "AAA";
     private static final StudyIdentifier STUDY_IDENTIFIER = new StudyIdentifierImpl("test-study");
     
     DynamoUserConsentDao userConsentDao;
@@ -74,11 +74,11 @@ public class DynamoUserConsentDaoMockTest {
     }
     
     private void createQueryWithResults() {
-        DynamoUserConsent2 existingConsent2 = new DynamoUserConsent2("AAA", "test-study");
+        DynamoUserConsent2 existingConsent2 = new DynamoUserConsent2(HEALTH_CODE, STUDY_IDENTIFIER.getIdentifier());
         existingConsent2.setConsentCreatedOn(studyConsent.getCreatedOn());
         existingConsent2.setSignedOn(DateTime.now().getMillis());
 
-        DynamoUserConsent3 existingConsent3 = new DynamoUserConsent3("AAA", "test-study");
+        DynamoUserConsent3 existingConsent3 = new DynamoUserConsent3(HEALTH_CODE, STUDY_IDENTIFIER.getIdentifier());
         existingConsent3.setConsentCreatedOn(studyConsent.getCreatedOn());
         existingConsent3.setSignedOn(DateTime.now().getMillis());
         
@@ -86,49 +86,78 @@ public class DynamoUserConsentDaoMockTest {
     }
     
     @Test
-    public void consentsWrittenToBothTables() {
-        userConsentDao.giveConsent("AAA", studyConsent);
+    public void giveConsent() {
+        userConsentDao.giveConsent(HEALTH_CODE, studyConsent);
         
-        ArgumentCaptor<DynamoUserConsent2> argCaptor2 = ArgumentCaptor.forClass(DynamoUserConsent2.class);
         ArgumentCaptor<DynamoUserConsent3> argCaptor3 = ArgumentCaptor.forClass(DynamoUserConsent3.class);
         
+        verify(mapper3).query(any(), any()); // queries and saves, doesn't speak to table2
         verify(mapper2).load(any());
-        verify(mapper2).save(argCaptor2.capture());
-        verify(mapper3).query(any(), any());
         verify(mapper3).save(argCaptor3.capture());
         verifyNoMoreInteractions(mapper2);
         verifyNoMoreInteractions(mapper3);
         
-        DynamoUserConsent2 cons2 = argCaptor2.getValue();
         DynamoUserConsent3 cons3 = argCaptor3.getValue();
         
-        assertEquals(studyConsent.getCreatedOn(), cons2.getConsentCreatedOn());
-        assertTrue(cons2.getSignedOn() > 0L);
-        assertEquals("AAA", cons2.getHealthCode());
-        assertEquals("AAA:test-study", cons2.getHealthCodeStudy());
-        
-        assertEquals(cons2.getConsentCreatedOn(), cons3.getConsentCreatedOn());
-        assertEquals((Long)cons2.getSignedOn(), (Long)cons3.getSignedOn());
-        assertEquals(cons2.getHealthCode(), cons3.getHealthCode());
-        assertEquals(cons2.getHealthCodeStudy(), cons3.getHealthCodeStudy());
-        assertEquals(cons2.getStudyIdentifier(), cons3.getStudyIdentifier());
+        assertTrue(cons3.getConsentCreatedOn() > 0);
+        assertEquals((Long)cons3.getSignedOn(), (Long)cons3.getSignedOn());
+        assertEquals(cons3.getHealthCode(), cons3.getHealthCode());
+        assertEquals(cons3.getHealthCodeStudy(), cons3.getHealthCodeStudy());
+        assertEquals(cons3.getStudyIdentifier(), cons3.getStudyIdentifier());
     }
     
     @Test
-    public void throwExceptionIfConsentExists() {
-        DynamoUserConsent2 existingConsent = new DynamoUserConsent2("AAA", "test-study");
-        existingConsent.setConsentCreatedOn(studyConsent.getCreatedOn());
-        existingConsent.setSignedOn(DateTime.now().getMillis());
-
-        when(mapper2.load(any())).thenReturn(existingConsent);
+    public void giveConsentWhenConsentExists() {
+        createQueryWithResults();
 
         try {
-            userConsentDao.giveConsent("AAA", studyConsent);
+            userConsentDao.giveConsent(HEALTH_CODE, studyConsent);
             fail("Should have thrown exception");
         } catch(EntityAlreadyExistsException e) {
             assertNull(e.getEntity());
             assertEquals("Consent already exists.", e.getMessage());
         }
+        verify(mapper3).query(any(), any()); // queried then threw exception, didn't touch table2
+        verifyNoMoreInteractions(mapper2);
+        verifyNoMoreInteractions(mapper3);
+    }
+    
+    @Test
+    public void hasConsentedWhenTable3Exists() {
+        createQueryWithResults();
+        
+        boolean hasConsented = userConsentDao.hasConsented(HEALTH_CODE, STUDY_IDENTIFIER);
+        
+        assertTrue(hasConsented);
+        verify(mapper3).query(any(), any());
+        verifyNoMoreInteractions(mapper2);
+        verifyNoMoreInteractions(mapper3);
+    }
+    
+    @Test
+    public void hasConsentedWhenTable2Exists() {
+        DynamoUserConsent2 existingConsent2 = new DynamoUserConsent2(HEALTH_CODE, STUDY_IDENTIFIER.getIdentifier());
+        existingConsent2.setConsentCreatedOn(studyConsent.getCreatedOn());
+        existingConsent2.setSignedOn(DateTime.now().getMillis());
+
+        doReturn(existingConsent2).when(mapper2).load(any());
+        
+        boolean hasConsented = userConsentDao.hasConsented(HEALTH_CODE, STUDY_IDENTIFIER);
+        
+        assertTrue(hasConsented);
+        verify(mapper3).query(any(), any());
+        verify(mapper2).load(any());
+        verifyNoMoreInteractions(mapper2);
+        verifyNoMoreInteractions(mapper3);
+    }
+    
+    @Test
+    public void hasConsentedNoConsent() {
+        // Very similar to consenting when consent is in table 2, except, no consent there.
+        boolean hasConsented = userConsentDao.hasConsented(HEALTH_CODE, STUDY_IDENTIFIER);
+        
+        assertFalse(hasConsented);
+        verify(mapper3).query(any(), any());
         verify(mapper2).load(any());
         verifyNoMoreInteractions(mapper2);
         verifyNoMoreInteractions(mapper3);
@@ -138,7 +167,7 @@ public class DynamoUserConsentDaoMockTest {
     public void withdrawUpdatesBothTables() {
         createQueryWithResults();
         
-        userConsentDao.withdrawConsent("AAA", STUDY_IDENTIFIER);
+        userConsentDao.withdrawConsent(HEALTH_CODE, STUDY_IDENTIFIER);
         
         verify(mapper2).load(any());
         verify(mapper2).delete(any(DynamoUserConsent2.class));
@@ -149,156 +178,84 @@ public class DynamoUserConsentDaoMockTest {
     }
     
     @Test
-    public void getConsentFromOriginalTableOnly() {
-        createQueryWithResults();
-        
-        UserConsent consent = userConsentDao.getUserConsent("AAA", STUDY_IDENTIFIER);
-        assertTrue(consent instanceof DynamoUserConsent2);
-        assertEquals("test-study", consent.getStudyIdentifier());
-        
-        verify(mapper2).load(any());
-        verifyNoMoreInteractions(mapper2);
-        verifyNoMoreInteractions(mapper3);
-    }
-    
-    @Test
-    public void testIfConsentedFromOriginalTable() {
-        createQueryWithResults();
-        
-        userConsentDao.hasConsented("AAA", STUDY_IDENTIFIER);
-        
-        verify(mapper2).load(any());
-        verifyNoMoreInteractions(mapper2);
-        verifyNoMoreInteractions(mapper3);
-    }
-    
-    @Test
-    public void saveFirstTableThrowsErrorSecondTableIgnored() {
-        doThrow(new ConcurrentModificationException()).when(mapper3).save(any());
-        
-        // If mapper3 throws exception on save, do not call mapper2, and do propagate exception
-        try {
-            userConsentDao.giveConsent("AAA", studyConsent);
-            fail("Should have thrown exception");
-        } catch(ConcurrentModificationException e) {
-            verify(mapper2).load(any());
-            verify(mapper3).query(any(), any());
-            verify(mapper3).save(any());
-            // No mapper 2 save, 3 failed
-            verifyNoMoreInteractions(mapper3);
-            verifyNoMoreInteractions(mapper2);
-        }
-    }
-    
-    @Test
-    public void saveSecondTableThrowsErrorFirstUndone() {
-        doThrow(new ConcurrentModificationException()).when(mapper2).save(any());
-        
-        // If mapper2 throws exception on save, undo save to mapper3, then propagate exception 
-        try {
-            userConsentDao.giveConsent("AAA", studyConsent);
-            fail("Should have thrown exception");
-        } catch(ConcurrentModificationException e) {
-            verify(mapper2).load(any());
-            // saves successfully
-            verify(mapper3).query(any(), any());
-            verify(mapper3).save(any());
-            // but two throws an error, so 3 deletes
-            verify(mapper2).save(any());
-            verify(mapper3).delete(any());
-            verifyNoMoreInteractions(mapper3);
-            verifyNoMoreInteractions(mapper2);
-        }
-    }
-    
-    @Test
     public void withdrawFirstTableThrowsErrorSecondTableIgnored() {
+        createQueryWithResults();
+        doThrow(new ConcurrentModificationException()).when(mapper2).delete(any());
+        
+        try {
+            userConsentDao.withdrawConsent(HEALTH_CODE, STUDY_IDENTIFIER);
+            fail("Should have thrown exception");
+        } catch(ConcurrentModificationException e) {
+            verify(mapper2).load(any());
+            verify(mapper2).delete(any()); // this fails, mapper2 not called
+            verifyNoMoreInteractions(mapper2);
+            verifyNoMoreInteractions(mapper3);
+        }
+    }
+    
+    @Test
+    public void withdrawSecondTableThrowsException() {
         createQueryWithResults();
         doThrow(new ConcurrentModificationException()).when(mapper3).delete(any());
         
-        // If mapper3 throws exception on save, do not call mapper2, and do propagate exception
+        // If mapper2 throws exception on delete, resave to mapper3, then propagate exception 
         try {
-            userConsentDao.withdrawConsent("AAA", STUDY_IDENTIFIER);
+            userConsentDao.withdrawConsent(HEALTH_CODE, STUDY_IDENTIFIER);
             fail("Should have thrown exception");
         } catch(ConcurrentModificationException e) {
             verify(mapper2).load(any());
+            verify(mapper2).delete(any()); // throws exception
             verify(mapper3).query(any(), any());
             verify(mapper3).delete(any());
-            // No mapper 2 delete, 3 failed
-            verifyNoMoreInteractions(mapper3);
             verifyNoMoreInteractions(mapper2);
+            verifyNoMoreInteractions(mapper3);
         }
     }
     
     @Test
-    public void withdrawSecondTableThrowsErrorFirstUndone() {
+    public void getConsentFromTable3First() {
         createQueryWithResults();
-        doThrow(new ConcurrentModificationException()).when(mapper2).delete(any());
         
-        // If mapper2 throws exception on delete, resave to mapper3, then propagate exception 
-        try {
-            userConsentDao.withdrawConsent("AAA", STUDY_IDENTIFIER);
-            fail("Should have thrown exception");
-        } catch(ConcurrentModificationException e) {
-            ArgumentCaptor<DynamoUserConsent3> argCapture = ArgumentCaptor.forClass(DynamoUserConsent3.class);
-            
-            verify(mapper2).load(any());
-            // saves successfully
-            verify(mapper3).query(any(), any());
-            verify(mapper3).delete(any());
-            // but two throws an error, so 3 deletes
-            verify(mapper2).delete(any());
-            verify(mapper3).save(argCapture.capture());
-            verifyNoMoreInteractions(mapper3);
-            verifyNoMoreInteractions(mapper2);
-            
-            // the version needs to be null on this save or it'll throw a concurrent modification exception
-            assertNull(argCapture.getValue().getVersion());
-        }
+        UserConsent consent = userConsentDao.getUserConsent(HEALTH_CODE, STUDY_IDENTIFIER);
+        assertTrue(consent instanceof DynamoUserConsent3);
+        assertEquals(STUDY_IDENTIFIER.getIdentifier(), consent.getStudyIdentifier());
+        
+        verify(mapper3).query(any(), any());
+        verifyNoMoreInteractions(mapper2);
+        verifyNoMoreInteractions(mapper3);
     }
 
-    @SuppressWarnings("unchecked")
+    @Test
+    public void getConsentFallsbackToTable2() {
+        DynamoUserConsent2 existingConsent2 = new DynamoUserConsent2(HEALTH_CODE, STUDY_IDENTIFIER.getIdentifier());
+        existingConsent2.setConsentCreatedOn(studyConsent.getCreatedOn());
+        existingConsent2.setSignedOn(DateTime.now().getMillis());
+        doReturn(existingConsent2).when(mapper2).load(any());
+
+        UserConsent consent = userConsentDao.getUserConsent(HEALTH_CODE, STUDY_IDENTIFIER);
+        assertTrue(consent instanceof DynamoUserConsent2);
+        assertEquals(STUDY_IDENTIFIER.getIdentifier(), consent.getStudyIdentifier());
+        
+        verify(mapper3).query(any(), any());
+        verify(mapper2).load(any());
+        verifyNoMoreInteractions(mapper2);
+        verifyNoMoreInteractions(mapper3);
+    }
+    
     @Test
     public void deleteFirstTableThrowsErrorSecondTableIgnored() {
         createQueryWithResults();
-        doThrow(new ConcurrentModificationException()).when(mapper3).batchDelete((List<DynamoUserConsent3>)any());
+        doThrow(new ConcurrentModificationException()).when(mapper2).delete(any());
         
         // If mapper3 throws exception on delete, do not call mapper2, and do propagate exception
         try {
-            userConsentDao.deleteConsentRecords("AAA", STUDY_IDENTIFIER);
+            userConsentDao.deleteConsentRecords(HEALTH_CODE, STUDY_IDENTIFIER);
             fail("Should have thrown exception");
         } catch(ConcurrentModificationException e) {
-            verify(mapper3).query(any(), any());
-            verify(mapper3).batchDelete((List<DynamoUserConsent3>)any()); // exception thrown
-            verifyNoMoreInteractions(mapper3); // No compensation needed
-            verifyNoMoreInteractions(mapper2);
-        }
-    }
-    
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    @Test
-    public void deleteSecondTableThrowsErrorFirstUndone() {
-        createQueryWithResults();
-        doThrow(new ConcurrentModificationException()).when(mapper2).delete(any());
-        
-        // If mapper2 throws exception on delete, resave to mapper3, then propagate exception 
-        try {
-            userConsentDao.deleteConsentRecords("AAA", STUDY_IDENTIFIER);
-            fail("Should have thrown exception");
-        } catch(ConcurrentModificationException e) {
-            ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
-            verify(mapper3).query(any(), any());
-            verify(mapper3).batchDelete((List<DynamoUserConsent3>)any());
             verify(mapper2).load(any());
-            verify(mapper2).delete(any()); // exception
-            verify(mapper3).batchSave(captor.capture()); // compensate for failed delete
+            verify(mapper2).delete(any());
             verifyNoMoreInteractions(mapper3);
             verifyNoMoreInteractions(mapper2);
-            
-            // We want to see the #3 consent has no version
-            List<DynamoUserConsent3> consent = (List<DynamoUserConsent3>)captor.getValue();
-            assertNull(consent.get(0).getVersion());
-            
         }
     }
     
@@ -309,7 +266,7 @@ public class DynamoUserConsentDaoMockTest {
         // There is no #3 record, so migration should occur
         when(mapper3.query(any(), any())).thenReturn(mock(PaginatedQueryList.class));
         
-        boolean result = userConsentDao.migrateConsent("AAA", STUDY_IDENTIFIER);
+        boolean result = userConsentDao.migrateConsent(HEALTH_CODE, STUDY_IDENTIFIER);
         
         ArgumentCaptor<DynamoUserConsent3> captor3 = ArgumentCaptor.forClass(DynamoUserConsent3.class);
         
@@ -321,8 +278,8 @@ public class DynamoUserConsentDaoMockTest {
         verifyNoMoreInteractions(mapper2);
         
         assertTrue(captor3.getValue().getSignedOn() > 0);
-        assertEquals("AAA", captor3.getValue().getHealthCode());
-        assertEquals("test-study", captor3.getValue().getStudyIdentifier());
+        assertEquals(HEALTH_CODE, captor3.getValue().getHealthCode());
+        assertEquals(STUDY_IDENTIFIER.getIdentifier(), captor3.getValue().getStudyIdentifier());
         assertTrue(captor3.getValue().getConsentCreatedOn() > 0);
         assertNull(captor3.getValue().getVersion());
     }
@@ -331,7 +288,7 @@ public class DynamoUserConsentDaoMockTest {
     public void doNotMigrateBetweenTablesWhenConsentDoesntExist() {
         createQueryWithResults();
         
-        boolean result = userConsentDao.migrateConsent("AAA", STUDY_IDENTIFIER);
+        boolean result = userConsentDao.migrateConsent(HEALTH_CODE, STUDY_IDENTIFIER);
         
         assertFalse(result);
         verify(mapper2).load(any());

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoUserConsentDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoUserConsentDaoMockTest.java
@@ -1,0 +1,165 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
+import org.sagebionetworks.bridge.models.accounts.UserConsent;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.datamodeling.PaginatedQueryList;
+
+public class DynamoUserConsentDaoMockTest {
+
+    private static final StudyIdentifier STUDY_IDENTIFIER = new StudyIdentifierImpl("test-study");
+    
+    DynamoUserConsentDao userConsentDao;
+    
+    DynamoStudyConsent1 studyConsent;
+    
+    DynamoDBMapper mapper2;
+    
+    DynamoDBMapper mapper3;
+    
+    @Before
+    public void before() {
+        studyConsent = new DynamoStudyConsent1();
+        studyConsent.setActive(true);
+        studyConsent.setCreatedOn(DateTime.now().getMillis());
+        studyConsent.setStudyKey("test-study");
+        studyConsent.setStoragePath("test-study.12341234123");
+        
+        mapper2 = mock(DynamoDBMapper.class);
+        mapper3 = mock(DynamoDBMapper.class);
+        
+        createQueryResults(null, null);
+        
+        userConsentDao = new DynamoUserConsentDao();
+        userConsentDao.setDdbMapper2(mapper2);
+        userConsentDao.setDdbMapper3(mapper3);
+    }
+    
+    @SuppressWarnings("unchecked")
+    private void createQueryResults(DynamoUserConsent2 consent2, DynamoUserConsent3 consent3) {
+        PaginatedQueryList<DynamoUserConsent3> list3 = mock(PaginatedQueryList.class);
+        if (consent2 == null) {
+            when(list3.isEmpty()).thenReturn(true);
+        } else {
+            when(list3.isEmpty()).thenReturn(false);
+            when(list3.get(0)).thenReturn(consent3);
+        }
+        doReturn(consent2).when(mapper2).load(any());
+        doReturn(list3).when(mapper3).query(any(), any());
+    }
+    
+    private void createQueryWithResults() {
+        DynamoUserConsent2 existingConsent2 = new DynamoUserConsent2("AAA", "test-study");
+        existingConsent2.setConsentCreatedOn(studyConsent.getCreatedOn());
+        existingConsent2.setSignedOn(DateTime.now().getMillis());
+
+        DynamoUserConsent3 existingConsent3 = new DynamoUserConsent3();
+        existingConsent3.setHealthCodeStudy("AAA", "test-study");
+        existingConsent3.setConsentCreatedOn(studyConsent.getCreatedOn());
+        existingConsent3.setSignedOn(DateTime.now().getMillis());
+        
+        createQueryResults(existingConsent2, existingConsent3);
+    }
+    
+    @Test
+    public void consentsWrittenToBothTables() {
+        userConsentDao.giveConsent("AAA", studyConsent);
+        
+        ArgumentCaptor<DynamoUserConsent2> argCaptor2 = ArgumentCaptor.forClass(DynamoUserConsent2.class);
+        ArgumentCaptor<DynamoUserConsent3> argCaptor3 = ArgumentCaptor.forClass(DynamoUserConsent3.class);
+        
+        verify(mapper2).load(any());
+        verify(mapper2).save(argCaptor2.capture());
+        verify(mapper3).query(any(), any());
+        verify(mapper3).save(argCaptor3.capture());
+        verifyNoMoreInteractions(mapper2);
+        verifyNoMoreInteractions(mapper3);
+        
+        DynamoUserConsent2 cons2 = argCaptor2.getValue();
+        DynamoUserConsent3 cons3 = argCaptor3.getValue();
+        
+        assertEquals(studyConsent.getCreatedOn(), cons2.getConsentCreatedOn());
+        assertTrue(cons2.getSignedOn() > 0L);
+        assertEquals("AAA", cons2.getHealthCode());
+        assertEquals("AAA:test-study", cons2.getHealthCodeStudy());
+        
+        assertEquals(cons2.getConsentCreatedOn(), cons3.getConsentCreatedOn());
+        assertEquals((Long)cons2.getSignedOn(), (Long)cons3.getSignedOn());
+        assertEquals(cons2.getHealthCode(), cons3.getHealthCode());
+        assertEquals(cons2.getHealthCodeStudy(), cons3.getHealthCodeStudy());
+        assertEquals(cons2.getStudyIdentifier(), cons3.getStudyIdentifier());
+    }
+    
+    @Test
+    public void throwExceptionIfConsentExists() {
+        DynamoUserConsent2 existingConsent = new DynamoUserConsent2("AAA", "test-study");
+        existingConsent.setConsentCreatedOn(studyConsent.getCreatedOn());
+        existingConsent.setSignedOn(DateTime.now().getMillis());
+
+        when(mapper2.load(any())).thenReturn(existingConsent);
+
+        try {
+            userConsentDao.giveConsent("AAA", studyConsent);
+            fail("Should have thrown exception");
+        } catch(EntityAlreadyExistsException e) {
+        }
+        verify(mapper2).load(any());
+        verifyNoMoreInteractions(mapper2);
+        verifyNoMoreInteractions(mapper3);
+    }
+    
+    @Test
+    public void withdrawUpdatesBothTables() {
+        createQueryWithResults();
+        
+        userConsentDao.withdrawConsent("AAA", STUDY_IDENTIFIER);
+        
+        verify(mapper2).load(any());
+        verify(mapper2).delete(any(DynamoUserConsent2.class));
+        verify(mapper3).query(any(), any());
+        verify(mapper3).delete(any(DynamoUserConsent3.class));
+        verifyNoMoreInteractions(mapper2);
+        verifyNoMoreInteractions(mapper3);
+    }
+    
+    @Test
+    public void getConsentFromOriginalTableOnly() {
+        createQueryWithResults();
+        
+        UserConsent consent = userConsentDao.getUserConsent("AAA", STUDY_IDENTIFIER);
+        assertTrue(consent instanceof DynamoUserConsent2);
+        assertEquals("test-study", consent.getStudyIdentifier());
+        
+        verify(mapper2).load(any());
+        verifyNoMoreInteractions(mapper2);
+        verifyNoMoreInteractions(mapper3);
+    }
+    
+    @Test
+    public void testIfConsentedFromOriginalTable() {
+        createQueryWithResults();
+        
+        userConsentDao.hasConsented("AAA", STUDY_IDENTIFIER);
+        
+        verify(mapper2).load(any());
+        verifyNoMoreInteractions(mapper2);
+        verifyNoMoreInteractions(mapper3);
+    }
+}

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoUserConsentDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoUserConsentDaoMockTest.java
@@ -105,10 +105,9 @@ public class DynamoUserConsentDaoMockTest {
         
         assertTrue(cons3.getConsentCreatedOn() > 0);
         assertTrue(cons3.getSignedOn() > 0);
-        assertNotNull(cons3.getHealthCode());
-        assertNotNull(cons3.getHealthCodeStudy());
-        assertNotNull(cons3.getStudyIdentifier());
-        assertTrue(cons3.getHealthCodeStudy().contains(cons3.getHealthCode()));
+        assertEquals(HEALTH_CODE, cons3.getHealthCode());
+        assertEquals(HEALTH_CODE+":"+studyConsent.getStudyKey(), cons3.getHealthCodeStudy());
+        assertEquals(studyConsent.getStudyKey(), cons3.getStudyIdentifier());
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoUserConsentDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoUserConsentDaoMockTest.java
@@ -1,14 +1,21 @@
 package org.sagebionetworks.bridge.dynamodb;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+
+import java.util.ConcurrentModificationException;
+import java.util.List;
+import java.util.stream.Stream;
 
 import org.joda.time.DateTime;
 import org.junit.Before;
@@ -54,15 +61,16 @@ public class DynamoUserConsentDaoMockTest {
     
     @SuppressWarnings("unchecked")
     private void createQueryResults(DynamoUserConsent2 consent2, DynamoUserConsent3 consent3) {
-        PaginatedQueryList<DynamoUserConsent3> list3 = mock(PaginatedQueryList.class);
+        PaginatedQueryList<DynamoUserConsent3> pqList = mock(PaginatedQueryList.class);
         if (consent2 == null) {
-            when(list3.isEmpty()).thenReturn(true);
+            when(pqList.isEmpty()).thenReturn(true);
         } else {
-            when(list3.isEmpty()).thenReturn(false);
-            when(list3.get(0)).thenReturn(consent3);
+            when(pqList.isEmpty()).thenReturn(false);
+            when(pqList.get(0)).thenReturn(consent3);
+            when(pqList.stream()).thenReturn(Stream.of(consent3));
         }
         doReturn(consent2).when(mapper2).load(any());
-        doReturn(list3).when(mapper3).query(any(), any());
+        doReturn(pqList).when(mapper3).query(any(), any());
     }
     
     private void createQueryWithResults() {
@@ -70,8 +78,7 @@ public class DynamoUserConsentDaoMockTest {
         existingConsent2.setConsentCreatedOn(studyConsent.getCreatedOn());
         existingConsent2.setSignedOn(DateTime.now().getMillis());
 
-        DynamoUserConsent3 existingConsent3 = new DynamoUserConsent3();
-        existingConsent3.setHealthCodeStudy("AAA", "test-study");
+        DynamoUserConsent3 existingConsent3 = new DynamoUserConsent3("AAA", "test-study");
         existingConsent3.setConsentCreatedOn(studyConsent.getCreatedOn());
         existingConsent3.setSignedOn(DateTime.now().getMillis());
         
@@ -162,4 +169,173 @@ public class DynamoUserConsentDaoMockTest {
         verifyNoMoreInteractions(mapper2);
         verifyNoMoreInteractions(mapper3);
     }
+    
+    @Test
+    public void saveFirstTableThrowsErrorSecondTableIgnored() {
+        doThrow(new ConcurrentModificationException()).when(mapper3).save(any());
+        
+        // If mapper3 throws exception on save, do not call mapper2, and do propagate exception
+        try {
+            userConsentDao.giveConsent("AAA", studyConsent);
+            fail("Should have thrown exception");
+        } catch(ConcurrentModificationException e) {
+            verify(mapper2).load(any());
+            verify(mapper3).query(any(), any());
+            verify(mapper3).save(any());
+            // No mapper 2 save, 3 failed
+            verifyNoMoreInteractions(mapper3);
+            verifyNoMoreInteractions(mapper2);
+        }
+    }
+    
+    @Test
+    public void saveSecondTableThrowsErrorFirstUndone() {
+        doThrow(new ConcurrentModificationException()).when(mapper2).save(any());
+        
+        // If mapper2 throws exception on save, undo save to mapper3, then propagate exception 
+        try {
+            userConsentDao.giveConsent("AAA", studyConsent);
+            fail("Should have thrown exception");
+        } catch(ConcurrentModificationException e) {
+            verify(mapper2).load(any());
+            // saves successfully
+            verify(mapper3).query(any(), any());
+            verify(mapper3).save(any());
+            // but two throws an error, so 3 deletes
+            verify(mapper2).save(any());
+            verify(mapper3).delete(any());
+            verifyNoMoreInteractions(mapper3);
+            verifyNoMoreInteractions(mapper2);
+        }
+    }
+    
+    @Test
+    public void withdrawFirstTableThrowsErrorSecondTableIgnored() {
+        createQueryWithResults();
+        doThrow(new ConcurrentModificationException()).when(mapper3).delete(any());
+        
+        // If mapper3 throws exception on save, do not call mapper2, and do propagate exception
+        try {
+            userConsentDao.withdrawConsent("AAA", STUDY_IDENTIFIER);
+            fail("Should have thrown exception");
+        } catch(ConcurrentModificationException e) {
+            verify(mapper2).load(any());
+            verify(mapper3).query(any(), any());
+            verify(mapper3).delete(any());
+            // No mapper 2 delete, 3 failed
+            verifyNoMoreInteractions(mapper3);
+            verifyNoMoreInteractions(mapper2);
+        }
+    }
+    
+    @Test
+    public void withdrawSecondTableThrowsErrorFirstUndone() {
+        createQueryWithResults();
+        doThrow(new ConcurrentModificationException()).when(mapper2).delete(any());
+        
+        // If mapper2 throws exception on delete, resave to mapper3, then propagate exception 
+        try {
+            userConsentDao.withdrawConsent("AAA", STUDY_IDENTIFIER);
+            fail("Should have thrown exception");
+        } catch(ConcurrentModificationException e) {
+            ArgumentCaptor<DynamoUserConsent3> argCapture = ArgumentCaptor.forClass(DynamoUserConsent3.class);
+            
+            verify(mapper2).load(any());
+            // saves successfully
+            verify(mapper3).query(any(), any());
+            verify(mapper3).delete(any());
+            // but two throws an error, so 3 deletes
+            verify(mapper2).delete(any());
+            verify(mapper3).save(argCapture.capture());
+            verifyNoMoreInteractions(mapper3);
+            verifyNoMoreInteractions(mapper2);
+            
+            // the version needs to be null on this save or it'll throw a concurrent modification exception
+            assertNull(argCapture.getValue().getVersion());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void deleteFirstTableThrowsErrorSecondTableIgnored() {
+        createQueryWithResults();
+        doThrow(new ConcurrentModificationException()).when(mapper3).batchDelete((List<DynamoUserConsent3>)any());
+        
+        // If mapper3 throws exception on delete, do not call mapper2, and do propagate exception
+        try {
+            userConsentDao.deleteConsentRecords("AAA", STUDY_IDENTIFIER);
+            fail("Should have thrown exception");
+        } catch(ConcurrentModificationException e) {
+            verify(mapper3).query(any(), any());
+            verify(mapper3).batchDelete((List<DynamoUserConsent3>)any()); // exception thrown
+            verifyNoMoreInteractions(mapper3); // No compensation needed
+            verifyNoMoreInteractions(mapper2);
+        }
+    }
+    
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Test
+    public void deleteSecondTableThrowsErrorFirstUndone() {
+        createQueryWithResults();
+        doThrow(new ConcurrentModificationException()).when(mapper2).delete(any());
+        
+        // If mapper2 throws exception on delete, resave to mapper3, then propagate exception 
+        try {
+            userConsentDao.deleteConsentRecords("AAA", STUDY_IDENTIFIER);
+            fail("Should have thrown exception");
+        } catch(ConcurrentModificationException e) {
+            ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
+            verify(mapper3).query(any(), any());
+            verify(mapper3).batchDelete((List<DynamoUserConsent3>)any());
+            verify(mapper2).load(any());
+            verify(mapper2).delete(any()); // exception
+            verify(mapper3).batchSave(captor.capture()); // compensate for failed delete
+            verifyNoMoreInteractions(mapper3);
+            verifyNoMoreInteractions(mapper2);
+            
+            // We want to see the #3 consent has no version
+            List<DynamoUserConsent3> consent = (List<DynamoUserConsent3>)captor.getValue();
+            assertNull(consent.get(0).getVersion());
+            
+        }
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void canMigrateBetweenTablesConsentExists() {
+        createQueryWithResults();
+        // There is no #3 record, so migration should occur
+        when(mapper3.query(any(), any())).thenReturn(mock(PaginatedQueryList.class));
+        
+        boolean result = userConsentDao.migrateConsent("AAA", STUDY_IDENTIFIER);
+        
+        ArgumentCaptor<DynamoUserConsent3> captor3 = ArgumentCaptor.forClass(DynamoUserConsent3.class);
+        
+        assertTrue(result);
+        verify(mapper2).load(any());
+        verify(mapper3).query(any(), any());
+        verify(mapper3).save(captor3.capture());
+        verifyNoMoreInteractions(mapper3);
+        verifyNoMoreInteractions(mapper2);
+        
+        assertTrue(captor3.getValue().getSignedOn() > 0);
+        assertEquals("AAA", captor3.getValue().getHealthCode());
+        assertEquals("test-study", captor3.getValue().getStudyIdentifier());
+        assertTrue(captor3.getValue().getConsentCreatedOn() > 0);
+        assertNull(captor3.getValue().getVersion());
+    }
+    
+    @Test
+    public void doNotMigrateBetweenTablesWhenConsentDoesntExist() {
+        createQueryWithResults();
+        
+        boolean result = userConsentDao.migrateConsent("AAA", STUDY_IDENTIFIER);
+        
+        assertFalse(result);
+        verify(mapper2).load(any());
+        verify(mapper3).query(any(), any());
+        verifyNoMoreInteractions(mapper3);
+        verifyNoMoreInteractions(mapper2);
+    }
+
 }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoUserConsentDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoUserConsentDaoMockTest.java
@@ -126,6 +126,8 @@ public class DynamoUserConsentDaoMockTest {
             userConsentDao.giveConsent("AAA", studyConsent);
             fail("Should have thrown exception");
         } catch(EntityAlreadyExistsException e) {
+            assertNull(e.getEntity());
+            assertEquals("Consent already exists.", e.getMessage());
         }
         verify(mapper2).load(any());
         verifyNoMoreInteractions(mapper2);

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoUserConsentDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoUserConsentDaoTest.java
@@ -28,7 +28,6 @@ public class DynamoUserConsentDaoTest {
 
     @BeforeClass
     public static void beforeClass() {
-        System.out.println("beforeClass fired");
         DynamoInitializer.init(DynamoUserConsent2.class);
         DynamoInitializer.init(DynamoUserConsent3.class);
     }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoUserConsentDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoUserConsentDaoTest.java
@@ -8,6 +8,7 @@ import javax.annotation.Resource;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
@@ -25,10 +26,15 @@ public class DynamoUserConsentDaoTest {
     @Resource
     private DynamoUserConsentDao userConsentDao;
 
-    @Before
-    public void before() {
+    @BeforeClass
+    public static void beforeClass() {
+        System.out.println("beforeClass fired");
         DynamoInitializer.init(DynamoUserConsent2.class);
         DynamoInitializer.init(DynamoUserConsent3.class);
+    }
+    
+    @Before
+    public void before() {
         userConsentDao.deleteConsentRecords(HEALTH_CODE, STUDY_IDENTIFIER);
         for (int i=1; i < 6; i++) {
             userConsentDao.deleteConsentRecords(HEALTH_CODE+i, STUDY_IDENTIFIER);

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoUserConsentDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoUserConsentDaoTest.java
@@ -28,14 +28,21 @@ public class DynamoUserConsentDaoTest {
     @Before
     public void before() {
         DynamoInitializer.init(DynamoUserConsent2.class);
-        DynamoTestUtil.clearTable(DynamoUserConsent2.class);
+        DynamoInitializer.init(DynamoUserConsent3.class);
+        userConsentDao.deleteConsentRecords(HEALTH_CODE, STUDY_IDENTIFIER);
+        for (int i=1; i < 6; i++) {
+            userConsentDao.deleteConsentRecords(HEALTH_CODE+i, STUDY_IDENTIFIER);
+        }
     }
 
     @After
     public void after() {
-        DynamoTestUtil.clearTable(DynamoUserConsent2.class);
+        userConsentDao.deleteConsentRecords(HEALTH_CODE, STUDY_IDENTIFIER);
+        for (int i=1; i < 6; i++) {
+            userConsentDao.deleteConsentRecords(HEALTH_CODE+i, STUDY_IDENTIFIER);
+        }
     }
-
+    
     @Test
     public void canConsentToStudy() {
         // Not consented yet

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoUserConsentTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoUserConsentTest.java
@@ -21,7 +21,7 @@ public class DynamoUserConsentTest {
         DynamoStudyConsent1 studyConsent = new DynamoStudyConsent1();
         studyConsent.setStudyKey(studyKey);
         studyConsent.setCreatedOn(consentTimestamp);
-        userConsent = new DynamoUserConsent2(healthCode, studyConsent);
+        userConsent = new DynamoUserConsent2(healthCode, studyConsent.getStudyKey());
         assertEquals(healthCode + ":" + studyKey, userConsent.getHealthCodeStudy());
         assertEquals(healthCode, userConsent.getHealthCode());
         assertEquals(studyKey, userConsent.getStudyKey());

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoUserConsentTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoUserConsentTest.java
@@ -18,10 +18,8 @@ public class DynamoUserConsentTest {
 
         // Test constructor 2
         long consentTimestamp = 789L;
-        DynamoStudyConsent1 studyConsent = new DynamoStudyConsent1();
-        studyConsent.setStudyKey(studyKey);
-        studyConsent.setCreatedOn(consentTimestamp);
-        userConsent = new DynamoUserConsent2(healthCode, studyConsent.getStudyKey());
+        userConsent = new DynamoUserConsent2(healthCode, studyKey);
+        userConsent.setConsentCreatedOn(consentTimestamp);
         assertEquals(healthCode + ":" + studyKey, userConsent.getHealthCodeStudy());
         assertEquals(healthCode, userConsent.getHealthCode());
         assertEquals(studyKey, userConsent.getStudyKey());

--- a/test/org/sagebionetworks/bridge/exceptions/EntityAlreadyExistsExceptionTest.java
+++ b/test/org/sagebionetworks/bridge/exceptions/EntityAlreadyExistsExceptionTest.java
@@ -1,0 +1,15 @@
+package org.sagebionetworks.bridge.exceptions;
+
+import org.junit.Test;
+
+public class EntityAlreadyExistsExceptionTest {
+
+    /**
+     * Some entities are not exposed through the API and when such an internal entity already exists, we cannot return
+     * the object the user just submitted to us. The exception should still work.
+     */
+    @Test(expected = NullPointerException.class)
+    public void testExceptionSerializesWithoutEntity() throws Exception {
+        new EntityAlreadyExistsException(null, "This should throw an exception");
+    }
+}


### PR DESCRIPTION
- there can now be multiple user consents. The new table still has a healthCode:study key, but now includes a signedOn range key.
- also includes a withdrawal field
- this check-in writes to both DynamUserConsent2 and DynamoUserConsent3, and keeps them in sync.
- created a migration to write consent records for existing users in UserConsent3 table.
- minor: renaming studyKey to studyIdentiifer in new table, removing direct dependency on study consent (the timestamp of its creation is recorded in the user's consent record as well);
- should not impact behavior of the system at this time, but needs to be deployed in order to do migrations which will take awhile.
