### PR TITLE
Creating a hacked schedules endpoint for clients that don't correctly…

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/ScheduleController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ScheduleController.java
@@ -54,8 +54,8 @@ public class ScheduleController extends BaseController {
         JsonNode node = BridgeObjectMapper.get().valueToTree(new ResourceList<Schedule>(schedules));
         ArrayNode items = (ArrayNode)node.get("items");
         for (int i=0; i < items.size(); i++) {
-            Schedule schedule = plans.get(i).getStrategy().getAllPossibleSchedules().get(0);
-            if (schedule.getPersistent()) {
+            // If it's marked persistent it's also a once-time schedule. Hack this to make it a recurring schedule.
+            if (schedules.get(i).getPersistent()) {
                 ((ObjectNode)items.get(i)).put("scheduleType", ScheduleType.RECURRING.name().toLowerCase());
             }
         }

--- a/conf/routes
+++ b/conf/routes
@@ -56,7 +56,8 @@ GET    /v3/surveyresponses/:identifier @org.sagebionetworks.bridge.play.controll
 POST   /v3/surveyresponses/:identifier @org.sagebionetworks.bridge.play.controllers.SurveyResponseController.appendSurveyAnswers(identifier: String)
 
 # Schedules
-GET    /v3/schedules   @org.sagebionetworks.bridge.play.controllers.ScheduleController.getSchedules
+GET    /v3/schedules   @org.sagebionetworks.bridge.play.controllers.ScheduleController.getSchedulesV3
+GET    /v4/schedules   @org.sagebionetworks.bridge.play.controllers.ScheduleController.getSchedules
 
 # ScheduledActivities (nee Tasks)
 GET    /v3/tasks       @org.sagebionetworks.bridge.play.controllers.ScheduledActivityController.getTasks(until: String ?= null, offset: String ?= null, daysAhead: String ?= null)

--- a/test/org/sagebionetworks/bridge/play/controllers/ScheduleControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ScheduleControllerTest.java
@@ -1,6 +1,8 @@
 package org.sagebionetworks.bridge.play.controllers;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.mock;
@@ -11,16 +13,23 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.sagebionetworks.bridge.TestUtils;
+import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.accounts.User;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
+import org.sagebionetworks.bridge.models.schedules.Activity;
+import org.sagebionetworks.bridge.models.schedules.Schedule;
 import org.sagebionetworks.bridge.models.schedules.SchedulePlan;
+import org.sagebionetworks.bridge.models.schedules.ScheduleType;
+import org.sagebionetworks.bridge.models.schedules.SimpleScheduleStrategy;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.services.SchedulePlanService;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Lists;
 
 import play.mvc.Result;
@@ -69,5 +78,58 @@ public class ScheduleControllerTest {
         JsonNode node = BridgeObjectMapper.get().readTree(content);
         
         assertEquals(1, node.get("total").asInt());
+    }
+    
+    @Test
+    public void getSchedulesV3AdjustsScheduleTypes() throws Exception {
+        List<SchedulePlan> plans = Lists.newArrayList();
+
+        Schedule schedule = new Schedule();
+        schedule.addActivity(new Activity.Builder().withLabel("Label").withTask("foo").build());
+        schedule.setEventId("activity:"+schedule.getActivities().get(0).getGuid()+":finished");
+        schedule.setScheduleType(ScheduleType.ONCE);
+        SimpleScheduleStrategy strategy = new SimpleScheduleStrategy();
+        strategy.setSchedule(schedule);
+        
+        SchedulePlan plan = new DynamoSchedulePlan();
+        plan.setLabel("Label");
+        plan.setGuid("BBB");
+        plan.setStudyKey("study-key");
+        plan.setStrategy(strategy);
+        plans.add(plan);
+
+        schedule = new Schedule();
+        schedule.addActivity(new Activity.Builder().withLabel("Label").withTask("foo").build());
+        schedule.setEventId("activity:"+schedule.getActivities().get(0).getGuid()+":finished");
+        schedule.setScheduleType(ScheduleType.ONCE);
+        strategy = new SimpleScheduleStrategy();
+        strategy.setSchedule(schedule);
+        
+        plan = new DynamoSchedulePlan();
+        plan.setLabel("Label");
+        plan.setGuid("BBB");
+        plan.setStudyKey("study-key");
+        plan.setStrategy(strategy);
+        plans.add(plan);
+        
+        SchedulePlanService schedulePlanService = mock(SchedulePlanService.class);
+        when(schedulePlanService.getSchedulePlans(any(), any())).thenReturn(plans);
+        controller.setSchedulePlanService(schedulePlanService);
+        
+        Result result = controller.getSchedulesV3();
+        
+        String content = Helpers.contentAsString(result);
+        JsonNode node = BridgeObjectMapper.get().readTree(content);
+        ArrayNode array = (ArrayNode)node.get("items");
+        
+        // Verify that both objects have been adjusted so that despite the fact that they are 
+        // marked as persistent, they are also marked as recurring.
+        ObjectNode schedule1 = (ObjectNode)array.get(0);
+        assertTrue(schedule1.get("persistent").asBoolean());
+        assertEquals("recurring", schedule1.get("scheduleType").asText());
+        
+        ObjectNode schedule2 = (ObjectNode)array.get(1);
+        assertTrue(schedule2.get("persistent").asBoolean());
+        assertEquals("recurring", schedule2.get("scheduleType").asText());
     }
 }

--- a/test/org/sagebionetworks/bridge/play/controllers/ScheduleControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ScheduleControllerTest.java
@@ -80,6 +80,7 @@ public class ScheduleControllerTest {
         assertEquals(1, node.get("total").asInt());
     }
     
+    @SuppressWarnings("deprecation")
     @Test
     public void getSchedulesV3AdjustsScheduleTypes() throws Exception {
         List<SchedulePlan> plans = Lists.newArrayList();


### PR DESCRIPTION
Our 1.1 apps are the only apps using the /v3/schedules, and they were incorrectly implemented. After some reverse engineering, Erin believes changing the schedules this way will get them to work:

https://sagebionetworks.jira.com/browse/BRIDGE-907

In short, persistent schedules get their scheduleType adjusted in the JSON, since persistence is a calculated property. Created normal v4 version of the endpoint that I will put in the documents, deprecated the /v3/schedules endpoint.
