### PR TITLE
Criteria schedule strategies

### DIFF
--- a/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
+++ b/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
@@ -368,12 +368,6 @@ public class BridgeSpringConfig {
         return DynamoUtils.getMapper(DynamoScheduledActivity.class, bridgeConfig, client);
     }
     
-    @Bean(name = "activityRunKeyIndex")
-    @Autowired
-    public DynamoIndexHelper activityRunKeyIndex(final BridgeConfig bridgeConfig, final AmazonDynamoDB client) {
-        return DynamoIndexHelper.create(DynamoScheduledActivity.class, "hashKey-runKey-index", bridgeConfig, client);
-    }
-    
     @Bean(name = "activitySchedulePlanGuidIndex")
     @Autowired
     public DynamoIndexHelper activitySchedulePlanGuidIndex(final BridgeConfig bridgeConfig, final AmazonDynamoDB client) {

--- a/app/org/sagebionetworks/bridge/dao/ScheduledActivityDao.java
+++ b/app/org/sagebionetworks/bridge/dao/ScheduledActivityDao.java
@@ -26,14 +26,6 @@ public interface ScheduledActivityDao {
     public List<ScheduledActivity> getActivities(ScheduleContext context);
     
     /**
-     * Have any of the activities for this run key been created?
-     * @param healthCode
-     * @param runKey
-     * @return
-     */
-    public boolean activityRunHasNotOccurred(String healthCode, String runKey);
-    
-    /**
      * Save activities (activities will only be saved if they are not in the database).
      * @param activities
      */

--- a/app/org/sagebionetworks/bridge/dao/ScheduledActivityDao.java
+++ b/app/org/sagebionetworks/bridge/dao/ScheduledActivityDao.java
@@ -68,4 +68,11 @@ public interface ScheduledActivityDao {
      */
     public void deleteActivitiesForSchedulePlan(String schedulePlanGuid);
     
+    /**
+     * In calculating activities to return to a user, any activities found that are no longer in the list of scheduled
+     * activites are deleted through this method
+     * 
+     * @param activitiesToDelete
+     */
+    public void deleteActivities(List<ScheduledActivity> activitiesToDelete);
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSchedulePlanDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSchedulePlanDao.java
@@ -58,6 +58,9 @@ public class DynamoSchedulePlanDao implements SchedulePlanDao {
         
         ArrayList<SchedulePlan> plans = Lists.newArrayListWithCapacity(dynamoPlans.size());
         for(DynamoSchedulePlan dynamoPlan : dynamoPlans) {
+            // We still do this, but I would like to move to filtering through a specific schedule plan strategy, 
+            // rather than through the schedule plan itself. This pushes the complexity down to a specific strategy
+            // class and encapsulates the logic better.
             if (clientInfo.isTargetedAppVersion(dynamoPlan.getMinAppVersion(), dynamoPlan.getMaxAppVersion())) {
                 plans.add(dynamoPlan);
             }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivity.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivity.java
@@ -19,7 +19,6 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIgnore;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIndexHashKey;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIndexRangeKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMarshalling;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
@@ -46,12 +45,9 @@ public final class DynamoScheduledActivity implements ScheduledActivity, BridgeE
     private LocalDateTime localScheduledOn;
     private LocalDateTime localExpiresOn;
     private Activity activity;
-    private String runKey;
     private Long hidesOn;
     private boolean persistent;
     private DateTimeZone timeZone;
-    private Integer minAppVersion;
-    private Integer maxAppVersion;
 
     public DynamoScheduledActivity() {
         setHidesOn(new Long(Long.MAX_VALUE));
@@ -162,19 +158,6 @@ public final class DynamoScheduledActivity implements ScheduledActivity, BridgeE
         this.hidesOn = hidesOn;
     }
 
-    @DynamoDBAttribute
-    @Override
-    @JsonIgnore
-    @DynamoDBIndexRangeKey(localSecondaryIndexName = "hashKey-runKey-index")
-    public String getRunKey() {
-        return this.runKey;
-    }
-
-    @Override
-    public void setRunKey(String runKey) {
-        this.runKey = runKey;
-    }
-
     @DynamoDBHashKey
     @Override
     public String getHealthCode() {
@@ -270,29 +253,9 @@ public final class DynamoScheduledActivity implements ScheduledActivity, BridgeE
     }
 
     @Override
-    public Integer getMinAppVersion() {
-        return minAppVersion;
-    }
-
-    @Override
-    public void setMinAppVersion(Integer minAppVersion) {
-        this.minAppVersion = minAppVersion;
-    }
-
-    @Override
-    public Integer getMaxAppVersion() {
-        return maxAppVersion;
-    }
-
-    @Override
-    public void setMaxAppVersion(Integer maxAppVersion) {
-        this.maxAppVersion = maxAppVersion;
-    }
-
-    @Override
     public int hashCode() {
-        return Objects.hash(activity, guid, localScheduledOn, localExpiresOn, startedOn, finishedOn, healthCode, runKey,
-                hidesOn, persistent, timeZone, minAppVersion, maxAppVersion, schedulePlanGuid);
+        return Objects.hash(activity, guid, localScheduledOn, localExpiresOn, startedOn, finishedOn, healthCode, 
+                hidesOn, persistent, timeZone, schedulePlanGuid);
     }
 
     @Override
@@ -306,16 +269,15 @@ public final class DynamoScheduledActivity implements ScheduledActivity, BridgeE
                 && Objects.equals(localScheduledOn, other.localScheduledOn) && Objects.equals(guid, other.guid)
                 && Objects.equals(startedOn, other.startedOn) && Objects.equals(finishedOn, other.finishedOn)
                 && Objects.equals(healthCode, other.healthCode) && Objects.equals(hidesOn, other.hidesOn)
-                && Objects.equals(runKey, other.runKey) && Objects.equals(persistent, other.persistent)
-                && Objects.equals(timeZone, other.timeZone) && Objects.equals(minAppVersion, other.minAppVersion)
-                && Objects.equals(maxAppVersion, other.maxAppVersion) && Objects.equals(schedulePlanGuid, other.schedulePlanGuid));
+                && Objects.equals(persistent, other.persistent) && Objects.equals(timeZone, other.timeZone) 
+                && Objects.equals(schedulePlanGuid, other.schedulePlanGuid));
     }
 
     @Override
     public String toString() {
         return String.format(
-                "DynamoScheduledActivity [healthCode=%s, guid=%s, localScheduledOn=%s, localExpiresOn=%s, startedOn=%s, finishedOn=%s, persistent=%s, timeZone=%s, minAppVersion=%s, maxAppVersion=%s, activity=%s, schedulePlanGuid=%s]",
+                "DynamoScheduledActivity [healthCode=%s, guid=%s, localScheduledOn=%s, localExpiresOn=%s, startedOn=%s, finishedOn=%s, persistent=%s, timeZone=%s, activity=%s, schedulePlanGuid=%s]",
                 healthCode, guid, localScheduledOn, localExpiresOn, startedOn, finishedOn, persistent, timeZone,
-                minAppVersion, maxAppVersion, activity, schedulePlanGuid);
+                activity, schedulePlanGuid);
     }
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDao.java
@@ -17,7 +17,6 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper.FailedBatch;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
 import com.amazonaws.services.dynamodbv2.datamodeling.PaginatedQueryList;
-import com.amazonaws.services.dynamodbv2.document.RangeKeyCondition;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
 import com.amazonaws.services.dynamodbv2.model.Condition;
@@ -27,17 +26,11 @@ import com.google.common.collect.Lists;
 public class DynamoScheduledActivityDao implements ScheduledActivityDao {
     
     private DynamoDBMapper mapper;
-    private DynamoIndexHelper runKeyIndex;
     private DynamoIndexHelper schedulePlanIndex;
     
     @Resource(name = "activityDdbMapper")
     public final void setDdbMapper(DynamoDBMapper mapper) {
         this.mapper = mapper;
-    }
-    
-    @Resource(name = "activityRunKeyIndex")
-    public final void setActivityRunKeyIndex(DynamoIndexHelper index) {
-        this.runKeyIndex = index;
     }
     
     @Resource(name = "activitySchedulePlanGuidIndex")
@@ -83,14 +76,6 @@ public class DynamoScheduledActivityDao implements ScheduledActivityDao {
             activities.add(activity);
         }
         return activities;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
-    public boolean activityRunHasNotOccurred(String healthCode, String runKey) {
-        RangeKeyCondition rangeKeyCondition = new RangeKeyCondition("runKey").eq(runKey);
-        int count = runKeyIndex.queryKeyCount("healthCode", healthCode, rangeKeyCondition);
-        return (count == 0);
     }
     
     /** {@inheritDoc} */

--- a/app/org/sagebionetworks/bridge/models/accounts/User.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/User.java
@@ -32,6 +32,7 @@ public class User implements BridgeEntity {
     private boolean signedMostRecentConsent;
     private SharingScope sharingScope;
     private Set<Roles> roles = Sets.newHashSet();
+    private Set<String> dataGroups = Sets.newHashSet();
 
     public User() {
     }
@@ -164,6 +165,14 @@ public class User implements BridgeEntity {
     
     public boolean isInRole(Set<Roles> roleSet) {
         return roleSet != null && !Collections.disjoint(roles, roleSet);
+    }
+    
+    public Set<String> getDataGroups() {
+        return dataGroups;
+    }
+
+    public void setDataGroups(Set<String> dataGroups) {
+        this.dataGroups = dataGroups;
     }
 
     @Override

--- a/app/org/sagebionetworks/bridge/models/schedules/ABTestScheduleStrategy.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/ABTestScheduleStrategy.java
@@ -1,9 +1,11 @@
 package org.sagebionetworks.bridge.models.schedules;
 
+import static java.util.stream.Collectors.toList;
+
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import org.sagebionetworks.bridge.validators.ScheduleValidator;
 import org.springframework.validation.Errors;
@@ -11,7 +13,7 @@ import org.springframework.validation.Errors;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
-public class ABTestScheduleStrategy implements ScheduleStrategy {
+public final class ABTestScheduleStrategy implements ScheduleStrategy {
     
     public static class ScheduleGroup {
         private int percentage;
@@ -120,31 +122,21 @@ public class ABTestScheduleStrategy implements ScheduleStrategy {
 
     @Override
     public List<Schedule> getAllPossibleSchedules() {
-        return ImmutableList.copyOf(groups.stream().map(ScheduleGroup::getSchedule).collect(Collectors.toList()));
+        return ImmutableList.copyOf(groups.stream().map(ScheduleGroup::getSchedule).collect(toList()));
     }
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((groups == null) ? 0 : groups.hashCode());
-        return result;
+        return Objects.hash(groups);
     }
     @Override
     public boolean equals(Object obj) {
         if (this == obj)
             return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
+        if (obj == null || getClass() != obj.getClass())
             return false;
         ABTestScheduleStrategy other = (ABTestScheduleStrategy) obj;
-        if (groups == null) {
-            if (other.groups != null)
-                return false;
-        } else if (!groups.equals(other.groups))
-            return false;
-        return true;
+        return Objects.equals(groups, other.groups);
     }
     @Override
     public String toString() {

--- a/app/org/sagebionetworks/bridge/models/schedules/ABTestScheduleStrategy.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/ABTestScheduleStrategy.java
@@ -95,7 +95,7 @@ public class ABTestScheduleStrategy implements ScheduleStrategy {
         return group.getSchedule();
     }
     @Override
-    public void validate(Set<String> taskIdentifiers, Errors errors) {
+    public void validate(Set<String> dataGroups, Set<String> taskIdentifiers, Errors errors) {
         int percentage = 0;
         for (ScheduleGroup group : groups) {
             percentage += group.getPercentage();

--- a/app/org/sagebionetworks/bridge/models/schedules/ABTestScheduleStrategy.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/ABTestScheduleStrategy.java
@@ -3,13 +3,11 @@ package org.sagebionetworks.bridge.models.schedules;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
-import org.sagebionetworks.bridge.models.accounts.User;
-import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.validators.ScheduleValidator;
 import org.springframework.validation.Errors;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 public class ABTestScheduleStrategy implements ScheduleStrategy {
@@ -79,14 +77,14 @@ public class ABTestScheduleStrategy implements ScheduleStrategy {
     }
     
     @Override
-    public Schedule getScheduleForUser(StudyIdentifier study, SchedulePlan plan, User user) {
+    public Schedule getScheduleForUser(SchedulePlan plan, ScheduleContext context) {
         if (groups.isEmpty()) {
             return null;
         }
         // Randomly assign to a group, weighted based on the percentage representation of the group.
         ScheduleGroup group = null;
         long seed = UUID.fromString(plan.getGuid()).getLeastSignificantBits()
-                + UUID.fromString(user.getHealthCode()).getLeastSignificantBits();        
+                + UUID.fromString(context.getHealthCode()).getLeastSignificantBits();        
         
         int i = 0;
         int perc = (int)(seed % 100.0) + 1;
@@ -121,12 +119,7 @@ public class ABTestScheduleStrategy implements ScheduleStrategy {
 
     @Override
     public List<Schedule> getAllPossibleSchedules() {
-        List<Schedule> lists = Lists.newArrayListWithCapacity(groups.size());
-        for (ScheduleGroup group : groups) {
-            lists.add(group.getSchedule());
-        }
-        // The list is immutable, the contents are not. We use this to fix up activities, for example.
-        return ImmutableList.copyOf(lists);
+        return groups.stream().map(ScheduleGroup::getSchedule).collect(Collectors.toList());
     }
 
     @Override

--- a/app/org/sagebionetworks/bridge/models/schedules/ABTestScheduleStrategy.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/ABTestScheduleStrategy.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import org.sagebionetworks.bridge.validators.ScheduleValidator;
 import org.springframework.validation.Errors;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 public class ABTestScheduleStrategy implements ScheduleStrategy {
@@ -119,7 +120,7 @@ public class ABTestScheduleStrategy implements ScheduleStrategy {
 
     @Override
     public List<Schedule> getAllPossibleSchedules() {
-        return groups.stream().map(ScheduleGroup::getSchedule).collect(Collectors.toList());
+        return ImmutableList.copyOf(groups.stream().map(ScheduleGroup::getSchedule).collect(Collectors.toList()));
     }
 
     @Override

--- a/app/org/sagebionetworks/bridge/models/schedules/ActivityScheduler.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/ActivityScheduler.java
@@ -7,7 +7,6 @@ import java.util.List;
 
 import org.joda.time.DateTime;
 import org.joda.time.LocalTime;
-import org.sagebionetworks.bridge.BridgeUtils;
 
 public abstract class ActivityScheduler {
 
@@ -78,9 +77,6 @@ public abstract class ActivityScheduler {
                         schActivity.setExpiresOn(expiresOn);
                         schActivity.setHidesOn(expiresOn.getMillis());
                     }
-                    schActivity.setRunKey(BridgeUtils.generateScheduledActivityRunKey(schActivity, plan.getGuid()));
-                    schActivity.setMinAppVersion(plan.getMinAppVersion());
-                    schActivity.setMaxAppVersion(plan.getMaxAppVersion());
                     scheduledActivities.add(schActivity);
                 }
             }

--- a/app/org/sagebionetworks/bridge/models/schedules/CriteriaScheduleStrategy.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/CriteriaScheduleStrategy.java
@@ -12,6 +12,7 @@ import org.sagebionetworks.bridge.validators.ScheduleValidator;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
@@ -205,7 +206,8 @@ public class CriteriaScheduleStrategy implements ScheduleStrategy {
     
     @Override
     public List<Schedule> getAllPossibleSchedules() {
-        return scheduleCriteria.stream().map(ScheduleCriteria::getSchedule).collect(Collectors.toList());
+        return ImmutableList.copyOf(
+                scheduleCriteria.stream().map(ScheduleCriteria::getSchedule).collect(Collectors.toList()));
     }
 
     @Override

--- a/app/org/sagebionetworks/bridge/models/schedules/CriteriaScheduleStrategy.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/CriteriaScheduleStrategy.java
@@ -1,0 +1,185 @@
+package org.sagebionetworks.bridge.models.schedules;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.validation.Errors;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
+public class CriteriaScheduleStrategy implements ScheduleStrategy {
+
+    public static class ScheduleCriteria {
+        private final Schedule schedule;
+        private final Integer minAppVersion;
+        private final Integer maxAppVersion;
+        private final Set<String> allOfGroups;
+        private final Set<String> noneOfGroups;
+
+        @JsonCreator
+        private ScheduleCriteria(@JsonProperty("schedule") Schedule schedule, @JsonProperty("minAppVersin") Integer minAppVersion, 
+                @JsonProperty("maxAppVersion") Integer maxAppVersion, @JsonProperty("allOfGroups") Set<String> allOfGroups, 
+                @JsonProperty("noneOfGroups") Set<String> noneOfGroups) {
+            this.schedule = schedule;
+            this.minAppVersion = minAppVersion;
+            this.maxAppVersion = maxAppVersion;
+            this.allOfGroups = allOfGroups;
+            this.noneOfGroups = noneOfGroups;
+        }
+        public Schedule getSchedule() {
+            return schedule;
+        }
+        public Integer getMinAppVersion() {
+            return minAppVersion;
+        }
+        public Integer getMaxAppVersion() {
+            return maxAppVersion;
+        }
+        public Set<String> getAllOfGroups() {
+            return allOfGroups;
+        }
+        public Set<String> getNoneOfGroups() {
+            return noneOfGroups;
+        }
+        
+        public static class Builder {
+            private Schedule schedule;
+            private Integer minAppVersion;
+            private Integer maxAppVersion;
+            private Set<String> allOfGroups = Sets.newHashSet();
+            private Set<String> noneOfGroups = Sets.newHashSet();
+            
+            public Builder withSchedule(Schedule schedule) {
+                this.schedule = schedule;
+                return this;
+            }
+            public Builder withMinAppVersion(Integer minAppVersion) {
+                this.minAppVersion = minAppVersion;
+                return this;
+            }
+            public Builder withMaxAppVersion(Integer maxAppVersion) {
+                this.maxAppVersion = maxAppVersion;
+                return this;
+            }
+            public Builder addRequiredGroup(String... groups) {
+                for (String group : groups) {
+                    this.allOfGroups.add(group);    
+                }
+                return this;
+            }
+            public Builder addProhibitedGroup(String... groups) {
+                for (String group : groups) {
+                    this.noneOfGroups.add(group);    
+                }
+                return this;
+            }
+            public ScheduleCriteria build() {
+                return new ScheduleCriteria(schedule, minAppVersion, maxAppVersion, allOfGroups, noneOfGroups);
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(minAppVersion, maxAppVersion, allOfGroups, noneOfGroups, schedule);
+        }
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null || getClass() != obj.getClass())
+                return false;
+            ScheduleCriteria other = (ScheduleCriteria) obj;
+            return Objects.equals(minAppVersion, other.minAppVersion) && Objects.equals(maxAppVersion, other.maxAppVersion)
+                    && Objects.equals(allOfGroups, other.allOfGroups) && Objects.equals(noneOfGroups, other.noneOfGroups) 
+                    && Objects.equals(schedule, other.schedule);
+        }
+        @Override
+        public String toString() {
+            return "ScheduleCriteria [schedule=" + schedule + ", minAppVersion=" + minAppVersion + ", maxAppVersion="
+                    + maxAppVersion + ", allOfGroups=" + allOfGroups + ", noneOfGroups=" + noneOfGroups + "]";
+        }
+    }
+    
+    private List<ScheduleCriteria> criteria = Lists.newArrayList();
+    
+    public void addCriteria(ScheduleCriteria criteria) {
+        this.criteria.add(criteria);
+    }
+    
+    public List<ScheduleCriteria> getCriteria() {
+        return criteria;
+    }
+    
+    public void setCriteria(List<ScheduleCriteria> criteria) {
+        this.criteria = criteria;
+    }
+    
+    @Override
+    public Schedule getScheduleForUser(SchedulePlan plan, ScheduleContext context) {
+        for (ScheduleCriteria crit : criteria) {
+            if (matches(crit, context)){
+                return crit.getSchedule();    
+            }
+        }
+        return null;
+    }
+    
+    public boolean matches(ScheduleCriteria crit, ScheduleContext context) {
+        Integer appVersion = context.getClientInfo().getAppVersion();
+        if (appVersion != null) {
+            if (crit.getMinAppVersion() != null && appVersion < crit.getMinAppVersion()) {
+                return false;
+            }
+            if (crit.getMaxAppVersion() != null && appVersion > crit.getMaxAppVersion()) {
+                return false;
+            }
+        }
+        
+        Set<String> dataGroups = context.getUserDataGroups();
+        if (!dataGroups.containsAll(crit.getAllOfGroups())) {
+            return false;
+        }
+        for (String group : crit.getNoneOfGroups()) {
+            if (dataGroups.contains(group)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public void validate(Set<String> taskIdentifiers, Errors errors) {
+        
+    }
+
+    @Override
+    public List<Schedule> getAllPossibleSchedules() {
+        return criteria.stream().map(ScheduleCriteria::getSchedule).collect(Collectors.toList());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(criteria);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null || getClass() != obj.getClass())
+            return false;
+        CriteriaScheduleStrategy other = (CriteriaScheduleStrategy) obj;
+        return Objects.equals(criteria, other.criteria);
+    }
+
+    @Override
+    public String toString() {
+        return "CriteriaScheduleStrategy [criteria=" + criteria + "]";
+    }
+
+}

--- a/app/org/sagebionetworks/bridge/models/schedules/CriteriaScheduleStrategy.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/CriteriaScheduleStrategy.java
@@ -16,7 +16,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
-public class CriteriaScheduleStrategy implements ScheduleStrategy {
+public final class CriteriaScheduleStrategy implements ScheduleStrategy {
 
     public static class ScheduleCriteria {
         private final Schedule schedule;
@@ -132,7 +132,7 @@ public class CriteriaScheduleStrategy implements ScheduleStrategy {
         }
     }
     
-    private List<ScheduleCriteria> scheduleCriteria = Lists.newArrayList();
+    private final List<ScheduleCriteria> scheduleCriteria = Lists.newArrayList();
     
     public void addCriteria(ScheduleCriteria criteria) {
         this.scheduleCriteria.add(criteria);
@@ -143,7 +143,9 @@ public class CriteriaScheduleStrategy implements ScheduleStrategy {
     }
     
     public void setScheduleCriteria(List<ScheduleCriteria> criteria) {
-        this.scheduleCriteria = criteria;
+        if (criteria != null) {
+            this.scheduleCriteria.addAll(criteria);    
+        }
     }
     
     @Override

--- a/app/org/sagebionetworks/bridge/models/schedules/CriteriaScheduleStrategy.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/CriteriaScheduleStrategy.java
@@ -132,21 +132,20 @@ public class CriteriaScheduleStrategy implements ScheduleStrategy {
     public boolean matches(ScheduleCriteria crit, ScheduleContext context) {
         Integer appVersion = context.getClientInfo().getAppVersion();
         if (appVersion != null) {
-            if (crit.getMinAppVersion() != null && appVersion < crit.getMinAppVersion()) {
-                return false;
-            }
-            if (crit.getMaxAppVersion() != null && appVersion > crit.getMaxAppVersion()) {
+            if ((crit.getMinAppVersion() != null && appVersion < crit.getMinAppVersion()) ||
+                (crit.getMaxAppVersion() != null && appVersion > crit.getMaxAppVersion())) {
                 return false;
             }
         }
-        
         Set<String> dataGroups = context.getUserDataGroups();
-        if (!dataGroups.containsAll(crit.getAllOfGroups())) {
-            return false;
-        }
-        for (String group : crit.getNoneOfGroups()) {
-            if (dataGroups.contains(group)) {
+        if (dataGroups != null) {
+            if (!dataGroups.containsAll(crit.getAllOfGroups())) {
                 return false;
+            }
+            for (String group : crit.getNoneOfGroups()) {
+                if (dataGroups.contains(group)) {
+                    return false;
+                }
             }
         }
         return true;

--- a/app/org/sagebionetworks/bridge/models/schedules/ScheduleContext.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/ScheduleContext.java
@@ -31,6 +31,7 @@ public final class ScheduleContext {
     private final Map<String,DateTime> events;
     private final DateTime now;
     private final User user;
+    private final Set<String> dataGroups;
     
     private ScheduleContext(ClientInfo clientInfo, DateTimeZone zone, DateTime endsOn,
             Map<String, DateTime> events, DateTime now, User user) {
@@ -42,6 +43,7 @@ public final class ScheduleContext {
         this.events = events;
         this.now = now;
         this.user = user;
+        this.dataGroups = (user == null) ? null : user.getDataGroups();
     }
     
     /**
@@ -114,7 +116,7 @@ public final class ScheduleContext {
     }
     
     public Set<String> getUserDataGroups() {
-        return Sets.newHashSet(); // TODO
+        return dataGroups;
     }
     
     @Override

--- a/app/org/sagebionetworks/bridge/models/schedules/ScheduleContext.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/ScheduleContext.java
@@ -12,7 +12,6 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Sets;
 
 /**
  * All the information necessary to convert a schedule into a set of activities, on a given request. 

--- a/app/org/sagebionetworks/bridge/models/schedules/ScheduleContext.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/ScheduleContext.java
@@ -120,7 +120,7 @@ public final class ScheduleContext {
     
     @Override
     public int hashCode() {
-        return Objects.hash(studyId, healthCode, clientInfo, zone, endsOn, events, now, user);
+        return Objects.hash(studyId, healthCode, clientInfo, zone, endsOn, events, now, user, dataGroups);
     }
 
     @Override
@@ -133,13 +133,14 @@ public final class ScheduleContext {
         return (Objects.equals(studyId, other.studyId) && Objects.equals(healthCode, other.healthCode)
                 && Objects.equals(endsOn, other.endsOn) && Objects.equals(zone, other.zone)
                 && Objects.equals(clientInfo, other.clientInfo) && Objects.equals(events, other.events)
-                && Objects.equals(now, other.now) && Objects.equals(user, other.user));
+                && Objects.equals(now, other.now) && Objects.equals(user, other.user)
+                && Objects.equals(dataGroups, other.dataGroups));
     }
 
     @Override
     public String toString() {
         return "ScheduleContext [clientInfo=" + clientInfo + ", zone=" + zone + ", endsOn=" + 
-                endsOn + ", events=" + events + ", user=" + user + "]";
+                endsOn + ", events=" + events + ", user=" + user + ", dataGroups=" + dataGroups + "]";
     }
     
     public static class Builder {

--- a/app/org/sagebionetworks/bridge/models/schedules/ScheduleStrategy.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/ScheduleStrategy.java
@@ -3,8 +3,6 @@ package org.sagebionetworks.bridge.models.schedules;
 import java.util.List;
 import java.util.Set;
 
-import org.sagebionetworks.bridge.models.accounts.User;
-import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.springframework.validation.Errors;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -24,12 +22,11 @@ public interface ScheduleStrategy {
      * (the implementation for assigning schedules), however, it needs to be idempotent (each 
      * call for a user must return the same schedule), and it must be possible to enumerate all 
      * possible schedules that can be returned by this strategy.
-     * @param studyIdentifier
      * @param plan
-     * @param user
+     * @param context
      * @return
      */
-    public Schedule getScheduleForUser(StudyIdentifier studyIdentifier, SchedulePlan plan, User user);
+    public Schedule getScheduleForUser(SchedulePlan plan, ScheduleContext context);
     
     /**
      * Validate that the strategy implementation instance is valid.

--- a/app/org/sagebionetworks/bridge/models/schedules/ScheduleStrategy.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/ScheduleStrategy.java
@@ -13,7 +13,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonTypeInfo( use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes({
     @Type(name="SimpleScheduleStrategy", value=SimpleScheduleStrategy.class),
-    @Type(name="ABTestScheduleStrategy", value=ABTestScheduleStrategy.class)
+    @Type(name="ABTestScheduleStrategy", value=ABTestScheduleStrategy.class),
+    @Type(name="CriteriaScheduleStrategy", value=CriteriaScheduleStrategy.class)
 })
 public interface ScheduleStrategy {
     
@@ -30,10 +31,11 @@ public interface ScheduleStrategy {
     
     /**
      * Validate that the strategy implementation instance is valid.
+     * @param dataGroups
      * @param taskIdentifiers
      * @param errors
      */
-    public void validate(Set<String> taskIdentifiers, Errors errors);
+    public void validate(Set<String> dataGroups, Set<String> taskIdentifiers, Errors errors);
     
     /**
      * Get all possible schedules that this schedule strategy might schedule. This can be used to 

--- a/app/org/sagebionetworks/bridge/models/schedules/ScheduledActivity.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/ScheduledActivity.java
@@ -102,21 +102,8 @@ public interface ScheduledActivity extends BridgeEntity {
 
     public void setHidesOn(Long hidesOn);
 
-    public String getRunKey();
-
-    public void setRunKey(String runKey);
-
     public boolean getPersistent();
 
     public void setPersistent(boolean persistent);
-    
-    public void setMinAppVersion(Integer minAppVersion);
-    
-    public Integer getMinAppVersion();
-    
-    public void setMaxAppVersion(Integer maxAppVersion);
-    
-    public Integer getMaxAppVersion();
-    
 
 }

--- a/app/org/sagebionetworks/bridge/models/schedules/ScheduledActivityStatus.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/ScheduledActivityStatus.java
@@ -41,4 +41,11 @@ public enum ScheduledActivityStatus {
     public static final Set<ScheduledActivityStatus> DELETABLE_STATUSES = EnumSet.of(ScheduledActivityStatus.SCHEDULED,
             ScheduledActivityStatus.AVAILABLE, ScheduledActivityStatus.EXPIRED);
     
+    /**
+     * This activity has been found in database, it should be scheduled, but whether we return it or not ultimately 
+     * depends on whether it should be visible. All the visible statuses are enumerated here.
+     */
+    public static final Set<ScheduledActivityStatus> VISIBLE_STATUSES = EnumSet.of(ScheduledActivityStatus.SCHEDULED,
+            ScheduledActivityStatus.AVAILABLE, ScheduledActivityStatus.STARTED);
+    
 }

--- a/app/org/sagebionetworks/bridge/models/schedules/SimpleScheduleStrategy.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/SimpleScheduleStrategy.java
@@ -4,8 +4,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.sagebionetworks.bridge.json.BridgeTypeName;
-import org.sagebionetworks.bridge.models.accounts.User;
-import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.validators.ScheduleValidator;
 import org.springframework.validation.Errors;
 
@@ -30,7 +28,7 @@ public class SimpleScheduleStrategy implements ScheduleStrategy {
     }
     
     @Override
-    public Schedule getScheduleForUser(StudyIdentifier studyIdentifier, SchedulePlan plan, User user) {
+    public Schedule getScheduleForUser(SchedulePlan plan, ScheduleContext context) {
         return schedule;
     }
     

--- a/app/org/sagebionetworks/bridge/models/schedules/SimpleScheduleStrategy.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/SimpleScheduleStrategy.java
@@ -33,7 +33,7 @@ public class SimpleScheduleStrategy implements ScheduleStrategy {
     }
     
     @Override
-    public void validate(Set<String> taskIdentifiers, Errors errors) {
+    public void validate(Set<String> dataGroups, Set<String> taskIdentifiers, Errors errors) {
         if (schedule == null) {
             errors.rejectValue("schedule", "is required");
         } else {

--- a/app/org/sagebionetworks/bridge/play/controllers/ScheduleController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ScheduleController.java
@@ -54,7 +54,9 @@ public class ScheduleController extends BaseController {
         List<Schedule> schedules = Lists.newArrayListWithCapacity(plans.size());
         for (SchedulePlan plan : plans) {
             Schedule schedule = plan.getStrategy().getScheduleForUser(plan, context);
-            schedules.add(schedule);
+            if (schedule != null) {
+                schedules.add(schedule);    
+            }
         }
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(new ResourceList<Schedule>(schedules));
@@ -82,7 +84,9 @@ public class ScheduleController extends BaseController {
         List<Schedule> schedules = Lists.newArrayListWithCapacity(plans.size());
         for (SchedulePlan plan : plans) {
             Schedule schedule = plan.getStrategy().getScheduleForUser(plan, context);
-            schedules.add(schedule);
+            if (schedule != null) {
+                schedules.add(schedule);    
+            }
         }
         return okResult(schedules);
     }

--- a/app/org/sagebionetworks/bridge/play/controllers/ScheduleController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ScheduleController.java
@@ -8,10 +8,12 @@ import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.ResourceList;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.schedules.Schedule;
+import org.sagebionetworks.bridge.models.schedules.ScheduleContext;
 import org.sagebionetworks.bridge.models.schedules.SchedulePlan;
 import org.sagebionetworks.bridge.models.schedules.ScheduleType;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.services.SchedulePlanService;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 
@@ -44,10 +46,14 @@ public class ScheduleController extends BaseController {
         StudyIdentifier studyId = session.getStudyIdentifier();
         ClientInfo clientInfo = getClientInfoFromUserAgentHeader();
         
+        ScheduleContext context = new ScheduleContext.Builder()
+                .withClientInfo(clientInfo)
+                .withUser(session.getUser()).build();
+        
         List<SchedulePlan> plans = schedulePlanService.getSchedulePlans(clientInfo, studyId);
         List<Schedule> schedules = Lists.newArrayListWithCapacity(plans.size());
         for (SchedulePlan plan : plans) {
-            Schedule schedule = plan.getStrategy().getScheduleForUser(session.getStudyIdentifier(), plan, session.getUser());
+            Schedule schedule = plan.getStrategy().getScheduleForUser(plan, context);
             schedules.add(schedule);
         }
         
@@ -68,10 +74,14 @@ public class ScheduleController extends BaseController {
         StudyIdentifier studyId = session.getStudyIdentifier();
         ClientInfo clientInfo = getClientInfoFromUserAgentHeader();
         
+        ScheduleContext context = new ScheduleContext.Builder()
+                .withClientInfo(clientInfo)
+                .withUser(session.getUser()).build();
+        
         List<SchedulePlan> plans = schedulePlanService.getSchedulePlans(clientInfo, studyId);
         List<Schedule> schedules = Lists.newArrayListWithCapacity(plans.size());
         for (SchedulePlan plan : plans) {
-            Schedule schedule = plan.getStrategy().getScheduleForUser(session.getStudyIdentifier(), plan, session.getUser());
+            Schedule schedule = plan.getStrategy().getScheduleForUser(plan, context);
             schedules.add(schedule);
         }
         return okResult(schedules);

--- a/app/org/sagebionetworks/bridge/play/controllers/ScheduledActivityController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ScheduledActivityController.java
@@ -97,9 +97,11 @@ public class ScheduledActivityController extends BaseController {
         }
         ClientInfo clientInfo = getClientInfoFromUserAgentHeader();
 
-        ScheduleContext context = new ScheduleContext.Builder().withStudyIdentifier(session.getStudyIdentifier())
-                .withClientInfo(clientInfo).withTimeZone(zone).withEndsOn(endsOn)
-                .withHealthCode(session.getUser().getHealthCode()).build();
+        ScheduleContext context = new ScheduleContext.Builder().withUser(session.getUser())
+                .withClientInfo(clientInfo)
+                .withTimeZone(zone)
+                .withEndsOn(endsOn)
+                .build();
         return scheduledActivityService.getScheduledActivities(session.getUser(), context);
     }
 }

--- a/app/org/sagebionetworks/bridge/services/SchedulePlanServiceImpl.java
+++ b/app/org/sagebionetworks/bridge/services/SchedulePlanServiceImpl.java
@@ -63,7 +63,7 @@ public class SchedulePlanServiceImpl implements SchedulePlanService {
         plan.setStudyKey(study.getIdentifier());
 
         // Delete existing GUIDs so this is a new object (or recreate them)
-        Validate.entityThrowingException(new SchedulePlanValidator(study.getTaskIdentifiers()), plan);
+        Validate.entityThrowingException(new SchedulePlanValidator(study.getDataGroups(), study.getTaskIdentifiers()), plan);
         updateGuids(plan);
 
         StudyIdentifier studyId = new StudyIdentifierImpl(plan.getStudyKey());
@@ -79,7 +79,7 @@ public class SchedulePlanServiceImpl implements SchedulePlanService {
         // Plan must always be in user's study
         plan.setStudyKey(study.getIdentifier());
         
-        Validate.entityThrowingException(new SchedulePlanValidator(study.getTaskIdentifiers()), plan);
+        Validate.entityThrowingException(new SchedulePlanValidator(study.getDataGroups(), study.getTaskIdentifiers()), plan);
         
         StudyIdentifier studyId = new StudyIdentifierImpl(plan.getStudyKey());
         lookupSurveyReferenceIdentifiers(studyId, plan);

--- a/app/org/sagebionetworks/bridge/services/ScheduledActivityOperations.java
+++ b/app/org/sagebionetworks/bridge/services/ScheduledActivityOperations.java
@@ -1,0 +1,46 @@
+package org.sagebionetworks.bridge.services;
+
+import java.util.Set;
+
+import org.sagebionetworks.bridge.models.schedules.ScheduledActivity;
+
+import com.google.common.collect.Sets;
+
+final class ScheduledActivityOperations {
+
+    private final Set<ScheduledActivity> saves;
+    private final Set<ScheduledActivity> deletes;
+    private final Set<ScheduledActivity> results;
+    
+    ScheduledActivityOperations() {
+        saves = Sets.newHashSet();
+        deletes = Sets.newHashSet();
+        results = Sets.newHashSet();
+    }
+    
+    void save(ScheduledActivity activity) {
+        saves.add(activity);
+        results.add(activity);
+    }
+    
+    void delete(ScheduledActivity activity) {
+        deletes.add(activity);
+    }
+    
+    void result(ScheduledActivity activity) {
+        results.add(activity);
+    }
+    
+    Set<ScheduledActivity> getSavables() {
+        return saves;
+    }
+    
+    Set<ScheduledActivity> getDeletables() {
+        return deletes;
+    }
+    
+    Set<ScheduledActivity> getResults() {
+        return results;
+    }
+
+}

--- a/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
+++ b/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
@@ -204,7 +204,7 @@ public class ScheduledActivityService {
         List<SchedulePlan> plans = schedulePlanService.getSchedulePlans(context.getClientInfo(), studyId);
         
         for (SchedulePlan plan : plans) {
-            Schedule schedule = plan.getStrategy().getScheduleForUser(studyId, plan, user);
+            Schedule schedule = plan.getStrategy().getScheduleForUser(plan, context);
             
             List<ScheduledActivity> activities = schedule.getScheduler().getScheduledActivities(plan, context);
             for (ScheduledActivity activity : activities) {

--- a/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
+++ b/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
@@ -205,10 +205,11 @@ public class ScheduledActivityService {
         
         for (SchedulePlan plan : plans) {
             Schedule schedule = plan.getStrategy().getScheduleForUser(plan, context);
-            
-            List<ScheduledActivity> activities = schedule.getScheduler().getScheduledActivities(plan, context);
-            for (ScheduledActivity activity : activities) {
-                scheduledActivities.put(activity.getRunKey(), activity);
+            if (schedule != null) {
+                List<ScheduledActivity> activities = schedule.getScheduler().getScheduledActivities(plan, context);
+                for (ScheduledActivity activity : activities) {
+                    scheduledActivities.put(activity.getRunKey(), activity);
+                }
             }
         }
         return scheduledActivities;

--- a/app/org/sagebionetworks/bridge/validators/SchedulePlanValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/SchedulePlanValidator.java
@@ -10,9 +10,11 @@ import org.springframework.validation.Validator;
 
 public class SchedulePlanValidator implements Validator {
 
+    private final Set<String> dataGroups;
     private final Set<String> taskIdentifiers;
     
-    public SchedulePlanValidator(Set<String> taskIdentifiers) {
+    public SchedulePlanValidator(Set<String> dataGroups, Set<String> taskIdentifiers) {
+        this.dataGroups = dataGroups;
         this.taskIdentifiers = taskIdentifiers;
     }
     
@@ -44,7 +46,7 @@ public class SchedulePlanValidator implements Validator {
             errors.rejectValue("strategy", "is required");
         } else {
             errors.pushNestedPath("strategy");
-            plan.getStrategy().validate(taskIdentifiers, errors);
+            plan.getStrategy().validate(dataGroups, taskIdentifiers, errors);
             errors.popNestedPath();
         }
     }

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -104,7 +104,9 @@ public class TestUtils {
         List<ScheduledActivity> scheduledActivities = Lists.newArrayList();
         for (SchedulePlan plan : plans) {
             Schedule schedule = plan.getStrategy().getScheduleForUser(plan, context);
-            scheduledActivities.addAll(schedule.getScheduler().getScheduledActivities(plan, context));
+            if (schedule != null) {
+                scheduledActivities.addAll(schedule.getScheduler().getScheduledActivities(plan, context));    
+            }
         }
         Collections.sort(scheduledActivities, ScheduledActivity.SCHEDULED_ACTIVITY_COMPARATOR);
         return scheduledActivities;

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -103,7 +103,7 @@ public class TestUtils {
     public static List<ScheduledActivity> runSchedulerForActivities(List<SchedulePlan> plans, User user, ScheduleContext context) {
         List<ScheduledActivity> scheduledActivities = Lists.newArrayList();
         for (SchedulePlan plan : plans) {
-            Schedule schedule = plan.getStrategy().getScheduleForUser(context.getStudyIdentifier(), plan, user);
+            Schedule schedule = plan.getStrategy().getScheduleForUser(plan, context);
             scheduledActivities.addAll(schedule.getScheduler().getScheduledActivities(plan, context));
         }
         Collections.sort(scheduledActivities, ScheduledActivity.SCHEDULED_ACTIVITY_COMPARATOR);

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSchedulePlanTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSchedulePlanTest.java
@@ -5,7 +5,13 @@ import static org.junit.Assert.assertEquals;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Test;
+
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.schedules.CriteriaScheduleStrategy;
+import org.sagebionetworks.bridge.models.schedules.Schedule;
+import org.sagebionetworks.bridge.models.schedules.ScheduleType;
+import org.sagebionetworks.bridge.models.schedules.CriteriaScheduleStrategy.ScheduleCriteria;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -22,6 +28,15 @@ public class DynamoSchedulePlanTest {
     @Test
     public void canSerializeDynamoSchedulePlan() throws Exception {
         DateTime datetime = DateTime.now().withZone(DateTimeZone.UTC);
+
+        Schedule schedule = new Schedule();
+        schedule.setScheduleType(ScheduleType.ONCE);
+        schedule.addActivity(TestConstants.TEST_3_ACTIVITY);
+        
+        CriteriaScheduleStrategy strategy = new CriteriaScheduleStrategy();
+        ScheduleCriteria criteria = new ScheduleCriteria.Builder().withMinAppVersion(1).withMaxAppVersion(10)
+                .withSchedule(schedule).build();
+        strategy.addCriteria(criteria);
         
         DynamoSchedulePlan plan = new DynamoSchedulePlan();
         plan.setLabel("Label");
@@ -31,6 +46,7 @@ public class DynamoSchedulePlanTest {
         plan.setModifiedOn(datetime.getMillis());
         plan.setStudyKey("test-study");
         plan.setVersion(2L);
+        plan.setStrategy(strategy);
         
         String json = BridgeObjectMapper.get().writeValueAsString(plan);
         JsonNode node = BridgeObjectMapper.get().readTree(json);
@@ -51,6 +67,8 @@ public class DynamoSchedulePlanTest {
         assertEquals(plan.getGuid(), plan2.getGuid());
         assertEquals(plan.getLabel(), plan2.getLabel());
         assertEquals(plan.getModifiedOn(), plan2.getModifiedOn());
+        
+        assertEquals(plan, plan2);
     }
     
 }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDaoMockTest.java
@@ -150,39 +150,7 @@ public class DynamoScheduledActivityDaoMockTest {
         verifyNoMoreInteractions(mapper);
     }
 
-    @SuppressWarnings("unchecked")
-    @Test
-    public void activitySchedulerFiltersActivities() throws Exception {
-        DateTime endsOn = NOW.plus(Period.parse("P4D"));
-        Map<String, DateTime> events = Maps.newHashMap();
-        events.put("enrollment", ENROLLMENT);
-        ScheduleContext context = new ScheduleContext.Builder()
-            .withUser(user)
-            .withClientInfo(ClientInfo.fromUserAgentCache("App/5"))
-            .withTimeZone(PACIFIC_TIME_ZONE)
-            .withEndsOn(endsOn)
-            .withEvents(events).build();
-
-        List<ScheduledActivity> activities = TestUtils.runSchedulerForActivities(user, context);
-        mockQuery(activities);
-        List<ScheduledActivity> activities2 = activityDao.getActivities(context);
-
-        // The test schedules have these appVersions applied to them
-        // SchedulePlan DDD/Activity 1: version 2-5
-        // SchedulePlan BBB/Activity 2: version 9+
-        // SchedulePlan CCC/Activity 3: version 5-8
-        // Activity_1 and Activity_3 will match v5, Activity_2 will not. These results are 
-        // just like the next test of 4 days, but without the Activity_2 activity
-        // Activities are sorted first by date, then by label ("Activity1", "Activity2" & "Activity3")
-        assertEquals(3, activities2.size());
-        assertScheduledActivity(activities2.get(0), ACTIVITY_3_REF, "2015-04-13T13:00:00-07:00");
-        assertScheduledActivity(activities2.get(1), ACTIVITY_1_REF, "2015-04-14T13:00:00-07:00");
-        assertScheduledActivity(activities2.get(2), ACTIVITY_3_REF, "2015-04-15T13:00:00-07:00");
-
-        verify(mapper).query((Class<DynamoScheduledActivity>) any(Class.class),
-                        (DynamoDBQueryExpression<DynamoScheduledActivity>) any(DynamoDBQueryExpression.class));
-        verifyNoMoreInteractions(mapper);
-    }
+    // The test here involved filtering that now happens in the service. New tests created there.
     
     @SuppressWarnings("unchecked")
     @Test

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDaoMockTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.TestConstants.ENROLLMENT;
-import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 
 import java.util.List;
 import java.util.Map;
@@ -128,11 +127,10 @@ public class DynamoScheduledActivityDaoMockTest {
         Map<String, DateTime> events = Maps.newHashMap();
         events.put("enrollment", ENROLLMENT);
         ScheduleContext context = new ScheduleContext.Builder()
-            .withStudyIdentifier(TEST_STUDY)
+            .withUser(user)
             .withClientInfo(ClientInfo.UNKNOWN_CLIENT)
             .withTimeZone(PACIFIC_TIME_ZONE)
             .withEndsOn(endsOn)
-            .withHealthCode(HEALTH_CODE)
             .withEvents(events).build();
 
         List<ScheduledActivity> activities = TestUtils.runSchedulerForActivities(user, context);
@@ -159,11 +157,10 @@ public class DynamoScheduledActivityDaoMockTest {
         Map<String, DateTime> events = Maps.newHashMap();
         events.put("enrollment", ENROLLMENT);
         ScheduleContext context = new ScheduleContext.Builder()
-            .withStudyIdentifier(TEST_STUDY)
+            .withUser(user)
             .withClientInfo(ClientInfo.fromUserAgentCache("App/5"))
             .withTimeZone(PACIFIC_TIME_ZONE)
             .withEndsOn(endsOn)
-            .withHealthCode(HEALTH_CODE)
             .withEvents(events).build();
 
         List<ScheduledActivity> activities = TestUtils.runSchedulerForActivities(user, context);
@@ -195,11 +192,10 @@ public class DynamoScheduledActivityDaoMockTest {
         events.put("enrollment", ENROLLMENT);
 
         ScheduleContext context = new ScheduleContext.Builder()
-            .withStudyIdentifier(TEST_STUDY)
+            .withUser(user)
             .withClientInfo(ClientInfo.UNKNOWN_CLIENT)
             .withTimeZone(PACIFIC_TIME_ZONE)
             .withEndsOn(endsOn)
-            .withHealthCode(HEALTH_CODE)
             .withEvents(events).build();
 
         List<ScheduledActivity> activities = TestUtils.runSchedulerForActivities(user, context);

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDaoTest.java
@@ -168,7 +168,6 @@ public class DynamoScheduledActivityDaoTest {
 
         // Get one schedule plan GUID to delete and the initial count
         int initialCount = activities.size();
-        String taskRunForActivityDeleted = findAnActivityFor(activities, testPlan).getRunKey();
         
         activityDao.deleteActivitiesForSchedulePlan(testPlan.getGuid());
         
@@ -190,14 +189,6 @@ public class DynamoScheduledActivityDaoTest {
         
         activityDao.deleteActivitiesForSchedulePlan(testPlan2.getGuid());
         activities = activityDao.getActivities(context);
-        
-        // We've verified that activities are deleted (above), but the one we finished, although not returned 
-        // when we query for tasks, will return false when we ask if its run key has not occurred. Because it's
-        // still in the table.
-        assertFalse(activityDao.activityRunHasNotOccurred(context.getHealthCode(), finishedActivity.getRunKey()));
-
-        // This is true, it was deleted, so it's like it never happened
-        assertTrue(activityDao.activityRunHasNotOccurred(context.getHealthCode(), taskRunForActivityDeleted));
     }
     
     private List<SchedulePlan> getSchedulePlans() {

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDaoTest.java
@@ -107,11 +107,10 @@ public class DynamoScheduledActivityDaoTest {
         events.put("enrollment", ENROLLMENT);
         
         ScheduleContext context = new ScheduleContext.Builder()
-            .withStudyIdentifier(TEST_STUDY)
+            .withUser(user)
             .withClientInfo(ClientInfo.UNKNOWN_CLIENT)
             .withTimeZone(DateTimeZone.UTC)
             .withEndsOn(endsOn)
-            .withHealthCode(user.getHealthCode())
             .withEvents(events).build();
         
         List<ScheduledActivity> activitiesToSchedule = TestUtils.runSchedulerForActivities(user, context);
@@ -153,11 +152,10 @@ public class DynamoScheduledActivityDaoTest {
         events.put("enrollment", ENROLLMENT);
         
         ScheduleContext context = new ScheduleContext.Builder()
-            .withStudyIdentifier(TEST_STUDY)
+            .withUser(user)
             .withClientInfo(ClientInfo.UNKNOWN_CLIENT)
             .withTimeZone(DateTimeZone.UTC)
             .withEndsOn(endsOn)
-            .withHealthCode(user.getHealthCode())
             .withEvents(events).build();
         
         // Schedule plans are specific to this test because we're going to delete them;

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityTest.java
@@ -103,8 +103,6 @@ public class DynamoScheduledActivityTest {
         schActivity.setGuid("AAA-BBB-CCC");
         schActivity.setHealthCode("FFF-GGG-HHH");
         schActivity.setPersistent(true);
-        schActivity.setMinAppVersion(1);
-        schActivity.setMaxAppVersion(3);
         
         BridgeObjectMapper mapper = BridgeObjectMapper.get();
         String output = ScheduledActivity.SCHEDULED_ACTIVITY_WRITER.writeValueAsString(schActivity);
@@ -115,8 +113,6 @@ public class DynamoScheduledActivityTest {
         assertEquals(expiresOnString, node.get("expiresOn").asText());
         assertEquals("scheduled", node.get("status").asText());
         assertEquals("ScheduledActivity", node.get("type").asText());
-        assertEquals(1, node.get("minAppVersion").asInt());
-        assertEquals(3, node.get("maxAppVersion").asInt());
         assertTrue(node.get("persistent").asBoolean());
         
         JsonNode activityNode = node.get("activity");
@@ -235,7 +231,6 @@ public class DynamoScheduledActivityTest {
         act.setLocalScheduledOn(LocalDateTime.parse("2015-10-01T10:10:10.000"));
         act.setLocalExpiresOn(LocalDateTime.parse("2015-10-01T14:10:10.000"));
         act.setHidesOn(DateTime.parse("2015-10-01T14:10:10.000-06:00").getMillis());
-        act.setRunKey("runKey");
         act.setHealthCode("healthCode");
         act.setGuid("activityGuid");
         act.setSchedulePlanGuid("schedulePlanGuid");
@@ -243,8 +238,6 @@ public class DynamoScheduledActivityTest {
         act.setStartedOn(DateTime.parse("2015-10-10T08:08:08.000Z").getMillis());
         act.setFinishedOn(DateTime.parse("2015-12-05T08:08:08.000Z").getMillis());
         act.setPersistent(true);
-        act.setMinAppVersion(1);
-        act.setMaxAppVersion(2);
         
         String json = ScheduledActivity.SCHEDULED_ACTIVITY_WRITER.writeValueAsString(act);
         JsonNode node = BridgeObjectMapper.get().readTree(json);
@@ -253,14 +246,12 @@ public class DynamoScheduledActivityTest {
         assertEquals("2015-10-10T08:08:08.000Z", node.get("startedOn").asText());
         assertEquals("2015-12-05T08:08:08.000Z", node.get("finishedOn").asText());
         assertEquals("true", node.get("persistent").asText());
-        assertEquals("1", node.get("minAppVersion").asText());
-        assertEquals("2", node.get("maxAppVersion").asText());
         assertEquals("finished", node.get("status").asText());
         assertEquals("ScheduledActivity", node.get("type").asText());
         assertEquals("2015-10-01T10:10:10.000-06:00", node.get("scheduledOn").asText());
         assertEquals("2015-10-01T14:10:10.000-06:00", node.get("expiresOn").asText());
         // all the above, plus activity, and nothing else
-        assertEquals(11, TestUtils.getFieldNamesSet(node).size());
+        assertEquals(9, TestUtils.getFieldNamesSet(node).size());
 
         JsonNode activityNode = node.get("activity");
         assertEquals("Activity1", activityNode.get("label").asText());

--- a/test/org/sagebionetworks/bridge/models/schedules/ABTestScheduleStrategyTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/ABTestScheduleStrategyTest.java
@@ -12,8 +12,17 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 
 import com.google.common.collect.ImmutableList;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+
 public class ABTestScheduleStrategyTest {
 
+    @Test
+    public void hashCodeEquals() {
+        EqualsVerifier.forClass(ABTestScheduleStrategy.class).suppress(Warning.NONFINAL_FIELDS)
+            .allFieldsShouldBeUsed().verify();
+    }
+    
     @Test
     public void testScheduleCollector() {
         StudyIdentifier studyId = new StudyIdentifierImpl("test-study");

--- a/test/org/sagebionetworks/bridge/models/schedules/ActivitySchedulerTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/ActivitySchedulerTest.java
@@ -110,13 +110,10 @@ public class ActivitySchedulerTest {
         assertNotNull(schActivity.getGuid());
         assertEquals("Activity3", schActivity.getActivity().getLabel());
         assertEquals("BBB", schActivity.getSchedulePlanGuid());
-        assertEquals(0, schActivity.getMinAppVersion().intValue());
-        assertEquals(1000, schActivity.getMaxAppVersion().intValue());
         assertNotNull(schActivity.getScheduledOn());
         assertNotNull(schActivity.getExpiresOn());
         assertEquals("AAA", schActivity.getHealthCode());
         assertEquals(DateTimeZone.UTC, schActivity.getTimeZone());
-        assertNotNull(schActivity.getRunKey());
     }
     
     /**

--- a/test/org/sagebionetworks/bridge/models/schedules/ActivitySchedulerTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/ActivitySchedulerTest.java
@@ -9,7 +9,7 @@ import static org.sagebionetworks.bridge.models.schedules.ScheduleTestUtils.asDT
 import static org.sagebionetworks.bridge.models.schedules.ScheduleTestUtils.asLong;
 import static org.sagebionetworks.bridge.models.schedules.ScheduleTestUtils.assertDates;
 import static org.sagebionetworks.bridge.models.schedules.ScheduleType.ONCE;
-import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 
 import java.util.List;
 import java.util.Map;
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
 import org.sagebionetworks.bridge.dynamodb.DynamoScheduledActivity;
+import org.sagebionetworks.bridge.models.accounts.User;
 import org.sagebionetworks.bridge.validators.ScheduleValidator;
 import org.sagebionetworks.bridge.validators.Validate;
 
@@ -39,6 +40,7 @@ public class ActivitySchedulerTest {
     private static final DateTime ENROLLMENT = DateTime.parse("2015-03-23T10:00:00Z");
     private static final DateTime NOW = DateTime.parse("2015-03-26T14:40:00Z");
     
+    private User user;
     private List<ScheduledActivity> scheduledActivities;
     private Map<String,DateTime> events;
     private DynamoSchedulePlan plan = new DynamoSchedulePlan();
@@ -46,6 +48,10 @@ public class ActivitySchedulerTest {
     
     @Before
     public void before() {
+        user = new User();
+        user.setHealthCode("AAA");
+        user.setStudyKey(TEST_STUDY_IDENTIFIER);
+        
         plan.setGuid("BBB");
         plan.setMinAppVersion(0);
         plan.setMaxAppVersion(1000);
@@ -75,7 +81,7 @@ public class ActivitySchedulerTest {
         Map<String,DateTime> empty = Maps.newHashMap();
         
         ScheduleContext context = new ScheduleContext.Builder()
-            .withStudyIdentifier(TEST_STUDY)
+            .withUser(user)
             .withTimeZone(DateTimeZone.UTC)
             .withEndsOn(NOW.plusWeeks(1))
             .withEvents(empty).build();
@@ -83,7 +89,7 @@ public class ActivitySchedulerTest {
         assertEquals(0, scheduledActivities.size());
         
         context = new ScheduleContext.Builder()
-            .withStudyIdentifier(TEST_STUDY)
+            .withUser(user)
             .withTimeZone(DateTimeZone.UTC)
             .withEndsOn(NOW.plusWeeks(1)).build();
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, context);
@@ -338,8 +344,8 @@ public class ActivitySchedulerTest {
     }
 
     private ScheduleContext getContext(DateTimeZone zone, DateTime endsOn) {
-        return new ScheduleContext.Builder().withStudyIdentifier(TEST_STUDY)
-            .withTimeZone(zone).withEndsOn(endsOn).withHealthCode("AAA").withEvents(events).build();
+        return new ScheduleContext.Builder().withUser(user)
+            .withTimeZone(zone).withEndsOn(endsOn).withEvents(events).build();
     }
     
 }

--- a/test/org/sagebionetworks/bridge/models/schedules/CriteriaScheduleStrategyTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/CriteriaScheduleStrategyTest.java
@@ -1,0 +1,61 @@
+package org.sagebionetworks.bridge.models.schedules;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.schedules.CriteriaScheduleStrategy.ScheduleCriteria;
+
+public class CriteriaScheduleStrategyTest {
+    
+    private CriteriaScheduleStrategy strategy;
+    
+    @Before
+    public void before() {
+        strategy = new CriteriaScheduleStrategy();
+    }
+    
+    @Test
+    public void canSerialize() throws Exception {
+        ScheduleCriteria criteria = getCriteriaOne();
+        strategy.addCriteria(criteria);
+
+        criteria = getCriteriaTwo();
+        strategy.addCriteria(criteria);
+        
+        String json = BridgeObjectMapper.get().writeValueAsString(strategy);
+        
+        CriteriaScheduleStrategy newStrategy = BridgeObjectMapper.get().readValue(json, CriteriaScheduleStrategy.class);
+        assertEquals(strategy, newStrategy);
+    }
+
+    private ScheduleCriteria getCriteriaOne() {
+        Schedule schedule = new Schedule();
+        schedule.setScheduleType(ScheduleType.ONCE);
+        schedule.addActivity(TestConstants.TEST_3_ACTIVITY);
+        ScheduleCriteria criteria = new ScheduleCriteria.Builder()
+            .withSchedule(schedule)
+            .withMinAppVersion(2)
+            .withMaxAppVersion(12)
+            .addProhibitedGroup("notThisGroup")
+            .addRequiredGroup("groupA","groupB").build();
+        return criteria;
+    }
+
+    private ScheduleCriteria getCriteriaTwo() {
+        ScheduleCriteria criteria;
+        Schedule schedule = new Schedule();
+        schedule.setScheduleType(ScheduleType.RECURRING);
+        schedule.addActivity(TestConstants.TEST_3_ACTIVITY);
+        schedule.setInterval("P3D");
+        
+        criteria = new ScheduleCriteria.Builder()
+            .withSchedule(schedule)
+            .withMaxAppVersion(4).build();
+        return criteria;
+    }
+
+}

--- a/test/org/sagebionetworks/bridge/models/schedules/CriteriaScheduleStrategyTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/CriteriaScheduleStrategyTest.java
@@ -25,6 +25,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.common.collect.Sets;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
+
 public class CriteriaScheduleStrategyTest {
     
     private Schedule strategyWithAppVersions = makeValidSchedule("Strategy With App Versions");
@@ -37,6 +39,11 @@ public class CriteriaScheduleStrategyTest {
     private CriteriaScheduleStrategy strategy;
     private SchedulePlan plan;
     private SchedulePlanValidator validator;
+    
+    @Test
+    public void hashCodeEquals() {
+        EqualsVerifier.forClass(CriteriaScheduleStrategy.class).allFieldsShouldBeUsed().verify();
+    }
     
     @Before
     public void before() {

--- a/test/org/sagebionetworks/bridge/models/schedules/CriteriaScheduleStrategyTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/CriteriaScheduleStrategyTest.java
@@ -1,61 +1,234 @@
 package org.sagebionetworks.bridge.models.schedules;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
+
+import java.util.List;
+import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Test;
 
-import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.ClientInfo;
+import org.sagebionetworks.bridge.models.accounts.User;
 import org.sagebionetworks.bridge.models.schedules.CriteriaScheduleStrategy.ScheduleCriteria;
+
+import com.google.common.collect.Sets;
 
 public class CriteriaScheduleStrategyTest {
     
+    private Schedule strategyWithAppVersions = new Schedule();
+    private Schedule strategyWithOneRequiredDataGroup = new Schedule();
+    private Schedule strategyWithRequiredDataGroups = new Schedule();
+    private Schedule strategyWithOneProhibitedDataGroup = new Schedule();
+    private Schedule strategyWithProhibitedDataGroups = new Schedule();
+    private Schedule strategyNoCriteria = new Schedule();
+    
     private CriteriaScheduleStrategy strategy;
+    private static final SchedulePlan PLAN = new DynamoSchedulePlan();
     
     @Before
     public void before() {
         strategy = new CriteriaScheduleStrategy();
+        strategyWithAppVersions.setLabel("Strategy With App Versions");
+        strategyWithOneRequiredDataGroup.setLabel("Strategy With One Required Data Group");
+        strategyWithRequiredDataGroups.setLabel("Strategy With Required Data Groups");
+        strategyWithOneProhibitedDataGroup.setLabel("Strategy With One Prohibited Data Group");
+        strategyWithProhibitedDataGroups.setLabel("Strategy With One Prohibited Data Groups");
+        strategyNoCriteria.setLabel("Strategy No Criteria");
     }
     
     @Test
     public void canSerialize() throws Exception {
-        ScheduleCriteria criteria = getCriteriaOne();
-        strategy.addCriteria(criteria);
-
-        criteria = getCriteriaTwo();
-        strategy.addCriteria(criteria);
+        setUpStrategyWithAppVersions();
+        setUpStrategyNoCriteria();
         
         String json = BridgeObjectMapper.get().writeValueAsString(strategy);
-        
         CriteriaScheduleStrategy newStrategy = BridgeObjectMapper.get().readValue(json, CriteriaScheduleStrategy.class);
+        
         assertEquals(strategy, newStrategy);
     }
-
-    private ScheduleCriteria getCriteriaOne() {
-        Schedule schedule = new Schedule();
-        schedule.setScheduleType(ScheduleType.ONCE);
-        schedule.addActivity(TestConstants.TEST_3_ACTIVITY);
-        ScheduleCriteria criteria = new ScheduleCriteria.Builder()
-            .withSchedule(schedule)
-            .withMinAppVersion(2)
-            .withMaxAppVersion(12)
-            .addProhibitedGroup("notThisGroup")
-            .addRequiredGroup("groupA","groupB").build();
-        return criteria;
-    }
-
-    private ScheduleCriteria getCriteriaTwo() {
-        ScheduleCriteria criteria;
-        Schedule schedule = new Schedule();
-        schedule.setScheduleType(ScheduleType.RECURRING);
-        schedule.addActivity(TestConstants.TEST_3_ACTIVITY);
-        schedule.setInterval("P3D");
+    
+    @Test
+    public void filtersOnMinAppVersion() {
+        setUpStrategyWithAppVersions();
+        setUpStrategyNoCriteria();
         
-        criteria = new ScheduleCriteria.Builder()
-            .withSchedule(schedule)
-            .withMaxAppVersion(4).build();
-        return criteria;
+        Schedule schedule = getSchedule(ClientInfo.UNKNOWN_CLIENT);
+        assertEquals(strategyWithAppVersions, schedule);
+        
+        schedule = getSchedule(ClientInfo.fromUserAgentCache("app/2"));
+        assertEquals(strategyNoCriteria, schedule);
+    }
+    
+    @Test
+    public void filtersOnMaxAppVersion() {
+        setUpStrategyWithAppVersions();
+        setUpStrategyNoCriteria();
+        
+        Schedule schedule = getSchedule(ClientInfo.UNKNOWN_CLIENT);
+        assertEquals(strategyWithAppVersions, schedule);
+        
+        schedule = getSchedule(ClientInfo.fromUserAgentCache("app/44"));
+        assertEquals(strategyNoCriteria, schedule);
+    }
+    
+    @Test
+    public void filtersOnRequiredDataGroup() {
+        setUpStrategyWithOneRequiredDataGroup();
+        setUpStrategyNoCriteria();
+        
+        Schedule schedule = getSchedule(Sets.newHashSet("group1"));
+        assertEquals(strategyWithOneRequiredDataGroup, schedule);
+        
+        schedule = getSchedule(Sets.newHashSet("someRandomToken"));
+        assertEquals(strategyNoCriteria, schedule);
+    }
+    
+    @Test
+    public void filtersOnRequiredDataGroups() {
+        setUpStrategyWithRequiredDataGroups();
+        setUpStrategyNoCriteria();
+        
+        Schedule schedule = getSchedule(Sets.newHashSet("group1"));
+        assertEquals(strategyNoCriteria, schedule);
+        
+        schedule = getSchedule(Sets.newHashSet("group1","group2","group3"));
+        assertEquals(strategyWithRequiredDataGroups, schedule);
+        
+        schedule = getSchedule(Sets.newHashSet("someRandomToken"));
+        assertEquals(strategyNoCriteria, schedule);
+    }
+    
+    @Test
+    public void filtersOnProhibitedDataGroup() {
+        setUpStrategyWithOneProhibitedDataGroup();
+        setUpStrategyNoCriteria();
+        
+        Schedule schedule = getSchedule(Sets.newHashSet("groupNotProhibited"));
+        assertEquals(strategyWithOneProhibitedDataGroup, schedule);
+        
+        schedule = getSchedule(Sets.newHashSet("group1"));
+        assertEquals(strategyNoCriteria, schedule);
+    }
+    
+    @Test
+    public void filtersOnProhibitedDataGroups() {
+        setUpStrategyWithProhibitedDataGroups();
+        setUpStrategyNoCriteria();
+        
+        Schedule schedule = getSchedule(Sets.newHashSet("group1"));
+        assertEquals(strategyNoCriteria, schedule);
+        
+        schedule = getSchedule(Sets.newHashSet("group1","foo"));
+        assertEquals(strategyNoCriteria, schedule);
+        
+        schedule = getSchedule(Sets.newHashSet());
+        assertEquals(strategyWithProhibitedDataGroups, schedule);
+    }
+    
+    @Test
+    public void noMatchingFilterReturnsNull() {
+        setUpStrategyWithAppVersions();
+        setUpStrategyWithProhibitedDataGroups();
+        
+        User user = getUser();
+        user.setDataGroups(Sets.newHashSet("group1"));
+        ScheduleContext context = new ScheduleContext.Builder()
+                .withClientInfo(ClientInfo.fromUserAgentCache("app/44"))
+                .withUser(user).build();
+
+        Schedule schedule = strategy.getScheduleForUser(PLAN, context);
+        assertNull(schedule);
+    }
+    
+    @Test
+    public void canMixMultipleCriteria() {
+        setUpStrategyWithAppVersions();
+        setUpStrategyWithOneRequiredDataGroup();
+        setUpStrategyWithProhibitedDataGroups();
+        
+        User user = getUser();
+        user.setDataGroups(Sets.newHashSet("group3"));
+        ScheduleContext context = new ScheduleContext.Builder()
+                .withClientInfo(ClientInfo.fromUserAgentCache("app/44"))
+                .withUser(user).build();
+        
+        Schedule schedule = strategy.getScheduleForUser(PLAN, context);
+        assertEquals(strategyWithProhibitedDataGroups, schedule);
     }
 
+    @Test
+    public void canGetAllPossibleScheduled() {
+        setUpStrategyWithAppVersions();
+        setUpStrategyWithOneRequiredDataGroup();
+        setUpStrategyWithProhibitedDataGroups();
+
+        List<Schedule> schedules = strategy.getAllPossibleSchedules();
+        assertEquals(3, schedules.size());
+    }
+    
+    @Test
+    public void validate() {
+        
+    }
+    
+    private Schedule getSchedule(ClientInfo info) {
+        ScheduleContext context = new ScheduleContext.Builder().withClientInfo(info).build();
+        return strategy.getScheduleForUser(PLAN, context);
+    }
+    
+    private Schedule getSchedule(Set<String> dataGroups) {
+        User user = getUser();
+        user.setDataGroups(dataGroups);
+        ScheduleContext context = new ScheduleContext.Builder()
+                .withClientInfo(ClientInfo.UNKNOWN_CLIENT).withUser(user).build();
+        return strategy.getScheduleForUser(PLAN, context);
+    }
+    
+    private User getUser() {
+        User user = new User();
+        user.setHealthCode("AAA");
+        user.setStudyKey(TEST_STUDY_IDENTIFIER);
+        return user;
+    }
+    
+    private void setUpStrategyWithAppVersions() {
+        strategy.addCriteria(new ScheduleCriteria.Builder()
+            .withSchedule(strategyWithAppVersions)
+            .withMinAppVersion(4)
+            .withMaxAppVersion(12).build());
+    }
+
+    private void setUpStrategyNoCriteria() {
+        strategy.addCriteria(new ScheduleCriteria.Builder()
+            .withSchedule(strategyNoCriteria).build());
+    }
+
+    private void setUpStrategyWithOneRequiredDataGroup() {
+        strategy.addCriteria(new ScheduleCriteria.Builder()
+            .addRequiredGroup("group1")
+            .withSchedule(strategyWithOneRequiredDataGroup).build());
+    }
+    
+    private void setUpStrategyWithRequiredDataGroups() {
+        strategy.addCriteria(new ScheduleCriteria.Builder()
+            .addRequiredGroup("group1", "group2")
+            .withSchedule(strategyWithRequiredDataGroups).build());
+    }
+    
+    private void setUpStrategyWithOneProhibitedDataGroup() {
+        strategy.addCriteria(new ScheduleCriteria.Builder()
+            .addProhibitedGroup("group1")
+            .withSchedule(strategyWithOneProhibitedDataGroup).build());
+    }
+    
+    private void setUpStrategyWithProhibitedDataGroups() {
+        strategy.addCriteria(new ScheduleCriteria.Builder()
+            .addProhibitedGroup("group1","group2")
+            .withSchedule(strategyWithProhibitedDataGroups).build());
+    }
 }

--- a/test/org/sagebionetworks/bridge/models/schedules/CriteriaScheduleStrategyTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/CriteriaScheduleStrategyTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.models.schedules;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 
@@ -10,45 +11,69 @@ import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
+import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.accounts.User;
 import org.sagebionetworks.bridge.models.schedules.CriteriaScheduleStrategy.ScheduleCriteria;
+import org.sagebionetworks.bridge.validators.SchedulePlanValidator;
+import org.sagebionetworks.bridge.validators.Validate;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.common.collect.Sets;
 
 public class CriteriaScheduleStrategyTest {
     
-    private Schedule strategyWithAppVersions = new Schedule();
-    private Schedule strategyWithOneRequiredDataGroup = new Schedule();
-    private Schedule strategyWithRequiredDataGroups = new Schedule();
-    private Schedule strategyWithOneProhibitedDataGroup = new Schedule();
-    private Schedule strategyWithProhibitedDataGroups = new Schedule();
-    private Schedule strategyNoCriteria = new Schedule();
+    private Schedule strategyWithAppVersions = makeValidSchedule("Strategy With App Versions");
+    private Schedule strategyWithOneRequiredDataGroup = makeValidSchedule("Strategy With One Required Data Group");
+    private Schedule strategyWithRequiredDataGroups = makeValidSchedule("Strategy With Required Data Groups");
+    private Schedule strategyWithOneProhibitedDataGroup = makeValidSchedule("Strategy With One Prohibited Data Group");
+    private Schedule strategyWithProhibitedDataGroups = makeValidSchedule("Strategy With One Prohibited Data Groups");
+    private Schedule strategyNoCriteria = makeValidSchedule("Strategy No Criteria");
     
     private CriteriaScheduleStrategy strategy;
-    private static final SchedulePlan PLAN = new DynamoSchedulePlan();
+    private SchedulePlan plan;
+    private SchedulePlanValidator validator;
     
     @Before
     public void before() {
         strategy = new CriteriaScheduleStrategy();
-        strategyWithAppVersions.setLabel("Strategy With App Versions");
-        strategyWithOneRequiredDataGroup.setLabel("Strategy With One Required Data Group");
-        strategyWithRequiredDataGroups.setLabel("Strategy With Required Data Groups");
-        strategyWithOneProhibitedDataGroup.setLabel("Strategy With One Prohibited Data Group");
-        strategyWithProhibitedDataGroups.setLabel("Strategy With One Prohibited Data Groups");
-        strategyNoCriteria.setLabel("Strategy No Criteria");
+
+        plan = new DynamoSchedulePlan();
+        plan.setLabel("Schedule plan label");
+        plan.setStudyKey(TEST_STUDY_IDENTIFIER);
+        plan.setStrategy(strategy);
+        
+        validator = new SchedulePlanValidator(Sets.newHashSet(), Sets.newHashSet("tapTest"));
     }
     
     @Test
     public void canSerialize() throws Exception {
+        BridgeObjectMapper mapper = BridgeObjectMapper.get();
+        
         setUpStrategyWithAppVersions();
         setUpStrategyNoCriteria();
         
-        String json = BridgeObjectMapper.get().writeValueAsString(strategy);
-        CriteriaScheduleStrategy newStrategy = BridgeObjectMapper.get().readValue(json, CriteriaScheduleStrategy.class);
+        String json = mapper.writeValueAsString(strategy);
         
+        JsonNode node = mapper.readTree(json);
+        assertEquals("CriteriaScheduleStrategy", node.get("type").asText());
+        assertNotNull(node.get("scheduleCriteria"));
+        
+        ArrayNode array = (ArrayNode)node.get("scheduleCriteria");
+        JsonNode child1 = array.get(0);
+        assertEquals("ScheduleCriteria", child1.get("type").asText());
+        assertEquals(4, child1.get("minAppVersion").asInt());
+        assertEquals(12, child1.get("maxAppVersion").asInt());
+        assertNotNull(child1.get("allOfGroups"));
+        assertNotNull(child1.get("noneOfGroups"));
+        assertNotNull(child1.get("schedule"));
+        
+        // But mostly, if this isn't all serialized, and then deserialized, these won't be equal
+        CriteriaScheduleStrategy newStrategy = mapper.readValue(json, CriteriaScheduleStrategy.class);
         assertEquals(strategy, newStrategy);
     }
     
@@ -141,7 +166,7 @@ public class CriteriaScheduleStrategyTest {
                 .withClientInfo(ClientInfo.fromUserAgentCache("app/44"))
                 .withUser(user).build();
 
-        Schedule schedule = strategy.getScheduleForUser(PLAN, context);
+        Schedule schedule = strategy.getScheduleForUser(plan, context);
         assertNull(schedule);
     }
     
@@ -157,7 +182,7 @@ public class CriteriaScheduleStrategyTest {
                 .withClientInfo(ClientInfo.fromUserAgentCache("app/44"))
                 .withUser(user).build();
         
-        Schedule schedule = strategy.getScheduleForUser(PLAN, context);
+        Schedule schedule = strategy.getScheduleForUser(plan, context);
         assertEquals(strategyWithProhibitedDataGroups, schedule);
     }
 
@@ -172,13 +197,53 @@ public class CriteriaScheduleStrategyTest {
     }
     
     @Test
-    public void validate() {
+    public void validatePasses() {
+        setUpStrategyWithAppVersions();
+        setUpStrategyWithOneRequiredDataGroup();
+        setUpStrategyWithProhibitedDataGroups();
+        setUpStrategyNoCriteria();
         
+        // We're looking here specifically for errors generated by the strategy, not the plan
+        // it's embedded in or the schedules. I've made those valid so they don't add errors.
+        strategy.addCriteria(new ScheduleCriteria.Builder()
+                .withMinAppVersion(-2)
+                .withMaxAppVersion(-10)
+                .withSchedule(strategyWithOneRequiredDataGroup).build());
+        
+        try {
+            Validate.entityThrowingException(validator, plan);            
+        } catch(InvalidEntityException e) {
+            String fieldName = "strategy.scheduleCriteria[1].allOfGroups";
+            List<String> errors = e.getErrors().get(fieldName);
+            assertEquals(fieldName+" 'group1' is not in enumeration: <no data groups declared>", errors.get(0));
+            
+            fieldName = "strategy.scheduleCriteria[2].noneOfGroups";
+            errors = e.getErrors().get(fieldName);
+            assertEquals(fieldName+" 'group2' is not in enumeration: <no data groups declared>", errors.get(0));
+            assertEquals(fieldName+" 'group1' is not in enumeration: <no data groups declared>", errors.get(1));
+            
+            fieldName = "strategy.scheduleCriteria[4].minAppVersion";
+            errors = e.getErrors().get(fieldName);
+            assertEquals(fieldName+" cannot be negative", errors.get(0));
+            
+            fieldName = "strategy.scheduleCriteria[4].maxAppVersion";
+            errors = e.getErrors().get(fieldName);
+            assertEquals(fieldName+" cannot be less than minAppVersion", errors.get(0));
+            assertEquals(fieldName+" cannot be negative", errors.get(1));
+        }
     }
     
+    private Schedule makeValidSchedule(String label) {
+        Schedule schedule = new Schedule();
+        schedule.setLabel(label);
+        schedule.setScheduleType(ScheduleType.ONCE);
+        schedule.addActivity(TestConstants.TEST_3_ACTIVITY);
+        return schedule;
+    }
+
     private Schedule getSchedule(ClientInfo info) {
         ScheduleContext context = new ScheduleContext.Builder().withClientInfo(info).build();
-        return strategy.getScheduleForUser(PLAN, context);
+        return strategy.getScheduleForUser(plan, context);
     }
     
     private Schedule getSchedule(Set<String> dataGroups) {
@@ -186,7 +251,7 @@ public class CriteriaScheduleStrategyTest {
         user.setDataGroups(dataGroups);
         ScheduleContext context = new ScheduleContext.Builder()
                 .withClientInfo(ClientInfo.UNKNOWN_CLIENT).withUser(user).build();
-        return strategy.getScheduleForUser(PLAN, context);
+        return strategy.getScheduleForUser(plan, context);
     }
     
     private User getUser() {

--- a/test/org/sagebionetworks/bridge/models/schedules/CronActivitySchedulerTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/CronActivitySchedulerTest.java
@@ -6,7 +6,7 @@ import static org.sagebionetworks.bridge.models.schedules.ScheduleTestUtils.asse
 import static org.sagebionetworks.bridge.models.schedules.ScheduleType.ONCE;
 import static org.sagebionetworks.bridge.models.schedules.ScheduleType.RECURRING;
 import static org.sagebionetworks.bridge.TestConstants.TEST_3_ACTIVITY;
-import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 
 import java.util.List;
 import java.util.Map;
@@ -16,6 +16,7 @@ import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.Test;
 import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
+import org.sagebionetworks.bridge.models.accounts.User;
 
 import com.google.common.collect.Maps;
 
@@ -116,8 +117,11 @@ public class CronActivitySchedulerTest {
     }
     
     private ScheduleContext getContext(DateTime endsOn) {
+        User user = new User();
+        user.setStudyKey(TEST_STUDY_IDENTIFIER);
+        
         return new ScheduleContext.Builder()
-            .withStudyIdentifier(TEST_STUDY)
+            .withUser(user)
             .withTimeZone(DateTimeZone.UTC)
             .withEndsOn(endsOn)
             .withEvents(events).build();

--- a/test/org/sagebionetworks/bridge/models/schedules/IntervalActivitySchedulerTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/IntervalActivitySchedulerTest.java
@@ -6,7 +6,7 @@ import static org.sagebionetworks.bridge.models.schedules.ScheduleTestUtils.asDT
 import static org.sagebionetworks.bridge.models.schedules.ScheduleTestUtils.assertDates;
 import static org.sagebionetworks.bridge.models.schedules.ScheduleType.ONCE;
 import static org.sagebionetworks.bridge.models.schedules.ScheduleType.RECURRING;
-import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 
 import java.util.List;
 import java.util.Map;
@@ -19,6 +19,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
+import org.sagebionetworks.bridge.models.accounts.User;
 
 import com.google.common.collect.Maps;
 
@@ -481,11 +482,14 @@ public class IntervalActivitySchedulerTest {
     }
 
     private ScheduleContext getContext(DateTime endsOn) {
+        User user = new User();
+        user.setHealthCode("AAA");
+        user.setStudyKey(TEST_STUDY_IDENTIFIER);
+        
         return new ScheduleContext.Builder()
-            .withStudyIdentifier(TEST_STUDY)
+            .withUser(user)
             .withTimeZone(DateTimeZone.UTC)
             .withEndsOn(endsOn)
-            .withHealthCode("AAA")
             .withEvents(events).build();
     }
     

--- a/test/org/sagebionetworks/bridge/models/schedules/ScheduleStrategyTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/ScheduleStrategyTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,6 +40,7 @@ public class ScheduleStrategyTest {
         for (int i = 0; i < 1000; i++) {
             User user = new User(Integer.toString(i), "test" + i + "@sagebridge.org");
             user.setHealthCode(BridgeUtils.generateGuid());
+            user.setStudyKey(TEST_STUDY_IDENTIFIER);
             users.add(user);
         }
         study = TestUtils.getValidStudy(ScheduleStrategyTest.class);
@@ -99,7 +101,8 @@ public class ScheduleStrategyTest {
 
         List<Schedule> schedules = Lists.newArrayList();
         for (User user : users) {
-            Schedule schedule = plan.getStrategy().getScheduleForUser(study, plan, user);
+            ScheduleContext context = new ScheduleContext.Builder().withUser(user).build();
+            Schedule schedule = plan.getStrategy().getScheduleForUser(plan, context);
             schedules.add(schedule);
         }
 

--- a/test/org/sagebionetworks/bridge/play/controllers/ScheduleControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ScheduleControllerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 
 import java.util.List;
 
@@ -61,6 +62,7 @@ public class ScheduleControllerTest {
         controller.setSchedulePlanService(schedulePlanService);
         
         User user = new User();
+        user.setStudyKey(TEST_STUDY_IDENTIFIER);
         
         UserSession session = mock(UserSession.class);
         when(session.getStudyIdentifier()).thenReturn(studyId);

--- a/test/org/sagebionetworks/bridge/play/controllers/ScheduledActivityControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ScheduledActivityControllerTest.java
@@ -60,7 +60,6 @@ public class ScheduledActivityControllerTest {
         schActivity.setGuid(BridgeUtils.generateGuid());
         schActivity.setScheduledOn(DateTime.now(DateTimeZone.UTC).minusDays(1));
         schActivity.setActivity(TestConstants.TEST_3_ACTIVITY);
-        schActivity.setRunKey(BridgeUtils.generateScheduledActivityRunKey(schActivity, BridgeUtils.generateGuid()));
         List<ScheduledActivity> list = Lists.newArrayList(schActivity);
         
         String json = BridgeObjectMapper.get().writeValueAsString(list);

--- a/test/org/sagebionetworks/bridge/play/controllers/ScheduledActivityControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ScheduledActivityControllerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 
 import java.util.List;
 
@@ -69,6 +70,7 @@ public class ScheduledActivityControllerTest {
         UserSession session = new UserSession();
         User user = new User();
         user.setHealthCode("BBB");
+        user.setStudyKey(TEST_STUDY_IDENTIFIER);
         session.setUser(user);
         
         scheduledActivityService = mock(ScheduledActivityService.class);

--- a/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceMockTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 
 import java.util.List;
 import java.util.Map;
@@ -129,14 +130,15 @@ public class ScheduledActivityServiceMockTest {
     @Test(expected = BadRequestException.class)
     public void rejectsEndsOnBeforeNow() {
         service.getScheduledActivities(user, new ScheduleContext.Builder()
-            .withStudyIdentifier(TEST_STUDY)
-            .withTimeZone(DateTimeZone.UTC).withEndsOn(DateTime.now().minusSeconds(1)).build());
+            .withUser(user)
+            .withTimeZone(DateTimeZone.UTC)
+            .withEndsOn(DateTime.now().minusSeconds(1)).build());
     }
     
     @Test(expected = BadRequestException.class)
     public void rejectsEndsOnTooFarInFuture() {
         service.getScheduledActivities(user, new ScheduleContext.Builder()
-            .withStudyIdentifier(TEST_STUDY)
+            .withUser(user)
             .withTimeZone(DateTimeZone.UTC)
             .withEndsOn(DateTime.now().plusDays(ScheduleContextValidator.MAX_EXPIRES_ON_DAYS).plusSeconds(1)).build());
     }
@@ -227,12 +229,14 @@ public class ScheduledActivityServiceMockTest {
     @SuppressWarnings({"unchecked","rawtypes"})
     @Test
     public void changePublishedAndAbsoluteSurveyActivity() {
+        User user = new User();
+        user.setStudyKey(TEST_STUDY_IDENTIFIER);
+        user.setHealthCode(HEALTH_CODE);
         service.getScheduledActivities(user, new ScheduleContext.Builder()
-            .withStudyIdentifier(TEST_STUDY)
+            .withUser(user)
             .withClientInfo(ClientInfo.UNKNOWN_CLIENT)
             .withTimeZone(DateTimeZone.UTC)
-            .withEndsOn(endsOn.plusDays(2))
-            .withHealthCode(HEALTH_CODE).build());
+            .withEndsOn(endsOn.plusDays(2)).build());
 
         ArgumentCaptor<List> argument = ArgumentCaptor.forClass(List.class);
         verify(activityDao).saveActivities(argument.capture());
@@ -277,8 +281,8 @@ public class ScheduledActivityServiceMockTest {
         Map<String,DateTime> events = Maps.newHashMap();
         events.put("enrollment", ENROLLMENT);
         
-        return new ScheduleContext.Builder().withStudyIdentifier(TEST_STUDY).withTimeZone(DateTimeZone.UTC)
-            .withEndsOn(endsOn).withHealthCode(HEALTH_CODE).withEvents(events).build();
+        return new ScheduleContext.Builder().withUser(user).withTimeZone(DateTimeZone.UTC)
+            .withEndsOn(endsOn).withEvents(events).build();
     }
     
 }

--- a/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceMockTest.java
@@ -101,7 +101,6 @@ public class ScheduledActivityServiceMockTest {
             return schActivity;
         });
         when(activityDao.getActivities(context)).thenReturn(scheduledActivities);
-        when(activityDao.activityRunHasNotOccurred(anyString(), anyString())).thenReturn(true);
         
         Survey survey = new DynamoSurvey();
         survey.setGuid("guid");

--- a/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceTest.java
@@ -205,11 +205,10 @@ public class ScheduledActivityServiceTest {
     private ScheduleContext getContext(DateTimeZone zone, DateTime endsOn) {
         // Setting the endsOn value to the end of the day, as we do in the controller.
         return new ScheduleContext.Builder()
-            .withStudyIdentifier(TEST_STUDY)
+            .withUser(testUser.getUser())
             .withClientInfo(ClientInfo.UNKNOWN_CLIENT)
             .withTimeZone(zone)
             // Setting the endsOn value to the end of the day, as we do in the controller.
-            .withEndsOn(endsOn.withHourOfDay(23).withMinuteOfHour(59).withSecondOfMinute(59))
-            .withHealthCode(testUser.getUser().getHealthCode()).build();
+            .withEndsOn(endsOn.withHourOfDay(23).withMinuteOfHour(59).withSecondOfMinute(59)).build();
     }
 }

--- a/test/org/sagebionetworks/bridge/validators/ScheduleContextValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/ScheduleContextValidatorTest.java
@@ -5,24 +5,34 @@ import static org.junit.Assert.fail;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.junit.Before;
 import org.junit.Test;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.models.ClientInfo;
+import org.sagebionetworks.bridge.models.accounts.User;
 import org.sagebionetworks.bridge.models.schedules.ScheduleContext;
 
 public class ScheduleContextValidatorTest {
 
     private ScheduleContextValidator validator = new ScheduleContextValidator();
+    
+    private User user;
+    
+    @Before
+    public void before() {
+        user = new User();
+        user.setStudyKey("test-id");
+        user.setHealthCode("AAA");
+    }
 
     @Test
     public void validContext() {
         // The minimum you need to have a valid schedule context.
         ScheduleContext context = new ScheduleContext.Builder()
-            .withStudyIdentifier("test-id")
             .withClientInfo(ClientInfo.UNKNOWN_CLIENT)
             .withEndsOn(DateTime.now().plusDays(2))
             .withTimeZone(DateTimeZone.forOffsetHours(-3))
-            .withHealthCode("AAA")
+            .withUser(user)
             .build();
         
         Validate.nonEntityThrowingException(validator, context);
@@ -31,10 +41,9 @@ public class ScheduleContextValidatorTest {
     @Test
     public void clientInfoRequired() {
         ScheduleContext context = new ScheduleContext.Builder()
-                .withStudyIdentifier("test-id")
                 .withEndsOn(DateTime.now().plusDays(2))
                 .withTimeZone(DateTimeZone.forOffsetHours(-3))
-                .withHealthCode("AAA")
+                .withUser(user)
                 .build();
         try {
             Validate.nonEntityThrowingException(validator, context);
@@ -61,8 +70,8 @@ public class ScheduleContextValidatorTest {
     @Test
     public void endsOnAfterNow() {
         ScheduleContext context = new ScheduleContext.Builder()
-            .withStudyIdentifier("study-id").withTimeZone(DateTimeZone.UTC)
-            .withEndsOn(DateTime.now().minusHours(1)).withHealthCode("healthCode").build();
+            .withTimeZone(DateTimeZone.UTC)
+            .withEndsOn(DateTime.now().minusHours(1)).withUser(user).build();
         try {
             Validate.nonEntityThrowingException(validator, context);
             fail("Should have thrown exception");
@@ -76,8 +85,8 @@ public class ScheduleContextValidatorTest {
         // Setting this two days past the maximum. Will always fail.
         DateTime endsOn = DateTime.now().plusDays(ScheduleContextValidator.MAX_EXPIRES_ON_DAYS+2);
         ScheduleContext context = new ScheduleContext.Builder()
-            .withStudyIdentifier("study-id").withTimeZone(DateTimeZone.UTC)
-            .withEndsOn(endsOn).withHealthCode("healthCode").build();
+            .withTimeZone(DateTimeZone.UTC)
+            .withEndsOn(endsOn).withUser(user).build();
         try {
             Validate.nonEntityThrowingException(validator, context);
             fail("Should have thrown exception");

--- a/test/org/sagebionetworks/bridge/validators/SchedulePlanValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/SchedulePlanValidatorTest.java
@@ -21,7 +21,7 @@ public class SchedulePlanValidatorTest {
 
     @Before
     public void before() throws Exception {
-        validator = new SchedulePlanValidator(Sets.newHashSet("tapTest"));
+        validator = new SchedulePlanValidator(Sets.newHashSet(), Sets.newHashSet("tapTest"));
     }
 
     @Test


### PR DESCRIPTION
New schedule strategy that selects a schedule based on client info like app version or the data groups of the user. Can be used to server different schedules/activities to different users. I feel it may eventually replace filtering by app version at the schedule plan level, which is getting messy in the UI.

Also implements another method for finding and suppressing persisted tasks that no longer match user-supplied criteria like app version. No longer copying this information into the task, instead, comparing persisted tasks to the tasks retrieved from the scheduler, and if a persisted task isn't in that list, it isn't returned.

DON'T MERGE. This needs to be substantially revised after the introduction of criteria-related code that will be similar for the selection of both schedules and consents.
