### PR TITLE
Defects

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/ConsentController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ConsentController.java
@@ -79,6 +79,7 @@ public class ConsentController extends BaseController {
         final long withdrewOn = DateTime.now().getMillis();
         
         consentService.withdrawConsent(study, session.getUser(), withdrawal, withdrewOn);
+        updateSessionUser(session, session.getUser());
         
         return okResult("User has been withdrawn from the study.");
     }

--- a/app/org/sagebionetworks/bridge/services/ConsentServiceImpl.java
+++ b/app/org/sagebionetworks/bridge/services/ConsentServiceImpl.java
@@ -208,8 +208,7 @@ public class ConsentServiceImpl implements ConsentService {
         String externalId = optionsService.getOption(user.getHealthCode(), ParticipantOption.EXTERNAL_IDENTIFIER);
         MimeTypeEmailProvider consentEmail = new WithdrawConsentEmailProvider(study, externalId, user, withdrawal, withdrewOn);
         sendMailService.sendEmail(consentEmail);
-        
-        System.out.println("YES DID GET HERE");
+
         user.setConsent(false);
     }
     

--- a/app/org/sagebionetworks/bridge/services/ConsentServiceImpl.java
+++ b/app/org/sagebionetworks/bridge/services/ConsentServiceImpl.java
@@ -203,11 +203,13 @@ public class ConsentServiceImpl implements ConsentService {
         decrementStudyEnrollment(study);
 
         optionsService.setOption(study, user.getHealthCode(), SharingScope.NO_SHARING);
+        user.setSharingScope(SharingScope.NO_SHARING);
         
         String externalId = optionsService.getOption(user.getHealthCode(), ParticipantOption.EXTERNAL_IDENTIFIER);
         MimeTypeEmailProvider consentEmail = new WithdrawConsentEmailProvider(study, externalId, user, withdrawal, withdrewOn);
         sendMailService.sendEmail(consentEmail);
         
+        System.out.println("YES DID GET HERE");
         user.setConsent(false);
     }
     

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoActivityEventDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoActivityEventDaoTest.java
@@ -79,6 +79,21 @@ public class DynamoActivityEventDaoTest {
         assertEquals(0, map.size());
     }
     
