### PR TITLE
Fixing fact that DDB doesn't accept empty sets

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
@@ -50,6 +50,8 @@ public final class DynamoStudy implements Study {
 
     public DynamoStudy() {
         profileAttributes = new HashSet<>();
+        taskIdentifiers = new HashSet<>();
+        dataGroups = new HashSet<>();
     }
 
     /** {@inheritDoc} */
@@ -189,6 +191,7 @@ public final class DynamoStudy implements Study {
     }
 
     /** {@inheritDoc} */
+    @DynamoDBMarshalling(marshallerClass = StringSetMarshaller.class)
     @Override
     public Set<String> getTaskIdentifiers() {
         return taskIdentifiers;
@@ -200,6 +203,7 @@ public final class DynamoStudy implements Study {
     }
     
     /** {@inheritDoc} */
+    @DynamoDBMarshalling(marshallerClass = StringSetMarshaller.class)
     @Override
     public Set<String> getDataGroups() {
         return dataGroups;

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyDaoTest.java
@@ -84,6 +84,28 @@ public class DynamoStudyDaoTest {
             // expected
         }
     }
+    
+    @Test
+    public void stringSetsCanBeEmpty() throws Exception {
+        Study study = TestUtils.getValidStudy(DynamoStudyDaoTest.class);
+        study = studyDao.createStudy(study);
+        
+        // This triggers an error without the JSON serializer annotations because DDB doesn't support empty sets
+        study.setTaskIdentifiers(Sets.newHashSet());
+        studyDao.updateStudy(study);
+        
+        // We get what we want here because it deserializes the empty array
+        study = studyDao.getStudy(study.getIdentifier()); 
+        assertEquals(0, study.getTaskIdentifiers().size());
+        
+        // These two are now equivalent insofar as they throw no error and the object can always present a non-null field
+        study.setTaskIdentifiers(null);
+        studyDao.updateStudy(study);
+        
+        // We get what we want here because we set the field to an empty set in the constructor. It's never null.
+        study = studyDao.getStudy(study.getIdentifier());
+        assertEquals(0, study.getTaskIdentifiers().size());
+    }
 
     @Test
     public void canRetrieveAllStudies() throws InterruptedException {


### PR DESCRIPTION
which do appear in the JSON. DynamoDB does not support empty sets. So  the following two are not the same:

```
    study.setTaskIdentifiers(null);
    studyDao.updateStudy(study);
```

Works fine, but

```
    study.setTaskIdentifiers(Sets.newHashSet());
    studyDao.updateStudy(study);
```

Throws an error. The issue is that it's not uncommon for the JSON coming back to have an empty array for the property, which should be allowed but looks like the second code block.

I'm changing this to follow the same pattern as userProfileAttributes, which is an approach that never does anything surprising. You could also forcibly null out these fields (then DDB is happy), but that's error-prone compared to always being able to assume the set exists, empty or not.
