### PR TITLE
Health code export

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
@@ -47,6 +47,7 @@ public final class DynamoStudy implements Study {
     private EmailTemplate verifyEmailTemplate;
     private EmailTemplate resetPasswordTemplate;
     private boolean strictUploadValidationEnabled;
+    private boolean healthCodeExportEnabled;
 
     public DynamoStudy() {
         profileAttributes = new HashSet<>();
@@ -286,6 +287,18 @@ public final class DynamoStudy implements Study {
     public void setStrictUploadValidationEnabled(boolean enabled) {
         this.strictUploadValidationEnabled = enabled;
     }
+    
+    /** {@inheritDoc} */
+    @Override
+    public boolean isHealthCodeExportEnabled() {
+        return healthCodeExportEnabled;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setHealthCodeExportEnabled(boolean enabled) {
+        this.healthCodeExportEnabled = enabled;
+    }
 
     @Override
     public int hashCode() {
@@ -309,6 +322,7 @@ public final class DynamoStudy implements Study {
         result = prime * result + Objects.hashCode(resetPasswordTemplate);
         result = prime * result + Objects.hashCode(active);
         result = prime * result + Objects.hashCode(strictUploadValidationEnabled);
+        result = prime * result + Objects.hashCode(healthCodeExportEnabled);
         return result;
     }
 
@@ -334,7 +348,8 @@ public final class DynamoStudy implements Study {
                 && Objects.equals(dataGroups, other.dataGroups)
                 && Objects.equals(sponsorName, other.sponsorName)
                 && Objects.equals(technicalEmail, other.technicalEmail)
-                && Objects.equals(strictUploadValidationEnabled, other.strictUploadValidationEnabled);
+                && Objects.equals(strictUploadValidationEnabled, other.strictUploadValidationEnabled)
+                && Objects.equals(healthCodeExportEnabled, other.healthCodeExportEnabled);
     }
 
     @Override
@@ -343,9 +358,10 @@ public final class DynamoStudy implements Study {
             "DynamoStudy [name=%s, active=%s, sponsorName=%s, identifier=%s, stormpathHref=%s, minAgeOfConsent=%s, "
                             + "maxNumOfParticipants=%s, supportEmail=%s, technicalEmail=%s, consentNotificationEmail=%s, "
                             + "version=%s, userProfileAttributes=%s, taskIdentifiers=%s, dataGroups=%s, passwordPolicy=%s, "
-                            + "verifyEmailTemplate=%s, resetPasswordTemplate=%s, strictUploadValidationEnabled=%s]",
+                            + "verifyEmailTemplate=%s, resetPasswordTemplate=%s, strictUploadValidationEnabled=%s, healthCodeExportEnabled=%s]",
             name, active, sponsorName, identifier, stormpathHref, minAgeOfConsent, maxNumOfParticipants,
             supportEmail, technicalEmail, consentNotificationEmail, version, profileAttributes, taskIdentifiers, 
-            dataGroups, passwordPolicy, verifyEmailTemplate, resetPasswordTemplate, strictUploadValidationEnabled);
+            dataGroups, passwordPolicy, verifyEmailTemplate, resetPasswordTemplate, strictUploadValidationEnabled, 
+            healthCodeExportEnabled);
     }
 }

--- a/app/org/sagebionetworks/bridge/models/accounts/UserProfile.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/UserProfile.java
@@ -19,6 +19,7 @@ public class UserProfile {
     public static final String LAST_NAME_FIELD = "lastName";
     public static final String EMAIL_FIELD = "email";
     public static final String USERNAME_FIELD = "username";
+    public static final String HEALTH_CODE_FIELD = "healthCode";
     /**
      * These fields are not part of the profile, but they are used on export to expose the participant option values, so
      * studies cannot override these values as extended user profile attributes.

--- a/app/org/sagebionetworks/bridge/models/studies/Study.java
+++ b/app/org/sagebionetworks/bridge/models/studies/Study.java
@@ -185,8 +185,14 @@ public interface Study extends BridgeEntity, StudyIdentifier {
     public String getConsentPDF();
 
     /** True if uploads in this study should fail on strict validation errors. */
-    boolean isStrictUploadValidationEnabled();
+    public boolean isStrictUploadValidationEnabled();
 
     /** @see #isStrictUploadValidationEnabled */
-    void setStrictUploadValidationEnabled(boolean enabled);
+    public void setStrictUploadValidationEnabled(boolean enabled);
+    
+    /** True if this study will export the healthCode when generating a participant roster. */
+    public boolean isHealthCodeExportEnabled();
+    
+    /** @see #isHealthCodeExportEnabled(); */
+    public void setHealthCodeExportEnabled(boolean enabled);
 }

--- a/app/org/sagebionetworks/bridge/models/studies/StudyParticipant.java
+++ b/app/org/sagebionetworks/bridge/models/studies/StudyParticipant.java
@@ -47,4 +47,10 @@ public final class StudyParticipant extends HashMap<String,String> {
     public void setNotifyByEmail(Boolean notifyByEmail) {
         put(UserProfile.NOTIFY_BY_EMAIL_FIELD, notifyByEmail.toString());
     }
+    public String getHealthCode() {
+        return getEmpty(UserProfile.HEALTH_CODE_FIELD);
+    }
+    public void setHealthCode(String healthCode) {
+        put(UserProfile.HEALTH_CODE_FIELD, healthCode);
+    }
 }

--- a/app/org/sagebionetworks/bridge/services/ParticipantRosterGenerator.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantRosterGenerator.java
@@ -79,6 +79,9 @@ public class ParticipantRosterGenerator implements Runnable {
                         // Whether present or not, add an entry.
                         participant.put(attribute, value);
                     }
+                    if (study.isHealthCodeExportEnabled()) {
+                        participant.setHealthCode(healthCode);
+                    }
                     participants.add(participant);
                     logger.debug("processing account #" + (count++));
                 } else {

--- a/app/org/sagebionetworks/bridge/services/StudyServiceImpl.java
+++ b/app/org/sagebionetworks/bridge/services/StudyServiceImpl.java
@@ -185,10 +185,11 @@ public class StudyServiceImpl implements StudyService {
         Study originalStudy = studyDao.getStudy(study.getIdentifier());
         study.setStormpathHref(originalStudy.getStormpathHref());
         study.setActive(true);
-        // study.setActive(originalStudy.isActive());
-        // And this cannot be set unless you're an administrator.
+        // And this cannot be set unless you're an administrator. Regardless of what the 
+        // developer set, set these back to the original study.
         if (!isAdminUpdate) {
             study.setMaxNumOfParticipants(originalStudy.getMaxNumOfParticipants());
+            study.setHealthCodeExportEnabled(originalStudy.isHealthCodeExportEnabled());
         }
         Validate.entityThrowingException(validator, study);
 

--- a/app/org/sagebionetworks/bridge/services/StudyServiceImpl.java
+++ b/app/org/sagebionetworks/bridge/services/StudyServiceImpl.java
@@ -157,6 +157,7 @@ public class StudyServiceImpl implements StudyService {
             studyConsentService.publishConsent(study, view.getCreatedOn());
             
             study.setActive(true);
+            study.setStrictUploadValidationEnabled(true);
 
             String directory = directoryDao.createDirectoryForStudy(study);
             study.setStormpathHref(directory);

--- a/app/org/sagebionetworks/bridge/services/email/ParticipantRosterProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/ParticipantRosterProvider.java
@@ -81,6 +81,9 @@ public class ParticipantRosterProvider implements MimeTypeEmailProvider {
         for (String attribute : study.getUserProfileAttributes()) {
             append(sb, StringUtils.capitalize(attribute), true);
         }
+        if (study.isHealthCodeExportEnabled()) {
+            append(sb, "Health Code", true);
+        }
         sb.append(NEWLINE);
         for (int i=0; i < participants.size(); i++) {
             StudyParticipant participant = participants.get(i);
@@ -94,6 +97,9 @@ public class ParticipantRosterProvider implements MimeTypeEmailProvider {
             append(sb, (notifyByEmail == null) ? "" : notifyByEmail.toString().toLowerCase(), true);
             for (String attribute : study.getUserProfileAttributes()) {
                 append(sb, participant.getEmpty(attribute), true);
+            }
+            if (study.isHealthCodeExportEnabled()) {
+                append(sb, participant.getHealthCode(), true);
             }
             sb.append(NEWLINE);
         }

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -193,6 +193,7 @@ public class TestUtils {
         study.setTaskIdentifiers(Sets.newHashSet("task1", "task2"));
         study.setDataGroups(Sets.newHashSet("beta_users", "production_users"));
         study.setStrictUploadValidationEnabled(true);
+        study.setHealthCodeExportEnabled(true);
         return study;
     }
     

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
@@ -63,6 +63,7 @@ public class DynamoStudyTest {
         assertEquals(study.getConsentPDF(), JsonUtils.asText(node, "consentPDF"));
         assertEquals((Long)study.getVersion(), (Long)node.get("version").asLong());
         assertTrue(node.get("strictUploadValidationEnabled").asBoolean());
+        assertTrue(node.get("healthCodeExportEnabled").asBoolean());
         assertEquals("Study", node.get("type").asText());
         
         String htmlURL = "http://" + BridgeConfigFactory.getConfig().getHostnameWithPostfix("docs") + "/" + study.getIdentifier() + "/consent.html";

--- a/test/org/sagebionetworks/bridge/services/StudyServiceImplTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceImplTest.java
@@ -88,12 +88,16 @@ public class StudyServiceImplTest {
     @Test
     public void crudStudy() {
         study = TestUtils.getValidStudy(StudyServiceImplTest.class);
-        // verify this can be null, that's okay
+        // verify this can be null, that's okay, and the flags are reset correctly on create
         study.setTaskIdentifiers(null);
+        study.setActive(false);
+        study.setHealthCodeExportEnabled(true);
         study = studyService.createStudy(study);
         
         assertNotNull("Version has been set", study.getVersion());
-        assertTrue(study.isActive());
+        assertTrue(study.isActive()); // study is active
+        assertTrue(study.isHealthCodeExportEnabled()); // health code will not be exported
+        
         verify(cache).setStudy(study);
         verifyNoMoreInteractions(cache);
         reset(cache);

--- a/test/org/sagebionetworks/bridge/services/StudyServiceImplTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceImplTest.java
@@ -91,13 +91,15 @@ public class StudyServiceImplTest {
         // verify this can be null, that's okay, and the flags are reset correctly on create
         study.setTaskIdentifiers(null);
         study.setActive(false);
+        study.setStrictUploadValidationEnabled(false);
         study.setHealthCodeExportEnabled(true);
         study = studyService.createStudy(study);
         
         assertNotNull("Version has been set", study.getVersion());
-        assertTrue(study.isActive()); // study is active
-        assertTrue(study.isHealthCodeExportEnabled()); // health code will not be exported
-        
+        assertTrue(study.isActive());
+        assertTrue(study.isStrictUploadValidationEnabled()); // by default set to true
+        assertTrue(study.isHealthCodeExportEnabled()); // it was set true in the study
+
         verify(cache).setStudy(study);
         verifyNoMoreInteractions(cache);
         reset(cache);

--- a/test/org/sagebionetworks/bridge/services/StudyServiceImplTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceImplTest.java
@@ -220,21 +220,24 @@ public class StudyServiceImplTest {
     
     @Test
     public void adminsCanSomeValuesResearchersCannot() {
-        study = TestUtils.getValidStudy(StudyServiceImplTest.class); // it's 200.
+        study = TestUtils.getValidStudy(StudyServiceImplTest.class);
+        study.setMaxNumOfParticipants(200);
+        study.setHealthCodeExportEnabled(false);
         study = studyService.createStudy(study);
         
-        // Okay, now that it's set, researchers can change it to no effect
+        // Okay, now that these are set, researchers cannot change them
         study.setMaxNumOfParticipants(1000);
         study.setHealthCodeExportEnabled(true);
-        study = studyService.updateStudy(study, false);
-        assertEquals(200, study.getMaxNumOfParticipants()); // nope
-        assertFalse(study.isHealthCodeExportEnabled()); // nope
+        study = studyService.updateStudy(study, false); // nope
+        assertEquals(200, study.getMaxNumOfParticipants());
+        assertFalse("This should be null", study.isHealthCodeExportEnabled());
         
+        // But administrators can
         study.setMaxNumOfParticipants(1000);
         study.setHealthCodeExportEnabled(true);
-        study = studyService.updateStudy(study, true);
-        assertEquals(1000, study.getMaxNumOfParticipants()); // yep
-        assertTrue(study.isHealthCodeExportEnabled()); // yep
+        study = studyService.updateStudy(study, true); // yep
+        assertEquals(1000, study.getMaxNumOfParticipants());
+        assertTrue(study.isHealthCodeExportEnabled());
     }
     
     @Test(expected=InvalidEntityException.class)

--- a/test/org/sagebionetworks/bridge/services/StudyServiceImplTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceImplTest.java
@@ -109,6 +109,7 @@ public class StudyServiceImplTest {
         
         Study newStudy = studyService.getStudy(study.getIdentifier());
         assertTrue(newStudy.isActive());
+        assertTrue(newStudy.isStrictUploadValidationEnabled());
         assertEquals(study.getIdentifier(), newStudy.getIdentifier());
         assertEquals("Test Study [StudyServiceImplTest]", newStudy.getName());
         assertEquals(200, newStudy.getMaxNumOfParticipants());
@@ -218,18 +219,22 @@ public class StudyServiceImplTest {
     }
     
     @Test
-    public void adminsCanChangeMaxNumParticipantsResearchersCannot() {
+    public void adminsCanSomeValuesResearchersCannot() {
         study = TestUtils.getValidStudy(StudyServiceImplTest.class); // it's 200.
         study = studyService.createStudy(study);
         
-        // Okay, not that it's set, researchers can change it to no effect
+        // Okay, now that it's set, researchers can change it to no effect
         study.setMaxNumOfParticipants(1000);
+        study.setHealthCodeExportEnabled(true);
         study = studyService.updateStudy(study, false);
         assertEquals(200, study.getMaxNumOfParticipants()); // nope
+        assertFalse(study.isHealthCodeExportEnabled()); // nope
         
         study.setMaxNumOfParticipants(1000);
+        study.setHealthCodeExportEnabled(true);
         study = studyService.updateStudy(study, true);
         assertEquals(1000, study.getMaxNumOfParticipants()); // yep
+        assertTrue(study.isHealthCodeExportEnabled()); // yep
     }
     
     @Test(expected=InvalidEntityException.class)

--- a/test/org/sagebionetworks/bridge/services/email/ParticipantRosterGeneratorTest.java
+++ b/test/org/sagebionetworks/bridge/services/email/ParticipantRosterGeneratorTest.java
@@ -109,9 +109,23 @@ public class ParticipantRosterGeneratorTest {
         assertEquals("first.last@test.com", p.getEmail());
         assertEquals("(206) 111-2222", p.get("phone"));
         assertEquals("true", p.get("can_recontact"));
+        assertEquals("healthCode", p.getHealthCode());
         assertNull(p.get("another_attribute"));
     }
 
+    @Test
+    public void generatorWithoutHealthCodeExportDoesntExportHealthCode() {
+        study.setHealthCodeExportEnabled(false);
+        generator.run();
+        verify(sendMailService).sendEmail(argument.capture());
+        
+        ParticipantRosterProvider provider = argument.getValue();
+        
+        for (StudyParticipant participant : provider.getParticipants()) {
+            assertEquals("", participant.getHealthCode());
+        }
+    }
+    
     private Account createAccount(String email, String firstName, String lastName, String phone, boolean hasConsented) {
         Account account = mock(Account.class);
         when(account.getEmail()).thenReturn(email);

--- a/test/org/sagebionetworks/bridge/services/email/ParticipantRosterProviderTest.java
+++ b/test/org/sagebionetworks/bridge/services/email/ParticipantRosterProviderTest.java
@@ -36,6 +36,7 @@ public class ParticipantRosterProviderTest {
         participant.put("phone", "(123) 456-7890");
         participant.setNotifyByEmail(Boolean.FALSE);
         participant.put("recontact", "true");
+        participant.setHealthCode("AAA");
         List<StudyParticipant> participants = Lists.newArrayList(participant);
 
         ParticipantRosterProvider provider = new ParticipantRosterProvider(study, participants);
@@ -64,41 +65,64 @@ public class ParticipantRosterProviderTest {
         participant.setNotifyByEmail(Boolean.FALSE);
         participant.put("recontact", "false");
         participant.put(UserProfile.SHARING_SCOPE_FIELD, SharingScope.NO_SHARING.name());
+        participant.setHealthCode("AAA");
         List<StudyParticipant> participants = Lists.newArrayList(participant);
 
-        String headerString = row("Email", "First Name", "Last Name", "Sharing Scope", "Email Notifications", "Phone", "Recontact");
+        String headerString = row("Email", "First Name", "Last Name", "Sharing Scope", "Email Notifications", "Phone", "Recontact", "Health Code");
         
         ParticipantRosterProvider provider = new ParticipantRosterProvider(study, participants);
-        String output = headerString + row("test@test.com", "First", "Last", "Not Sharing", "false", "(123) 456-7890", "false");
-        assertEquals("1", output, provider.createParticipantTSV());
+        String output = headerString + row("test@test.com", "First", "Last", "Not Sharing", "false", "(123) 456-7890", "false", "AAA");
+        assertEquals(output, provider.createParticipantTSV());
         
         participant.setLastName(null);
-        output = headerString + row("test@test.com","First","","Not Sharing","false","(123) 456-7890","false");
-        assertEquals("2", output, provider.createParticipantTSV());
+        output = headerString + row("test@test.com","First","","Not Sharing","false","(123) 456-7890","false", "AAA");
+        assertEquals(output, provider.createParticipantTSV());
         
         participant.setFirstName(null);
         participant.setLastName("Last");
-        output = headerString + row("test@test.com","","Last","Not Sharing","false","(123) 456-7890","false");
-        assertEquals("3", output, provider.createParticipantTSV());
+        output = headerString + row("test@test.com","","Last","Not Sharing","false","(123) 456-7890","false", "AAA");
+        assertEquals(output, provider.createParticipantTSV());
         
         participant.remove("phone");
-        output = headerString + row("test@test.com","","Last","Not Sharing","false","","false");
-        assertEquals("4", output, provider.createParticipantTSV());
+        output = headerString + row("test@test.com","","Last","Not Sharing","false","","false", "AAA");
+        assertEquals(output, provider.createParticipantTSV());
         
         participant.remove(UserProfile.SHARING_SCOPE_FIELD);
-        output = headerString + row("test@test.com","","Last","","false","","false");
-        assertEquals("5", output, provider.createParticipantTSV());
+        output = headerString + row("test@test.com","","Last","","false","","false", "AAA");
+        assertEquals(output, provider.createParticipantTSV());
         
         StudyParticipant numberTwo = new StudyParticipant();
         numberTwo.setEmail("test2@test.com");
         
         // This is pretty broken, but you should still get output. 
         participants.add(numberTwo);
-        output = headerString + row("test@test.com","","Last","","false","","false") + row("test2@test.com","","","","","","");
+        output = headerString + row("test@test.com","","Last","","false","","false", "AAA") + row("test2@test.com","","","","","","","");
         assertEquals("6", output, provider.createParticipantTSV());
         
         participants.clear();
         assertEquals(headerString, provider.createParticipantTSV());
+    }
+    
+    @Test
+    public void noHealthCodeExportMeansNoColumn() {
+        study.setHealthCodeExportEnabled(false);
+        
+        StudyParticipant participant = new StudyParticipant();
+        participant.setFirstName("First");
+        participant.setLastName("Last");
+        participant.setEmail("test@test.com");
+        participant.put("phone", "(123)\t456-7890"); // Tab snuck into this string should be converted to a space
+        participant.setNotifyByEmail(Boolean.FALSE);
+        participant.put("recontact", "false");
+        participant.put(UserProfile.SHARING_SCOPE_FIELD, SharingScope.NO_SHARING.name());
+        participant.setHealthCode("AAA");
+        List<StudyParticipant> participants = Lists.newArrayList(participant);
+
+        String headerString = row("Email", "First Name", "Last Name", "Sharing Scope", "Email Notifications", "Phone", "Recontact");
+        
+        ParticipantRosterProvider provider = new ParticipantRosterProvider(study, participants);
+        String output = headerString + row("test@test.com", "First", "Last", "Not Sharing", "false", "(123) 456-7890", "false");
+        assertEquals(output, provider.createParticipantTSV());
     }
     
     private String row(String... fields) {


### PR DESCRIPTION
- study now has a setting as to whether or not health code should be exported as part of the participant roster;
- this setting is false by default and can only be set to true by an administrator
- the roster includes a "health code" column if set to true;
- when a study is created, strict validation is enabled by default (minor fix)
