### PR TITLE
Test fixes

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/SubpopulationDao.java
+++ b/app/org/sagebionetworks/bridge/dao/SubpopulationDao.java
@@ -64,8 +64,10 @@ public interface SubpopulationDao {
      * one has signed a consent for this subpopulation and need to keep the consent document around. 
      * @param studyId
      * @param guid
+     * @param physicalDelete physically delete this subpopulation from the database. This is only done via an 
+     *      admin-api for the purposes of cleanup after integration tests. 
      */
-    public void deleteSubpopulation(StudyIdentifier studyId, SubpopulationGuid subpopGuid);
+    public void deleteSubpopulation(StudyIdentifier studyId, SubpopulationGuid subpopGuid, boolean physicalDelete);
     
     /**
      * Delete all subpopulations. This is a physical delete and not a logical delete, and is not exposed 

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
@@ -40,7 +40,6 @@ public final class DynamoStudy implements Study {
     private int maxNumOfParticipants;
     private Long version;
     private boolean active;
-    private StudyIdentifier studyIdentifier;
     private Set<String> profileAttributes;
     private Set<String> taskIdentifiers;
     private Set<String> dataGroups;
@@ -91,10 +90,7 @@ public final class DynamoStudy implements Study {
 
     @Override
     public void setIdentifier(String identifier) {
-        if (identifier != null) {
-            this.identifier = identifier;
-            this.studyIdentifier = new StudyIdentifierImpl(identifier);
-        }
+        this.identifier = identifier;
     }
 
     /** {@inheritDoc} */
@@ -102,7 +98,7 @@ public final class DynamoStudy implements Study {
     @JsonIgnore
     @DynamoDBIgnore
     public StudyIdentifier getStudyIdentifier() {
-        return studyIdentifier;
+        return (identifier == null) ? null : new StudyIdentifierImpl(identifier);
     }
 
     /** {@inheritDoc} */

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDao.java
@@ -24,9 +24,6 @@ import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
-import com.amazonaws.services.dynamodbv2.model.Condition;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper.FailedBatch;
 import com.google.common.collect.ImmutableList;
 
@@ -94,12 +91,6 @@ public class DynamoSubpopulationDao implements SubpopulationDao {
         DynamoDBQueryExpression<DynamoSubpopulation> query = 
                 new DynamoDBQueryExpression<DynamoSubpopulation>().withHashKeyValues(hashKey);
         
-        if (!includeDeleted) {
-            query.withQueryFilterEntry("deleted", new Condition()
-               .withComparisonOperator(ComparisonOperator.EQ)
-               .withAttributeValueList(new AttributeValue().withN("0")));
-        }
-
         // Get all the records because we only create a default if there are no physical records, 
         // regardless of the deletion status.
         List<DynamoSubpopulation> subpops = mapper.query(DynamoSubpopulation.class, query);
@@ -107,7 +98,10 @@ public class DynamoSubpopulationDao implements SubpopulationDao {
             Subpopulation subpop = createDefaultSubpopulation(studyId);
             return ImmutableList.of(subpop);
         }
-        return ImmutableList.copyOf(subpops);
+        // Now filter out deleted subpopulations, if requested
+        return subpops.stream()
+                .filter(subpop -> includeDeleted || !subpop.isDeleted())
+        .collect(toImmutableList());
     }
     
     @Override

--- a/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
@@ -118,14 +118,12 @@ public abstract class BaseController extends Controller {
         return session;
     }
     
-    UserSession getAuthenticatedSession(Roles... roles) {
-        checkNotNull(roles);
+    UserSession getAuthenticatedSession(Roles role) {
+        checkNotNull(role);
         
         UserSession session = getAuthenticatedSession();
-        for (Roles role : roles) {
-            if (session.getUser().isInRole(role)) {
-                return session;
-            }
+        if (session.getUser().isInRole(role)) {
+            return session;
         }
         throw new UnauthorizedException();
     }

--- a/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
@@ -118,14 +118,16 @@ public abstract class BaseController extends Controller {
         return session;
     }
     
-    UserSession getAuthenticatedSession(Roles role) {
-        checkNotNull(role);
+    UserSession getAuthenticatedSession(Roles... roles) {
+        checkNotNull(roles);
         
         UserSession session = getAuthenticatedSession();
-        if (!session.getUser().isInRole(role)) {
-            throw new UnauthorizedException();
+        for (Roles role : roles) {
+            if (session.getUser().isInRole(role)) {
+                return session;
+            }
         }
-        return session;
+        throw new UnauthorizedException();
     }
     
     void setSessionToken(String sessionToken) {

--- a/app/org/sagebionetworks/bridge/play/controllers/SubpopulationController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/SubpopulationController.java
@@ -72,12 +72,13 @@ public class SubpopulationController extends BaseController {
         if (!session.getUser().isInRole(DELETE_ROLES)) {
             throw new UnauthorizedException();
         }
+        // Only admins can request a physical delete.
+        boolean physicalDelete = ("true".equals(physicalDeleteString));
+        if (physicalDelete && session.getUser().isInRole(DEVELOPER)) {
+            throw new UnauthorizedException();
+        }
         
         SubpopulationGuid subpopGuid = SubpopulationGuid.create(guid);
-        
-        // Only admins can request a physical delete.
-        boolean physicalDelete = (session.getUser().isInRole(ADMIN) && "true".equals(physicalDeleteString));
-        
         subpopService.deleteSubpopulation(session.getStudyIdentifier(), subpopGuid, physicalDelete);
 
         String message = (physicalDelete) ? "Subpopulation has been permanently deleted." : "Subpopulation has been deleted.";

--- a/app/org/sagebionetworks/bridge/services/SubpopulationService.java
+++ b/app/org/sagebionetworks/bridge/services/SubpopulationService.java
@@ -150,13 +150,15 @@ public class SubpopulationService {
      * Delete a subpopulation.
      * @param studyId
      * @param subpopGuid
+     * @param physicalDelete if true, will physically remove the record from the database. Otherwise, it is 
+     *      marked deleted in the database.
      */
-    public void deleteSubpopulation(StudyIdentifier studyId, SubpopulationGuid subpopGuid) {
+    public void deleteSubpopulation(StudyIdentifier studyId, SubpopulationGuid subpopGuid, boolean physicalDelete) {
         checkNotNull(studyId);
         checkNotNull(subpopGuid);
         
         // Will throw EntityNotFoundException if the subpopulation is not in the study
-        subpopDao.deleteSubpopulation(studyId, subpopGuid);
+        subpopDao.deleteSubpopulation(studyId, subpopGuid, physicalDelete);
     }
     
     /**

--- a/conf/routes
+++ b/conf/routes
@@ -19,7 +19,7 @@ GET    /v3/subpopulations        @org.sagebionetworks.bridge.play.controllers.Su
 POST   /v3/subpopulations        @org.sagebionetworks.bridge.play.controllers.SubpopulationController.createSubpopulation
 GET    /v3/subpopulations/:guid  @org.sagebionetworks.bridge.play.controllers.SubpopulationController.getSubpopulation(guid: String)
 POST   /v3/subpopulations/:guid  @org.sagebionetworks.bridge.play.controllers.SubpopulationController.updateSubpopulation(guid: String)
-DELETE /v3/subpopulations/:guid  @org.sagebionetworks.bridge.play.controllers.SubpopulationController.deleteSubpopulation(guid: String)
+DELETE /v3/subpopulations/:guid  @org.sagebionetworks.bridge.play.controllers.SubpopulationController.deleteSubpopulation(guid: String, physical: String ?= "false")
 
 # Consents (now associated to a subpopulation)
 GET    /v3/subpopulations/:guid/consents/signature            @org.sagebionetworks.bridge.play.controllers.ConsentController.getConsentSignatureV2(guid: String)

--- a/test/org/sagebionetworks/bridge/TestUserAdminHelper.java
+++ b/test/org/sagebionetworks/bridge/TestUserAdminHelper.java
@@ -181,8 +181,7 @@ public class TestUserAdminHelper {
             }
             String name = makeRandomUserName(cls);
             SignUp finalSignUp = (signUp != null) ? signUp : new SignUp(name, name + EMAIL_DOMAIN, PASSWORD, roles, dataGroups);
-            UserSession session = userAdminService.createUser(finalSignUp, study, subpopGuid,
-                    signIn, consent);
+            UserSession session = userAdminService.createUser(finalSignUp, study, subpopGuid, signIn, consent);
             
             return new TestUser(finalSignUp, study, session);
         }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
@@ -26,7 +26,7 @@ public class DynamoStudyTest {
     @Test
     public void equalsHashCode() {
         // studyIdentifier is derived from the identifier
-        EqualsVerifier.forClass(DynamoStudy.class).allFieldsShouldBeUsedExcept("studyIdentifier")
+        EqualsVerifier.forClass(DynamoStudy.class).allFieldsShouldBeUsed()
             .suppress(Warning.NONFINAL_FIELDS)
             .withPrefabValues(ObjectMapper.class, new ObjectMapper(), new ObjectMapper())
             .withPrefabValues(JsonFactory.class, new JsonFactory(), new JsonFactory()).verify();

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
@@ -11,6 +11,7 @@ import org.sagebionetworks.bridge.json.JsonUtils;
 import org.sagebionetworks.bridge.models.studies.EmailTemplate;
 import org.sagebionetworks.bridge.models.studies.PasswordPolicy;
 import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -96,6 +97,16 @@ public class DynamoStudyTest {
         // Deserialize back to a POJO and verify.
         final Study deserStudy = BridgeObjectMapper.get().readValue(json, Study.class);
         assertEquals(study, deserStudy);
+    }
+    
+    @Test
+    public void settingStringOrObjectStudyIdentifierSetsTheOther() {
+        DynamoStudy study = new DynamoStudy();
+        study.setIdentifier("test-study");
+        assertEquals(study.getStudyIdentifier(), new StudyIdentifierImpl("test-study"));
+        
+        study.setIdentifier(null);
+        assertNull(study.getStudyIdentifier());
     }
     
     void assertEqualsAndNotNull(Object expected, Object actual) {

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDaoTest.java
@@ -107,7 +107,7 @@ public class DynamoSubpopulationDaoTest {
         assertTrue(deletedSubpop.isDeleted());
         
         // ... and it hides the subpop in the query used to find subpopulations for a user
-        List<Subpopulation> subpopulations = dao.getSubpopulations(studyId, true, false);
+        List<Subpopulation> subpopulations = dao.getSubpopulations(studyId, false, false);
         assertEquals(0, subpopulations.size());
     }
     

--- a/test/org/sagebionetworks/bridge/play/controllers/SubpopulationControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SubpopulationControllerTest.java
@@ -200,16 +200,9 @@ public class SubpopulationControllerTest {
         verify(subpopService).deleteSubpopulation(STUDY_IDENTIFIER, SUBPOP_GUID, false);
     }
     
-    @Test
+    @Test(expected = UnauthorizedException.class)
     public void researchersCannotSubmitPhysicalDelete() throws Exception {
-        Result result = controller.deleteSubpopulation(SUBPOP_GUID.getGuid(), "true");
-        assertEquals(200, result.status());
-        String json = Helpers.contentAsString(result);
-        JsonNode node = BridgeObjectMapper.get().readTree(json);
-        
-        // Message does not indicate a physical delete, false is submitted
-        assertEquals("Subpopulation has been deleted.", node.get("message").asText());
-        verify(subpopService).deleteSubpopulation(STUDY_IDENTIFIER, SUBPOP_GUID, false);
+        controller.deleteSubpopulation(SUBPOP_GUID.getGuid(), "true");
     }
 
     @Test
@@ -221,7 +214,7 @@ public class SubpopulationControllerTest {
         String json = Helpers.contentAsString(result);
         JsonNode node = BridgeObjectMapper.get().readTree(json);
         
-        // Message does not indicate a physical delete, false is submitted
+        // Message indicates a physical (permanent) delete, true is submitted
         assertEquals("Subpopulation has been permanently deleted.", node.get("message").asText());
         verify(subpopService).deleteSubpopulation(STUDY_IDENTIFIER, SUBPOP_GUID, true);
     }

--- a/test/org/sagebionetworks/bridge/services/ConsentServiceImplTest.java
+++ b/test/org/sagebionetworks/bridge/services/ConsentServiceImplTest.java
@@ -102,7 +102,6 @@ public class ConsentServiceImplTest {
         
         // Default is always created, so use it for this test.
         defaultSubpopulation = subpopService.getSubpopulations(study).get(0);
-        System.out.println(defaultSubpopulation.getGuidString());
         
         testUser = helper.getBuilder(ConsentServiceImplTest.class).withStudy(study).withConsent(false).build();
         

--- a/test/org/sagebionetworks/bridge/services/ConsentServiceImplTest.java
+++ b/test/org/sagebionetworks/bridge/services/ConsentServiceImplTest.java
@@ -370,7 +370,7 @@ public class ConsentServiceImplTest {
         statuses = consentService.getConsentStatuses(context);
         assertConsented(statuses, true);
         
-        consentService.withdrawConsent(study, defaultSubpopulation.getGuid(), testUser.getUser(), new Withdrawal("Nada"),
+        consentService.withdrawConsent(study, defaultSubpopulation.getGuid(), testUser.getUser(), WITHDRAWAL,
                 DateTime.now().getMillis());
         
         // your sharing has been turned off because not all required consents are signed
@@ -384,14 +384,12 @@ public class ConsentServiceImplTest {
         assertFalse(statuses.get(optionalSubpop.getGuid()).isConsented());
         // Just verify that it now doesn't appear to exist, so this is an exception
         try {
-            consentService.withdrawConsent(study, defaultSubpopulation.getGuid(), testUser.getUser(), new Withdrawal("Nada"),
-                    DateTime.now().getMillis());
+            consentService.withdrawConsent(study, defaultSubpopulation.getGuid(), testUser.getUser(), WITHDRAWAL, UNIX_TIMESTAMP);
             fail("Should have thrown exception");
         } catch(EntityNotFoundException e) {
         }
         
-        consentService.withdrawConsent(study, requiredSubpop.getGuid(), testUser.getUser(), new Withdrawal("Nada"),
-                DateTime.now().getMillis());
+        consentService.withdrawConsent(study, requiredSubpop.getGuid(), testUser.getUser(), WITHDRAWAL, UNIX_TIMESTAMP);
         
         statuses = consentService.getConsentStatuses(context);
         assertNotConsented(statuses);

--- a/test/org/sagebionetworks/bridge/services/ConsentServiceImplTest.java
+++ b/test/org/sagebionetworks/bridge/services/ConsentServiceImplTest.java
@@ -102,6 +102,7 @@ public class ConsentServiceImplTest {
         
         // Default is always created, so use it for this test.
         defaultSubpopulation = subpopService.getSubpopulations(study).get(0);
+        System.out.println(defaultSubpopulation.getGuidString());
         
         testUser = helper.getBuilder(ConsentServiceImplTest.class).withStudy(study).withConsent(false).build();
         

--- a/test/org/sagebionetworks/bridge/services/StudyEnrollmentServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyEnrollmentServiceTest.java
@@ -32,8 +32,6 @@ import org.sagebionetworks.bridge.redis.RedisKey;
 @RunWith(SpringJUnit4ClassRunner.class)
 public class StudyEnrollmentServiceTest {
     
-    //private static final String NUM_PARTICIPANTS_KEY = RedisKey.NUM_OF_PARTICIPANTS.getRedisKey("test");
-    
     @Resource
     private StudyEnrollmentService studyEnrollmentService;
     

--- a/test/org/sagebionetworks/bridge/services/SubpopulationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SubpopulationServiceTest.java
@@ -230,9 +230,9 @@ public class SubpopulationServiceTest {
     
     @Test
     public void deleteSubpopulation() {
-        service.deleteSubpopulation(TEST_STUDY, SUBPOP_GUID);
+        service.deleteSubpopulation(TEST_STUDY, SUBPOP_GUID, true);
         
-        verify(dao).deleteSubpopulation(TEST_STUDY, SUBPOP_GUID);
+        verify(dao).deleteSubpopulation(TEST_STUDY, SUBPOP_GUID, true);
     }
     
 }


### PR DESCRIPTION
- fixing a couple of tests that left subpopulations in the subpops table (e.g. the study enrollment service test);
- filtering deleted subpopulations in DDB mapper code (doesn't change throughput however);
- added a physical delete parameter to the delete API call, only available to admins, to do a physical delete of subpopulations for clean-up after the integration tests.
