### PR TITLE
fix external ID bug

### DIFF
--- a/app/org/sagebionetworks/bridge/models/healthdata/HealthDataRecordBuilder.java
+++ b/app/org/sagebionetworks/bridge/models/healthdata/HealthDataRecordBuilder.java
@@ -25,8 +25,8 @@ public abstract class HealthDataRecordBuilder {
     private String studyId;
     private LocalDate uploadDate;
     private String uploadId;
-    private ParticipantOption.SharingScope userSharingScope;
     private String userExternalId;
+    private ParticipantOption.SharingScope userSharingScope;
     private Long version;
 
     /** Copies all fields from the specified record into the builder. This is useful for updating records. */
@@ -41,6 +41,7 @@ public abstract class HealthDataRecordBuilder {
         studyId = record.getStudyId();
         uploadDate = record.getUploadDate();
         uploadId = record.getUploadId();
+        userExternalId = record.getUserExternalId();
         userSharingScope = record.getUserSharingScope();
         version = record.getVersion();
         return this;
@@ -183,8 +184,9 @@ public abstract class HealthDataRecordBuilder {
     }
 
     /** @see org.sagebionetworks.bridge.models.healthdata.HealthDataRecord#getVersion */
-    public void setVersion(Long version) {
+    public HealthDataRecordBuilder withVersion(Long version) {
         this.version = version;
+        return this;
     }
 
     /**

--- a/test/org/sagebionetworks/bridge/models/healthdata/HealthDataRecordTest.java
+++ b/test/org/sagebionetworks/bridge/models/healthdata/HealthDataRecordTest.java
@@ -70,7 +70,9 @@ public class HealthDataRecordTest {
         HealthDataRecord record = DAO.getRecordBuilder().withData(data).withHealthCode("required healthcode")
                 .withId("optional record ID").withCreatedOn(arbitraryTimestamp).withMetadata(metadata)
                 .withSchemaId("required schema").withSchemaRevision(3).withStudyId("required study")
-                .withUploadDate(uploadDate).build();
+                .withUploadDate(uploadDate).withUploadId("optional upload ID")
+                .withUserExternalId("optional external ID")
+                .withUserSharingScope(ParticipantOption.SharingScope.SPONSORS_AND_PARTNERS).withVersion(42L).build();
 
         // validate
         assertEquals("required healthcode", record.getHealthCode());
@@ -80,12 +82,37 @@ public class HealthDataRecordTest {
         assertEquals(3, record.getSchemaRevision());
         assertEquals("required study", record.getStudyId());
         assertEquals("2014-02-12", record.getUploadDate().toString(ISODateTimeFormat.date()));
+        assertEquals("optional upload ID", record.getUploadId());
+        assertEquals("optional external ID", record.getUserExternalId());
+        assertEquals(ParticipantOption.SharingScope.SPONSORS_AND_PARTNERS, record.getUserSharingScope());
+        assertEquals(42, record.getVersion().longValue());
 
         assertEquals(1, record.getData().size());
         assertEquals("myDataValue", record.getData().get("myData").asText());
 
         assertEquals(1, record.getMetadata().size());
         assertEquals("myMetaValue", record.getMetadata().get("myMetadata").asText());
+
+        // test copy constructor
+        HealthDataRecord copyRecord = DAO.getRecordBuilder().copyOf(record).build();
+        assertEquals("required healthcode", copyRecord.getHealthCode());
+        assertEquals("optional record ID", copyRecord.getId());
+        assertEquals(arbitraryTimestamp, copyRecord.getCreatedOn().longValue());
+        assertEquals("required schema", copyRecord.getSchemaId());
+        assertEquals(3, copyRecord.getSchemaRevision());
+        assertEquals("required study", copyRecord.getStudyId());
+        assertEquals("2014-02-12", copyRecord.getUploadDate().toString(ISODateTimeFormat.date()));
+        assertEquals("optional upload ID", copyRecord.getUploadId());
+        assertEquals("optional external ID", copyRecord.getUserExternalId());
+        assertEquals(ParticipantOption.SharingScope.SPONSORS_AND_PARTNERS, copyRecord.getUserSharingScope());
+        assertEquals(42, copyRecord.getVersion().longValue());
+
+        assertEquals(1, copyRecord.getData().size());
+        assertEquals("myDataValue", copyRecord.getData().get("myData").asText());
+
+        assertEquals(1, copyRecord.getMetadata().size());
+        assertEquals("myMetaValue", copyRecord.getMetadata().get("myMetadata").asText());
+
     }
 
     @Test(expected = InvalidEntityException.class)

--- a/test/org/sagebionetworks/bridge/upload/UploadArtifactsHandlerTest.java
+++ b/test/org/sagebionetworks/bridge/upload/UploadArtifactsHandlerTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.upload;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -12,12 +13,10 @@ import java.util.TreeMap;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Charsets;
-import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
+import org.joda.time.format.ISODateTimeFormat;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dao.ParticipantOption;
@@ -26,13 +25,13 @@ import org.sagebionetworks.bridge.dynamodb.DynamoHealthDataRecord;
 import org.sagebionetworks.bridge.dynamodb.DynamoUpload2;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.healthdata.HealthDataAttachment;
-import org.sagebionetworks.bridge.models.healthdata.HealthDataAttachmentBuilder;
 import org.sagebionetworks.bridge.models.healthdata.HealthDataRecord;
 import org.sagebionetworks.bridge.models.healthdata.HealthDataRecordBuilder;
 import org.sagebionetworks.bridge.s3.S3Helper;
 import org.sagebionetworks.bridge.services.HealthDataService;
 
 public class UploadArtifactsHandlerTest {
+    private static final long ARBITRARY_TIMESTAMP = 1424136378727L;
     private static final String ATTACHMENT_ID_BAR = "attachment-bar";
     private static final String ATTACHMENT_ID_FOO = "attachment-foo";
     private static final String ATTACHMENT_TEXT_BAR = "This is bar";
@@ -65,19 +64,10 @@ public class UploadArtifactsHandlerTest {
 
         when(mockHealthDataService.getRecordById(TEST_RECORD_ID)).thenReturn(intermediateRecord);
 
-        when(mockHealthDataService.getAttachmentBuilder()).thenAnswer(new Answer<HealthDataAttachmentBuilder>() {
-            @Override
-            public HealthDataAttachmentBuilder answer(InvocationOnMock invocation) {
-                return new DynamoHealthDataAttachment.Builder();
-            }
-        });
+        when(mockHealthDataService.getAttachmentBuilder()).thenAnswer(
+                invocation -> new DynamoHealthDataAttachment.Builder());
 
-        when(mockHealthDataService.getRecordBuilder()).thenAnswer(new Answer<HealthDataRecordBuilder>() {
-            @Override
-            public HealthDataRecordBuilder answer(InvocationOnMock invocation) {
-                return new DynamoHealthDataRecord.Builder();
-            }
-        });
+        when(mockHealthDataService.getRecordBuilder()).thenAnswer(invocation -> new DynamoHealthDataRecord.Builder());
 
         // mock S3 helper
         S3Helper mockS3Helper = mock(S3Helper.class);
@@ -117,6 +107,21 @@ public class UploadArtifactsHandlerTest {
         // First record is the intermediate record. This will have data, but no record ID, since record ID is assigned
         // by this call.
         HealthDataRecord createIntermediateRecordArg = createRecordArgList.get(0);
+        assertEquals("dummy-healthcode", createIntermediateRecordArg.getHealthCode());
+        assertNull(createIntermediateRecordArg.getId());
+        assertEquals(ARBITRARY_TIMESTAMP, createIntermediateRecordArg.getCreatedOn().longValue());
+        assertEquals("dummy-schema", createIntermediateRecordArg.getSchemaId());
+        assertEquals(1, createIntermediateRecordArg.getSchemaRevision());
+        assertEquals("dummy-study", createIntermediateRecordArg.getStudyId());
+        assertEquals("2015-11-18", createIntermediateRecordArg.getUploadDate().toString(ISODateTimeFormat.date()));
+        assertEquals(TEST_UPLOAD_ID, createIntermediateRecordArg.getUploadId());
+        assertEquals("dummy-external-ID", createIntermediateRecordArg.getUserExternalId());
+        assertEquals(ParticipantOption.SharingScope.SPONSORS_AND_PARTNERS, createIntermediateRecordArg.getUserSharingScope());
+        assertEquals(42, createIntermediateRecordArg.getVersion().longValue());
+
+        assertTrue(createIntermediateRecordArg.getMetadata().isObject());
+        assertEquals(0, createIntermediateRecordArg.getMetadata().size());
+
         JsonNode createIntermediateRecordDataJson = createIntermediateRecordArg.getData();
         assertEquals(2, createIntermediateRecordDataJson.size());
         assertEquals("This is a string", createIntermediateRecordDataJson.get("json.json.string").textValue());
@@ -124,7 +129,21 @@ public class UploadArtifactsHandlerTest {
 
         // Second record is the final record. This has data (with attachments) and record ID;
         HealthDataRecord createFinalRecordArg = createRecordArgList.get(1);
+        assertEquals("dummy-healthcode", createFinalRecordArg.getHealthCode());
         assertEquals(TEST_RECORD_ID, createFinalRecordArg.getId());
+        assertEquals(ARBITRARY_TIMESTAMP, createFinalRecordArg.getCreatedOn().longValue());
+        assertEquals("dummy-schema", createFinalRecordArg.getSchemaId());
+        assertEquals(1, createFinalRecordArg.getSchemaRevision());
+        assertEquals("dummy-study", createFinalRecordArg.getStudyId());
+        assertEquals("2015-11-18", createFinalRecordArg.getUploadDate().toString(ISODateTimeFormat.date()));
+        assertEquals(TEST_UPLOAD_ID, createFinalRecordArg.getUploadId());
+        assertEquals("dummy-external-ID", createFinalRecordArg.getUserExternalId());
+        assertEquals(ParticipantOption.SharingScope.SPONSORS_AND_PARTNERS, createFinalRecordArg.getUserSharingScope());
+        assertEquals(42, createFinalRecordArg.getVersion().longValue());
+
+        assertTrue(createFinalRecordArg.getMetadata().isObject());
+        assertEquals(0, createFinalRecordArg.getMetadata().size());
+
         JsonNode createFinalRecordDataJson = createFinalRecordArg.getData();
         assertEquals(4, createFinalRecordDataJson.size());
         assertEquals("This is a string", createFinalRecordDataJson.get("json.json.string").textValue());
@@ -154,10 +173,12 @@ public class UploadArtifactsHandlerTest {
     // creates a record builder that has all the valid values filled in, with the data JsonNode specified
     private static HealthDataRecordBuilder createValidRecordBuilder(JsonNode dataNode) {
         // none of these values matter (except data, which is specified), so just fill in whatever
-        return new DynamoHealthDataRecord.Builder().withCreatedOn(DateTime.now().getMillis()).withData(dataNode)
+        // All that matters is that the values are written to DDB.
+        return new DynamoHealthDataRecord.Builder().withCreatedOn(ARBITRARY_TIMESTAMP).withData(dataNode)
                 .withHealthCode("dummy-healthcode").withMetadata(BridgeObjectMapper.get().createObjectNode())
                 .withSchemaId("dummy-schema").withSchemaRevision(1).withStudyId("dummy-study")
-                .withUploadDate(LocalDate.now())
-                .withUserSharingScope(ParticipantOption.SharingScope.SPONSORS_AND_PARTNERS);
+                .withUploadDate(LocalDate.parse("2015-11-18")).withUploadId(TEST_UPLOAD_ID)
+                .withUserExternalId("dummy-external-ID")
+                .withUserSharingScope(ParticipantOption.SharingScope.SPONSORS_AND_PARTNERS).withVersion(42L);
     }
 }


### PR DESCRIPTION
There was a bug in the Health Data Record copy constructor that didn't propagate the external ID. This change fixes the bug and adds a few unit tests to test the fix. Note that this bug only triggers if there's an attachment in the upload.

Note that the fixes and tests won't catch if we add another new field to the record. For that, we'd need the equivalent of EqualsVerifier for copy constructors.

Testing done:
- ran updated unit tests
- manually tested upload (with an upload) and verified the external ID is propagated
