### PR TITLE
Adding data groups to the creation of health data records.

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataRecord.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataRecord.java
@@ -1,6 +1,9 @@
 package org.sagebionetworks.bridge.dynamodb;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
+
+import java.util.Set;
+
 import org.joda.time.LocalDate;
 import org.sagebionetworks.bridge.dao.ParticipantOption;
 import org.sagebionetworks.bridge.json.DateTimeToLongDeserializer;
@@ -36,6 +39,7 @@ public class DynamoHealthDataRecord implements HealthDataRecord {
     private String uploadId;
     private ParticipantOption.SharingScope userSharingScope;
     private String userExternalId;
+    private Set<String> userDataGroups;
     private Long version;
 
     /** {@inheritDoc} */
@@ -182,6 +186,18 @@ public class DynamoHealthDataRecord implements HealthDataRecord {
     }
 
     /** {@inheritDoc} */
+    @Override
+    public Set<String> getUserDataGroups() {
+        return userDataGroups;
+    }
+    
+    /** @see #getUserDataGroups() */
+    public void setUserDataGroups(Set<String> userDataGroups) {
+        // DDB doesn't support empty sets, use null reference for empty set. This is also enforced by the builder.
+        this.userDataGroups = (userDataGroups != null && !userDataGroups.isEmpty()) ? userDataGroups : null;
+    }
+    
+    /** {@inheritDoc} */
     @DynamoDBVersionAttribute
     public Long getVersion() {
         return version;
@@ -210,6 +226,7 @@ public class DynamoHealthDataRecord implements HealthDataRecord {
             record.setUploadId(getUploadId());
             record.setUserSharingScope(getUserSharingScope());
             record.setUserExternalId(getUserExternalId());
+            record.setUserDataGroups(getUserDataGroups());
             record.setVersion(getVersion());
             return record;
         }

--- a/app/org/sagebionetworks/bridge/models/healthdata/HealthDataRecord.java
+++ b/app/org/sagebionetworks/bridge/models/healthdata/HealthDataRecord.java
@@ -3,6 +3,9 @@ package org.sagebionetworks.bridge.models.healthdata;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
+
+import java.util.Set;
+
 import org.joda.time.LocalDate;
 import org.sagebionetworks.bridge.dao.ParticipantOption;
 import org.sagebionetworks.bridge.dynamodb.DynamoHealthDataRecord;
@@ -63,6 +66,12 @@ public interface HealthDataRecord extends BridgeEntity {
      */
     String getUserExternalId();
 
+    /**
+     * The data groups assigned to the user submitting this health data. This set will be null if there are no data 
+     * groups assigned to the user.
+     */
+    Set<String> getUserDataGroups();
+    
     /**
      * Record version. This is used to detect concurrency conflicts. For creating new health data records, this field
      * should be left unspecified. For updating records, this field should match the version of the most recent GET

--- a/app/org/sagebionetworks/bridge/models/healthdata/HealthDataRecordBuilder.java
+++ b/app/org/sagebionetworks/bridge/models/healthdata/HealthDataRecordBuilder.java
@@ -1,6 +1,9 @@
 package org.sagebionetworks.bridge.models.healthdata;
 
 import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.Set;
+
 import org.joda.time.LocalDate;
 
 import org.sagebionetworks.bridge.dao.ParticipantOption;
@@ -26,6 +29,7 @@ public abstract class HealthDataRecordBuilder {
     private LocalDate uploadDate;
     private String uploadId;
     private String userExternalId;
+    private Set<String> userDataGroups;
     private ParticipantOption.SharingScope userSharingScope;
     private Long version;
 
@@ -42,6 +46,7 @@ public abstract class HealthDataRecordBuilder {
         uploadDate = record.getUploadDate();
         uploadId = record.getUploadId();
         userExternalId = record.getUserExternalId();
+        userDataGroups = record.getUserDataGroups();
         userSharingScope = record.getUserSharingScope();
         version = record.getVersion();
         return this;
@@ -171,13 +176,24 @@ public abstract class HealthDataRecordBuilder {
     public String getUserExternalId() {
         return userExternalId;
     }
-        
+    
     /** @see org.sagebionetworks.bridge.models.healthdata.HealthDataRecord#getUserExternalId */
     public HealthDataRecordBuilder withUserExternalId(String externalId) {
         this.userExternalId = externalId;
         return this;
     }
+    
+    /** @see org.sagebionetworks.bridge.models.healthdata.HealthDataRecord#getUserDataGroups */
+    public Set<String> getUserDataGroups() {
+        return (userDataGroups == null || userDataGroups.isEmpty()) ? null : userDataGroups;
+    }
 
+    /** @see org.sagebionetworks.bridge.models.healthdata.HealthDataRecord#getUserDataGroups */
+    public HealthDataRecordBuilder withUserDataGroups(Set<String> userDataGroups) {
+        this.userDataGroups = userDataGroups;
+        return this;
+    }
+    
     /** @see org.sagebionetworks.bridge.models.healthdata.HealthDataRecord#getVersion */
     public Long getVersion() {
         return version;

--- a/app/org/sagebionetworks/bridge/upload/TranscribeConsentHandler.java
+++ b/app/org/sagebionetworks/bridge/upload/TranscribeConsentHandler.java
@@ -1,16 +1,22 @@
 package org.sagebionetworks.bridge.upload;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.sagebionetworks.bridge.dao.ParticipantOption;
 import org.sagebionetworks.bridge.dao.ParticipantOption.SharingScope;
 import org.sagebionetworks.bridge.models.healthdata.HealthDataRecordBuilder;
 import org.sagebionetworks.bridge.services.ParticipantOptionsService;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.Sets;
 
 @Component
 public class TranscribeConsentHandler implements UploadValidationHandler {
@@ -31,7 +37,7 @@ public class TranscribeConsentHandler implements UploadValidationHandler {
         // sharing_scope, and if it doesn't, default to no_sharing
         String sharingScopeString = options.get(ParticipantOption.SHARING_SCOPE);
         SharingScope userSharingScope;
-        if (StringUtils.isBlank(sharingScopeString)) {
+        if (isBlank(sharingScopeString)) {
             userSharingScope = SharingScope.NO_SHARING;
         } else {
             userSharingScope = SharingScope.valueOf(sharingScopeString);
@@ -39,9 +45,15 @@ public class TranscribeConsentHandler implements UploadValidationHandler {
 
         // Also get external ID
         String userExternalId = options.get(ParticipantOption.EXTERNAL_IDENTIFIER);
+        
+        // And get user data groups
+        String dataGroupsSer = options.get(ParticipantOption.DATA_GROUPS);
+        Set<String> userDataGroups = (isNotBlank(dataGroupsSer))
+                ? Sets.newHashSet(Splitter.on(",").split(dataGroupsSer)) : null;
 
         // write sharing scope to health data record
         HealthDataRecordBuilder recordBuilder = context.getHealthDataRecordBuilder();
-        recordBuilder.withUserSharingScope(userSharingScope).withUserExternalId(userExternalId);
+        recordBuilder.withUserSharingScope(userSharingScope).withUserExternalId(userExternalId)
+                .withUserDataGroups(userDataGroups);
     }
 }

--- a/test/org/sagebionetworks/bridge/models/healthdata/HealthDataRecordTest.java
+++ b/test/org/sagebionetworks/bridge/models/healthdata/HealthDataRecordTest.java
@@ -80,7 +80,9 @@ public class HealthDataRecordTest {
                 .withSchemaId("required schema").withSchemaRevision(3).withStudyId("required study")
                 .withUploadDate(uploadDate).withUploadId("optional upload ID")
                 .withUserExternalId("optional external ID")
-                .withUserSharingScope(ParticipantOption.SharingScope.SPONSORS_AND_PARTNERS).withVersion(42L).build();
+                .withUserSharingScope(ParticipantOption.SharingScope.SPONSORS_AND_PARTNERS)
+                .withUserDataGroups(USER_DATA_GROUPS)
+                .withVersion(42L).build();
 
         // validate
         assertEquals("required healthcode", record.getHealthCode());
@@ -93,6 +95,7 @@ public class HealthDataRecordTest {
         assertEquals("optional upload ID", record.getUploadId());
         assertEquals("optional external ID", record.getUserExternalId());
         assertEquals(ParticipantOption.SharingScope.SPONSORS_AND_PARTNERS, record.getUserSharingScope());
+        assertEquals(USER_DATA_GROUPS, record.getUserDataGroups());
         assertEquals(42, record.getVersion().longValue());
 
         assertEquals(1, record.getData().size());
@@ -113,6 +116,7 @@ public class HealthDataRecordTest {
         assertEquals("optional upload ID", copyRecord.getUploadId());
         assertEquals("optional external ID", copyRecord.getUserExternalId());
         assertEquals(ParticipantOption.SharingScope.SPONSORS_AND_PARTNERS, copyRecord.getUserSharingScope());
+        assertEquals(USER_DATA_GROUPS, record.getUserDataGroups());
         assertEquals(42, copyRecord.getVersion().longValue());
 
         assertEquals(1, copyRecord.getData().size());
@@ -120,7 +124,6 @@ public class HealthDataRecordTest {
 
         assertEquals(1, copyRecord.getMetadata().size());
         assertEquals("myMetaValue", copyRecord.getMetadata().get("myMetadata").asText());
-
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/upload/UploadArtifactsHandlerTest.java
+++ b/test/org/sagebionetworks/bridge/upload/UploadArtifactsHandlerTest.java
@@ -9,10 +9,13 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Charsets;
+import com.google.common.collect.Sets;
+
 import org.joda.time.LocalDate;
 import org.joda.time.format.ISODateTimeFormat;
 import org.junit.Test;
@@ -40,6 +43,7 @@ public class UploadArtifactsHandlerTest {
     private static final byte[] BYTES_FOO = ATTACHMENT_TEXT_FOO.getBytes(Charsets.UTF_8);
     private static final String TEST_RECORD_ID = "test-record";
     private static final String TEST_UPLOAD_ID = "test-upload";
+    private static final Set<String> USER_DATA_GROUPS = Sets.newHashSet("group1","group2");
 
     @Test
     public void test() throws Exception {
@@ -117,6 +121,7 @@ public class UploadArtifactsHandlerTest {
         assertEquals(TEST_UPLOAD_ID, createIntermediateRecordArg.getUploadId());
         assertEquals("dummy-external-ID", createIntermediateRecordArg.getUserExternalId());
         assertEquals(ParticipantOption.SharingScope.SPONSORS_AND_PARTNERS, createIntermediateRecordArg.getUserSharingScope());
+        assertEquals(USER_DATA_GROUPS, createIntermediateRecordArg.getUserDataGroups());
         assertEquals(42, createIntermediateRecordArg.getVersion().longValue());
 
         assertTrue(createIntermediateRecordArg.getMetadata().isObject());
@@ -139,6 +144,7 @@ public class UploadArtifactsHandlerTest {
         assertEquals(TEST_UPLOAD_ID, createFinalRecordArg.getUploadId());
         assertEquals("dummy-external-ID", createFinalRecordArg.getUserExternalId());
         assertEquals(ParticipantOption.SharingScope.SPONSORS_AND_PARTNERS, createFinalRecordArg.getUserSharingScope());
+        assertEquals(USER_DATA_GROUPS, createFinalRecordArg.getUserDataGroups());
         assertEquals(42, createFinalRecordArg.getVersion().longValue());
 
         assertTrue(createFinalRecordArg.getMetadata().isObject());
@@ -179,6 +185,8 @@ public class UploadArtifactsHandlerTest {
                 .withSchemaId("dummy-schema").withSchemaRevision(1).withStudyId("dummy-study")
                 .withUploadDate(LocalDate.parse("2015-11-18")).withUploadId(TEST_UPLOAD_ID)
                 .withUserExternalId("dummy-external-ID")
-                .withUserSharingScope(ParticipantOption.SharingScope.SPONSORS_AND_PARTNERS).withVersion(42L);
+                .withUserSharingScope(ParticipantOption.SharingScope.SPONSORS_AND_PARTNERS)
+                .withUserDataGroups(USER_DATA_GROUPS)
+                .withVersion(42L);
     }
 }


### PR DESCRIPTION
Of note: DDB does not support empty string sets (I believe it throws an error), but rather than use the StringSetMarshaller and serialize this to a JSON array "[]", I am only setting data groups in the health record if the set is non-empty. So the reference is either null, or a non-empty set. None of the tests actually test against DDB to verify this works, shall we add a non-mock DAO test for this?
