### PR TITLE
Improving efficiency of DDB use during the participant roster generation

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/ParticipantOptionsDao.java
+++ b/app/org/sagebionetworks/bridge/dao/ParticipantOptionsDao.java
@@ -39,6 +39,16 @@ public interface ParticipantOptionsDao {
     public void deleteAllParticipantOptions(String healthCode);
     
     /**
+     * Get all options for all participants in a study. For batch operations on all participants in a 
+     * study that require multiple entries per participant from the participant options table, this is 
+     * the most efficient way to get those values.
+     * 
+     * @param studyIdentifier
+     *   
+     */
+    public Map<ParticipantOption,OptionLookup> getAllOptionsForAllStudyParticipants(StudyIdentifier studyIdentifier);
+
+    /**
      * Get all options and their values set for a participant as a map of key/value pairs.
      * If a value is not set, the value will be null in the map. Map will be returned whether 
      * any values have been set for this participant or not.

--- a/app/org/sagebionetworks/bridge/models/accounts/UserProfile.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/UserProfile.java
@@ -22,6 +22,7 @@ public class UserProfile {
     public static final String HEALTH_CODE_FIELD = "healthCode";
     public static final String SUBPOPULATION_NAMES_FIELD = "subpopulations";
     public static final String EXTERNAL_ID_FIELD = "externalId";
+    public static final String DATA_GROUPS_FIELD = "dataGroups";
     
     /**
      * These fields are not part of the profile, but they are used on export to expose the participant option values, so

--- a/app/org/sagebionetworks/bridge/models/studies/StudyParticipant.java
+++ b/app/org/sagebionetworks/bridge/models/studies/StudyParticipant.java
@@ -1,9 +1,13 @@
 package org.sagebionetworks.bridge.models.studies;
 
 import java.util.HashMap;
+import java.util.Set;
 
+import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.dao.ParticipantOption.SharingScope;
 import org.sagebionetworks.bridge.models.accounts.UserProfile;
+
+import com.google.common.base.Joiner;
 
 @SuppressWarnings("serial")
 public final class StudyParticipant extends HashMap<String,String> {
@@ -59,6 +63,14 @@ public final class StudyParticipant extends HashMap<String,String> {
     public void setNotifyByEmail(Boolean notifyByEmail) {
         if (notifyByEmail != null) {
             put(UserProfile.NOTIFY_BY_EMAIL_FIELD, notifyByEmail.toString());    
+        }
+    }
+    public String getDataGroups() {
+        return getEmpty(UserProfile.DATA_GROUPS_FIELD);
+    }
+    public void setDataGroups(Set<String> dataGroups) {
+        if (dataGroups != null) {
+            put(UserProfile.DATA_GROUPS_FIELD, BridgeUtils.setToCommaList(dataGroups));    
         }
     }
     public String getHealthCode() {

--- a/app/org/sagebionetworks/bridge/services/ParticipantOptionsService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantOptionsService.java
@@ -32,7 +32,7 @@ public class ParticipantOptionsService {
     /**
      * Get all options and their values set for a participant as a map of key/value pairs.
      * If a value is not set, the value will be null in the map. Map will be returned whether 
-     * any values have been set for this participant or not.
+     * any values have been set for this participant or not. 
      * @param healthCode
      * @return
      */
@@ -40,6 +40,18 @@ public class ParticipantOptionsService {
         checkArgument(isNotBlank(healthCode));
         
         return optionsDao.getAllParticipantOptions(healthCode);
+    }
+    
+    /**
+     * Get all options for all participants in a study. For batch operations on all participants in a 
+     * study that require multiple entries per participant from the participant options table, this is 
+     * the most efficient way to get those values.
+     * 
+     * @param studyIdentifier
+     *   
+     */
+    public Map<ParticipantOption,OptionLookup> getAllOptionsForAllStudyParticipants(StudyIdentifier studyIdentifier) {
+        return optionsDao.getAllOptionsForAllStudyParticipants(studyIdentifier);
     }
 
     /**

--- a/app/org/sagebionetworks/bridge/services/email/ParticipantRosterProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/ParticipantRosterProvider.java
@@ -83,6 +83,7 @@ public class ParticipantRosterProvider implements MimeTypeEmailProvider {
         append(sb, "Sharing Scope", true);
         append(sb, "Email Notifications", true);
         append(sb, "External ID", true);
+        append(sb, "Data Groups", true);
         for (String attribute : study.getUserProfileAttributes()) {
             append(sb, StringUtils.capitalize(attribute), true);
         }
@@ -102,6 +103,7 @@ public class ParticipantRosterProvider implements MimeTypeEmailProvider {
             append(sb, (scope == null) ? "" : scope.getLabel(), true);
             append(sb, (notifyByEmail == null) ? "" : notifyByEmail.toString().toLowerCase(), true);
             append(sb, participant.getExternalId(), true);
+            append(sb, participant.getDataGroups(), true);
             for (String attribute : study.getUserProfileAttributes()) {
                 append(sb, participant.getEmpty(attribute), true);
             }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoParticipantOptionsDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoParticipantOptionsDaoTest.java
@@ -150,7 +150,6 @@ public class DynamoParticipantOptionsDaoTest {
         assertEquals(SharingScope.NO_SHARING, sharingScope.getSharingScope(healthCode+"2"));
         assertEquals(SharingScope.SPONSORS_AND_PARTNERS, sharingScope.getSharingScope(healthCode+"3"));
         
-        
         // healthCode options are deleted in the @After method
         optionsDao.deleteAllParticipantOptions(healthCode+"2");
         optionsDao.deleteAllParticipantOptions(healthCode+"3");

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoParticipantOptionsDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoParticipantOptionsDaoTest.java
@@ -149,5 +149,10 @@ public class DynamoParticipantOptionsDaoTest {
         assertEquals(SharingScope.ALL_QUALIFIED_RESEARCHERS, sharingScope.getSharingScope(healthCode));
         assertEquals(SharingScope.NO_SHARING, sharingScope.getSharingScope(healthCode+"2"));
         assertEquals(SharingScope.SPONSORS_AND_PARTNERS, sharingScope.getSharingScope(healthCode+"3"));
+        
+        
+        // healthCode options are deleted in the @After method
+        optionsDao.deleteAllParticipantOptions(healthCode+"2");
+        optionsDao.deleteAllParticipantOptions(healthCode+"3");
     }
 }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoParticipantOptionsDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoParticipantOptionsDaoTest.java
@@ -115,4 +115,39 @@ public class DynamoParticipantOptionsDaoTest {
         optionsDao.deleteAllParticipantOptions(healthCode+"3");
     }
     
+    @Test
+    public void getAllOptionsForAllStudyParticipants() {
+        optionsDao.setOption(study, healthCode, EXTERNAL_IDENTIFIER, TEST_EXT_ID);
+        optionsDao.setOption(study, healthCode+"2", EXTERNAL_IDENTIFIER, TEST_EXT_ID_2);
+        optionsDao.setOption(study, healthCode+"3", EXTERNAL_IDENTIFIER, TEST_EXT_ID_3);
+        
+        Set<String> dataGroups1 = Sets.newHashSet("group1");
+        Set<String> dataGroups2 = Sets.newHashSet("group1","group2");
+        Set<String> dataGroups3 = Sets.newHashSet("group1","group2","group3");
+        optionsDao.setOption(study, healthCode, DATA_GROUPS, BridgeUtils.setToCommaList(dataGroups1));
+        optionsDao.setOption(study, healthCode+"2", DATA_GROUPS, BridgeUtils.setToCommaList(dataGroups2));
+        optionsDao.setOption(study, healthCode+"3", DATA_GROUPS, BridgeUtils.setToCommaList(dataGroups3));
+        
+        optionsDao.setOption(study, healthCode, SHARING_SCOPE, SharingScope.ALL_QUALIFIED_RESEARCHERS.name());
+        optionsDao.setOption(study, healthCode+"2", SHARING_SCOPE, SharingScope.NO_SHARING.name());
+        optionsDao.setOption(study, healthCode+"3", SHARING_SCOPE, SharingScope.SPONSORS_AND_PARTNERS.name());
+        
+        Map<ParticipantOption,OptionLookup> map = optionsDao.getAllOptionsForAllStudyParticipants(study);
+        
+        OptionLookup externalIds = map.get(EXTERNAL_IDENTIFIER);
+        OptionLookup dataGroups = map.get(DATA_GROUPS);
+        OptionLookup sharingScope = map.get(SHARING_SCOPE);
+        
+        assertEquals(TEST_EXT_ID, externalIds.get(healthCode));
+        assertEquals(TEST_EXT_ID_2, externalIds.get(healthCode+"2"));
+        assertEquals(TEST_EXT_ID_3, externalIds.get(healthCode+"3"));
+        
+        assertEquals(dataGroups1, dataGroups.getDataGroups(healthCode));
+        assertEquals(dataGroups2, dataGroups.getDataGroups(healthCode+"2"));
+        assertEquals(dataGroups3, dataGroups.getDataGroups(healthCode+"3"));
+        
+        assertEquals(SharingScope.ALL_QUALIFIED_RESEARCHERS, sharingScope.getSharingScope(healthCode));
+        assertEquals(SharingScope.NO_SHARING, sharingScope.getSharingScope(healthCode+"2"));
+        assertEquals(SharingScope.SPONSORS_AND_PARTNERS, sharingScope.getSharingScope(healthCode+"3"));
+    }
 }

--- a/test/org/sagebionetworks/bridge/services/ParticipantOptionsServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantOptionsServiceTest.java
@@ -178,5 +178,16 @@ public class ParticipantOptionsServiceTest {
         verifyNoMoreInteractions(mockDao);
     }
     
+    @Test
+    public void getAllOptionsForAllStudyParticipants() {
+        Map<ParticipantOption,OptionLookup> map = Maps.newHashMap();
+        when(mockDao.getAllOptionsForAllStudyParticipants(TEST_STUDY)).thenReturn(map);
+        
+        Map<ParticipantOption,OptionLookup> result = service.getAllOptionsForAllStudyParticipants(TEST_STUDY);
+        assertEquals(map, result);
+        
+        verify(mockDao).getAllOptionsForAllStudyParticipants(TEST_STUDY);
+        verifyNoMoreInteractions(mockDao);
+    }
     
 }

--- a/test/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceParticipantRosterTest.java
+++ b/test/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceParticipantRosterTest.java
@@ -63,7 +63,7 @@ public class SendMailViaAmazonServiceParticipantRosterTest {
         participant.setSubpopulationNames("Group 1, Group 2");
         List<StudyParticipant> participants = Lists.newArrayList(participant);
         
-        String header = row("Email", "First Name", "Last Name", "Sharing Scope", "Email Notifications", "External ID", "Phone", "Recontact", "Health Code", "Consent Groups");
+        String header = row("Email", "First Name", "Last Name", "Sharing Scope", "Email Notifications", "External ID", "Data Groups", "Phone", "Recontact", "Health Code", "Consent Groups");
         
         ParticipantRosterProvider provider = new ParticipantRosterProvider(study, participants);
         service.sendEmail(provider);
@@ -82,7 +82,7 @@ public class SendMailViaAmazonServiceParticipantRosterTest {
         String rawMessage = new String(req.getRawMessage().getData().array(), Charsets.UTF_8);
         
         assertTrue("Has right subject", rawMessage.contains("Study participants for Test Study"));
-        String output = header + row("test@test.com", "First", "Last", "All Qualified Researchers", "false", "abc", "(123) 456-7890", "", "AAA", "Group 1, Group 2");
+        String output = header + row("test@test.com", "First", "Last", "All Qualified Researchers", "false", "abc", "", "(123) 456-7890", "", "AAA", "Group 1, Group 2");
         
         assertTrue("TSV has the participant", rawMessage.contains(output));
         assertTrue("text description of participant", rawMessage.contains("There is 1 user enrolled in this study."));

--- a/test/org/sagebionetworks/bridge/services/email/ParticipantRosterProviderTest.java
+++ b/test/org/sagebionetworks/bridge/services/email/ParticipantRosterProviderTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -84,34 +85,37 @@ public class ParticipantRosterProviderTest {
         participant.put(UserProfile.SHARING_SCOPE_FIELD, SharingScope.NO_SHARING.name());
         participant.setHealthCode("AAA");
         participant.setExternalId("abc");
+        
+        // Force the order of these
+        participant.setDataGroups(Sets.newHashSet("group1"));
         participant.setSubpopulationNames("Default Consent Group");
         List<StudyParticipant> participants = Lists.newArrayList(participant);
 
-        String headerString = row("Email", "First Name", "Last Name", "Sharing Scope", "Email Notifications", "External ID", "Phone", "Recontact", "Health Code", "Consent Groups");
+        String headerString = row("Email", "First Name", "Last Name", "Sharing Scope", "Email Notifications", "External ID", "Data Groups", "Phone", "Recontact", "Health Code", "Consent Groups");
         
         ParticipantRosterProvider provider = new ParticipantRosterProvider(study, participants);
-        String output = headerString + row("test@test.com", "First", "Last", "Not Sharing", "false", "abc", "(123) 456-7890", "false", "AAA", "Default Consent Group");
+        String output = headerString + row("test@test.com", "First", "Last", "Not Sharing", "false", "abc", "group1", "(123) 456-7890", "false", "AAA", "Default Consent Group");
         assertEquals(output, provider.createParticipantTSV());
         
         participant.setLastName(null);
-        output = headerString + row("test@test.com","First","","Not Sharing","false","abc","(123) 456-7890","false", "AAA", "Default Consent Group");
+        output = headerString + row("test@test.com","First","","Not Sharing","false","abc","group1","(123) 456-7890","false", "AAA", "Default Consent Group");
         assertEquals(output, provider.createParticipantTSV());
         
         participant.setFirstName(null);
         participant.setLastName("Last");
-        output = headerString + row("test@test.com","","Last","Not Sharing","false","abc","(123) 456-7890","false", "AAA", "Default Consent Group");
+        output = headerString + row("test@test.com","","Last","Not Sharing","false","abc","group1","(123) 456-7890","false", "AAA", "Default Consent Group");
         assertEquals(output, provider.createParticipantTSV());
         
         participant.setExternalId(null);
-        output = headerString + row("test@test.com","","Last","Not Sharing","false","","(123) 456-7890","false", "AAA", "Default Consent Group");
+        output = headerString + row("test@test.com","","Last","Not Sharing","false","","group1","(123) 456-7890","false", "AAA", "Default Consent Group");
         assertEquals(output, provider.createParticipantTSV());
         
         participant.remove("phone");
-        output = headerString + row("test@test.com","","Last","Not Sharing","false","","","false", "AAA", "Default Consent Group");
+        output = headerString + row("test@test.com","","Last","Not Sharing","false","","group1","","false", "AAA", "Default Consent Group");
         assertEquals(output, provider.createParticipantTSV());
         
         participant.remove(UserProfile.SHARING_SCOPE_FIELD);
-        output = headerString + row("test@test.com","","Last","","false","","","false","AAA", "Default Consent Group");
+        output = headerString + row("test@test.com","","Last","","false","","group1","","false","AAA", "Default Consent Group");
         assertEquals(output, provider.createParticipantTSV());
         
         StudyParticipant numberTwo = new StudyParticipant();
@@ -119,7 +123,7 @@ public class ParticipantRosterProviderTest {
         
         // This is pretty broken, but you should still get output. 
         participants.add(numberTwo);
-        output = headerString + row("test@test.com","","Last","","false","","","false", "AAA", "Default Consent Group") + row("test2@test.com","","","","","","","","","");
+        output = headerString + row("test@test.com","","Last","","false","","group1","","false", "AAA", "Default Consent Group") + row("test2@test.com","","","","","","","","","","");
         assertEquals(output, provider.createParticipantTSV());
         
         participants.clear();
@@ -143,11 +147,11 @@ public class ParticipantRosterProviderTest {
         participant.setSubpopulationNames("Default Consent Group");
         List<StudyParticipant> participants = Lists.newArrayList(participant);
 
-        String headerString = row("Email", "First Name", "Last Name", "Sharing Scope", "Email Notifications", "External ID", "Phone", "Recontact", "Consent Groups");
+        String headerString = row("Email", "First Name", "Last Name", "Sharing Scope", "Email Notifications", "External ID", "Data Groups", "Phone", "Recontact", "Consent Groups");
         
         ParticipantRosterProvider provider = new ParticipantRosterProvider(study, participants);
-        String output = headerString + row("test@test.com", "First", "Last", "Not Sharing", "false", "abc", "(123) 456-7890", "false", "Default Consent Group");
-        
+        String output = headerString + row("test@test.com", "First", "Last", "Not Sharing", "false", "abc", "", "(123) 456-7890", "false", "Default Consent Group");
+
         assertEquals(output, provider.createParticipantTSV());
     }
     


### PR DESCRIPTION
- Adding data groups to the participant roster
- Reducing participant options fetch to one scan of that table per roster export
- Retrieving and caching subpopulations once for roster export
