### PR TITLE
Export external ID as part of the participant roster.

### DIFF
--- a/app/org/sagebionetworks/bridge/models/accounts/UserProfile.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/UserProfile.java
@@ -20,6 +20,8 @@ public class UserProfile {
     public static final String EMAIL_FIELD = "email";
     public static final String USERNAME_FIELD = "username";
     public static final String HEALTH_CODE_FIELD = "healthCode";
+    public static final String EXTERNAL_ID_FIELD = "externalId";
+    
     /**
      * These fields are not part of the profile, but they are used on export to expose the participant option values, so
      * studies cannot override these values as extended user profile attributes.

--- a/app/org/sagebionetworks/bridge/models/studies/StudyParticipant.java
+++ b/app/org/sagebionetworks/bridge/models/studies/StudyParticipant.java
@@ -31,6 +31,12 @@ public final class StudyParticipant extends HashMap<String,String> {
     public void setEmail(String email) {
         put(UserProfile.EMAIL_FIELD, email);
     }
+    public String getExternalId() {
+        return getEmpty(UserProfile.EXTERNAL_ID_FIELD);
+    }
+    public void setExternalId(String externalId) {
+        put(UserProfile.EXTERNAL_ID_FIELD, externalId);
+    }
     public SharingScope getSharingScope() {
         String name = get(UserProfile.SHARING_SCOPE_FIELD);
         return (name == null) ? null : SharingScope.valueOf(name);

--- a/app/org/sagebionetworks/bridge/services/ParticipantRosterGenerator.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantRosterGenerator.java
@@ -70,7 +70,8 @@ public class ParticipantRosterGenerator implements Runnable {
                 study, ParticipantOption.SHARING_SCOPE);
             OptionLookup emailLookup = optionsService.getOptionForAllStudyParticipants(
                 study, ParticipantOption.EMAIL_NOTIFICATIONS);
-            
+            OptionLookup externalIdLookup = optionsService.getOptionForAllStudyParticipants(
+                study, ParticipantOption.EXTERNAL_IDENTIFIER);
             int count = 0;
             List<StudyParticipant> participants = Lists.newArrayList();
             while (accounts.hasNext()) {
@@ -86,6 +87,7 @@ public class ParticipantRosterGenerator implements Runnable {
                         Boolean notifyByEmail = Boolean.valueOf(emailLookup.get(healthCode));
                         participant.setSharingScope(sharing);
                         participant.setNotifyByEmail(notifyByEmail);
+                        participant.setExternalId(externalIdLookup.get(healthCode));
                     }
                     participant.setFirstName(account.getFirstName());
                     participant.setLastName(account.getLastName());

--- a/app/org/sagebionetworks/bridge/services/email/ParticipantRosterProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/ParticipantRosterProvider.java
@@ -82,6 +82,7 @@ public class ParticipantRosterProvider implements MimeTypeEmailProvider {
         append(sb, "Last Name", true);
         append(sb, "Sharing Scope", true);
         append(sb, "Email Notifications", true);
+        append(sb, "External ID", true);
         for (String attribute : study.getUserProfileAttributes()) {
             append(sb, StringUtils.capitalize(attribute), true);
         }
@@ -99,6 +100,7 @@ public class ParticipantRosterProvider implements MimeTypeEmailProvider {
             append(sb, participant.getLastName(), true);
             append(sb, (scope == null) ? "" : scope.getLabel(), true);
             append(sb, (notifyByEmail == null) ? "" : notifyByEmail.toString().toLowerCase(), true);
+            append(sb, participant.getExternalId(), true);
             for (String attribute : study.getUserProfileAttributes()) {
                 append(sb, participant.getEmpty(attribute), true);
             }

--- a/test/org/sagebionetworks/bridge/services/email/ParticipantRosterProviderTest.java
+++ b/test/org/sagebionetworks/bridge/services/email/ParticipantRosterProviderTest.java
@@ -83,29 +83,34 @@ public class ParticipantRosterProviderTest {
         participant.put("recontact", "false");
         participant.put(UserProfile.SHARING_SCOPE_FIELD, SharingScope.NO_SHARING.name());
         participant.setHealthCode("AAA");
+        participant.setExternalId("abc");
         List<StudyParticipant> participants = Lists.newArrayList(participant);
 
-        String headerString = row("Email", "First Name", "Last Name", "Sharing Scope", "Email Notifications", "Phone", "Recontact", "Health Code");
+        String headerString = row("Email", "First Name", "Last Name", "Sharing Scope", "Email Notifications", "External ID", "Phone", "Recontact", "Health Code");
         
         ParticipantRosterProvider provider = new ParticipantRosterProvider(study, participants);
-        String output = headerString + row("test@test.com", "First", "Last", "Not Sharing", "false", "(123) 456-7890", "false", "AAA");
+        String output = headerString + row("test@test.com", "First", "Last", "Not Sharing", "false", "abc", "(123) 456-7890", "false", "AAA");
         assertEquals(output, provider.createParticipantTSV());
         
         participant.setLastName(null);
-        output = headerString + row("test@test.com","First","","Not Sharing","false","(123) 456-7890","false", "AAA");
+        output = headerString + row("test@test.com","First","","Not Sharing","false","abc","(123) 456-7890","false", "AAA");
         assertEquals(output, provider.createParticipantTSV());
         
         participant.setFirstName(null);
         participant.setLastName("Last");
-        output = headerString + row("test@test.com","","Last","Not Sharing","false","(123) 456-7890","false", "AAA");
+        output = headerString + row("test@test.com","","Last","Not Sharing","false","abc","(123) 456-7890","false", "AAA");
         assertEquals(output, provider.createParticipantTSV());
         
         participant.remove("phone");
-        output = headerString + row("test@test.com","","Last","Not Sharing","false","","false", "AAA");
+        output = headerString + row("test@test.com","","Last","Not Sharing","false","abc", "","false", "AAA");
         assertEquals(output, provider.createParticipantTSV());
         
         participant.remove(UserProfile.SHARING_SCOPE_FIELD);
-        output = headerString + row("test@test.com","","Last","","false","","false", "AAA");
+        output = headerString + row("test@test.com","","Last","","false","abc","","false","AAA");
+        assertEquals(output, provider.createParticipantTSV());
+        
+        participant.setExternalId(null);
+        output = headerString + row("test@test.com","","Last","","false","","","false","AAA");
         assertEquals(output, provider.createParticipantTSV());
         
         StudyParticipant numberTwo = new StudyParticipant();
@@ -113,7 +118,7 @@ public class ParticipantRosterProviderTest {
         
         // This is pretty broken, but you should still get output. 
         participants.add(numberTwo);
-        output = headerString + row("test@test.com","","Last","","false","","false", "AAA") + row("test2@test.com","","","","","","","");
+        output = headerString + row("test@test.com","","Last","","false","", "","false", "AAA") + row("test2@test.com","","","","","","","","");
         assertEquals("6", output, provider.createParticipantTSV());
         
         participants.clear();
@@ -130,15 +135,16 @@ public class ParticipantRosterProviderTest {
         participant.setEmail("test@test.com");
         participant.put("phone", "(123)\t456-7890"); // Tab snuck into this string should be converted to a space
         participant.setNotifyByEmail(Boolean.FALSE);
+        participant.setExternalId("abc");
         participant.put("recontact", "false");
         participant.put(UserProfile.SHARING_SCOPE_FIELD, SharingScope.NO_SHARING.name());
         participant.setHealthCode("AAA");
         List<StudyParticipant> participants = Lists.newArrayList(participant);
 
-        String headerString = row("Email", "First Name", "Last Name", "Sharing Scope", "Email Notifications", "Phone", "Recontact");
+        String headerString = row("Email", "First Name", "Last Name", "Sharing Scope", "Email Notifications", "External ID", "Phone", "Recontact");
         
         ParticipantRosterProvider provider = new ParticipantRosterProvider(study, participants);
-        String output = headerString + row("test@test.com", "First", "Last", "Not Sharing", "false", "(123) 456-7890", "false");
+        String output = headerString + row("test@test.com", "First", "Last", "Not Sharing", "false", "abc", "(123) 456-7890", "false");
         assertEquals(output, provider.createParticipantTSV());
     }
     


### PR DESCRIPTION
Surprised it's not there already, but it isn't. This would be the FPHS code in the FPHS study (for example).