+    @Test
+    public void neverUpdateEnrollmentTaskEvent() {
+        final DateTime firstEvent = DateTime.now();
+        
+        ActivityEvent event = getEnrollmentEvent(firstEvent);
+        activityEventDao.publishEvent(event);
+        
+        // This does not work. You can't do this.
+        event = getEnrollmentEvent(firstEvent.plusHours(2));
+        activityEventDao.publishEvent(event);
+        
+        Map<String,DateTime> eventMap = activityEventDao.getActivityEventMap("BBB");
+        assertEquals(firstEvent, eventMap.get("enrollment"));
+    }
+    
     private DynamoActivityEvent getEnrollmentEvent(DateTime timestamp) {
         return new DynamoActivityEvent.Builder().withHealthCode("BBB")
             .withObjectType(ActivityEventObjectType.ENROLLMENT).withTimestamp(timestamp).build();

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDaoTest.java
@@ -157,7 +157,6 @@ public class DynamoScheduledActivityDaoTest {
         List<SchedulePlan> plans = getSchedulePlans();
         SchedulePlan testPlan = plans.get(0);
         SchedulePlan testPlan2 = plans.get(1);
-        SchedulePlan testPlan3 = plans.get(2);
         
         List<ScheduledActivity> activities = TestUtils.runSchedulerForActivities(plans, user, context);
         activityDao.saveActivities(activities);

--- a/test/org/sagebionetworks/bridge/play/controllers/ConsentControllerMockedTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ConsentControllerMockedTest.java
@@ -52,7 +52,8 @@ public class ConsentControllerMockedTest {
 
     private StudyService studyService;
     private ConsentService consentService;
-    ParticipantOptionsService optionsService;
+    private ParticipantOptionsService optionsService;
+    private CacheProvider cacheProvider;
 
     @Before
     public void before() {
@@ -80,7 +81,8 @@ public class ConsentControllerMockedTest {
         optionsService = mock(ParticipantOptionsService.class);
         controller.setOptionsService(optionsService);
 
-        controller.setCacheProvider(mock(CacheProvider.class));
+        cacheProvider = mock(CacheProvider.class);
+        controller.setCacheProvider(cacheProvider);
     }
 
     @After
@@ -169,6 +171,8 @@ public class ConsentControllerMockedTest {
         // Should call the service and withdraw
         verify(consentService).withdrawConsent(any(Study.class), any(User.class), captor.capture(), any(Long.class));
         assertEquals("Because, reasons.", captor.getValue().getReason());
+        
+        verify(cacheProvider).setUserSession(session);
     }
 
     @Test

--- a/test/org/sagebionetworks/bridge/play/controllers/ConsentControllerMockedTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ConsentControllerMockedTest.java
@@ -154,9 +154,6 @@ public class ConsentControllerMockedTest {
     
     @Test
     public void canWithdrawConsent() throws Exception {
-        CacheProvider cacheProvider = mock(CacheProvider.class);
-        controller.setCacheProvider(cacheProvider);
-        
         String json = "{\"reason\":\"Because, reasons.\"}";
         Context context = TestUtils.mockPlayContextWithJson(json);
         Http.Context.current.set(context);

--- a/test/org/sagebionetworks/bridge/play/controllers/ConsentControllerMockedTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ConsentControllerMockedTest.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.bridge.play.controllers;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
@@ -170,11 +169,6 @@ public class ConsentControllerMockedTest {
         // Should call the service and withdraw
         verify(consentService).withdrawConsent(any(Study.class), any(User.class), captor.capture(), any(Long.class));
         assertEquals("Because, reasons.", captor.getValue().getReason());
-        
-        // Should update the user's session to be non-consented
-        ArgumentCaptor<UserSession> sessionCaptor = ArgumentCaptor.forClass(UserSession.class);
-        verify(cacheProvider).setUserSession(sessionCaptor.capture());
-        assertFalse(sessionCaptor.getValue().getUser().doesConsent());
     }
 
     @Test

--- a/test/org/sagebionetworks/bridge/services/ConsentServiceImplMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/ConsentServiceImplMockTest.java
@@ -86,9 +86,9 @@ public class ConsentServiceImplMockTest {
         consentService.setStudyConsentService(studyConsentService);
         
         study = TestUtils.getValidStudy(ConsentServiceImplMockTest.class);
-        user = new User();
-        user.setHealthCode("BBB");
-        user.setEmail("bbb@bbb.com");
+        user = mock(User.class);
+        when(user.getHealthCode()).thenReturn("BBB");
+        when(user.getEmail()).thenReturn("bbb@bbb.com");
         consentSignature = new ConsentSignature.Builder().withName("Test User").withBirthdate("1990-01-01")
                 .withSignedOn(UNIX_TIMESTAMP).build();
         
@@ -126,7 +126,8 @@ public class ConsentServiceImplMockTest {
     
     @Test
     public void noActivityEventIfAlreadyConsented() {
-        user.setConsent(true);
+        when(user.doesConsent()).thenReturn(true);
+        when(user.isConsent()).thenReturn(true);
         
         try {
             consentService.consentToResearch(study, user, consentSignature, SharingScope.NO_SHARING, false);
@@ -181,6 +182,9 @@ public class ConsentServiceImplMockTest {
         assertEquals("Notification of consent withdrawal for Test Study [ConsentServiceImplMockTest]", email.getSubject());
         assertEquals("<p>User   &lt;bbb@bbb.com&gt; withdrew from the study on October 28, 2015. </p><p>Reason:</p><p>For reasons.</p>", 
                     email.getMessageParts().get(0).getContent());
+        
+        verify(user).setConsent(false);
+        verify(user).setSharingScope(SharingScope.NO_SHARING);
     }
     
     @Test
@@ -203,7 +207,7 @@ public class ConsentServiceImplMockTest {
         
         when(accountDao.getAccount(study, user.getEmail())).thenReturn(acct);
         doThrow(new BridgeServiceException("Something bad happend", 500)).when(userConsentDao)
-            .withdrawConsent(user.getHealthCode(), study, UNIX_TIMESTAMP);
+            .withdrawConsent("BBB", study, UNIX_TIMESTAMP);
         
         ArgumentCaptor<Account> captor = ArgumentCaptor.forClass(Account.class);
         


### PR DESCRIPTION
- Update user's session to be non-consented when consent is withdrawn;
- Do not recreate an enrollment event when a user re-enrolls in a study. This causes one-time activities scheduled at the time of enrollment to be duplicated. We don't want these to happen again when re-enrolling.
