### PR TITLE
Dont delete activities

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/ScheduledActivityDao.java
+++ b/app/org/sagebionetworks/bridge/dao/ScheduledActivityDao.java
@@ -51,14 +51,4 @@ public interface ScheduledActivityDao {
      */
     public void deleteActivitiesForUser(String healthCode);
     
-    /**
-     * Delete the scheduled activities for a schedule plan (with the exception of started activities, which the user has
-     * seen and started working on, it would be annoying for these to disappear on the user). We do this when a schedule
-     * plan is updated or deleted, to update the tasks that are returned to a user so the reflect the current state of
-     * the schedule plans.
-     * 
-     * @param schedulePlanGuid
-     */
-    public void deleteActivitiesForSchedulePlan(String schedulePlanGuid);
-    
 }

--- a/app/org/sagebionetworks/bridge/models/studies/StudyParticipant.java
+++ b/app/org/sagebionetworks/bridge/models/studies/StudyParticipant.java
@@ -7,8 +7,6 @@ import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.dao.ParticipantOption.SharingScope;
 import org.sagebionetworks.bridge.models.accounts.UserProfile;
 
-import com.google.common.base.Joiner;
-
 @SuppressWarnings("serial")
 public final class StudyParticipant extends HashMap<String,String> {
     

--- a/app/org/sagebionetworks/bridge/services/SchedulePlanService.java
+++ b/app/org/sagebionetworks/bridge/services/SchedulePlanService.java
@@ -29,7 +29,6 @@ public class SchedulePlanService {
     
     private SchedulePlanDao schedulePlanDao;
     private SurveyService surveyService;
-    private ScheduledActivityService activityService;
 
     @Autowired
     public final void setSchedulePlanDao(SchedulePlanDao schedulePlanDao) {
@@ -38,10 +37,6 @@ public class SchedulePlanService {
     @Autowired
     public final void setSurveyService(SurveyService surveyService) {
         this.surveyService = surveyService;
-    }
-    @Autowired
-    public final void setScheduledActivityService(ScheduledActivityService activityService) {
-        this.activityService = activityService;
     }
 
     public List<SchedulePlan> getSchedulePlans(ClientInfo clientInfo, StudyIdentifier studyIdentifier) {
@@ -79,9 +74,7 @@ public class SchedulePlanService {
         
         StudyIdentifier studyId = new StudyIdentifierImpl(plan.getStudyKey());
         lookupSurveyReferenceIdentifiers(studyId, plan);
-        plan = schedulePlanDao.updateSchedulePlan(studyId, plan);
-        activityService.deleteActivitiesForSchedulePlan(plan.getGuid());
-        return plan;
+        return schedulePlanDao.updateSchedulePlan(studyId, plan);
     }
 
     public void deleteSchedulePlan(StudyIdentifier studyIdentifier, String guid) {
@@ -89,8 +82,6 @@ public class SchedulePlanService {
         checkNotNull(isNotBlank(guid));
         
         schedulePlanDao.deleteSchedulePlan(studyIdentifier, guid);
-        
-        activityService.deleteActivitiesForSchedulePlan(guid);
     }
     
     /**

--- a/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
+++ b/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
@@ -155,12 +155,6 @@ public class ScheduledActivityService {
         activityDao.deleteActivitiesForUser(healthCode);
     }
     
-    public void deleteActivitiesForSchedulePlan(String schedulePlanGuid) {
-        checkArgument(isNotBlank(schedulePlanGuid));
-        
-        activityDao.deleteActivitiesForSchedulePlan(schedulePlanGuid);
-    }
-    
     protected List<ScheduledActivity> updateActivitiesAndCollectSaves(List<ScheduledActivity> scheduledActivities, List<ScheduledActivity> dbActivities) {
         Map<String, ScheduledActivity> dbMap = Maps.uniqueIndex(dbActivities, ScheduledActivity::getGuid);
         

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDaoTest.java
@@ -1,8 +1,6 @@
 package org.sagebionetworks.bridge.dynamodb;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.TestConstants.ENROLLMENT;
@@ -156,41 +154,6 @@ public class DynamoScheduledActivityDaoTest {
         activityDao.deleteActivitiesForUser(user.getHealthCode());
         savedActivities = activityDao.getActivities(context.getZone(), savedActivities);
         assertEquals("all activities deleted", 0, savedActivities.size());
-    }
-    
-    @Test
-    public void createActivitiesAndDeleteSomeBySchedulePlan() throws Exception {
-        DateTime endsOn = DateTime.now().plus(Period.parse("P4D"));
-        
-        ScheduleContext context = new ScheduleContext.Builder()
-                .withUser(user)
-                .withClientInfo(ClientInfo.UNKNOWN_CLIENT)
-                .withTimeZone(DateTimeZone.UTC)
-                .withEndsOn(endsOn)
-                .withEvents(eventMap()).build();
-        
-        // Schedule plans are specific to this test because we're going to delete them;
-        List<SchedulePlan> plans = getSchedulePlans();
-        SchedulePlan testPlan = plans.get(0);
-        
-        List<ScheduledActivity> activities = TestUtils.runSchedulerForActivities(plans, context);
-        activityDao.saveActivities(activities);
-
-        // Get one schedule plan GUID to delete and the initial count
-        int initialCount = activities.size();
-        assertTrue("there are activities", initialCount > 1);
-        activityDao.deleteActivitiesForSchedulePlan(testPlan.getGuid());
-
-        // Sleep before getting because of eventual consistency issues.
-        Thread.sleep(5000);
-
-        activities = activityDao.getActivities(context.getZone(), activities);
-        // The count is now less than before
-        assertTrue(initialCount > activities.size());
-        // and the supplied schedulePlanGuid cannot be found in any of the activities that still exist
-        for (ScheduledActivity activity : activities) {
-            assertNotEquals(testPlan.getGuid(), activity.getSchedulePlanGuid());
-        }
     }
     
     private Map<String,DateTime> eventMap() {

--- a/test/org/sagebionetworks/bridge/services/SchedulePlanServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/SchedulePlanServiceMockTest.java
@@ -45,7 +45,6 @@ public class SchedulePlanServiceMockTest {
     
     private SchedulePlanDao mockSchedulePlanDao;
     private SurveyService mockSurveyService;
-    private ScheduledActivityService mockActivityService;
     
     @Before
     public void before() {
@@ -56,12 +55,10 @@ public class SchedulePlanServiceMockTest {
         
         mockSchedulePlanDao = mock(SchedulePlanDao.class);
         mockSurveyService = mock(SurveyService.class);
-        mockActivityService = mock(ScheduledActivityService.class);
         
         service = new SchedulePlanService();
         service.setSchedulePlanDao(mockSchedulePlanDao);
         service.setSurveyService(mockSurveyService);
-        service.setScheduledActivityService(mockActivityService);
         
         Survey survey1 = TestUtils.getSurvey(false);
         survey1.setIdentifier("identifier1");
@@ -186,22 +183,6 @@ public class SchedulePlanServiceMockTest {
         
         plan = service.updateSchedulePlan(anotherStudy, plan);
         assertEquals("another-study", plan.getStudyKey());
-    }
-    
-    @Test
-    public void cleansUpScheduledActivitiesOnUpdate() {
-        SchedulePlan plan = getSchedulePlan();
-        when(mockSchedulePlanDao.updateSchedulePlan(study.getStudyIdentifier(), plan)).thenReturn(plan);
-        
-        service.updateSchedulePlan(study, plan);
-        verify(mockActivityService).deleteActivitiesForSchedulePlan("BBB");
-    }
-    
-    @Test
-    public void cleansUpScheduledActivitiesOnDelete() {
-        service.deleteSchedulePlan(TEST_STUDY, "BBB");
-        
-        verify(mockActivityService).deleteActivitiesForSchedulePlan("BBB");
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceMockTest.java
@@ -283,12 +283,6 @@ public class ScheduledActivityServiceMockTest {
         verify(activityDao).deleteActivitiesForUser("AAA");
     }
     
-    @Test
-    public void deleteScheduledActivitiesForSchedulePlan() {
-        service.deleteActivitiesForSchedulePlan("BBB");
-        verify(activityDao).deleteActivitiesForSchedulePlan("BBB");
-    }
-    
     @Test(expected = IllegalArgumentException.class)
     public void deleteActivitiesForUserRejectsBadValue() {
         service.deleteActivitiesForUser(null);

--- a/test/org/sagebionetworks/bridge/services/email/ParticipantRosterProviderTest.java
+++ b/test/org/sagebionetworks/bridge/services/email/ParticipantRosterProviderTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 import java.util.Set;
-import java.util.TreeSet;
 
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
Once in production, this becomes impossible as-is (you'll just get throughput exceptions). This was most important during study development where scheduling changes were not visible to developers or the total tasks (old and new) were confusing. Moving forward, clone a schedule plan and delete the old plan to force an update of tasks without having to delete the existing tasks.
