### PR TITLE
Misc small fixes

### DIFF
--- a/app/org/sagebionetworks/bridge/models/Metrics.java
+++ b/app/org/sagebionetworks/bridge/models/Metrics.java
@@ -36,6 +36,11 @@ public class Metrics {
         return Metrics.getCacheKey(json.get("request_id").asText());
     }
 
+    /** The JSON node backing this metrics object. This is used primarily for testing. */
+    public ObjectNode getJson() {
+        return json;
+    }
+
     public String toJsonString() {
         return json.toString();
     }

--- a/app/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -25,7 +25,7 @@ public interface AuthenticationService {
      */
     public UserSession getSession(String sessionToken);
 
-    public UserSession signIn(Study study, ClientInfo clientInfo, SignIn signIn) throws ConsentRequiredException, EntityNotFoundException;
+    public UserSession signIn(Study study, ClientInfo clientInfo, SignIn signIn) throws EntityNotFoundException;
 
     public void signOut(UserSession session);
 

--- a/app/org/sagebionetworks/bridge/services/AuthenticationServiceImpl.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationServiceImpl.java
@@ -8,7 +8,6 @@ import static org.sagebionetworks.bridge.dao.ParticipantOption.SharingScope;
 import java.util.Map;
 
 import org.sagebionetworks.bridge.BridgeUtils;
-import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.config.BridgeConfig;
 import org.sagebionetworks.bridge.dao.AccountDao;
@@ -125,7 +124,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
     }
 
     @Override
-    public UserSession signIn(Study study, ClientInfo clientInfo, SignIn signIn) throws ConsentRequiredException, EntityNotFoundException {
+    public UserSession signIn(Study study, ClientInfo clientInfo, SignIn signIn) throws EntityNotFoundException {
         checkNotNull(study, "Study cannot be null");
         checkNotNull(signIn, "Sign in cannot be null");
         Validate.entityThrowingException(signInValidator, signIn);
@@ -138,12 +137,6 @@ public class AuthenticationServiceImpl implements AuthenticationService {
             
             UserSession session = getSessionFromAccount(study, clientInfo, account);
             cacheProvider.setUserSession(session);
-            
-            // You can proceed if 1) you're some kind of system administrator (developer, researcher), or 2) 
-            // you've consented to research.
-            if (!session.getUser().doesConsent() && !session.getUser().isInRole(Roles.ADMINISTRATIVE_ROLES)) {
-                throw new ConsentRequiredException(session);
-            }
             return session;
         } finally {
             if (lockId != null) {
@@ -204,10 +197,6 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         Account account = accountDao.verifyEmail(study, verification);
         UserSession session = getSessionFromAccount(study, clientInfo, account);
         cacheProvider.setUserSession(session);
-
-        if (!session.getUser().doesConsent()) {
-            throw new ConsentRequiredException(session);
-        }
         return session;
     }
     

--- a/app/org/sagebionetworks/bridge/stormpath/StormpathAccountDao.java
+++ b/app/org/sagebionetworks/bridge/stormpath/StormpathAccountDao.java
@@ -33,6 +33,7 @@ import org.sagebionetworks.bridge.services.StudyService;
 import org.sagebionetworks.bridge.services.SubpopulationService;
 import org.sagebionetworks.bridge.util.BridgeCollectors;
 
+import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -299,6 +300,9 @@ public class StormpathAccountDao implements AccountDao {
         case 7104: // Account not found in the directory
         case 2016: // Property value does not match a known resource. Somehow this equals not found.
             throw new EntityNotFoundException(Account.class);
+        case 7101:
+            // Account is disabled for administrative reasons. This throws 423 LOCKED (WebDAV, not pure HTTP)
+            throw new BridgeServiceException("Account disabled, please contact user support", HttpStatus.SC_LOCKED);
         default:
             throw new ServiceUnavailableException(e);
         }

--- a/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2.java
+++ b/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2.java
@@ -494,6 +494,18 @@ public class IosSchemaValidationHandler2 implements UploadValidationHandler {
                         "Upload ID %s field %s could not be converted from JSON: %s", uploadId, fieldName,
                         ex.getMessage()));
             }
+        } else if (fieldDef.getType().equals(UploadFieldType.CALENDAR_DATE)) {
+            // Older iOS apps submit a timestamp instead of a calendar date. Use this hack to convert it back.
+            String dateStr = fieldValue.textValue();
+            LocalDate parsedDate = UploadUtil.parseIosCalendarDate(dateStr);
+            if (parsedDate != null) {
+                dataMap.put(fieldName, parsedDate.toString());
+            } else {
+                String warnMsg = "Upload ID " + uploadId + " field " + fieldName + " has invalid calendar date " +
+                        dateStr;
+                logger.warn(warnMsg);
+                context.addMessage(warnMsg);
+            }
         } else {
             dataMap.set(fieldName, fieldValue);
         }

