### PR TITLE
rate-limit ParticipantRosterGenerator

### DIFF
--- a/app/org/sagebionetworks/bridge/services/ParticipantRosterGenerator.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantRosterGenerator.java
@@ -90,7 +90,7 @@ public class ParticipantRosterGenerator implements Runnable {
                 try {
                     Thread.sleep(60);
                 } catch (InterruptedException ex) {
-                    // Interruptios should never happen. Set interrupt status for hygiene.
+                    // Interruptions should never happen. Set interrupt status for hygiene.
                     Thread.currentThread().interrupt();
                 }
 

--- a/app/org/sagebionetworks/bridge/services/ParticipantRosterGenerator.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantRosterGenerator.java
@@ -84,7 +84,16 @@ public class ParticipantRosterGenerator implements Runnable {
             List<StudyParticipant> participants = Lists.newArrayList();
             while (accounts.hasNext()) {
                 Account account = accounts.next();
-                
+
+                // Rate limit, so we don't end up consuming DDB as fast as possible. 60 millisecond sleep is
+                // ~16.7 accounts/sec. This will allow us to process 60k accounts in an hour.
+                try {
+                    Thread.sleep(60);
+                } catch (InterruptedException ex) {
+                    // Interruptios should never happen. Set interrupt status for hygiene.
+                    Thread.currentThread().interrupt();
+                }
+
                 // If we find no subpopulation names, this user hasn't consented to anything.
                 List<String> names = getSubpopulationNames(account);
                 if (!names.isEmpty()) {


### PR DESCRIPTION
ParticipantRosterGenerator doesn't have rate-limiting, which means it calls DDB as fast as Stormpath will vend accounts. This is problematic, as it means we cannot predict how much DDB throughput we need.

Adding rate limiting by sleeping between each account for 60ms. This is enough to handle up to 60k accounts per hour.

Testing done:
- ParticipantRosterGeneratorTest
- manually tested ParticipantRosterGenerator on my local server
