### PR TITLE
Once cached, any user could retrieve a survey. Fixed.

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/SurveyController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/SurveyController.java
@@ -82,22 +82,6 @@ public class SurveyController extends BaseController {
         verifySurveyIsInStudy(session, surveys);
         return okResult(surveys);
     }
-    
-    public Result getSurveyForUser(String surveyGuid, String createdOnString) throws Exception {
-        UserSession session = getAuthenticatedAndConsentedSession();
-        StudyIdentifier studyId = session.getStudyIdentifier();
-        
-        long createdOn = DateUtils.convertToMillisFromEpoch(createdOnString);
-        GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl(surveyGuid, createdOn);
-
-        ViewCacheKey<Survey> cacheKey = viewCache.getCacheKey(Survey.class, surveyGuid, createdOnString, studyId.getIdentifier());
-        
-        String json = getView(cacheKey, session, () -> {
-            return surveyService.getSurvey(keys);
-        });
-
-        return ok(json).as(JSON_MIME_TYPE);
-    }
 
     public Result getSurveyMostRecentlyPublishedVersionForUser(String surveyGuid) throws Exception {
         UserSession session = getAuthenticatedAndConsentedSession();
@@ -118,6 +102,18 @@ public class SurveyController extends BaseController {
         StudyIdentifier studyId = session.getStudyIdentifier();
         canAccessSurvey(session);
         
+        return getSurveyInternal(surveyGuid, createdOnString, session, studyId);
+    }
+    
+    public Result getSurveyForUser(String surveyGuid, String createdOnString) throws Exception {
+        UserSession session = getAuthenticatedAndConsentedSession();
+        StudyIdentifier studyId = session.getStudyIdentifier();
+        
+        return getSurveyInternal(surveyGuid, createdOnString, session, studyId);
+    }
+
+    private Result getSurveyInternal(String surveyGuid, String createdOnString, UserSession session,
+            StudyIdentifier studyId) {
         long createdOn = DateUtils.convertToMillisFromEpoch(createdOnString);
         GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl(surveyGuid, createdOn);
 

--- a/app/org/sagebionetworks/bridge/play/controllers/SurveyController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/SurveyController.java
@@ -111,20 +111,6 @@ public class SurveyController extends BaseController {
         
         return getSurveyInternal(surveyGuid, createdOnString, session, studyId);
     }
-
-    private Result getSurveyInternal(String surveyGuid, String createdOnString, UserSession session,
-            StudyIdentifier studyId) {
-        long createdOn = DateUtils.convertToMillisFromEpoch(createdOnString);
-        GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl(surveyGuid, createdOn);
-
-        ViewCacheKey<Survey> cacheKey = viewCache.getCacheKey(Survey.class, surveyGuid, createdOnString, studyId.getIdentifier());
-        
-        String json = getView(cacheKey, session, () -> {
-            return surveyService.getSurvey(keys);
-        });
-
-        return ok(json).as(JSON_MIME_TYPE);
-    }
     
     public Result getSurveyMostRecentVersion(String surveyGuid) throws Exception {
         UserSession session = getAuthenticatedSession(DEVELOPER);
@@ -264,6 +250,20 @@ public class SurveyController extends BaseController {
         expireCache(surveyGuid, createdOnString, studyId);
         
         return okResult(new GuidCreatedOnVersionHolderImpl(survey));
+    }
+    
+    private Result getSurveyInternal(String surveyGuid, String createdOnString, UserSession session,
+            StudyIdentifier studyId) {
+        long createdOn = DateUtils.convertToMillisFromEpoch(createdOnString);
+        GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl(surveyGuid, createdOn);
+
+        ViewCacheKey<Survey> cacheKey = viewCache.getCacheKey(Survey.class, surveyGuid, createdOnString, studyId.getIdentifier());
+        
+        String json = getView(cacheKey, session, () -> {
+            return surveyService.getSurvey(keys);
+        });
+
+        return ok(json).as(JSON_MIME_TYPE);
     }
     
     private String getView(ViewCacheKey<Survey> cacheKey, UserSession session, Supplier<Survey> supplier) {

--- a/app/org/sagebionetworks/bridge/play/controllers/SurveyController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/SurveyController.java
@@ -34,8 +34,8 @@ import com.google.common.base.Supplier;
 @Controller
 public class SurveyController extends BaseController {
 
-    private static final String MOSTRECENT_KEY = "mostrecent";
-    private static final String PUBLISHED_KEY = "published";
+    public static final String MOSTRECENT_KEY = "mostrecent";
+    public static final String PUBLISHED_KEY = "published";
 
     private SurveyService surveyService;
     

--- a/conf/routes
+++ b/conf/routes
@@ -62,7 +62,7 @@ POST   /v3/users/self/dataGroups        @org.sagebionetworks.bridge.play.control
 # Surveys
 GET    /v3/surveys                                           @org.sagebionetworks.bridge.play.controllers.SurveyController.getAllSurveysMostRecentVersion
 POST   /v3/surveys                                           @org.sagebionetworks.bridge.play.controllers.SurveyController.createSurvey
-GET    /v3/surveys/recent                                    @org.sagebionetworks.bridge.play.controllers.SurveyController.getAllSurveysMostRecentVersion2
+GET    /v3/surveys/recent                                    @org.sagebionetworks.bridge.play.controllers.SurveyController.getAllSurveysMostRecentVersion
 GET    /v3/surveys/published                                 @org.sagebionetworks.bridge.play.controllers.SurveyController.getAllSurveysMostRecentlyPublishedVersion
 GET    /v3/surveys/:surveyGuid/revisions                     @org.sagebionetworks.bridge.play.controllers.SurveyController.getSurveyAllVersions(surveyGuid: String)
 GET    /v3/surveys/:surveyGuid/revisions/recent              @org.sagebionetworks.bridge.play.controllers.SurveyController.getSurveyMostRecentVersion(surveyGuid: String)

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoTest.java
@@ -17,7 +17,6 @@ import java.util.Set;
 
 import javax.annotation.Resource;
 
-import org.joda.time.LocalDate;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,13 +25,11 @@ import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.exceptions.ConcurrentModificationException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.PublishedSurveyException;
-import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolder;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolderImpl;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.surveys.DateConstraints;
-import org.sagebionetworks.bridge.models.surveys.MultiValueConstraints;
 import org.sagebionetworks.bridge.models.surveys.Survey;
 import org.sagebionetworks.bridge.models.surveys.SurveyElement;
 import org.sagebionetworks.bridge.models.surveys.SurveyInfoScreen;

--- a/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
@@ -824,10 +824,11 @@ public class SurveyControllerTest {
         when(service.versionSurvey(any())).thenReturn(survey);
         when(service.updateSurvey(any())).thenReturn(survey);
         
-        // execute the text method, this should delete the cache
+        // execute the test method, this should delete the cache
         executeSurvey.execute(guid, now.toString());
+        verify(service).getSurvey(any());
         
-        // So this call hits the service, for a total of two calls to the service in total.
+        // This call now hits the service, not the cache, for a total of two calls to the service
         controller.getSurvey(guid, now.toString());
         verify(service, times(2)).getSurvey(any());
     }

--- a/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
@@ -8,8 +8,6 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
@@ -149,12 +149,11 @@ public class SurveyControllerTest {
         verifyNoMoreInteractions(service);
     }
     
-    @Test
-    public void getAllSurveysMostRecentVersion2() throws Exception {
+    public void getAllSurveysMostRecentVersion() throws Exception {
         setContext();
         when(service.getAllSurveysMostRecentVersion(any(StudyIdentifier.class))).thenReturn(getSurveys(3, false));
         
-        controller.getAllSurveysMostRecentVersion2();
+        controller.getAllSurveysMostRecentVersion();
         
         verify(service).getAllSurveysMostRecentVersion(any(StudyIdentifier.class));
         verifyNoMoreInteractions(service);
@@ -167,7 +166,7 @@ public class SurveyControllerTest {
         setUserSession("secondstudy");
 
         try {
-            controller.getAllSurveysMostRecentVersion2();
+            controller.getAllSurveysMostRecentVersion();
             fail("Should have thrown exception");
         } catch(UnauthorizedException e) {
             verify(service).getAllSurveysMostRecentVersion(any(StudyIdentifier.class));


### PR DESCRIPTION
Added the requestor's study to the key. When retrieved from the db, a requestor outside the study will get an error and no caching, thus a check each time, while someone in the study, who is successful, will get the survey cached under a key with that study in it. Users outside the study can thus never retrieve a cached version of the survey.

https://sagebionetworks.jira.com/browse/BRIDGE-1103
