### PR TITLE
Email when roster done

### DIFF
--- a/app/org/sagebionetworks/bridge/models/studies/StudyParticipant.java
+++ b/app/org/sagebionetworks/bridge/models/studies/StudyParticipant.java
@@ -45,7 +45,9 @@ public final class StudyParticipant extends HashMap<String,String> {
         return (emptyString == null) ? null : Boolean.valueOf(emptyString);
     }
     public void setNotifyByEmail(Boolean notifyByEmail) {
-        put(UserProfile.NOTIFY_BY_EMAIL_FIELD, notifyByEmail.toString());
+        if (notifyByEmail != null) {
+            put(UserProfile.NOTIFY_BY_EMAIL_FIELD, notifyByEmail.toString());    
+        }
     }
     public String getHealthCode() {
         return getEmpty(UserProfile.HEALTH_CODE_FIELD);

--- a/app/org/sagebionetworks/bridge/services/ParticipantRosterGenerator.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantRosterGenerator.java
@@ -15,6 +15,8 @@ import org.sagebionetworks.bridge.models.studies.StudyParticipant;
 import org.sagebionetworks.bridge.services.email.MimeTypeEmailProvider;
 import org.sagebionetworks.bridge.services.email.NotifyOperationsEmailProvider;
 import org.sagebionetworks.bridge.services.email.ParticipantRosterProvider;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -114,6 +116,10 @@ public class ParticipantRosterGenerator implements Runnable {
             
         } catch (Exception e) {
             logger.error(e.getMessage(), e);
+            
+            String subject = "Generating participant roster failed for the study '"+study.getName()+"'";
+            String message = ExceptionUtils.getStackTrace(e);
+            sendMailService.sendEmail(new NotifyOperationsEmailProvider(subject, message));
         }
     }
 

