### PR TITLE
remove getFphsExternalIds and limit addFphsExternalIds

### DIFF
--- a/conf/bridge-server.conf
+++ b/conf/bridge-server.conf
@@ -27,6 +27,11 @@ admin.password = dummy-value
 bridge.healthcode.key = KST6Md7/phHLZg+1FBgbmngKi53K/e7gLptQOEDii0M=
 bridge.healthcode.redis.key = zEjhUL/FVsN8vti6HO27XgrM32i1a3huEuXWD4Hq06I=
 
+local.fphs.id.add.limit = 10
+dev.fphs.id.add.limit = 10
+uat.fphs.id.add.limit = 100
+prod.fphs.id.add.limit = 100
+
 local.host.postfix = -local.sagebridge.org
 dev.host.postfix = -develop.sagebridge.org
 uat.host.postfix = -staging.sagebridge.org

--- a/conf/routes
+++ b/conf/routes
@@ -131,7 +131,6 @@ DELETE /v3/cache/:cacheKey @org.sagebionetworks.bridge.play.controllers.CacheAdm
 
 GET    /fphs/externalId   @org.sagebionetworks.bridge.play.controllers.FPHSController.verifyExternalIdentifier(identifier: String ?= null)
 POST   /fphs/externalId   @org.sagebionetworks.bridge.play.controllers.FPHSController.registerExternalIdentifier
-GET    /fphs/externalIds  @org.sagebionetworks.bridge.play.controllers.FPHSController.getExternalIdentifiers
 POST   /fphs/externalIds  @org.sagebionetworks.bridge.play.controllers.FPHSController.addExternalIdentifiers
 
 # OLD API ----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
These are for the FPHS list APIs. The Get API causes a full table scan, which can have disastrous consequences, so I removed that altogether. (The code is still in place because I wanted to keep changes minimal, plus there are some unit tests that depend on it.)

The Add API attempts to load every ID in the list from DDB, which can be equally disastrous for large list sizes, so I limited it. The limit is configurable for test purposes. In local and dev, it's set to 10 (where developer testing and unit tests are run). In uat and prod, it's set to 100.

Testing done:
- Ran FPHS DAO, Service, and Controller tests
- Manually called GET /fphs/externalIds and verified that the endpoint is gone.
- Manually called POST /fphs/externalIds with 11 IDs and verified the 400 with the expected message.
- Manually called POST /fphs/externalIds with 1 ID and verified it still works.
