### PR TITLE
add Mole Mapper to study whitelist

### DIFF
--- a/conf/bridge-server.conf
+++ b/conf/bridge-server.conf
@@ -100,4 +100,4 @@ uat.udd.sqs.queue.url = https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-
 prod.udd.sqs.queue.url = https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-UDD-Request-prod
 
 # List of studies that should never be deleted
-study.whitelist = api,asthma,breastcancer,cardiovascular,diabetes,parkinson
+study.whitelist = api,asthma,breastcancer,cardiovascular,diabetes,ohsu-molemapper,parkinson


### PR DESCRIPTION
This prevents it from being deleted and from getting its certs recreated.

I haven't added FPHS yet because adding it to the white list will prevent its certs from being created.

Testing done: There's not much I can test outside of running this in staging. I did verify that the server runs.
