### PR TITLE
Do not update api study

### DIFF
--- a/app/org/sagebionetworks/bridge/DefaultStudyBootstrapper.java
+++ b/app/org/sagebionetworks/bridge/DefaultStudyBootstrapper.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.bridge;
 
+import java.util.Set;
+
 import javax.annotation.PostConstruct;
 
 import org.sagebionetworks.bridge.dynamodb.DynamoInitializer;
@@ -16,6 +18,16 @@ import org.springframework.stereotype.Component;
 
 @Component("defaultStudyBootstrapper")
 public class DefaultStudyBootstrapper {
+    
+    /**
+     * The data group set in the test (api) study. This includes groups that are required for the SDK integration tests.
+     */
+    public static final Set<String> TEST_DATA_GROUPS = Sets.newHashSet("sdk-int-1","sdk-int-2", "group1");
+    
+    /**
+     * The task identifiers set in the test (api) study. This includes task identifiers that are required for the SDK integration tests.
+     */
+    public static final Set<String> TEST_TASK_IDENTIFIERS = Sets.newHashSet("task:AAA", "task:BBB", "task:CCC", "CCC", "task1");
 
     private StudyService studyService;
 
@@ -39,8 +51,8 @@ public class DefaultStudyBootstrapper {
             study.setTechnicalEmail("bridge-testing+technical@sagebase.org");
             study.setSupportEmail("support@sagebridge.org");
             study.setStormpathHref("https://enterprise.stormpath.io/v1/directories/3OBNJsxNxvaaK5nSFwv8RD");
-            study.setDataGroups(TestConstants.TEST_DATA_GROUPS);
-            study.setTaskIdentifiers(TestConstants.TEST_TASK_IDENTIFIERS);
+            study.setDataGroups(TEST_DATA_GROUPS);
+            study.setTaskIdentifiers(TEST_TASK_IDENTIFIERS);
             study.setUserProfileAttributes(Sets.newHashSet("phone","can_be_recontacted"));
             study.setPasswordPolicy(new PasswordPolicy(2, false, false, false, false));
             studyService.createStudy(study);

--- a/app/org/sagebionetworks/bridge/DefaultStudyBootstrapper.java
+++ b/app/org/sagebionetworks/bridge/DefaultStudyBootstrapper.java
@@ -40,6 +40,7 @@ public class DefaultStudyBootstrapper {
             study.setSupportEmail("support@sagebridge.org");
             study.setStormpathHref("https://enterprise.stormpath.io/v1/directories/3OBNJsxNxvaaK5nSFwv8RD");
             study.setDataGroups(TestConstants.TEST_DATA_GROUPS);
+            study.setTaskIdentifiers(TestConstants.TEST_TASK_IDENTIFIERS);
             study.setUserProfileAttributes(Sets.newHashSet("phone","can_be_recontacted"));
             study.setPasswordPolicy(new PasswordPolicy(2, false, false, false, false));
             studyService.createStudy(study);

--- a/app/org/sagebionetworks/bridge/DefaultStudyBootstrapper.java
+++ b/app/org/sagebionetworks/bridge/DefaultStudyBootstrapper.java
@@ -9,6 +9,8 @@ import org.sagebionetworks.bridge.models.studies.PasswordPolicy;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.services.StudyService;
 
+import com.google.common.collect.Sets;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -37,8 +39,8 @@ public class DefaultStudyBootstrapper {
             study.setTechnicalEmail("bridge-testing+technical@sagebase.org");
             study.setSupportEmail("support@sagebridge.org");
             study.setStormpathHref("https://enterprise.stormpath.io/v1/directories/3OBNJsxNxvaaK5nSFwv8RD");
-            study.getUserProfileAttributes().add("phone");
-            study.getUserProfileAttributes().add("can_be_recontacted");
+            study.setDataGroups(TestConstants.TEST_DATA_GROUPS);
+            study.setUserProfileAttributes(Sets.newHashSet("phone","can_be_recontacted"));
             study.setPasswordPolicy(new PasswordPolicy(2, false, false, false, false));
             studyService.createStudy(study);
         }

--- a/app/org/sagebionetworks/bridge/models/studies/StudyParticipant.java
+++ b/app/org/sagebionetworks/bridge/models/studies/StudyParticipant.java
@@ -7,8 +7,6 @@ import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.dao.ParticipantOption.SharingScope;
 import org.sagebionetworks.bridge.models.accounts.UserProfile;
 
-import com.google.common.base.Joiner;
-
 @SuppressWarnings("serial")
 public final class StudyParticipant extends HashMap<String,String> {
     

--- a/test/org/sagebionetworks/bridge/TestConstants.java
+++ b/test/org/sagebionetworks/bridge/TestConstants.java
@@ -41,9 +41,14 @@ public class TestConstants {
     public static final Activity TEST_3_ACTIVITY = new Activity.Builder().withLabel("Activity3").withGuid("AAA").withTask("tapTest").build();
     
     /**
-     * The data group set in the test (api) study.
+     * The data group set in the test (api) study. This includes groups that are required for the SDK integration tests.
      */
-    public static final Set<String> TEST_DATA_GROUPS = Sets.newHashSet("group1");
+    public static final Set<String> TEST_DATA_GROUPS = Sets.newHashSet("sdk-int-1","sdk-int-2", "group1");
+    
+    /**
+     * The task identifiers set in the test (api) study. This includes task identifiers that are required for the SDK integration tests.
+     */
+    public static final Set<String> TEST_TASK_IDENTIFIERS = Sets.newHashSet("task:AAA", "task:BBB", "task:CCC", "CCC", "task1");
     
     /**
      * During tests, must sometimes pause because the underlying query uses a DynamoDB global 

--- a/test/org/sagebionetworks/bridge/TestConstants.java
+++ b/test/org/sagebionetworks/bridge/TestConstants.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.bridge;
 
+import java.util.Set;
+
 import org.joda.time.DateTime;
 import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
@@ -7,6 +9,8 @@ import org.sagebionetworks.bridge.models.schedules.Activity;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
+
+import com.google.common.collect.Sets;
 
 public class TestConstants {
     public static final String DUMMY_IMAGE_DATA = "VGhpcyBpc24ndCBhIHJlYWwgaW1hZ2Uu";
@@ -35,6 +39,11 @@ public class TestConstants {
     public static final Activity TEST_1_ACTIVITY = new Activity.Builder().withLabel("Activity1").withPublishedSurvey("identifier1","AAA").build();
     public static final Activity TEST_2_ACTIVITY = new Activity.Builder().withLabel("Activity2").withPublishedSurvey("identifier2","BBB").build();
     public static final Activity TEST_3_ACTIVITY = new Activity.Builder().withLabel("Activity3").withGuid("AAA").withTask("tapTest").build();
+    
+    /**
+     * The data group set in the test (api) study.
+     */
+    public static final Set<String> TEST_DATA_GROUPS = Sets.newHashSet("group1");
     
     /**
      * During tests, must sometimes pause because the underlying query uses a DynamoDB global 

--- a/test/org/sagebionetworks/bridge/TestConstants.java
+++ b/test/org/sagebionetworks/bridge/TestConstants.java
@@ -1,7 +1,5 @@
 package org.sagebionetworks.bridge;
 
-import java.util.Set;
-
 import org.joda.time.DateTime;
 import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
@@ -9,8 +7,6 @@ import org.sagebionetworks.bridge.models.schedules.Activity;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
-
-import com.google.common.collect.Sets;
 
 public class TestConstants {
     public static final String DUMMY_IMAGE_DATA = "VGhpcyBpc24ndCBhIHJlYWwgaW1hZ2Uu";
@@ -39,16 +35,6 @@ public class TestConstants {
     public static final Activity TEST_1_ACTIVITY = new Activity.Builder().withLabel("Activity1").withPublishedSurvey("identifier1","AAA").build();
     public static final Activity TEST_2_ACTIVITY = new Activity.Builder().withLabel("Activity2").withPublishedSurvey("identifier2","BBB").build();
     public static final Activity TEST_3_ACTIVITY = new Activity.Builder().withLabel("Activity3").withGuid("AAA").withTask("tapTest").build();
-    
-    /**
-     * The data group set in the test (api) study. This includes groups that are required for the SDK integration tests.
-     */
-    public static final Set<String> TEST_DATA_GROUPS = Sets.newHashSet("sdk-int-1","sdk-int-2", "group1");
-    
-    /**
-     * The task identifiers set in the test (api) study. This includes task identifiers that are required for the SDK integration tests.
-     */
-    public static final Set<String> TEST_TASK_IDENTIFIERS = Sets.newHashSet("task:AAA", "task:BBB", "task:CCC", "CCC", "task1");
     
     /**
      * During tests, must sometimes pause because the underlying query uses a DynamoDB global 

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
@@ -52,8 +52,6 @@ import com.google.common.collect.Sets;
 @RunWith(SpringJUnit4ClassRunner.class)
 public class AuthenticationServiceTest {
 
-    private static final String TEST_DATA_GROUP = "group1";
-
     @Resource
     private CacheProvider cacheProvider;
 
@@ -80,13 +78,6 @@ public class AuthenticationServiceTest {
     @Before
     public void before() {
         testUser = helper.getBuilder(AuthenticationServiceTest.class).build();
-
-        cacheProvider.removeStudy(TestConstants.TEST_STUDY_IDENTIFIER);
-        Study study = studyService.getStudy(TestConstants.TEST_STUDY_IDENTIFIER);
-        if (!study.getDataGroups().contains(TEST_DATA_GROUP)) {
-            study.getDataGroups().add(TEST_DATA_GROUP);
-            studyService.updateStudy(study, true);
-        }
     }
 
     @After
@@ -250,15 +241,13 @@ public class AuthenticationServiceTest {
     
     @Test
     public void userCreatedWithDataGroupsHasThemOnSignIn() throws Exception {
-        Set<String> dataGroups = Sets.newHashSet(TEST_DATA_GROUP);
-        
         TestUser user = helper.getBuilder(AuthenticationServiceTest.class).withConsent(true)
-                .withDataGroups(dataGroups).build();
+                .withDataGroups(TestConstants.TEST_DATA_GROUPS).build();
         try {
             UserSession session = authService.signIn(user.getStudy(), ClientInfo.UNKNOWN_CLIENT, user.getSignIn());
             // Verify we created a list and the anticipated group was not null
             assertEquals(1, session.getUser().getDataGroups().size()); 
-            assertEquals(dataGroups, session.getUser().getDataGroups());
+            assertEquals(TestConstants.TEST_DATA_GROUPS, session.getUser().getDataGroups());
         } finally {
             helper.deleteUser(user);
         }

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
@@ -22,8 +22,8 @@ import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import org.sagebionetworks.bridge.DefaultStudyBootstrapper;
 import org.sagebionetworks.bridge.Roles;
-import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUserAdminHelper;
 import org.sagebionetworks.bridge.TestUserAdminHelper.TestUser;
 import org.sagebionetworks.bridge.TestUtils;
@@ -241,13 +241,14 @@ public class AuthenticationServiceTest {
     
     @Test
     public void userCreatedWithDataGroupsHasThemOnSignIn() throws Exception {
+        int numOfGroups = DefaultStudyBootstrapper.TEST_DATA_GROUPS.size();
         TestUser user = helper.getBuilder(AuthenticationServiceTest.class).withConsent(true)
-                .withDataGroups(TestConstants.TEST_DATA_GROUPS).build();
+                .withDataGroups(DefaultStudyBootstrapper.TEST_DATA_GROUPS).build();
         try {
             UserSession session = authService.signIn(user.getStudy(), ClientInfo.UNKNOWN_CLIENT, user.getSignIn());
             // Verify we created a list and the anticipated group was not null
-            assertEquals(1, session.getUser().getDataGroups().size()); 
-            assertEquals(TestConstants.TEST_DATA_GROUPS, session.getUser().getDataGroups());
+            assertEquals(numOfGroups, session.getUser().getDataGroups().size()); 
+            assertEquals(DefaultStudyBootstrapper.TEST_DATA_GROUPS, session.getUser().getDataGroups());
         } finally {
             helper.deleteUser(user);
         }

--- a/test/org/sagebionetworks/bridge/services/email/ParticipantRosterProviderTest.java
+++ b/test/org/sagebionetworks/bridge/services/email/ParticipantRosterProviderTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 import java.util.Set;
-import java.util.TreeSet;
 
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
- remove cases where the tests update the API study (moving this into the bootstrapper; all the studies in all environments are currently correct for the tests). There's a small chance that this can cause study version conflicts if multiple tests are running at the same time. For the most part, these study updates are in the SDK integration tests, however.
- removed all but two questions from the survey used in the DynamoSurveyDaoTest, to reduce DDB usage.
- note that there is a parallel change to the SDK integration tests so that they also do not attempt to update the API study (they are a greater concern than the one BridgePF test that did this).
