### PR TITLE
Limiting the number of scheduled activities (tasks) we will attempt to delete to keep tasks in sync with schedule plans

### DIFF
--- a/app/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/app/org/sagebionetworks/bridge/BridgeConstants.java
@@ -13,7 +13,7 @@ public class BridgeConstants {
     public static final String BRIDGE_STUDY_HEADER = "Bridge-Study";
 
     public static final String BRIDGE_HOST_HEADER = "Bridge-Host";
-    
+
     public static final String USER_AGENT_HEADER = "User-Agent";
 
     /** Used by Heroku to pass in the request ID */
@@ -26,7 +26,7 @@ public class BridgeConstants {
     public static final String CUSTOM_DATA_CONSENT_SIGNATURE_SUFFIX = "_consent_signature";
 
     public static final String CUSTOM_DATA_VERSION = "version";
-    
+
     public static final String STUDY_PROPERTY = "study";
 
     public static final DateTimeZone LOCAL_TIME_ZONE = DateTimeZone.forID("America/Los_Angeles");
@@ -35,16 +35,18 @@ public class BridgeConstants {
     public static final int BRIDGE_SESSION_EXPIRE_IN_SECONDS = 24 * 60 * 60;
 
     public static final int BRIDGE_UPDATE_ATTEMPT_EXPIRE_IN_SECONDS = 5 * 60;
-    
+
     public static final int BRIDGE_VIEW_EXPIRE_IN_SECONDS = 5 * 60 * 60;
 
     public static final String SCHEDULE_STRATEGY_PACKAGE = "org.sagebionetworks.bridge.models.schedules.";
 
     public static final String ASSETS_HOST = "assets.sagebridge.org";
-    
+
     public static final String JSON_MIME_TYPE = "application/json; charset=UTF-8";
 
     /** Per-request metrics expires in the cache after 120 seconds. */
     public static final int METRICS_EXPIRE_SECONDS = 2 * 60;
-    
+
+    public static final int SCHEDULED_ACTIVITIES_DELETE_THRESHOLD = 100;
+
 }

--- a/app/org/sagebionetworks/bridge/dao/ScheduledActivityDao.java
+++ b/app/org/sagebionetworks/bridge/dao/ScheduledActivityDao.java
@@ -7,58 +7,60 @@ import org.joda.time.DateTimeZone;
 import org.sagebionetworks.bridge.models.schedules.ScheduledActivity;
 
 public interface ScheduledActivityDao {
-    
+
     /**
      * Load an individual activity.
+     * 
      * @param timeZone
      * @param healthCode
      * @param guid
      * @return
      */
     public ScheduledActivity getActivity(DateTimeZone timeZone, String healthCode, String guid);
-   
+
     /**
      * Get a list of activities for a user. The list is derived from the scheduler.
+     * 
      * @param healthCode
      * @param timeZone
      * @param activityGuids
      * @return
      */
     public List<ScheduledActivity> getActivities(DateTimeZone timeZone, List<ScheduledActivity> activities);
-    
+
     /**
      * Save activities (activities will only be saved if they are not in the database).
+     * 
      * @param activities
      */
     public void saveActivities(List<ScheduledActivity> activities);
-    
+
     /**
      * Update the startedOn or finishedOn timestamps of the activities in the collection. Activities in this collection
-     * should also have a GUID. All other fields are ignored. Health code is supplied here because these activities come from
-     * the client and the client does not provide it.
+     * should also have a GUID. All other fields are ignored. Health code is supplied here because these activities come
+     * from the client and the client does not provide it.
      * 
      * @param healthCode
      * @param activities
      */
     public void updateActivities(String healthCode, List<ScheduledActivity> activities);
-    
+
     /**
-     * Physically delete all the activity records for this user. This method should only be called as a 
-     * user is being deleted. To do a logical delete, add a "finishedOn" timestamp to a scheduled activity 
-     * and update it. 
+     * Physically delete all the activity records for this user. This method should only be called as a user is being
+     * deleted. To do a logical delete, add a "finishedOn" timestamp to a scheduled activity and update it.
      * 
      * @param healthCode
      */
     public void deleteActivitiesForUser(String healthCode);
-    
+
     /**
-     * Delete the scheduled activities for a schedule plan (with the exception of started activities, which the user has
-     * seen and started working on, it would be annoying for these to disappear on the user). We do this when a schedule
-     * plan is updated or deleted, to update the tasks that are returned to a user so the reflect the current state of
-     * the schedule plans.
+     * Delete the scheduled activities for a schedule plan, with the exception of started activities. While this is very
+     * helpful for study development, when schedule plans and activities are changing and being tested, in production
+     * the activities for a plan can number in the tens or hundreds of thousands, so we <em>only</em> do this when the
+     * total number of activities are under a specified threshold count.
      * 
      * @param schedulePlanGuid
      */
-    public void deleteActivitiesForSchedulePlan(String schedulePlanGuid);
-    
+    public void deleteActivitiesForSchedulePlanIfUnderThreshold(String schedulePlanGuid, int threshold);
+
 }

--- a/app/org/sagebionetworks/bridge/models/studies/StudyParticipant.java
+++ b/app/org/sagebionetworks/bridge/models/studies/StudyParticipant.java
@@ -7,8 +7,6 @@ import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.dao.ParticipantOption.SharingScope;
 import org.sagebionetworks.bridge.models.accounts.UserProfile;
 
-import com.google.common.base.Joiner;
-
 @SuppressWarnings("serial")
 public final class StudyParticipant extends HashMap<String,String> {
     

--- a/app/org/sagebionetworks/bridge/services/SchedulePlanService.java
+++ b/app/org/sagebionetworks/bridge/services/SchedulePlanService.java
@@ -5,6 +5,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.util.List;
 
+import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.dao.SchedulePlanDao;
 import org.sagebionetworks.bridge.models.ClientInfo;
@@ -80,7 +81,8 @@ public class SchedulePlanService {
         StudyIdentifier studyId = new StudyIdentifierImpl(plan.getStudyKey());
         lookupSurveyReferenceIdentifiers(studyId, plan);
         plan = schedulePlanDao.updateSchedulePlan(studyId, plan);
-        activityService.deleteActivitiesForSchedulePlan(plan.getGuid());
+        
+        activityService.deleteActivitiesForSchedulePlan(plan.getGuid(), BridgeConstants.SCHEDULED_ACTIVITIES_DELETE_THRESHOLD);
         return plan;
     }
 
@@ -90,7 +92,7 @@ public class SchedulePlanService {
         
         schedulePlanDao.deleteSchedulePlan(studyIdentifier, guid);
         
-        activityService.deleteActivitiesForSchedulePlan(guid);
+        activityService.deleteActivitiesForSchedulePlan(guid, BridgeConstants.SCHEDULED_ACTIVITIES_DELETE_THRESHOLD);
     }
     
     /**

--- a/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
+++ b/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
@@ -155,10 +155,10 @@ public class ScheduledActivityService {
         activityDao.deleteActivitiesForUser(healthCode);
     }
     
-    public void deleteActivitiesForSchedulePlan(String schedulePlanGuid) {
+    public void deleteActivitiesForSchedulePlan(String schedulePlanGuid, int threshold) {
         checkArgument(isNotBlank(schedulePlanGuid));
         
-        activityDao.deleteActivitiesForSchedulePlan(schedulePlanGuid);
+        activityDao.deleteActivitiesForSchedulePlanIfUnderThreshold(schedulePlanGuid, threshold);
     }
     
     protected List<ScheduledActivity> updateActivitiesAndCollectSaves(List<ScheduledActivity> scheduledActivities, List<ScheduledActivity> dbActivities) {

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDaoTest.java
@@ -21,6 +21,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
@@ -179,7 +181,7 @@ public class DynamoScheduledActivityDaoTest {
         // Get one schedule plan GUID to delete and the initial count
         int initialCount = activities.size();
         assertTrue("there are activities", initialCount > 1);
-        activityDao.deleteActivitiesForSchedulePlan(testPlan.getGuid());
+        activityDao.deleteActivitiesForSchedulePlanIfUnderThreshold(testPlan.getGuid(), BridgeConstants.SCHEDULED_ACTIVITIES_DELETE_THRESHOLD);
 
         // Sleep before getting because of eventual consistency issues.
         Thread.sleep(5000);

--- a/test/org/sagebionetworks/bridge/services/SchedulePlanServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/SchedulePlanServiceMockTest.java
@@ -19,6 +19,8 @@ import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+
+import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dao.SchedulePlanDao;
 import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
@@ -194,14 +196,14 @@ public class SchedulePlanServiceMockTest {
         when(mockSchedulePlanDao.updateSchedulePlan(study.getStudyIdentifier(), plan)).thenReturn(plan);
         
         service.updateSchedulePlan(study, plan);
-        verify(mockActivityService).deleteActivitiesForSchedulePlan("BBB");
+        verify(mockActivityService).deleteActivitiesForSchedulePlan("BBB", BridgeConstants.SCHEDULED_ACTIVITIES_DELETE_THRESHOLD);
     }
     
     @Test
     public void cleansUpScheduledActivitiesOnDelete() {
         service.deleteSchedulePlan(TEST_STUDY, "BBB");
         
-        verify(mockActivityService).deleteActivitiesForSchedulePlan("BBB");
+        verify(mockActivityService).deleteActivitiesForSchedulePlan("BBB", BridgeConstants.SCHEDULED_ACTIVITIES_DELETE_THRESHOLD);
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceMockTest.java
@@ -285,8 +285,8 @@ public class ScheduledActivityServiceMockTest {
     
     @Test
     public void deleteScheduledActivitiesForSchedulePlan() {
-        service.deleteActivitiesForSchedulePlan("BBB");
-        verify(activityDao).deleteActivitiesForSchedulePlan("BBB");
+        service.deleteActivitiesForSchedulePlan("BBB", 50);
+        verify(activityDao).deleteActivitiesForSchedulePlanIfUnderThreshold("BBB", 50);
     }
     
     @Test(expected = IllegalArgumentException.class)

--- a/test/org/sagebionetworks/bridge/services/email/ParticipantRosterProviderTest.java
+++ b/test/org/sagebionetworks/bridge/services/email/ParticipantRosterProviderTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 import java.util.Set;
-import java.util.TreeSet;
 
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
In tests and development of studies, it's very useful to have them cleaned up, but in production, this easily exceeds throughput (I've tested this with very large values... at best we could do it if we rate-limited this and created a separate thread, but this is probably not necessary in production situations). So, limit to a threshold count indicative of development rather than production.
