### PR TITLE
Cleaning up to use 'identifier' in both of the client APIs

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/FPHSController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/FPHSController.java
@@ -31,12 +31,12 @@ public class FPHSController extends BaseController {
         this.fphsService = service; 
     }
     
-    public Result verifyExternalIdentifier(String externalId) throws Exception {
+    public Result verifyExternalIdentifier(String identifier) throws Exception {
         // public API, no restrictions. externalId can be null so we can create a 400 error in the service.
-        ExternalIdentifier identifier = new ExternalIdentifier(externalId);
-        fphsService.verifyExternalIdentifier(identifier);
+        ExternalIdentifier externalId = new ExternalIdentifier(identifier);
+        fphsService.verifyExternalIdentifier(externalId);
         
-        return okResult(identifier);
+        return okResult(externalId);
     }
     public Result registerExternalIdentifier() throws Exception {
         UserSession session = getAuthenticatedAndConsentedSession();

--- a/conf/routes
+++ b/conf/routes
@@ -107,7 +107,7 @@ DELETE /v3/cache/:cacheKey @org.sagebionetworks.bridge.play.controllers.CacheAdm
 
 # FOOTBALL PLAYERS HEATH STUDY API --------------------------------------------------------------------------
 
-GET    /fphs/externalId   @org.sagebionetworks.bridge.play.controllers.FPHSController.verifyExternalIdentifier(externalId: String ?= null)
+GET    /fphs/externalId   @org.sagebionetworks.bridge.play.controllers.FPHSController.verifyExternalIdentifier(identifier: String ?= null)
 POST   /fphs/externalId   @org.sagebionetworks.bridge.play.controllers.FPHSController.registerExternalIdentifier
 GET    /fphs/externalIds  @org.sagebionetworks.bridge.play.controllers.FPHSController.getExternalIdentifiers
 POST   /fphs/externalIds  @org.sagebionetworks.bridge.play.controllers.FPHSController.addExternalIdentifiers


### PR DESCRIPTION
We use identifier when registering, externalId when checking the code, use identifier both places. Consistent with the external ID API.
