### PR TITLE
upgrade Vagrant box from Ubuntu 14.10 to 15.04

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  config.vm.box = "chef/ubuntu-14.10"
+  config.vm.box = "bento/ubuntu-15.04"
   config.vm.provision :shell, path: "bootstrap.sh"
   config.vm.network :forwarded_port, host: 6379, guest: 6379
   config.vm.network :forwarded_port, host: 9000, guest: 9000


### PR DESCRIPTION
Ubuntu 14.10 stopped being supported in July. This prevents new developers from bootstrapping their Ubuntu box. This upgrades to Ubuntu 15.04.

Note that that Ubuntu 15.04 will be end of life in January. Hopefully by then, they'll be a bento box with 15.10 that we can upgrade to.

Testing done: vagrant destroy, followed by vagrant up. The ran BridgePF locally and verified that it launches successfully and can sign in and out.