--- a/test/org/sagebionetworks/bridge/play/controllers/AuthenticationControllerMockTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/AuthenticationControllerMockTest.java
@@ -1,12 +1,23 @@
 package org.sagebionetworks.bridge.play.controllers;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.any;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.EnumSet;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.http.HttpStatus;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -15,24 +26,48 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import org.sagebionetworks.bridge.Roles;
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
+import org.sagebionetworks.bridge.exceptions.ConsentRequiredException;
+import org.sagebionetworks.bridge.exceptions.NotAuthenticatedException;
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.Metrics;
+import org.sagebionetworks.bridge.models.accounts.EmailVerification;
+import org.sagebionetworks.bridge.models.accounts.SignIn;
 import org.sagebionetworks.bridge.models.accounts.SignUp;
+import org.sagebionetworks.bridge.models.accounts.User;
+import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.services.AuthenticationService;
 import org.sagebionetworks.bridge.services.StudyService;
 
 import play.mvc.Http;
 import play.mvc.Http.Context;
 import play.mvc.Result;
+import play.test.Helpers;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AuthenticationControllerMockTest {
+    private static final String TEST_INTERNAL_SESSION_ID = "internal-session-id";
+    private static final String TEST_PASSWORD = "password";
+    private static final String TEST_USER_STORMPATH_ID = "spId";
+    private static final String TEST_USERNAME = "username";
+    private static final String TEST_REQUEST_ID = "request-id";
+    private static final String TEST_SESSION_TOKEN = "session-token";
+    private static final String TEST_STUDY_ID_STRING = "study-key";
+    private static final StudyIdentifier TEST_STUDY_ID = new StudyIdentifierImpl(TEST_STUDY_ID_STRING);
+    private static final String TEST_VERIFY_EMAIL_TOKEN = "verify-email-token";
 
     AuthenticationController controller;
 
     @Mock
     AuthenticationService authenticationService;
+
+    private Study study;
     
     @Mock
     StudyService studyService;
@@ -42,11 +77,11 @@ public class AuthenticationControllerMockTest {
     
     @Before
     public void before() {
-        controller = new AuthenticationController();
+        controller = spy(new AuthenticationController());
         controller.setAuthenticationService(authenticationService);
         
-        Study study = new DynamoStudy();
-        when(studyService.getStudy("study-key")).thenReturn(study);
+        study = new DynamoStudy();
+        when(studyService.getStudy(TEST_STUDY_ID_STRING)).thenReturn(study);
         controller.setStudyService(studyService);
     }
     
@@ -57,10 +92,424 @@ public class AuthenticationControllerMockTest {
         
         Result result = controller.signUp();
         assertEquals(201, result.status());
-        verify(authenticationService).signUp(any(), signUpCaptor.capture(), eq(true));
+        verify(authenticationService).signUp(same(study), signUpCaptor.capture(), eq(true));
         
         SignUp signUp = signUpCaptor.getValue();
         assertTrue(signUp.getRoles().isEmpty());
     }
-    
+
+    @Test
+    public void getSessionIfItExistsNullToken() {
+        doReturn(null).when(controller).getSessionToken();
+        assertNull(controller.getSessionIfItExists());
+    }
+
+    @Test
+    public void getSessionIfItExistsEmptyToken() {
+        doReturn("").when(controller).getSessionToken();
+        assertNull(controller.getSessionIfItExists());
+    }
+
+    @Test
+    public void getSessionIfItExistsBlankToken() {
+        doReturn("   ").when(controller).getSessionToken();
+        assertNull(controller.getSessionIfItExists());
+    }
+
+    @Test
+    public void getSessionIfItExistsSuccess() {
+        // mock getSessionToken and getMetrics
+        doReturn(TEST_SESSION_TOKEN).when(controller).getSessionToken();
+
+        Metrics metrics = new Metrics(TEST_REQUEST_ID);
+        doReturn(metrics).when(controller).getMetrics();
+
+        // mock AuthenticationService
+        UserSession session = createSession();
+        when(authenticationService.getSession(TEST_SESSION_TOKEN)).thenReturn(session);
+
+        // execute and validate
+        UserSession retVal = controller.getSessionIfItExists();
+        assertSame(session, retVal);
+        assertSessionInfoInMetrics(metrics);
+    }
+
+    @Test(expected = NotAuthenticatedException.class)
+    public void getAuthenticatedSessionNullToken() {
+        doReturn(null).when(controller).getSessionToken();
+        controller.getAuthenticatedSession();
+    }
+
+    @Test(expected = NotAuthenticatedException.class)
+    public void getAuthenticatedSessionEmptyToken() {
+        doReturn("").when(controller).getSessionToken();
+        controller.getAuthenticatedSession();
+    }
+
+    @Test(expected = NotAuthenticatedException.class)
+    public void getAuthenticatedSessionBlankToken() {
+        doReturn("   ").when(controller).getSessionToken();
+        controller.getAuthenticatedSession();
+    }
+
+    @Test(expected = NotAuthenticatedException.class)
+    public void getAuthenticatedSessionNullSession() {
+        // mock getSessionToken and getMetrics
+        doReturn(TEST_SESSION_TOKEN).when(controller).getSessionToken();
+
+        Metrics metrics = new Metrics(TEST_REQUEST_ID);
+        doReturn(metrics).when(controller).getMetrics();
+
+        // mock AuthenticationService
+        when(authenticationService.getSession(TEST_SESSION_TOKEN)).thenReturn(null);
+
+        // execute
+        controller.getAuthenticatedSession();
+    }
+
+    @Test(expected = NotAuthenticatedException.class)
+    public void getAuthenticatedSessionNotAuthenticated() {
+        // mock getSessionToken and getMetrics
+        doReturn(TEST_SESSION_TOKEN).when(controller).getSessionToken();
+
+        Metrics metrics = new Metrics(TEST_REQUEST_ID);
+        doReturn(metrics).when(controller).getMetrics();
+
+        // mock AuthenticationService
+        UserSession session = createSession();
+        session.setAuthenticated(false);
+        when(authenticationService.getSession(TEST_SESSION_TOKEN)).thenReturn(session);
+
+        // execute
+        controller.getAuthenticatedSession();
+    }
+
+    @Test
+    public void getAuthenticatedSessionSuccess() {
+        // mock getSessionToken and getMetrics
+        doReturn(TEST_SESSION_TOKEN).when(controller).getSessionToken();
+
+        Metrics metrics = new Metrics(TEST_REQUEST_ID);
+        doReturn(metrics).when(controller).getMetrics();
+
+        // mock AuthenticationService
+        UserSession session = createSession();
+        when(authenticationService.getSession(TEST_SESSION_TOKEN)).thenReturn(session);
+
+        // execute and validate
+        UserSession retVal = controller.getAuthenticatedSession();
+        assertSame(session, retVal);
+        assertSessionInfoInMetrics(metrics);
+    }
+
+    @Test
+    public void signInExistingSession() throws Exception {
+        // mock getSessionToken and getMetrics
+        doReturn(TEST_SESSION_TOKEN).when(controller).getSessionToken();
+
+        Metrics metrics = new Metrics(TEST_REQUEST_ID);
+        doReturn(metrics).when(controller).getMetrics();
+
+        // mock AuthenticationService
+        UserSession session = createSession();
+        when(authenticationService.getSession(TEST_SESSION_TOKEN)).thenReturn(session);
+
+        // execute and validate
+        Result result = controller.signIn();
+        assertSessionInPlayResult(result);
+        assertSessionInfoInMetrics(metrics);
+    }
+
+    @Test
+    public void signInNewSession() throws Exception {
+        // mock getSessionToken and getMetrics
+        doReturn(null).when(controller).getSessionToken();
+
+        Metrics metrics = new Metrics(TEST_REQUEST_ID);
+        doReturn(metrics).when(controller).getMetrics();
+
+        // mock request
+        String requestJsonString = "{\n" +
+                "   \"username\":\"" + TEST_USERNAME + "\",\n" +
+                "   \"password\":\"" + TEST_PASSWORD + "\",\n" +
+                "   \"study\":\"" + TEST_STUDY_ID_STRING + "\"\n" +
+                "}";
+        Context context = TestUtils.mockPlayContextWithJson(requestJsonString);
+        Http.Context.current.set(context);
+
+        // mock AuthenticationService
+        UserSession session = createSession();
+        ArgumentCaptor<SignIn> signInCaptor = ArgumentCaptor.forClass(SignIn.class);
+        when(authenticationService.signIn(same(study), any(), signInCaptor.capture())).thenReturn(session);
+
+        // execute and validate
+        Result result = controller.signIn();
+        assertSessionInPlayResult(result);
+        assertSessionInfoInMetrics(metrics);
+
+        // validate signIn
+        SignIn signIn = signInCaptor.getValue();
+        assertEquals(TEST_USERNAME, signIn.getUsername());
+        assertEquals(TEST_PASSWORD, signIn.getPassword());
+    }
+
+    @Test
+    public void signInExistingSessionUnconsented() throws Exception {
+        // mock getSessionToken and getMetrics
+        doReturn(TEST_SESSION_TOKEN).when(controller).getSessionToken();
+
+        Metrics metrics = new Metrics(TEST_REQUEST_ID);
+        doReturn(metrics).when(controller).getMetrics();
+
+        // mock AuthenticationService
+        User user = new User();
+        user.setId(TEST_USER_STORMPATH_ID);
+
+        UserSession session = createSessionWithUser(user);
+        when(authenticationService.getSession(TEST_SESSION_TOKEN)).thenReturn(session);
+
+        // execute and validate
+        try {
+            controller.signIn();
+            fail("expected exception");
+        } catch (ConsentRequiredException ex) {
+            // expected exception
+        }
+        assertSessionInfoInMetrics(metrics);
+    }
+
+    @Test
+    public void signInNewSessionUnconsented() throws Exception {
+        // mock getSessionToken and getMetrics
+        doReturn(null).when(controller).getSessionToken();
+
+        Metrics metrics = new Metrics(TEST_REQUEST_ID);
+        doReturn(metrics).when(controller).getMetrics();
+
+        // mock request
+        String requestJsonString = "{\n" +
+                "   \"username\":\"" + TEST_USERNAME + "\",\n" +
+                "   \"password\":\"" + TEST_PASSWORD + "\",\n" +
+                "   \"study\":\"" + TEST_STUDY_ID_STRING + "\"\n" +
+                "}";
+        Context context = TestUtils.mockPlayContextWithJson(requestJsonString);
+        Http.Context.current.set(context);
+
+        // mock AuthenticationService
+        User user = new User();
+        user.setId(TEST_USER_STORMPATH_ID);
+
+        UserSession session = createSessionWithUser(user);
+
+        ArgumentCaptor<SignIn> signInCaptor = ArgumentCaptor.forClass(SignIn.class);
+        when(authenticationService.signIn(same(study), any(), signInCaptor.capture())).thenReturn(session);
+
+        // execute and validate
+        try {
+            controller.signIn();
+            fail("expected exception");
+        } catch (ConsentRequiredException ex) {
+            // expected exception
+        }
+        assertSessionInfoInMetrics(metrics);
+
+        // validate signIn
+        SignIn signIn = signInCaptor.getValue();
+        assertEquals(TEST_USERNAME, signIn.getUsername());
+        assertEquals(TEST_PASSWORD, signIn.getPassword());
+    }
+
+    @Test
+    public void signInExistingSessionUnconsentedAdmin() throws Exception {
+        // mock getSessionToken and getMetrics
+        doReturn(TEST_SESSION_TOKEN).when(controller).getSessionToken();
+
+        Metrics metrics = new Metrics(TEST_REQUEST_ID);
+        doReturn(metrics).when(controller).getMetrics();
+
+        // mock AuthenticationService
+        User user = new User();
+        user.setId(TEST_USER_STORMPATH_ID);
+        user.setRoles(EnumSet.of(Roles.DEVELOPER));
+
+        UserSession session = createSessionWithUser(user);
+        when(authenticationService.getSession(TEST_SESSION_TOKEN)).thenReturn(session);
+
+        // execute and validate
+        Result result = controller.signIn();
+        assertSessionInPlayResult(result);
+        assertSessionInfoInMetrics(metrics);
+    }
+
+    @Test
+    public void signInNewSessionUnconsentedAdmin() throws Exception {
+        // mock getSessionToken and getMetrics
+        doReturn(null).when(controller).getSessionToken();
+
+        Metrics metrics = new Metrics(TEST_REQUEST_ID);
+        doReturn(metrics).when(controller).getMetrics();
+
+        // mock request
+        String requestJsonString = "{\n" +
+                "   \"username\":\"" + TEST_USERNAME + "\",\n" +
+                "   \"password\":\"" + TEST_PASSWORD + "\",\n" +
+                "   \"study\":\"" + TEST_STUDY_ID_STRING + "\"\n" +
+                "}";
+        Context context = TestUtils.mockPlayContextWithJson(requestJsonString);
+        Http.Context.current.set(context);
+
+        // mock AuthenticationService
+        User user = new User();
+        user.setId(TEST_USER_STORMPATH_ID);
+        user.setRoles(EnumSet.of(Roles.DEVELOPER));
+
+        UserSession session = createSessionWithUser(user);
+
+        ArgumentCaptor<SignIn> signInCaptor = ArgumentCaptor.forClass(SignIn.class);
+        when(authenticationService.signIn(same(study), any(), signInCaptor.capture())).thenReturn(session);
+
+        // execute and validate
+        Result result = controller.signIn();
+        assertSessionInPlayResult(result);
+        assertSessionInfoInMetrics(metrics);
+
+        // validate signIn
+        SignIn signIn = signInCaptor.getValue();
+        assertEquals(TEST_USERNAME, signIn.getUsername());
+        assertEquals(TEST_PASSWORD, signIn.getPassword());
+    }
+
+    @Test
+    public void signOut() throws Exception {
+        // mock getSessionToken and getMetrics
+        doReturn(TEST_SESSION_TOKEN).when(controller).getSessionToken();
+
+        Metrics metrics = new Metrics(TEST_REQUEST_ID);
+        doReturn(metrics).when(controller).getMetrics();
+
+        // mock AuthenticationService
+        UserSession session = createSession();
+        when(authenticationService.getSession(TEST_SESSION_TOKEN)).thenReturn(session);
+
+        // execute and validate
+        Result result = controller.signOut();
+        assertEquals(HttpStatus.SC_OK, result.status());
+        assertSessionInfoInMetrics(metrics);
+
+        verify(authenticationService).signOut(session);
+    }
+
+    @Test
+    public void signOutAlreadySignedOut() throws Exception {
+        // mock getSessionToken and getMetrics
+        doReturn(null).when(controller).getSessionToken();
+
+        Metrics metrics = new Metrics(TEST_REQUEST_ID);
+        doReturn(metrics).when(controller).getMetrics();
+
+        // execute and validate
+        Result result = controller.signOut();
+        assertEquals(HttpStatus.SC_OK, result.status());
+
+        // No session, so no check on metrics or AuthService.signOut()
+    }
+
+    @Test
+    public void verifyEmail() throws Exception {
+        // mock getMetrics
+        Metrics metrics = new Metrics(TEST_REQUEST_ID);
+        doReturn(metrics).when(controller).getMetrics();
+
+        // mock request
+        String requestJsonString = "{\n" +
+                "   \"sptoken\":\"" + TEST_VERIFY_EMAIL_TOKEN + "\",\n" +
+                "   \"study\":\"" + TEST_STUDY_ID_STRING + "\"\n" +
+                "}";
+        Context context = TestUtils.mockPlayContextWithJson(requestJsonString);
+        Http.Context.current.set(context);
+
+        // mock AuthenticationService
+        UserSession session = createSession();
+        ArgumentCaptor<EmailVerification> emailVerifyCaptor = ArgumentCaptor.forClass(EmailVerification.class);
+        when(authenticationService.verifyEmail(same(study), any(), emailVerifyCaptor.capture())).thenReturn(session);
+
+        // execute and validate
+        Result result = controller.verifyEmail();
+        assertSessionInPlayResult(result);
+        assertSessionInfoInMetrics(metrics);
+
+        // validate email verification
+        EmailVerification emailVerify = emailVerifyCaptor.getValue();
+        assertEquals(TEST_VERIFY_EMAIL_TOKEN, emailVerify.getSptoken());
+    }
+
+    @Test
+    public void verifyEmailUnconsented() throws Exception {
+        // mock getMetrics
+        Metrics metrics = new Metrics(TEST_REQUEST_ID);
+        doReturn(metrics).when(controller).getMetrics();
+
+        // mock request
+        String requestJsonString = "{\n" +
+                "   \"sptoken\":\"" + TEST_VERIFY_EMAIL_TOKEN + "\",\n" +
+                "   \"study\":\"" + TEST_STUDY_ID_STRING + "\"\n" +
+                "}";
+        Context context = TestUtils.mockPlayContextWithJson(requestJsonString);
+        Http.Context.current.set(context);
+
+        // mock AuthenticationService
+        User user = new User();
+        user.setId(TEST_USER_STORMPATH_ID);
+
+        UserSession session = createSessionWithUser(user);
+        ArgumentCaptor<EmailVerification> emailVerifyCaptor = ArgumentCaptor.forClass(EmailVerification.class);
+        when(authenticationService.verifyEmail(same(study), any(), emailVerifyCaptor.capture())).thenReturn(session);
+
+        // execute and validate
+        try {
+            controller.verifyEmail();
+            fail("expected exception");
+        } catch (ConsentRequiredException ex) {
+            // expected exception
+        }
+        assertSessionInfoInMetrics(metrics);
+
+        // validate email verification
+        EmailVerification emailVerify = emailVerifyCaptor.getValue();
+        assertEquals(TEST_VERIFY_EMAIL_TOKEN, emailVerify.getSptoken());
+    }
+
+    private static void assertSessionInPlayResult(Result result) throws Exception {
+        assertEquals(HttpStatus.SC_OK, result.status());
+
+        // test only a few key values
+        String resultString = Helpers.contentAsString(result);
+        JsonNode resultNode = BridgeObjectMapper.get().readTree(resultString);
+        assertTrue(resultNode.get("authenticated").booleanValue());
+        assertEquals(TEST_SESSION_TOKEN, resultNode.get("sessionToken").textValue());
+    }
+
+    private static void assertSessionInfoInMetrics(Metrics metrics) {
+        ObjectNode metricsJsonNode = metrics.getJson();
+        assertEquals(TEST_INTERNAL_SESSION_ID, metricsJsonNode.get("session_id").textValue());
+        assertEquals(TEST_STUDY_ID_STRING, metricsJsonNode.get("study").textValue());
+        assertEquals(TEST_USER_STORMPATH_ID, metricsJsonNode.get("user_id").textValue());
+    }
+
+    private static UserSession createSession() {
+        User user = new User();
+        user.setId(TEST_USER_STORMPATH_ID);
+        user.setConsentStatuses(TestUtils.toMap(TestConstants.REQUIRED_SIGNED_CURRENT));
+        return createSessionWithUser(user);
+    }
+
+    private static UserSession createSessionWithUser(User user) {
+        UserSession session = new UserSession();
+        session.setAuthenticated(true);
+        session.setInternalSessionToken(TEST_INTERNAL_SESSION_ID);
+        session.setSessionToken(TEST_SESSION_TOKEN);
+        session.setStudyIdentifier(TEST_STUDY_ID);
+        session.setUser(user);
+        return session;
+    }
 }

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceImplTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceImplTest.java
@@ -31,7 +31,6 @@ import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dao.ParticipantOption.SharingScope;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
-import org.sagebionetworks.bridge.exceptions.ConsentRequiredException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.models.ClientInfo;
@@ -165,20 +164,6 @@ public class AuthenticationServiceImplTest {
         authService.resetPassword(new PasswordReset("newpassword", "resettoken"));
     }
 
-    @Test
-    public void unconsentedUserMustSignTOU() throws Exception {
-        TestUser user = helper.getBuilder(AuthenticationServiceImplTest.class)
-                .withConsent(false).withSignIn(false).build();
-        try {
-            // Create a user who has not consented.
-            authService.signIn(user.getStudy(), ClientInfo.UNKNOWN_CLIENT, user.getSignIn());
-            fail("Should have thrown consent exception");
-        } catch (ConsentRequiredException e) {
-        } finally {
-            helper.deleteUser(user);
-        }
-    }
-    
     @Test
     public void canResendEmailVerification() throws Exception {
         TestUser user = helper.getBuilder(AuthenticationServiceImplTest.class)

--- a/test/org/sagebionetworks/bridge/services/StormPathUserAdminServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/StormPathUserAdminServiceTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.services;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
@@ -19,7 +20,6 @@ import org.sagebionetworks.bridge.config.BridgeConfig;
 import org.sagebionetworks.bridge.dynamodb.DynamoTestUtil;
 import org.sagebionetworks.bridge.dynamodb.DynamoUserConsent3;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
-import org.sagebionetworks.bridge.exceptions.ConsentRequiredException;
 import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
 import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
@@ -97,12 +97,10 @@ public class StormPathUserAdminServiceTest {
         UserSession session1 = userAdminService.createUser(signUp, study, null, false, false);
         assertNull("No session", session1);
 
-        try {
-            authService.signIn(study, ClientInfo.UNKNOWN_CLIENT, new SignIn(signUp.getEmail(), signUp.getPassword()));
-            fail("Should throw a consent required exception");
-        } catch (ConsentRequiredException e) {
-            testUser = e.getUserSession().getUser();
-        }
+        UserSession session = authService.signIn(study, ClientInfo.UNKNOWN_CLIENT, new SignIn(signUp.getEmail(),
+                signUp.getPassword()));
+        testUser = session.getUser();
+        assertFalse(testUser.doesConsent());
     }
 
     // Next two test the same thing in two different ways.

--- a/test/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2Test.java
+++ b/test/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2Test.java
@@ -94,6 +94,10 @@ public class IosSchemaValidationHandler2Test {
                         .withType(UploadFieldType.STRING).build(),
                 new DynamoUploadFieldDefinition.Builder().withName("blob.json.blob")
                         .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("date.json.date")
+                        .withType(UploadFieldType.CALENDAR_DATE).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("date.json.timestampAsDate")
+                        .withType(UploadFieldType.CALENDAR_DATE).build(),
                 new DynamoUploadFieldDefinition.Builder().withName("optional").withRequired(false)
                         .withType(UploadFieldType.STRING).build(),
                 new DynamoUploadFieldDefinition.Builder().withName("optional_attachment").withRequired(false)
@@ -367,6 +371,9 @@ public class IosSchemaValidationHandler2Test {
                 "   },{\n" +
                 "       \"filename\":\"blob.json\",\n" +
                 "       \"timestamp\":\"2015-04-13T18:47:20-07:00\"\n" +
+                "   },{\n" +
+                "       \"filename\":\"date.json\",\n" +
+                "       \"timestamp\":\"2015-04-13T18:47:41-07:00\"\n" +
                 "   }],\n" +
                 "   \"item\":\"json-data\"\n" +
                 "}";
@@ -382,10 +389,17 @@ public class IosSchemaValidationHandler2Test {
                 "}";
         JsonNode blobJsonNode = BridgeObjectMapper.get().readTree(blobJsonText);
 
+        String dateJsonText = "{\n" +
+                "   \"date\":\"2015-12-25\",\n" +
+                "   \"timestampAsDate\":\"2015-12-25T14:41-0800\"\n" +
+                "}";
+        JsonNode dateJsonNode = BridgeObjectMapper.get().readTree(dateJsonText);
+
         context.setJsonDataMap(ImmutableMap.of(
                 "info.json", infoJsonNode,
                 "string.json", stringJsonNode,
-                "blob.json", blobJsonNode));
+                "blob.json", blobJsonNode,
+                "date.json", dateJsonNode));
         context.setUnzippedDataMap(ImmutableMap.<String, byte[]>of());
 
         // execute
@@ -400,8 +414,10 @@ public class IosSchemaValidationHandler2Test {
         assertEquals(1, recordBuilder.getSchemaRevision());
 
         JsonNode dataNode = recordBuilder.getData();
-        assertEquals(1, dataNode.size());
+        assertEquals(3, dataNode.size());
         assertEquals("This is a string", dataNode.get("string.json.string").textValue());
+        assertEquals("2015-12-25", dataNode.get("date.json.date").textValue());
+        assertEquals("2015-12-25", dataNode.get("date.json.timestampAsDate").textValue());
 
         Map<String, byte[]> attachmentMap = context.getAttachmentsByFieldName();
         assertEquals(1, attachmentMap.size());

--- a/test/org/sagebionetworks/bridge/upload/UploadUtilTest.java
+++ b/test/org/sagebionetworks/bridge/upload/UploadUtilTest.java
@@ -4,10 +4,60 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
 import org.junit.Test;
 
 // This file exists to support a hack, but we should still test it anyway.
 public class UploadUtilTest {
+    @Test
+    public void nullCalendarDate() {
+        assertNull(UploadUtil.parseIosCalendarDate(null));
+    }
+
+    @Test
+    public void emptyCalendarDate() {
+        assertNull(UploadUtil.parseIosCalendarDate(""));
+    }
+
+    @Test
+    public void blankCalendarDate() {
+        assertNull(UploadUtil.parseIosCalendarDate("   "));
+    }
+
+    @Test
+    public void shortMalformedCalendarDate() {
+        assertNull(UploadUtil.parseIosCalendarDate("Xmas2015"));
+    }
+
+    @Test
+    public void longMalformedCalendarDate() {
+        assertNull(UploadUtil.parseIosCalendarDate("December 25 2015"));
+    }
+
+    @Test
+    public void validCalendarDate() {
+        LocalDate date = UploadUtil.parseIosCalendarDate("2015-12-25");
+        assertEquals(2015, date.getYear());
+        assertEquals(12, date.getMonthOfYear());
+        assertEquals(25, date.getDayOfMonth());
+    }
+
+    @Test
+    public void timestampCalendarDate() {
+        LocalDate date = UploadUtil.parseIosCalendarDate("2015-12-25T14:33-0800");
+        assertEquals(2015, date.getYear());
+        assertEquals(12, date.getMonthOfYear());
+        assertEquals(25, date.getDayOfMonth());
+    }
+
+    @Test
+    public void truncatesIntoValidCalendarDate() {
+        LocalDate date = UploadUtil.parseIosCalendarDate("2015-12-25 @ lunchtime");
+        assertEquals(2015, date.getYear());
+        assertEquals(12, date.getMonthOfYear());
+        assertEquals(25, date.getDayOfMonth());
+    }
+
     @Test
     public void nullTimestamp() {
         assertNull(UploadUtil.parseIosTimestamp(null));


### PR DESCRIPTION
Fixes:
- signing in to disabled accounts now throws a 423 instead of a 503
- signIn and verifyEmail now display Stormpath token, study ID, and internal session token in the logs
- https://sagebionetworks.jira.com/browse/BRIDGE-1047 - signing in when already signed in now properly checks consent status
- https://sagebionetworks.jira.com/browse/BRIDGE-1065 - hack to convert timestamps into calendar dates
- as a side effect of these changes, the Auth Controller now checks Consent status and throws 412, not the Auth Service

Updated unit tests and ran unit tests for all affected files.

Manual Tests:
- sign up
- verify email, verify 412, check metrics in logs, sign out
- sign in, verify 412, check metrics in logs
- sign in again (from cached session), verify 412, check metrics in logs
- sign out, add developer role to account
- sign in, verify 200
- sign in again (from cached session), verify 200
- sign out, remove developer role from account, disable account
- sign in, verify 423
- sign out, re-enable account
- sign in, consent, sign out
- sign in, verify 200
- sign in again (from cached session), verify 200
- add schema with calendar date, upload data with timestamp instead of calendar date, verify that it passes strict validation