--- a/app/org/sagebionetworks/bridge/services/ParticipantRosterGenerator.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantRosterGenerator.java
@@ -78,6 +78,8 @@ public class ParticipantRosterGenerator implements Runnable {
                     SharingScope sharing = null;
                     Boolean notifyByEmail = null;
                     String healthCode = getHealthCode(account);
+                    // If there's no health code, this is not a participant, this is a researcher or admin.
+                    // We still export these folks.
                     if (healthCode != null) {
                         sharing = sharingLookup.getSharingScope(healthCode);
                         notifyByEmail = Boolean.valueOf(emailLookup.get(healthCode));

--- a/app/org/sagebionetworks/bridge/services/ParticipantRosterGenerator.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantRosterGenerator.java
@@ -77,21 +77,19 @@ public class ParticipantRosterGenerator implements Runnable {
                 Account account = accounts.next();
                 if (account.getActiveConsentSignature() != null) {
                     
-                    SharingScope sharing = null;
-                    Boolean notifyByEmail = null;
                     String healthCode = getHealthCode(account);
-                    // If there's no health code, this is not a participant, this is a researcher or admin.
-                    // We still export these folks.
-                    if (healthCode != null) {
-                        sharing = sharingLookup.getSharingScope(healthCode);
-                        notifyByEmail = Boolean.valueOf(emailLookup.get(healthCode));
-                    }
                     StudyParticipant participant = new StudyParticipant();
+                    // Accounts exist that have signatures but no health codes. This may only be from testing, 
+                    // but still, do not want to fail to export accounts because of this. So we check for this.
+                    if (healthCode != null) {
+                        SharingScope sharing = sharingLookup.getSharingScope(healthCode);
+                        Boolean notifyByEmail = Boolean.valueOf(emailLookup.get(healthCode));
+                        participant.setSharingScope(sharing);
+                        participant.setNotifyByEmail(notifyByEmail);
+                    }
                     participant.setFirstName(account.getFirstName());
                     participant.setLastName(account.getLastName());
                     participant.setEmail(account.getEmail());
-                    participant.setSharingScope(sharing);
-                    participant.setNotifyByEmail(notifyByEmail);
                     for (String attribute : study.getUserProfileAttributes()) {
                         String value = account.getAttribute(attribute);
                         // Whether present or not, add an entry.

--- a/app/org/sagebionetworks/bridge/services/ParticipantRosterGenerator.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantRosterGenerator.java
@@ -12,6 +12,7 @@ import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyParticipant;
 import org.sagebionetworks.bridge.services.email.MimeTypeEmailProvider;
+import org.sagebionetworks.bridge.services.email.NotifyOperationsEmailProvider;
 import org.sagebionetworks.bridge.services.email.ParticipantRosterProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -88,9 +89,11 @@ public class ParticipantRosterGenerator implements Runnable {
             Collections.sort(participants, STUDY_PARTICIPANT_COMPARATOR);
 
             MimeTypeEmailProvider roster = new ParticipantRosterProvider(study, participants);
-            logger.debug("sending roster to the sendMailService");
             sendMailService.sendEmail(roster);
-            logger.debug("roster sent.");
+            
+            String message = "The participant roster for the study '"+study.getName()+"' has been emailed to '"+study.getConsentNotificationEmail()+"'.";
+            sendMailService.sendEmail(new NotifyOperationsEmailProvider("A participant roster has been emailed", message));
+            
         } catch (Exception e) {
             logger.error(e.getMessage(), e);
         }

--- a/app/org/sagebionetworks/bridge/services/ParticipantRosterGenerator.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantRosterGenerator.java
@@ -80,7 +80,7 @@ public class ParticipantRosterGenerator implements Runnable {
                     String healthCode = getHealthCode(account);
                     StudyParticipant participant = new StudyParticipant();
                     // Accounts exist that have signatures but no health codes. This may only be from testing, 
-                    // but still, do not want to fail to export accounts because of this. So we check for this.
+                    // but still, do not want roster generation to fail because of this. So we check for this.
                     if (healthCode != null) {
                         SharingScope sharing = sharingLookup.getSharingScope(healthCode);
                         Boolean notifyByEmail = Boolean.valueOf(emailLookup.get(healthCode));

--- a/app/org/sagebionetworks/bridge/services/SendMailViaAmazonService.java
+++ b/app/org/sagebionetworks/bridge/services/SendMailViaAmazonService.java
@@ -55,7 +55,7 @@ public class SendMailViaAmazonService implements SendMailService {
     @Override
     public void sendEmail(MimeTypeEmailProvider provider) {
         try {
-            MimeTypeEmail email = provider.getEmail(supportEmail);
+            MimeTypeEmail email = provider.getMimeTypeEmail();
             for (String recipient: email.getRecipientAddresses()) {
                 sendEmail(recipient, email);    
             }
@@ -65,9 +65,11 @@ public class SendMailViaAmazonService implements SendMailService {
     }
 
     private void sendEmail(String recipient, MimeTypeEmail email) throws AmazonClientException, MessagingException, IOException {
+        String sendFrom = (email.getSenderAddress() == null) ? supportEmail :  email.getSenderAddress();
+        
         Session mailSession = Session.getInstance(new Properties(), null);
         MimeMessage mimeMessage = new MimeMessage(mailSession);
-        mimeMessage.setFrom(new InternetAddress(email.getSenderAddress()));
+        mimeMessage.setFrom(new InternetAddress(sendFrom));
         mimeMessage.setSubject(email.getSubject(), Charsets.UTF_8.name());
         mimeMessage.addRecipient(Message.RecipientType.TO, new InternetAddress(recipient));
 
@@ -85,7 +87,7 @@ public class SendMailViaAmazonService implements SendMailService {
         RawMessage sesRawMessage = new RawMessage(ByteBuffer.wrap(byteOutputStream.toByteArray()));
 
         SendRawEmailRequest req = new SendRawEmailRequest(sesRawMessage);
-        req.setSource(email.getSenderAddress());
+        req.setSource(sendFrom);
         req.setDestinations(Collections.singleton(recipient));
         emailClient.setRegion(REGION);
         SendRawEmailResult result = emailClient.sendRawEmail(req);

--- a/app/org/sagebionetworks/bridge/services/email/ConsentEmailProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/ConsentEmailProvider.java
@@ -1,7 +1,5 @@
 package org.sagebionetworks.bridge.services.email;
 
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
-
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Set;
@@ -59,14 +57,13 @@ public class ConsentEmailProvider implements MimeTypeEmailProvider {
     }
 
     @Override
-    public MimeTypeEmail getEmail(String defaultSender) throws MessagingException {
+    public MimeTypeEmail getMimeTypeEmail() throws MessagingException {
         MimeTypeEmailBuilder builder = new MimeTypeEmailBuilder();
 
         String subject = String.format(CONSENT_EMAIL_SUBJECT, study.getName());
         builder.withSubject(subject);
 
-        final String sendFromEmail = isNotBlank(study.getSupportEmail()) ? String.format("%s <%s>", study.getName(),
-                        study.getSupportEmail()) : defaultSender;
+        final String sendFromEmail = String.format("%s <%s>", study.getName(), study.getSupportEmail());
         builder.withSender(sendFromEmail);
 
         builder.withRecipient(user.getEmail());

--- a/app/org/sagebionetworks/bridge/services/email/MimeTypeEmail.java
+++ b/app/org/sagebionetworks/bridge/services/email/MimeTypeEmail.java
@@ -31,14 +31,12 @@ public final class MimeTypeEmail {
     private final List<MimeBodyPart> messageParts;
     
     MimeTypeEmail(String subject, String senderAddress, List<String> recipientAddresses, List<MimeBodyPart> messageParts) {
-        checkArgument(isNotBlank(senderAddress));
         checkArgument(isNotBlank(subject));
-        checkArgument(isNotBlank(senderAddress));
         checkArgument(recipientAddresses != null && !recipientAddresses.isEmpty());
         checkArgument(messageParts != null && !messageParts.isEmpty());
         
         this.subject = subject;
-        this.senderAddress = escapeEmailAddress(senderAddress);
+        this.senderAddress = (senderAddress != null) ? escapeEmailAddress(senderAddress) : null;
         this.recipientAddresses = Lists.transform(recipientAddresses, APPLY_EMAIL_ESCAPER);
         this.messageParts = ImmutableList.copyOf(messageParts);
     }

--- a/app/org/sagebionetworks/bridge/services/email/MimeTypeEmailBuilder.java
+++ b/app/org/sagebionetworks/bridge/services/email/MimeTypeEmailBuilder.java
@@ -13,18 +13,40 @@ class MimeTypeEmailBuilder {
     private List<String> recipientAddresses = Lists.newArrayList();
     private List<MimeBodyPart> messageParts = Lists.newArrayList();
     
+    /**
+     * The subject of the email. Required.
+     * @param subject
+     * @return
+     */
     MimeTypeEmailBuilder withSubject(String subject) {
         this.subject = subject;
         return this;
     }
+    /**
+     * The sender of the email. This value is optional (if not supplied, the server's 
+     * default support email address will be used).
+     * @param senderAddress
+     * @return
+     */
     MimeTypeEmailBuilder withSender(String senderAddress) {
         this.senderAddress = senderAddress;
         return this;
     }
+    /**
+     * A recipient for this email (may call this more than once and values will be accumulated).
+     * @param recipientAddress
+     * @return
+     */
     MimeTypeEmailBuilder withRecipient(String recipientAddress) {
         this.recipientAddresses.add(recipientAddress);
         return this;
     }
+    /**
+     * A body part for a MIME-based email message (may call this more than once and the body parts 
+     * will be accumulated).
+     * @param parts
+     * @return
+     */
     MimeTypeEmailBuilder withMessageParts(MimeBodyPart... parts) {
         if (parts != null) {
             for (MimeBodyPart part : parts) {
@@ -35,6 +57,10 @@ class MimeTypeEmailBuilder {
         }
         return this;
     }
+    /**
+     * Construct this MimeTypeEmail instance.
+     * @return
+     */
     MimeTypeEmail build() {
         return new MimeTypeEmail(subject, senderAddress, recipientAddresses, messageParts);
     }

--- a/app/org/sagebionetworks/bridge/services/email/MimeTypeEmailProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/MimeTypeEmailProvider.java
@@ -4,6 +4,6 @@ import javax.mail.MessagingException;
 
 public interface MimeTypeEmailProvider {
 
-    public MimeTypeEmail getEmail(String defaultSender) throws MessagingException;
+    public MimeTypeEmail getMimeTypeEmail() throws MessagingException;
     
 }

--- a/app/org/sagebionetworks/bridge/services/email/NotifyOperationsEmailProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/NotifyOperationsEmailProvider.java
@@ -1,0 +1,47 @@
+package org.sagebionetworks.bridge.services.email;
+
+import java.nio.charset.StandardCharsets;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeBodyPart;
+
+import org.sagebionetworks.bridge.config.BridgeConfig;
+import org.sagebionetworks.bridge.config.BridgeConfigFactory;
+
+public class NotifyOperationsEmailProvider implements MimeTypeEmailProvider {
+
+    private static final String SYSOPS_EMAIL = "sysops.email";
+    private static final BridgeConfig CONFIG = BridgeConfigFactory.getConfig();
+    
+    private String subject;
+    private String message;
+    
+    public NotifyOperationsEmailProvider(String subject, String message) {
+        this.subject = subject;
+        this.message = message;
+    }
+    
+    String getSubject() {
+        return subject;
+    }
+    
+    String getMessage() {
+        return message;
+    }
+    
+    @Override
+    public MimeTypeEmail getEmail(String defaultSender) throws MessagingException {
+        String sender = (defaultSender != null) ? defaultSender : CONFIG.getProperty(SYSOPS_EMAIL);
+        
+        MimeBodyPart body = new MimeBodyPart();
+        body.setText(message, StandardCharsets.UTF_8.name(), "text/plain");
+        
+        return new MimeTypeEmailBuilder()
+                .withSender(sender)
+                .withRecipient(CONFIG.getProperty(SYSOPS_EMAIL))
+                .withSubject(subject)
+                .withMessageParts(body)
+                .build();
+    }
+
+}

--- a/app/org/sagebionetworks/bridge/services/email/NotifyOperationsEmailProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/NotifyOperationsEmailProvider.java
@@ -36,14 +36,12 @@ public class NotifyOperationsEmailProvider implements MimeTypeEmailProvider {
     }
     
     @Override
-    public MimeTypeEmail getEmail(String defaultSender) throws MessagingException {
-        String sender = (defaultSender != null) ? defaultSender : SYSOPS_EMAIL;
-
+    public MimeTypeEmail getMimeTypeEmail() throws MessagingException {
         MimeBodyPart body = new MimeBodyPart();
         body.setContent(message, MIME_TYPE_TEXT);
         
         return new MimeTypeEmailBuilder()
-                .withSender(sender)
+                .withSender(SYSOPS_EMAIL)
                 .withRecipient(SYSOPS_EMAIL)
                 .withSubject(subject)
                 .withMessageParts(body)

--- a/app/org/sagebionetworks/bridge/services/email/NotifyOperationsEmailProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/NotifyOperationsEmailProvider.java
@@ -7,6 +7,11 @@ import javax.mail.internet.MimeBodyPart;
 
 import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 
+/**
+ * This is a simple and generic provider to send a notification via email to our sysops/devops email address. The first
+ * use of this is to verify that a participant roster has been completed and sent to the consent notification email for
+ * a study, because if this fails, we get no information about it one way or another.
+ */
 public class NotifyOperationsEmailProvider implements MimeTypeEmailProvider {
 
     private static final String SYSOPS_EMAIL = BridgeConfigFactory.getConfig().getProperty("sysops.email");

--- a/app/org/sagebionetworks/bridge/services/email/NotifyOperationsEmailProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/NotifyOperationsEmailProvider.java
@@ -2,8 +2,6 @@ package org.sagebionetworks.bridge.services.email;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.nio.charset.StandardCharsets;
-
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeBodyPart;
 
@@ -12,6 +10,7 @@ import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 public class NotifyOperationsEmailProvider implements MimeTypeEmailProvider {
 
     private static final String SYSOPS_EMAIL = BridgeConfigFactory.getConfig().getProperty("sysops.email");
+    private static final String MIME_TYPE_TEXT = "text/plain";
     
     private final String subject;
     private final String message;
@@ -34,9 +33,9 @@ public class NotifyOperationsEmailProvider implements MimeTypeEmailProvider {
     @Override
     public MimeTypeEmail getEmail(String defaultSender) throws MessagingException {
         String sender = (defaultSender != null) ? defaultSender : SYSOPS_EMAIL;
-        
+
         MimeBodyPart body = new MimeBodyPart();
-        body.setText(message, StandardCharsets.UTF_8.name(), "text/plain");
+        body.setContent(message, MIME_TYPE_TEXT);
         
         return new MimeTypeEmailBuilder()
                 .withSender(sender)

--- a/app/org/sagebionetworks/bridge/services/email/NotifyOperationsEmailProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/NotifyOperationsEmailProvider.java
@@ -1,22 +1,24 @@
 package org.sagebionetworks.bridge.services.email;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.nio.charset.StandardCharsets;
 
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeBodyPart;
 
-import org.sagebionetworks.bridge.config.BridgeConfig;
 import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 
 public class NotifyOperationsEmailProvider implements MimeTypeEmailProvider {
 
-    private static final String SYSOPS_EMAIL = "sysops.email";
-    private static final BridgeConfig CONFIG = BridgeConfigFactory.getConfig();
+    private static final String SYSOPS_EMAIL = BridgeConfigFactory.getConfig().getProperty("sysops.email");
     
-    private String subject;
-    private String message;
+    private final String subject;
+    private final String message;
     
     public NotifyOperationsEmailProvider(String subject, String message) {
+        checkNotNull(subject);
+        checkNotNull(message);
         this.subject = subject;
         this.message = message;
     }
@@ -31,14 +33,14 @@ public class NotifyOperationsEmailProvider implements MimeTypeEmailProvider {
     
     @Override
     public MimeTypeEmail getEmail(String defaultSender) throws MessagingException {
-        String sender = (defaultSender != null) ? defaultSender : CONFIG.getProperty(SYSOPS_EMAIL);
+        String sender = (defaultSender != null) ? defaultSender : SYSOPS_EMAIL;
         
         MimeBodyPart body = new MimeBodyPart();
         body.setText(message, StandardCharsets.UTF_8.name(), "text/plain");
         
         return new MimeTypeEmailBuilder()
                 .withSender(sender)
-                .withRecipient(CONFIG.getProperty(SYSOPS_EMAIL))
+                .withRecipient(SYSOPS_EMAIL)
                 .withSubject(subject)
                 .withMessageParts(body)
                 .build();

--- a/app/org/sagebionetworks/bridge/services/email/ParticipantRosterProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/ParticipantRosterProvider.java
@@ -32,10 +32,10 @@ public class ParticipantRosterProvider implements MimeTypeEmailProvider {
     }
     
     @Override
-    public MimeTypeEmail getEmail(String defaultSender) throws MessagingException {
+    public MimeTypeEmail getMimeTypeEmail() throws MessagingException {
         MimeTypeEmailBuilder builder = new MimeTypeEmailBuilder();
         
-        builder.withSender(defaultSender).withRecipient(study.getConsentNotificationEmail());
+        builder.withRecipient(study.getConsentNotificationEmail());
         
         String subject = String.format(PARTICIPANTS_EMAIL_SUBJECT, study.getName());
         builder.withSubject(subject);

--- a/app/org/sagebionetworks/bridge/services/email/WithdrawConsentEmailProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/WithdrawConsentEmailProvider.java
@@ -1,7 +1,5 @@
 package org.sagebionetworks.bridge.services.email;
 
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
-
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
 
@@ -37,14 +35,13 @@ public class WithdrawConsentEmailProvider implements MimeTypeEmailProvider {
     }
     
     @Override
-    public MimeTypeEmail getEmail(String defaultSender) throws MessagingException {
+    public MimeTypeEmail getMimeTypeEmail() throws MessagingException {
         MimeTypeEmailBuilder builder = new MimeTypeEmailBuilder();
 
         String subject = String.format(CONSENT_EMAIL_SUBJECT, study.getName());
         builder.withSubject(subject);
 
-        final String sendFromEmail = isNotBlank(study.getSupportEmail()) ? 
-                String.format("%s <%s>", study.getName(), study.getSupportEmail()) : defaultSender;
+        final String sendFromEmail = String.format("%s <%s>", study.getName(), study.getSupportEmail());
         builder.withSender(sendFromEmail);
 
         Set<String> emailAddresses = BridgeUtils.commaListToSet(study.getConsentNotificationEmail());

--- a/conf/bridge-server.conf
+++ b/conf/bridge-server.conf
@@ -13,6 +13,7 @@ redis.url = redis://provider:password@localhost:6379
 async.worker.thread.count = 20
 
 support.email = Bridge (Sage Bionetworks) <support@sagebridge.org>
+sysops.email = Bridge IT <bridgeit@sagebase.org>
 
 email.unsubscribe.token = dummy-value
 

--- a/conf/bridge-server.conf
+++ b/conf/bridge-server.conf
@@ -13,7 +13,7 @@ redis.url = redis://provider:password@localhost:6379
 async.worker.thread.count = 20
 
 support.email = Bridge (Sage Bionetworks) <support@sagebridge.org>
-sysops.email = Bridge IT <bridgeit@sagebase.org>
+sysops.email = Bridge IT <bridge-testing+sysops@sagebase.org>
 
 email.unsubscribe.token = dummy-value
 

--- a/test/org/sagebionetworks/bridge/services/ConsentServiceImplMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/ConsentServiceImplMockTest.java
@@ -175,7 +175,7 @@ public class ConsentServiceImplMockTest {
         assertFalse(user.isConsent());
         
         MimeTypeEmailProvider provider = emailCaptor.getValue();
-        MimeTypeEmail email = provider.getEmail("a@a.com");
+        MimeTypeEmail email = provider.getMimeTypeEmail();
         
         assertEquals("\"Test Study [ConsentServiceImplMockTest]\" <bridge-testing+support@sagebase.org>", email.getSenderAddress());
         assertEquals("bridge-testing+consent@sagebase.org", email.getRecipientAddresses().get(0));

--- a/test/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceConsentTest.java
+++ b/test/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceConsentTest.java
@@ -41,7 +41,6 @@ public class SendMailViaAmazonServiceConsentTest {
     
     private static final String FROM_STUDY_AS_FORMATTED = "\"Test Study (Sage)\" <study-support-email@study.com>";
     private static final String FROM_DEFAULT_UNFORMATTED = "Sage Bionetworks <test-sender@sagebase.org>";
-    private static final String FROM_DEFAULT_AS_FORMATTED = "\"Sage Bionetworks\" <test-sender@sagebase.org>";
 
     private SendMailViaAmazonService service;
     private AmazonSimpleEmailServiceClient emailClient;
@@ -77,25 +76,6 @@ public class SendMailViaAmazonServiceConsentTest {
         
         studyConsentService = mock(StudyConsentService.class);
         when(studyConsentService.getActiveConsent(any(StudyIdentifier.class))).thenReturn(view);
-    }
-    
-    @Test
-    public void whenNoStudySupportEmailUsesDefaultSupportEmail() {
-        study.setSupportEmail(""); // just a blank string, tricky
-
-        ConsentSignature consent = new ConsentSignature.Builder().withName("Test 2").withBirthdate("1950-05-05")
-                .withSignedOn(DateUtils.getCurrentMillisFromEpoch()).build();
-        User user = new User();
-        user.setEmail("test-user@sagebase.org");
-        
-        ConsentEmailProvider provider = new ConsentEmailProvider(study, user, consent, SharingScope.NO_SHARING,
-                        studyConsentService, consentBodyTemplate);
-        service.sendEmail(provider);
-
-        verify(emailClient).sendRawEmail(argument.capture());
-        SendRawEmailRequest req = argument.getValue();
-        
-        assertEquals("Correct sender", FROM_DEFAULT_AS_FORMATTED, req.getSource());
     }
 
     @Test

--- a/test/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceParticipantRosterTest.java
+++ b/test/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceParticipantRosterTest.java
@@ -75,7 +75,7 @@ public class SendMailViaAmazonServiceParticipantRosterTest {
         List<String> toList = req.getDestinations();
         assertEquals("Correct number of recipients", 1, toList.size());
         assertEquals("Correct recipient", "bridge-testing+consent@sagebase.org", toList.get(0));
-
+        
         // Validate message content. MIME message must be ASCII
         String rawMessage = new String(req.getRawMessage().getData().array(), Charsets.UTF_8);
         

--- a/test/org/sagebionetworks/bridge/services/email/ConsentEmailProviderTest.java
+++ b/test/org/sagebionetworks/bridge/services/email/ConsentEmailProviderTest.java
@@ -43,6 +43,7 @@ public class ConsentEmailProviderTest {
         Study study = new DynamoStudy();
         study.setName("Study Name");
         study.setSponsorName("Sponsor Name");
+        study.setSupportEmail("sender@default.com");
         study.setConsentNotificationEmail("consent@consent.com");
         
         User user = new User();
@@ -61,10 +62,10 @@ public class ConsentEmailProviderTest {
         StudyConsentView view = new StudyConsentView(new DynamoStudyConsent1(), LEGACY_DOCUMENT);
         when(studyConsentService.getActiveConsent(any(StudyIdentifier.class))).thenReturn(view);
         
-        MimeTypeEmail email = provider.getEmail("sender@default.com");
+        MimeTypeEmail email = provider.getMimeTypeEmail();
         MimeBodyPart body = email.getMessageParts().get(0);
         assertEquals("Consent Agreement for Study Name", email.getSubject());
-        assertEquals("sender@default.com", email.getSenderAddress());
+        assertEquals("\"Study Name\" <sender@default.com>", email.getSenderAddress());
         assertEquals("user@user.com", email.getRecipientAddresses().get(0));
         assertEquals("consent@consent.com", email.getRecipientAddresses().get(1));
         
@@ -79,10 +80,10 @@ public class ConsentEmailProviderTest {
         StudyConsentView view = new StudyConsentView(new DynamoStudyConsent1(), NEW_DOCUMENT_FRAGMENT);
         when(studyConsentService.getActiveConsent(any(StudyIdentifier.class))).thenReturn(view);
         
-        MimeTypeEmail email = provider.getEmail("sender@default.com");
+        MimeTypeEmail email = provider.getMimeTypeEmail();
         MimeBodyPart body = email.getMessageParts().get(0);
         assertEquals("Consent Agreement for Study Name", email.getSubject());
-        assertEquals("sender@default.com", email.getSenderAddress());
+        assertEquals("\"Study Name\" <sender@default.com>", email.getSenderAddress());
         assertEquals("user@user.com", email.getRecipientAddresses().get(0));
         assertEquals("consent@consent.com", email.getRecipientAddresses().get(1));
         

--- a/test/org/sagebionetworks/bridge/services/email/NotifyOperationsEmailProviderTest.java
+++ b/test/org/sagebionetworks/bridge/services/email/NotifyOperationsEmailProviderTest.java
@@ -1,0 +1,47 @@
+package org.sagebionetworks.bridge.services.email;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.config.BridgeConfigFactory;
+
+public class NotifyOperationsEmailProviderTest {
+
+    private String sysopsEmail;
+    private NotifyOperationsEmailProvider provider;
+    
+    @Before
+    public void before() {
+        // This is a quick and dirty implementation of the escaping that is done
+        // by the email service, so we can test without hardcoding the actual email.
+        sysopsEmail = BridgeConfigFactory.getConfig().getProperty("sysops.email");
+        String[] parts = sysopsEmail.split(" <");
+        sysopsEmail = "\"" + parts[0] + "\" <" + parts[1];
+    }
+    
+    @Test
+    public void testWithNoSender() throws Exception {
+        provider = new NotifyOperationsEmailProvider("Subject", "This is a test message.");
+        
+        MimeTypeEmail email = provider.getEmail(null);
+        assertEquals(sysopsEmail, email.getSenderAddress());
+        assertEquals(sysopsEmail, email.getRecipientAddresses().get(0));
+        assertEquals("Subject", email.getSubject());
+        assertEquals("This is a test message.", (String)email.getMessageParts().get(0).getContent());
+    }
+    
+    @Test
+    public void testWithSender() throws Exception {
+        provider = new NotifyOperationsEmailProvider("Subject", "This is a test message.");
+        
+        String emailEscaped = "\"Sender\" <sender@sender.com>";
+        MimeTypeEmail email = provider.getEmail("Sender <sender@sender.com>");
+        assertEquals(emailEscaped, email.getSenderAddress());
+        assertEquals(sysopsEmail, email.getRecipientAddresses().get(0));
+        assertEquals("Subject", email.getSubject());
+        assertEquals("This is a test message.", (String)email.getMessageParts().get(0).getContent());
+    }
+
+}

--- a/test/org/sagebionetworks/bridge/services/email/NotifyOperationsEmailProviderTest.java
+++ b/test/org/sagebionetworks/bridge/services/email/NotifyOperationsEmailProviderTest.java
@@ -15,7 +15,7 @@ public class NotifyOperationsEmailProviderTest {
     @Before
     public void before() {
         // This is a quick and dirty implementation of the escaping that is done
-        // by the email service, so we can test without hardcoding the actual email.
+        // by MimeTypeEmail, so we can test without hardcoding the actual email.
         sysopsEmail = BridgeConfigFactory.getConfig().getProperty("sysops.email");
         String[] parts = sysopsEmail.split(" <");
         sysopsEmail = "\"" + parts[0] + "\" <" + parts[1];

--- a/test/org/sagebionetworks/bridge/services/email/NotifyOperationsEmailProviderTest.java
+++ b/test/org/sagebionetworks/bridge/services/email/NotifyOperationsEmailProviderTest.java
@@ -1,6 +1,6 @@
 package org.sagebionetworks.bridge.services.email;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/test/org/sagebionetworks/bridge/services/email/NotifyOperationsEmailProviderTest.java
+++ b/test/org/sagebionetworks/bridge/services/email/NotifyOperationsEmailProviderTest.java
@@ -25,20 +25,8 @@ public class NotifyOperationsEmailProviderTest {
     public void testWithNoSender() throws Exception {
         provider = new NotifyOperationsEmailProvider("Subject", "This is a test message.");
         
-        MimeTypeEmail email = provider.getEmail(null);
+        MimeTypeEmail email = provider.getMimeTypeEmail();
         assertEquals(sysopsEmail, email.getSenderAddress());
-        assertEquals(sysopsEmail, email.getRecipientAddresses().get(0));
-        assertEquals("Subject", email.getSubject());
-        assertEquals("This is a test message.", (String)email.getMessageParts().get(0).getContent());
-    }
-    
-    @Test
-    public void testWithSender() throws Exception {
-        provider = new NotifyOperationsEmailProvider("Subject", "This is a test message.");
-        
-        String emailEscaped = "\"Sender\" <sender@sender.com>";
-        MimeTypeEmail email = provider.getEmail("Sender <sender@sender.com>");
-        assertEquals(emailEscaped, email.getSenderAddress());
         assertEquals(sysopsEmail, email.getRecipientAddresses().get(0));
         assertEquals("Subject", email.getSubject());
         assertEquals("This is a test message.", (String)email.getMessageParts().get(0).getContent());

--- a/test/org/sagebionetworks/bridge/services/email/ParticipantRosterGeneratorTest.java
+++ b/test/org/sagebionetworks/bridge/services/email/ParticipantRosterGeneratorTest.java
@@ -111,6 +111,7 @@ public class ParticipantRosterGeneratorTest {
         assertEquals("true", p.get("can_recontact"));
         assertNull(p.get("another_attribute"));
 
+        // Notification was sent to sysops
         assertNotNull(emailProvider);
         String subject = "A participant roster has been emailed";
         String body = "The participant roster for the study 'Test Study [ParticipantRosterGeneratorTest]' has been emailed to 'bridge-testing+consent@sagebase.org'.";

--- a/test/org/sagebionetworks/bridge/services/email/ParticipantRosterGeneratorTest.java
+++ b/test/org/sagebionetworks/bridge/services/email/ParticipantRosterGeneratorTest.java
@@ -124,11 +124,11 @@ public class ParticipantRosterGeneratorTest {
     public void generatorWithoutHealthCodeExportDoesntExportHealthCode() {
         study.setHealthCodeExportEnabled(false);
         generator.run();
-        verify(sendMailService).sendEmail(argument.capture());
+        verify(sendMailService, times(2)).sendEmail(argument.capture());
         
-        ParticipantRosterProvider provider = argument.getValue();
+        ParticipantRosterProvider rosterProvider = (ParticipantRosterProvider)argument.getAllValues().get(0);
         
-        for (StudyParticipant participant : provider.getParticipants()) {
+        for (StudyParticipant participant : rosterProvider.getParticipants()) {
             assertEquals("", participant.getHealthCode());
         }
     }

--- a/test/org/sagebionetworks/bridge/services/email/ParticipantRosterProviderTest.java
+++ b/test/org/sagebionetworks/bridge/services/email/ParticipantRosterProviderTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.services.email;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
@@ -123,6 +124,17 @@ public class ParticipantRosterProviderTest {
         ParticipantRosterProvider provider = new ParticipantRosterProvider(study, participants);
         String output = headerString + row("test@test.com", "First", "Last", "Not Sharing", "false", "(123) 456-7890", "false");
         assertEquals(output, provider.createParticipantTSV());
+    }
+    
+    @Test
+    public void assemblesCorrectEmail() throws Exception {
+        ParticipantRosterProvider provider = new ParticipantRosterProvider(study, Lists.newArrayList());
+        MimeTypeEmail email = provider.getMimeTypeEmail();
+        
+        assertEquals("Study participants for Test Study [ParticipantRosterProviderTest]", email.getSubject());
+        assertNull(email.getSenderAddress()); // comes from our default support address
+        assertEquals("bridge-testing+consent@sagebase.org", email.getRecipientAddresses().get(0));
+        assertEquals("bridge-testing+consent@sagebase.org", email.getRecipientAddresses().get(0));
     }
     
     private String row(String... fields) {

--- a/test/org/sagebionetworks/bridge/services/email/WithdrawConsentEmailProviderTest.java
+++ b/test/org/sagebionetworks/bridge/services/email/WithdrawConsentEmailProviderTest.java
@@ -40,7 +40,7 @@ public class WithdrawConsentEmailProviderTest {
         when(study.getSupportEmail()).thenReturn("c@c.com");
         when(user.getEmail()).thenReturn("d@d.com");
 
-        MimeTypeEmail email = provider.getEmail("foo@foo.com");
+        MimeTypeEmail email = provider.getMimeTypeEmail();
         
         List<String> recipients = email.getRecipientAddresses();
         assertEquals(1, recipients.size());
@@ -66,7 +66,7 @@ public class WithdrawConsentEmailProviderTest {
         when(user.getLastName()).thenReturn("Aubrey");
         when(user.getEmail()).thenReturn("d@d.com");
         
-        MimeTypeEmail email = provider.getEmail("foo@foo.com");
+        MimeTypeEmail email = provider.getMimeTypeEmail();
         
         List<String> recipients = email.getRecipientAddresses();
         assertEquals(2, recipients.size());


### PR DESCRIPTION
- Roster is prepared on a different thread, it now emails a systems operations email when that process succeeds or fails so we get visibility into this without having to assign ourselves to the list of consent notification emails (or look through the logs).
- Cleaned up the MimeTypeEmailProvider interface... it's now allowed to leave the sender blank and if the sender is blank, the sendMailService uses a default. No need to pass this value into every provider.
- Made the roster export resilient to accounts that have not consented. At least my account in development supposedly had a signature, but not a healthCode. That won't fail at this point.
