### PR TITLE
Change create behavior to re-create GUIDs

### DIFF
--- a/app/org/sagebionetworks/bridge/services/SurveyServiceImpl.java
+++ b/app/org/sagebionetworks/bridge/services/SurveyServiceImpl.java
@@ -3,7 +3,6 @@ package org.sagebionetworks.bridge.services;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static org.sagebionetworks.bridge.BridgeUtils.checkNewEntity;
 
 import java.util.List;
 
@@ -13,6 +12,7 @@ import org.sagebionetworks.bridge.dao.SurveyDao;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolder;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.surveys.Survey;
+import org.sagebionetworks.bridge.models.surveys.SurveyElement;
 import org.sagebionetworks.bridge.validators.SurveyValidator;
 import org.sagebionetworks.bridge.validators.Validate;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,11 +46,14 @@ public class SurveyServiceImpl implements SurveyService {
     @Override
     public Survey createSurvey(Survey survey) {
         checkNotNull(survey, "Survey cannot be null");
-        checkNewEntity(survey, survey.getGuid(), "Survey has a GUID; it may already exist");
-        checkNewEntity(survey, survey.getVersion(), "Survey has a version value; it may already exist");
         
         survey.setGuid(BridgeUtils.generateGuid());
-        Validate.entityThrowingException(validator, survey);    
+        survey.setVersion(null);
+        for (SurveyElement element : survey.getElements()) {
+            element.setGuid(BridgeUtils.generateGuid());
+        }
+
+        Validate.entityThrowingException(validator, survey);
         return surveyDao.createSurvey(survey);
     }
 


### PR DESCRIPTION
Surveys and schedule plans originally threw exceptions if you tried to create a model that already had GUIDs in it.

With the implementation of an activity builder that cannot build an invalid object, GUIDs were provided during construction if not specified. But this means that JSON deserialization can no longer tell the difference between someone submitting activities copied from another model, and new activities that have been supplied a GUID during deserialization.

I've changed the service create method to recreate all the guids on a plan, so you cannot inadvertently save a schedule plan with activities that have the same guids as another schedule plan (as the researcher UI recently did, breaking a lot of schedules).

Then for consistency, I changed the behavior of surveys the same way: if you load then create a survey, you will get a new survey copy with new GUIDs (not an exception, and not elements that have the same guids as the original survey elements).
