### PR TITLE
duplicate field names in Schemas

### DIFF
--- a/app/org/sagebionetworks/bridge/validators/UploadSchemaValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/UploadSchemaValidator.java
@@ -1,6 +1,8 @@
 package org.sagebionetworks.bridge.validators;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import com.google.common.base.Strings;
 
@@ -72,19 +74,30 @@ public class UploadSchemaValidator implements Validator {
             if (fieldDefList == null || fieldDefList.isEmpty()) {
                 errors.rejectValue("fieldDefinitions", "requires at least one definition");
             } else {
+                Set<String> fieldNameSet = new HashSet<>();
+
                 for (int i=0; i < fieldDefList.size(); i++) {
                     UploadFieldDefinition fieldDef = fieldDefList.get(i);
                     if (fieldDef == null) {
                         errors.rejectValue("fieldDefinitions" + i, "is required");
                     } else {
                         errors.pushNestedPath("fieldDefinitions" + i);
-                        if (Strings.isNullOrEmpty(fieldDef.getName())) {
+
+                        String fieldName = fieldDef.getName();
+                        if (Strings.isNullOrEmpty(fieldName)) {
                             errors.rejectValue("name", "is required");
+                        } else {
+                            if (fieldNameSet.contains(fieldName)) {
+                                errors.rejectValue("name", "duplicate name " + fieldName);
+                            }
+                            fieldNameSet.add(fieldName);
                         }
+
+                        //noinspection ConstantConditions
                         if (fieldDef.getType() == null) {
                             errors.rejectValue("type", "is required");
                         }
-                        // type, being a boolean, will default to false
+
                         errors.popNestedPath();
                     }
                     

--- a/app/org/sagebionetworks/bridge/validators/UploadSchemaValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/UploadSchemaValidator.java
@@ -88,7 +88,7 @@ public class UploadSchemaValidator implements Validator {
                             errors.rejectValue("name", "is required");
                         } else {
                             if (fieldNameSet.contains(fieldName)) {
-                                errors.rejectValue("name", "duplicate name " + fieldName);
+                                errors.rejectValue("name", "cannot use " + fieldName + " (used by another field)");
                             }
                             fieldNameSet.add(fieldName);
                         }

--- a/test/org/sagebionetworks/bridge/validators/UploadSchemaValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/UploadSchemaValidatorTest.java
@@ -352,6 +352,6 @@ public class UploadSchemaValidatorTest {
         } catch (InvalidEntityException ex) {
             thrownEx = ex;
         }
-        assertTrue(thrownEx.getMessage().contains("foo-field"));
+        assertTrue(thrownEx.getMessage().contains("cannot use foo-field (used by another field)"));
     }
 }

--- a/test/org/sagebionetworks/bridge/validators/UploadSchemaValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/UploadSchemaValidatorTest.java
@@ -303,14 +303,6 @@ public class UploadSchemaValidatorTest {
         UploadSchema schema = BridgeObjectMapper.get().readValue(json, UploadSchema.class);
         assertWillGenerateValidationError(schema, "fieldDefinitions0.type is required", "fieldDefinitions0.type");
         
-        // empty property
-        /* This throws an exception because type is an enumeration. This comes from Jackson, it's a whole
-         * separate project to change that behavior
-        json = "{\"name\":\"Upload Test iOS Survey\",\"schemaId\":\"upload-test-ios-survey\",\"schemaType\":\"ios_survey\",\"revision\":1,\"fieldDefinitions\":[{\"name\":\"foo\",\"required\":true,\"type\":\"\"}]}";
-        schema = BridgeObjectMapper.get().readValue(json, UploadSchema.class);
-        assertWillGenerateValidationError(schema, "fieldDefinitions0.type is required", "fieldDefinitions0.type");
-        */
-        
         // null property
         json = "{\"name\":\"Upload Test iOS Survey\",\"schemaId\":\"upload-test-ios-survey\",\"schemaType\":\"ios_survey\",\"revision\":1,\"fieldDefinitions\":[{\"name\":\"foo\",\"required\":true,\"type\":null}]}";
         schema = BridgeObjectMapper.get().readValue(json, UploadSchema.class);
@@ -334,5 +326,32 @@ public class UploadSchemaValidatorTest {
         schema = BridgeObjectMapper.get().readValue(json, UploadSchema.class);
         assertWillGenerateValidationError(schema, "fieldDefinitions0.name is required", "fieldDefinitions0.name");
     }
-    
+
+    @Test
+    public void duplicateFieldName() {
+        // set up schema to validate
+        DynamoUploadSchema schema = new DynamoUploadSchema();
+        schema.setName("Dupe Fields");
+        schema.setSchemaId("dupe-field-schema");
+        schema.setStudyId("test-study");
+        schema.setSchemaType(UploadSchemaType.IOS_SURVEY);
+
+        // test field def list
+        List<UploadFieldDefinition> fieldDefList = new ArrayList<>();
+        fieldDefList.add(new DynamoUploadFieldDefinition.Builder().withName("foo-field")
+                .withType(UploadFieldType.STRING).build());
+        fieldDefList.add(new DynamoUploadFieldDefinition.Builder().withName("foo-field")
+                .withType(UploadFieldType.INT).build());
+        schema.setFieldDefinitions(fieldDefList);
+
+        // validate
+        Exception thrownEx = null;
+        try {
+            Validate.entityThrowingException(UploadSchemaValidator.INSTANCE, schema);
+            fail("expected exception");
+        } catch (InvalidEntityException ex) {
+            thrownEx = ex;
+        }
+        assertTrue(thrownEx.getMessage().contains("foo-field"));
+    }
 }


### PR DESCRIPTION
Researchers can create schemas with duplicate field names. This breaks as you can't have duplicate column names in Synapse (and is also logically bad). Updated the Schema Validator to fail on duplicate field names.

Testing done:
- Schema Validator unit test
- Manual test creating a schema with duplicate field names and verifying that it fails

We'll also need to verify and delete the broken schemas in Staging.
