### PR TITLE
Sending 202 for async calls

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
@@ -189,6 +189,10 @@ public abstract class BaseController extends Controller {
         return created((JsonNode)mapper.valueToTree(obj));
     }
     
+    Result acceptedResult(String message) {
+        return status(202, Json.toJson(new StatusMessage(message)));
+    }
+    
     // This is needed or tests fail. It appears to be a bug in Play Framework,
     // that the asJson() method doesn't return a node in that context, possibly
     // because the root object in the JSON is an array (which is legal). 

--- a/app/org/sagebionetworks/bridge/play/controllers/StudyController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/StudyController.java
@@ -70,7 +70,8 @@ public class StudyController extends BaseController {
         Study study = studyService.getStudy(session.getStudyIdentifier());
 
         userProfileService.sendStudyParticipantRoster(study);
-        return okResult("A roster of study participants will be emailed to the study's consent notification contact.");
+        
+        return acceptedResult("A roster of study participants will be emailed to the study's consent notification contact.");
     }
 
     public Result updateStudyForDeveloper() throws Exception {

--- a/app/org/sagebionetworks/bridge/play/controllers/UserDataDownloadController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/UserDataDownloadController.java
@@ -34,6 +34,6 @@ public class UserDataDownloadController extends BaseController {
         DateRange dateRange = parseJson(request(), DateRange.class);
 
         userDataDownloadService.requestUserData(studyIdentifier, user, dateRange);
-        return okResult("Request submitted.");
+        return acceptedResult("Request submitted.");
     }
 }

--- a/test/org/sagebionetworks/bridge/play/controllers/StudyControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/StudyControllerTest.java
@@ -6,20 +6,29 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.sagebionetworks.bridge.Roles.RESEARCHER;
+import static org.sagebionetworks.bridge.TestUtils.mockPlayContext;
 
 import org.junit.Test;
 import org.sagebionetworks.bridge.Roles;
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.accounts.User;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
+import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
+import org.sagebionetworks.bridge.services.StudyService;
 import org.sagebionetworks.bridge.services.UploadCertificateService;
+import org.sagebionetworks.bridge.services.UserProfileService;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Sets;
 
+import play.mvc.Http;
 import play.mvc.Result;
 import play.test.Helpers;
 
@@ -70,6 +79,35 @@ public class StudyControllerTest {
         JsonNode node = BridgeObjectMapper.get().readTree(pemFile);
         assertTrue(node.get("publicKey").asText().contains("-----BEGIN CERTIFICATE-----"));
         assertEquals("CmsPublicKey", node.get("type").asText());
+    }
+    
+    @Test
+    public void canSendEmailRoster() throws Exception {
+        UserSession session = mock(UserSession.class);
+        StudyIdentifier studyId = new StudyIdentifierImpl(TestConstants.TEST_STUDY_IDENTIFIER);
+        when(session.getStudyIdentifier()).thenReturn(studyId);
+        
+        StudyController controller = spy(new StudyController());
+        doReturn(session).when(controller).getAuthenticatedSession(RESEARCHER);
+        
+        StudyService mockStudyService = mock(StudyService.class);
+        Study study = mock(Study.class);
+        when(mockStudyService.getStudy(studyId)).thenReturn(study);
+        controller.setStudyService(mockStudyService);
+        
+        UserProfileService userProfileService = mock(UserProfileService.class);
+        controller.setUserProfileService(userProfileService);
+        
+        Http.Context context = mockPlayContext();
+        Http.Context.current.set(context);
+        
+        Result result = controller.sendStudyParticipantsRoster();
+        assertEquals(202, result.status());
+        
+        String content = Helpers.contentAsString(result);
+        assertTrue(content.contains("A roster of study participants will be emailed"));
+
+        verify(userProfileService).sendStudyParticipantRoster(study);
     }
 
 }

--- a/test/org/sagebionetworks/bridge/play/controllers/UserDataDownloadControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/UserDataDownloadControllerTest.java
@@ -51,7 +51,7 @@ public class UserDataDownloadControllerTest {
 
         // execute and validate
         Result result = controller.requestUserData();
-        assertEquals(200, result.status());
+        assertEquals(202, result.status());
 
         // validate args sent to mock service
         ArgumentCaptor<DateRange> dateRangeCaptor = ArgumentCaptor.forClass(DateRange.class);


### PR DESCRIPTION
Return 202 (Accepted) for calls that return a 2xx response code before the final success or failure of the operation is known (in our case, the calls that send emails to downloads or with zip files attached, which may fail after the call). It means "The request has been accepted for processing, but the processing has not been completed." 

I know of these two calls, the send reset password request looks similar, but we know it is sent because it's sent during the course of the request, and presumably we would return a 500 if we failed to send the email.
