### PR TITLE
add Exporter attributes to Study

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
@@ -35,6 +35,8 @@ public final class DynamoStudy implements Study {
     private String identifier;
     private String stormpathHref;
     private String supportEmail;
+    private Long synapseDataAccessTeamId;
+    private String synapseProjectId;
     private String technicalEmail;
     private String consentNotificationEmail;
     private int minAgeOfConsent;
@@ -159,6 +161,30 @@ public final class DynamoStudy implements Study {
     @Override
     public void setSupportEmail(String supportEmail) {
         this.supportEmail = supportEmail;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Long getSynapseDataAccessTeamId() {
+        return synapseDataAccessTeamId;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setSynapseDataAccessTeamId(Long teamId) {
+        this.synapseDataAccessTeamId = teamId;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getSynapseProjectId() {
+        return synapseProjectId;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setSynapseProjectId(String projectId) {
+        this.synapseProjectId = projectId;
     }
 
     /** {@inheritDoc} */
@@ -325,6 +351,8 @@ public final class DynamoStudy implements Study {
         result = prime * result + Objects.hashCode(name);
         result = prime * result + Objects.hashCode(sponsorName);
         result = prime * result + Objects.hashCode(supportEmail);
+        result = prime * result + Objects.hashCode(synapseDataAccessTeamId);
+        result = prime * result + Objects.hashCode(synapseProjectId);
         result = prime * result + Objects.hashCode(technicalEmail);
         result = prime * result + Objects.hashCode(consentNotificationEmail);
         result = prime * result + Objects.hashCode(stormpathHref);
@@ -363,6 +391,8 @@ public final class DynamoStudy implements Study {
                 && Objects.equals(taskIdentifiers, other.taskIdentifiers)
                 && Objects.equals(dataGroups, other.dataGroups)
                 && Objects.equals(sponsorName, other.sponsorName)
+                && Objects.equals(synapseDataAccessTeamId, other.synapseDataAccessTeamId)
+                && Objects.equals(synapseProjectId, other.synapseProjectId)
                 && Objects.equals(technicalEmail, other.technicalEmail)
                 && Objects.equals(strictUploadValidationEnabled, other.strictUploadValidationEnabled)
                 && Objects.equals(healthCodeExportEnabled, other.healthCodeExportEnabled)
@@ -373,13 +403,14 @@ public final class DynamoStudy implements Study {
     public String toString() {
         return String.format(
             "DynamoStudy [name=%s, active=%s, sponsorName=%s, identifier=%s, stormpathHref=%s, minAgeOfConsent=%s, "
-                            + "maxNumOfParticipants=%s, supportEmail=%s, technicalEmail=%s, consentNotificationEmail=%s, "
+                            + "maxNumOfParticipants=%s, supportEmail=%s, synapseDataAccessTeamId=%s, "
+                            + "synapseProjectId=%s, technicalEmail=%s, consentNotificationEmail=%s, "
                             + "version=%s, userProfileAttributes=%s, taskIdentifiers=%s, dataGroups=%s, passwordPolicy=%s, "
                             + "verifyEmailTemplate=%s, resetPasswordTemplate=%s, strictUploadValidationEnabled=%s, "
                             + "healthCodeExportEnabled=%s, minSupportedAppVersions=%s]",
             name, active, sponsorName, identifier, stormpathHref, minAgeOfConsent, maxNumOfParticipants,
-            supportEmail, technicalEmail, consentNotificationEmail, version, profileAttributes, taskIdentifiers, 
-            dataGroups, passwordPolicy, verifyEmailTemplate, resetPasswordTemplate, strictUploadValidationEnabled, 
-            healthCodeExportEnabled, minSupportedAppVersions);
+            supportEmail, synapseDataAccessTeamId, synapseProjectId, technicalEmail, consentNotificationEmail, version,
+            profileAttributes, taskIdentifiers, dataGroups, passwordPolicy, verifyEmailTemplate, resetPasswordTemplate,
+            strictUploadValidationEnabled, healthCodeExportEnabled, minSupportedAppVersions);
     }
 }

--- a/app/org/sagebionetworks/bridge/models/studies/Study.java
+++ b/app/org/sagebionetworks/bridge/models/studies/Study.java
@@ -90,7 +90,19 @@ public interface Study extends BridgeEntity, StudyIdentifier {
      */
     public String getSupportEmail();
     public void setSupportEmail(String email);
-    
+
+    /** Synapse team ID that is granted read access to exported health data records. */
+    Long getSynapseDataAccessTeamId();
+
+    /** @see #getSynapseDataAccessTeamId */
+    void setSynapseDataAccessTeamId(Long teamId);
+
+    /** The Synapse project to export health data records to. */
+    String getSynapseProjectId();
+
+    /** @see #getSynapseProjectId */
+    void setSynapseProjectId(String projectId);
+
     /**
      * The email address for a technical contact who can coordinate with the Bridge Server team on 
      * issues related either to client development or hand-offs of the study data through the 

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -188,6 +188,8 @@ public class TestUtils {
         study.setMaxNumOfParticipants(200);
         study.setSponsorName("The Council on Test Studies");
         study.setConsentNotificationEmail("bridge-testing+consent@sagebase.org");
+        study.setSynapseDataAccessTeamId(1234L);
+        study.setSynapseProjectId("test-synapse-project-id");
         study.setTechnicalEmail("bridge-testing+technical@sagebase.org");
         study.setSupportEmail("bridge-testing+support@sagebase.org");
         study.setUserProfileAttributes(Sets.newHashSet("a", "b"));

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
@@ -45,6 +45,8 @@ public class DynamoStudyTest {
         
         assertEqualsAndNotNull(study.getConsentNotificationEmail(), node.get("consentNotificationEmail").asText());
         assertEqualsAndNotNull(study.getSupportEmail(), node.get("supportEmail").asText());
+        assertEqualsAndNotNull(study.getSynapseDataAccessTeamId(), node.get("synapseDataAccessTeamId").longValue());
+        assertEqualsAndNotNull(study.getSynapseProjectId(), node.get("synapseProjectId").textValue());
         assertEqualsAndNotNull(study.getTechnicalEmail(), node.get("technicalEmail").asText());
         assertEqualsAndNotNull(study.getSponsorName(), node.get("sponsorName").asText());
         assertEqualsAndNotNull(study.getName(), node.get("name").asText());


### PR DESCRIPTION
Study Exporter config for data access team (for permissions) and synapse project ID (so we know what project to export to). These used to live in a JSON file that was manually copied to each Bridge EX host. Now they will live in their proper Study in DDB.

Testing done:
- DynamoStudyTest
- manual local test, where I updated the new attributes in the API study, then GET'ed the study back and verified they were there
