### PR TITLE
No longer requiring consent to update football code

### DIFF
--- a/app/org/sagebionetworks/bridge/models/accounts/UserSessionInfo.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/UserSessionInfo.java
@@ -8,10 +8,7 @@ import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.config.Environment;
 import org.sagebionetworks.bridge.dao.ParticipantOption.SharingScope;
-import org.sagebionetworks.bridge.json.SubpopulationGuidDeserializer;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
-
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * Greatly trimmed user session object that is embedded in the initial render of the

--- a/app/org/sagebionetworks/bridge/play/controllers/FPHSController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/FPHSController.java
@@ -8,11 +8,14 @@ import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.accounts.ExternalIdentifier;
 import org.sagebionetworks.bridge.models.accounts.FPHSExternalIdentifier;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
+import org.sagebionetworks.bridge.models.schedules.ScheduleContext;
+import org.sagebionetworks.bridge.services.ConsentService;
 import org.sagebionetworks.bridge.services.FPHSService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.collect.Sets;
 
 import play.mvc.Result;
 
@@ -26,9 +29,16 @@ public class FPHSController extends BaseController {
 
     private FPHSService fphsService;
     
+    private ConsentService consentService;
+    
     @Autowired
     public final void setFPHSService(FPHSService service) {
         this.fphsService = service; 
+    }
+    
+    @Autowired
+    public final void setConsentService(ConsentService consentService) {
+        this.consentService = consentService; 
     }
     
     public Result verifyExternalIdentifier(String identifier) throws Exception {
@@ -39,10 +49,24 @@ public class FPHSController extends BaseController {
         return okResult(externalId);
     }
     public Result registerExternalIdentifier() throws Exception {
-        UserSession session = getAuthenticatedAndConsentedSession();
+        UserSession session = getAuthenticatedSession();
         
         ExternalIdentifier externalId = parseJson(request(), ExternalIdentifier.class);
         fphsService.registerExternalIdentifier(session.getStudyIdentifier(), session.getUser().getHealthCode(), externalId);
+
+        // This has been saved as an option as a service. Now we're updating the user's session.
+        // This needs to be generalized for a few methods that change data groups since these are 
+        // used to select consent status.
+        session.getUser().setDataGroups(Sets.newHashSet("football_player"));
+        ScheduleContext context = new ScheduleContext.Builder()
+                .withClientInfo(getClientInfoFromUserAgentHeader())
+                .withHealthCode(session.getUser().getHealthCode())
+                .withUserDataGroups(session.getUser().getDataGroups())
+                .withStudyIdentifier(session.getStudyIdentifier())
+                .build();
+        session.getUser().setConsentStatuses(consentService.getConsentStatuses(context));
+        updateSessionUser(session, session.getUser());
+        
         return okResult("External identifier added to user profile.");
     }
     public Result getExternalIdentifiers() throws Exception {

--- a/app/org/sagebionetworks/bridge/services/AuthenticationServiceImpl.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationServiceImpl.java
@@ -247,7 +247,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         
         accountDao.resetPassword(passwordReset);
     }
-
+    
     private UserSession getSessionFromAccount(Study study, ClientInfo clientInfo, Account account) {
         final UserSession session = getSession(account);
         session.setAuthenticated(true);

--- a/test/org/sagebionetworks/bridge/models/accounts/UserSessionTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/UserSessionTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Map;
-import java.util.Set;
 
 import org.junit.Test;
 


### PR DESCRIPTION
Updating users consent status and data groups as part of the registration call. Though I'm not aware of the client re-retrieving the session from the server, ever.

This should allow the client to sign the user up, register the code, and then consent to the correct football player specific consent (since it will then be selected). There are other alternative workflows, but this is one that I believe is close to the current client implementation.
