### PR TITLE
add Study Whitelist check to service and dao levels

### DIFF
--- a/app/org/sagebionetworks/bridge/exceptions/UnauthorizedException.java
+++ b/app/org/sagebionetworks/bridge/exceptions/UnauthorizedException.java
@@ -5,8 +5,11 @@ import org.apache.http.HttpStatus;
 @SuppressWarnings("serial")
 @NoStackTraceException
 public class UnauthorizedException extends BridgeServiceException {
-
     public UnauthorizedException() {
-        super("Caller does not have permission to access this service.", HttpStatus.SC_FORBIDDEN);
+        this("Caller does not have permission to access this service.");
+    }
+
+    public UnauthorizedException(String message) {
+        super(message, HttpStatus.SC_FORBIDDEN);
     }
 }

--- a/app/org/sagebionetworks/bridge/services/StudyServiceImpl.java
+++ b/app/org/sagebionetworks/bridge/services/StudyServiceImpl.java
@@ -26,6 +26,7 @@ import org.sagebionetworks.bridge.dao.StudyConsentDao;
 import org.sagebionetworks.bridge.dao.StudyDao;
 import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
+import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.models.studies.EmailTemplate;
 import org.sagebionetworks.bridge.models.studies.MimeType;
 import org.sagebionetworks.bridge.models.studies.PasswordPolicy;
@@ -211,6 +212,10 @@ public class StudyServiceImpl implements StudyService {
     @Override
     public void deleteStudy(String identifier) {
         checkArgument(isNotBlank(identifier), Validate.CANNOT_BE_BLANK, "identifier");
+
+        if (studyWhitelist.contains(identifier)) {
+            throw new UnauthorizedException(identifier + " is protected by whitelist.");
+        }
 
         // Verify the study exists before you do this.
         Study existing = getStudy(identifier);

--- a/conf/bridge-server.conf
+++ b/conf/bridge-server.conf
@@ -99,4 +99,4 @@ uat.udd.sqs.queue.url = https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-
 prod.udd.sqs.queue.url = https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-UDD-Request-prod
 
 # List of studies that should never be deleted
-study.whitelist = api,asthma,breastcancer,cardiovascular,diabetes,ohsu-molemapper,parkinson
+study.whitelist = api,asthma,breastcancer,cardiovascular,diabetes,fphs,ohsu-molemapper,parkinson

--- a/test/org/sagebionetworks/bridge/services/StudyServiceImplTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceImplTest.java
@@ -23,6 +23,7 @@ import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
 import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
+import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.models.studies.EmailTemplate;
 import org.sagebionetworks.bridge.models.studies.MimeType;
 import org.sagebionetworks.bridge.models.studies.PasswordPolicy;
@@ -251,4 +252,8 @@ public class StudyServiceImplTest {
         studyService.updateStudy(study, false);
     }
 
+    @Test(expected = UnauthorizedException.class)
+    public void cantDeleteApiStudy() {
+        studyService.deleteStudy("api");
+    }
 }


### PR DESCRIPTION
Because of runaway tests that accidentally delete the API study (and risk of deleting other studies), we decided to add the study whitelist to the service and dao levels as well. (https://sagebionetworks.jira.com/browse/BRIDGE-987)

Also adds fphs to the study whitelist.

Testing done:
- added tests to Service and DAO unit tests to attempt to delete the API study and verify that it fails
- ran Study Integration Tests to make sure general study operations still work fine
