### PR TITLE
Updating test to verify you can't switch between studies

### DIFF
--- a/test/org/sagebionetworks/bridge/TestConstants.java
+++ b/test/org/sagebionetworks/bridge/TestConstants.java
@@ -18,6 +18,7 @@ public class TestConstants {
     public static final String SIGN_IN_URL = API_URL + "/auth/signIn";
     public static final String SCHEDULES_API = API_URL + "/schedules";
     public static final String SCHEDULED_ACTIVITIES_API = API_URL + "/activities";
+    public static final String STUDIES_URL = API_URL + "/studies/";
 
     public static final String APPLICATION_JSON = "application/json";
     public static final String USERNAME = "username";

--- a/test/org/sagebionetworks/bridge/play/controllers/AuthenticationControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/AuthenticationControllerTest.java
@@ -26,15 +26,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.Roles;
-import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUserAdminHelper;
 import org.sagebionetworks.bridge.TestUserAdminHelper.TestUser;
 import org.sagebionetworks.bridge.TestUtils;
-import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
-import org.sagebionetworks.bridge.models.schedules.Schedule;
-import org.sagebionetworks.bridge.models.schedules.SchedulePlan;
-import org.sagebionetworks.bridge.models.schedules.ScheduleType;
-import org.sagebionetworks.bridge.models.schedules.SimpleScheduleStrategy;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.redis.JedisOps;
 import org.sagebionetworks.bridge.services.SchedulePlanServiceImpl;
@@ -70,8 +64,6 @@ public class AuthenticationControllerTest {
     private TestUser testUser;
     
     private Study secondStudy;
-    
-    private SchedulePlan plan;
     
     @Before
     public void before() {
@@ -141,9 +133,6 @@ public class AuthenticationControllerTest {
                     
                 } finally {
                     if (secondStudy != null) {
-                        if (plan != null) {
-                            schedulePlanService.deleteSchedulePlan(secondStudy.getStudyIdentifier(), plan.getGuid());        
-                        }
                         studyService.deleteStudy(secondStudy.getIdentifier());
                     }
                 }


### PR DESCRIPTION
Now that study is part of your initial authentication, this is pretty much impossible, but we verify you can't retrieve a study you don't belong to, which is close to the original purpose of this test. And we don't check this anywhere else that I know offhand.
