### PR TITLE
Username is removed from the system

### DIFF
--- a/app/org/sagebionetworks/bridge/json/SignInDeserializer.java
+++ b/app/org/sagebionetworks/bridge/json/SignInDeserializer.java
@@ -1,0 +1,30 @@
+package org.sagebionetworks.bridge.json;
+
+import java.io.IOException;
+
+import org.apache.commons.lang3.StringUtils;
+
+import org.sagebionetworks.bridge.models.accounts.SignIn;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class SignInDeserializer extends JsonDeserializer<SignIn> {
+
+    @Override
+    public SignIn deserialize(JsonParser parser, DeserializationContext context) throws IOException, JsonProcessingException {
+        JsonNode node = parser.getCodec().readTree(parser);
+        String username = JsonUtils.asText(node, "username");
+        String email = JsonUtils.asText(node, "email");
+        String password = JsonUtils.asText(node, "password");
+        
+        if (StringUtils.isNotBlank(username)) {
+            return new SignIn(username, password);
+        }
+        return new SignIn(email, password);
+    }
+
+}

--- a/app/org/sagebionetworks/bridge/models/accounts/Account.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/Account.java
@@ -25,9 +25,6 @@ public interface Account extends BridgeEntity {
         return null;
     }
     
-    public String getUsername();
-    public void setUsername(String username);
-    
     public String getFirstName();
     public void setFirstName(String firstName);
     

--- a/app/org/sagebionetworks/bridge/models/accounts/SignIn.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/SignIn.java
@@ -1,22 +1,25 @@
 package org.sagebionetworks.bridge.models.accounts;
 
 import org.apache.commons.lang3.StringUtils;
+
+import org.sagebionetworks.bridge.json.SignInDeserializer;
 import org.sagebionetworks.bridge.models.BridgeEntity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
+@JsonDeserialize(using = SignInDeserializer.class)
 public final class SignIn implements BridgeEntity {
 
-    private final String username;
+    private final String email;
     private final String password;
     
-    public SignIn(@JsonProperty("username") String username, @JsonProperty("password") String password) {
-        this.username = username;
+    public SignIn(String email, String password) {
+        this.email = email;
         this.password = password;
     }
-
-    public String getUsername() {
-        return username;
+    
+    public String getEmail() {
+        return email;
     }
 
     public String getPassword() {
@@ -24,6 +27,6 @@ public final class SignIn implements BridgeEntity {
     }
     
     public boolean isBlank() {
-        return StringUtils.isBlank(username) && StringUtils.isBlank(password);
+        return StringUtils.isBlank(email) && StringUtils.isBlank(password);
     }
 }

--- a/app/org/sagebionetworks/bridge/models/accounts/SignUp.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/SignUp.java
@@ -60,7 +60,7 @@ public final class SignUp implements BridgeEntity {
 
     @Override
     public String toString() {
-        return "SignUp [email=" + email + ", password=" + password + ", roles=" + roles + ", dataGroups="+ dataGroups +"]";
+        return "SignUp [email=" + email + ", password=[redacted], roles=" + roles + ", dataGroups="+ dataGroups +"]";
     }
 
 }

--- a/app/org/sagebionetworks/bridge/models/accounts/SignUp.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/SignUp.java
@@ -12,25 +12,18 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public final class SignUp implements BridgeEntity {
 
-    private final String username;
     private final String email;
     private final String password;
     private final Set<Roles> roles;
     private final Set<String> dataGroups;
 
     @JsonCreator
-    public SignUp(@JsonProperty("username") String username, @JsonProperty("email") String email, 
-            @JsonProperty("password") String password, @JsonProperty("roles") Set<Roles> roles, 
-            @JsonProperty("dataGroups") Set<String> dataGroups) {
-        this.username = username;
+    public SignUp(@JsonProperty("email") String email, @JsonProperty("password") String password,
+            @JsonProperty("roles") Set<Roles> roles, @JsonProperty("dataGroups") Set<String> dataGroups) {
         this.email = email;
         this.password = password;
         this.roles = BridgeUtils.nullSafeImmutableSet(roles);
         this.dataGroups = BridgeUtils.nullSafeImmutableSet(dataGroups);
-    }
-
-    public String getUsername() {
-        return username;
     }
 
     public String getEmail() {
@@ -51,7 +44,7 @@ public final class SignUp implements BridgeEntity {
 
     @Override
     public int hashCode() {
-        return Objects.hash(email, password, roles, username, dataGroups);
+        return Objects.hash(email, password, roles, dataGroups);
     }
 
     @Override
@@ -62,13 +55,12 @@ public final class SignUp implements BridgeEntity {
             return false;
         SignUp other = (SignUp) obj;
         return (Objects.equals(email, other.email) && Objects.equals(password, other.password) && 
-                Objects.equals(roles, other.roles) && Objects.equals(username,  other.username) && 
-                Objects.equals(dataGroups, other.dataGroups));
+                Objects.equals(roles, other.roles) && Objects.equals(dataGroups, other.dataGroups));
     }
 
     @Override
     public String toString() {
-        return "SignUp [username=" + username + ", email=" + email + ", password=" + password + ", roles=" + roles + ", dataGroups="+ dataGroups +"]";
+        return "SignUp [email=" + email + ", password=" + password + ", roles=" + roles + ", dataGroups="+ dataGroups +"]";
     }
 
 }

--- a/app/org/sagebionetworks/bridge/models/accounts/User.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/User.java
@@ -27,7 +27,6 @@ public final class User implements BridgeEntity {
             BridgeConfigFactory.getConfig().getProperty("bridge.healthcode.redis.key"));
 
     private String id;
-    private String username;
     private String firstName;
     private String lastName;
     private String email;
@@ -45,7 +44,6 @@ public final class User implements BridgeEntity {
     public User(Account account) {
         this();
         this.email = account.getEmail();
-        this.username = account.getUsername();
         this.firstName = account.getFirstName();
         this.lastName = account.getLastName();
         this.id = account.getId();
@@ -63,14 +61,6 @@ public final class User implements BridgeEntity {
 
     public void setEmail(String email) {
         this.email = email;
-    }
-
-    public String getUsername() {
-        return username;
-    }
-
-    public void setUsername(String username) {
-        this.username = username;
     }
 
     public String getFirstName() {
@@ -181,8 +171,8 @@ public final class User implements BridgeEntity {
     
     @Override
     public int hashCode() {
-        return Objects.hashCode(email, firstName, lastName, healthCode, id, roles, sharingScope, studyKey, username,
-                dataGroups, consentStatuses);
+        return Objects.hashCode(email, firstName, lastName, healthCode, id, roles, sharingScope, 
+                studyKey, dataGroups, consentStatuses);
     }
 
     @Override
@@ -196,13 +186,13 @@ public final class User implements BridgeEntity {
                 && Objects.equal(lastName, other.lastName) && Objects.equal(healthCode, other.healthCode)
                 && Objects.equal(id, other.id) && Objects.equal(roles, other.roles)
                 && Objects.equal(sharingScope, other.sharingScope) && Objects.equal(studyKey, other.studyKey)
-                && Objects.equal(username, other.username) && Objects.equal(dataGroups, other.dataGroups)
+                && Objects.equal(dataGroups, other.dataGroups)
                 && Objects.equal(consentStatuses, other.consentStatuses));
     }
 
     @Override
     public String toString() {
-        return String.format("User [email=%s, firstName=%s, lastName=%s, id=%s, roles=%s, sharingScope=%s, studyKey=%s, username=%s, dataGroups=%s, consentStatuses=%s]", 
-                email, firstName, lastName, id, roles, sharingScope, studyKey, username, dataGroups, consentStatuses);
+        return String.format("User [email=%s, firstName=%s, lastName=%s, id=%s, roles=%s, sharingScope=%s, studyKey=%s, dataGroups=%s, consentStatuses=%s]", 
+                email, firstName, lastName, id, roles, sharingScope, studyKey, dataGroups, consentStatuses);
     }
 }

--- a/app/org/sagebionetworks/bridge/models/accounts/UserProfile.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/UserProfile.java
@@ -55,7 +55,10 @@ public class UserProfile {
         return profile;
     }
 
-    // For backwards compatibility with API prior to the switch to using email only.
+    /**
+     * Provided for API compatibility, this is always the email address of the account. 
+     * @deprecated
+     */
     public String getUsername() {
         return this.email;
     }

--- a/app/org/sagebionetworks/bridge/models/accounts/UserProfile.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/UserProfile.java
@@ -18,7 +18,6 @@ public class UserProfile {
     public static final String FIRST_NAME_FIELD = "firstName";
     public static final String LAST_NAME_FIELD = "lastName";
     public static final String EMAIL_FIELD = "email";
-    public static final String USERNAME_FIELD = "username";
     public static final String HEALTH_CODE_FIELD = "healthCode";
     public static final String SUBPOPULATION_NAMES_FIELD = "subpopulations";
     public static final String EXTERNAL_ID_FIELD = "externalId";
@@ -32,11 +31,10 @@ public class UserProfile {
     public static final String NOTIFY_BY_EMAIL_FIELD = "notifyByEmail";
     
     public static final Set<String> FIXED_PROPERTIES = Sets.newHashSet(FIRST_NAME_FIELD, LAST_NAME_FIELD,
-            EMAIL_FIELD, USERNAME_FIELD, SHARING_SCOPE_FIELD);
+            EMAIL_FIELD, SHARING_SCOPE_FIELD);
     
     private String firstName;
     private String lastName;
-    private String username;
     private String email;
     private Map<String,String> attributes;
 
@@ -56,28 +54,23 @@ public class UserProfile {
         }
         return profile;
     }
-    
+
+    // For backwards compatibility with API prior to the switch to using email only.
+    public String getUsername() {
+        return this.email;
+    }
     public String getFirstName() {
         return this.firstName;
     }
     public void setFirstName(String firstName) {
         this.firstName = firstName;
     }
-
     public String getLastName() {
         return this.lastName;
     }
     public void setLastName(String lastName) {
         this.lastName = lastName;
     }
-
-    public String getUsername() {
-        return this.username;
-    }
-    public void setUsername(String username) {
-        this.username = username;
-    }
-
     public String getEmail() {
         return this.email;
     }

--- a/app/org/sagebionetworks/bridge/models/accounts/UserSessionInfo.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/UserSessionInfo.java
@@ -28,8 +28,8 @@ public class UserSessionInfo {
     private final boolean authenticated;
     private final SharingScope sharingScope;
     private final String sessionToken;
-    private final String username;
     private final String environment;
+    private final String email;
     private final Set<Roles> roles;
     private final Set<String> dataGroups;
     private final Map<SubpopulationGuid,ConsentStatus> consentStatuses;
@@ -38,10 +38,10 @@ public class UserSessionInfo {
         this.authenticated = session.isAuthenticated();
         this.sessionToken = session.getSessionToken();
         this.sharingScope = session.getUser().getSharingScope();
-        this.username = session.getUser().getUsername();
         this.roles = BridgeUtils.nullSafeImmutableSet(session.getUser().getRoles());
         this.dataGroups = BridgeUtils.nullSafeImmutableSet(session.getUser().getDataGroups());
         this.environment = ENVIRONMENTS.get(session.getEnvironment());
+        this.email = session.getUser().getEmail();
         this.consentStatuses = session.getUser().getConsentStatuses();
     }
 
@@ -67,7 +67,7 @@ public class UserSessionInfo {
         return sessionToken;
     }
     public String getUsername() {
-        return username;
+        return email;
     }
     public String getEnvironment() {
         return environment;

--- a/app/org/sagebionetworks/bridge/models/accounts/UserSessionInfo.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/UserSessionInfo.java
@@ -66,6 +66,10 @@ public class UserSessionInfo {
     public String getSessionToken() {
         return sessionToken;
     }
+    /**
+     * Provided for API compatibility, this is always the email address of the account. 
+     * @deprecated
+     */
     public String getUsername() {
         return email;
     }

--- a/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
@@ -46,8 +46,7 @@ public class AuthenticationController extends BaseController {
         JsonNode json = requestToJSON(request());
         SignUp signUp = parseJson(request(), SignUp.class);
         // this is now the only way to eliminate roles if set by the user...
-        signUp = new SignUp(signUp.getUsername(), signUp.getEmail(), 
-                signUp.getPassword(), null, signUp.getDataGroups()); 
+        signUp = new SignUp(signUp.getEmail(), signUp.getPassword(), null, signUp.getDataGroups()); 
         Study study = getStudyOrThrowException(json);
         authenticationService.signUp(study, signUp, true);
         return createdResult("Signed up.");

--- a/app/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -136,7 +136,7 @@ public class AuthenticationService {
         checkNotNull(signIn, "Sign in cannot be null");
         Validate.entityThrowingException(signInValidator, signIn);
 
-        final String signInLock = study.getIdentifier() + RedisKey.SEPARATOR + signIn.getUsername();
+        final String signInLock = study.getIdentifier() + RedisKey.SEPARATOR + signIn.getEmail();
         String lockId = null;
         try {
             lockId = lockDao.acquireLock(SignIn.class, signInLock, LOCK_EXPIRE_IN_SECONDS);

--- a/app/org/sagebionetworks/bridge/services/UserAdminService.java
+++ b/app/org/sagebionetworks/bridge/services/UserAdminService.java
@@ -128,7 +128,7 @@ public class UserAdminService {
         authenticationService.signUp(study, signUp, false);
 
         try {
-            SignIn signIn = new SignIn(signUp.getUsername(), signUp.getPassword());
+            SignIn signIn = new SignIn(signUp.getEmail(), signUp.getPassword());
             UserSession newUserSession = authenticationService.signIn(study, ClientInfo.UNKNOWN_CLIENT, signIn);
 
             if (consentUser) {

--- a/app/org/sagebionetworks/bridge/services/UserDataDownloadViaSqsService.java
+++ b/app/org/sagebionetworks/bridge/services/UserDataDownloadViaSqsService.java
@@ -52,14 +52,14 @@ public class UserDataDownloadViaSqsService implements UserDataDownloadService {
     public void requestUserData(@Nonnull StudyIdentifier studyIdentifier, @Nonnull User user,
             @Nonnull DateRange dateRange) throws JsonProcessingException {
         String studyId = studyIdentifier.getIdentifier();
-        String username = user.getUsername();
+        String email = user.getEmail();
         String startDateStr = dateRange.getStartDate().toString();
         String endDateStr = dateRange.getEndDate().toString();
 
         // construct message as string-string map
         Map<String, String> requestMap = new HashMap<>();
         requestMap.put(REQUEST_KEY_STUDY_ID, studyId);
-        requestMap.put(REQUEST_KEY_USERNAME, username);
+        requestMap.put(REQUEST_KEY_USERNAME, email);
         requestMap.put(REQUEST_KEY_START_DATE, startDateStr);
         requestMap.put(REQUEST_KEY_END_DATE, endDateStr);
 
@@ -70,7 +70,7 @@ public class UserDataDownloadViaSqsService implements UserDataDownloadService {
         // send to SQS
         String queueUrl = bridgeConfig.getProperty(CONFIG_KEY_UDD_SQS_QUEUE_URL);
         SendMessageResult sqsResult = sqsClient.sendMessage(queueUrl, requestJsonText);
-        logger.info("Sent request to SQS for hash[username]=" + username.hashCode() + ", study=" + studyId +
+        logger.info("Sent request to SQS for hash[username]=" + email.hashCode() + ", study=" + studyId +
                 ", startDate=" + startDateStr + ", endDate=" + endDateStr + "; received message ID=" +
                 sqsResult.getMessageId());
     }

--- a/app/org/sagebionetworks/bridge/services/UserProfileService.java
+++ b/app/org/sagebionetworks/bridge/services/UserProfileService.java
@@ -101,7 +101,6 @@ public class UserProfileService {
         UserProfile profile = new UserProfile();
         profile.setFirstName(account.getFirstName());
         profile.setLastName(account.getLastName());
-        profile.setUsername(account.getUsername());
         profile.setEmail(account.getEmail());
         for (String attribute : study.getUserProfileAttributes()) {
             profile.setAttribute(attribute, account.getAttribute(attribute));

--- a/app/org/sagebionetworks/bridge/stormpath/StormpathAccount.java
+++ b/app/org/sagebionetworks/bridge/stormpath/StormpathAccount.java
@@ -99,14 +99,6 @@ class StormpathAccount implements Account {
     }
     
     @Override
-    public String getUsername() {
-        return acct.getUsername();
-    }
-    @Override
-    public void setUsername(String username) {
-        acct.setUsername(username);
-    }
-    @Override
     public String getFirstName() {
         String firstName = acct.getGivenName();
         return (PLACEHOLDER_STRING.equals(firstName)) ? null : firstName;
@@ -147,6 +139,7 @@ class StormpathAccount implements Account {
     @Override
     public void setEmail(String email) {
         acct.setEmail(email);
+        acct.setUsername(email);
     }
     @Override
     public String getHealthId(){
@@ -282,8 +275,8 @@ class StormpathAccount implements Account {
     
     @Override
     public String toString() {
-        return String.format("StormpathAccount [username=%s, firstName=%s, lastName=%s, email=%s, roles=%s, signatures=%s]",
-                getUsername(), getFirstName(), getLastName(), getEmail(), getRoles(), getAllConsentSignatureHistories());
+        return String.format("StormpathAccount [firstName=%s, lastName=%s, email=%s, roles=%s, signatures=%s]",
+                getFirstName(), getLastName(), getEmail(), getRoles(), getAllConsentSignatureHistories());
     }
 
 }

--- a/app/org/sagebionetworks/bridge/stormpath/StormpathAccountDao.java
+++ b/app/org/sagebionetworks/bridge/stormpath/StormpathAccountDao.java
@@ -183,7 +183,7 @@ public class StormpathAccountDao implements AccountDao {
     public Account authenticate(Study study, SignIn signIn) {
         checkNotNull(study);
         checkNotNull(signIn);
-        checkArgument(isNotBlank(signIn.getUsername()));
+        checkArgument(isNotBlank(signIn.getEmail()));
         checkArgument(isNotBlank(signIn.getPassword()));
         
         try {
@@ -191,7 +191,7 @@ public class StormpathAccountDao implements AccountDao {
             List<SubpopulationGuid> subpopGuids = getSubpopulationGuids(study);
             
             AuthenticationRequest<?,?> request = UsernamePasswordRequest.builder()
-                    .setUsernameOrEmail(signIn.getUsername())
+                    .setUsernameOrEmail(signIn.getEmail())
                     .setPassword(signIn.getPassword())
                     .inAccountStore(directory).build();
             AuthenticationResult result = application.authenticateAccount(request);
@@ -230,7 +230,6 @@ public class StormpathAccountDao implements AccountDao {
         
         com.stormpath.sdk.account.Account acct = client.instantiate(com.stormpath.sdk.account.Account.class);
         Account account = new StormpathAccount(study.getStudyIdentifier(), subpopGuids, acct, encryptors);
-        account.setUsername(signUp.getUsername());
         account.setEmail(signUp.getEmail());
         account.setFirstName(StormpathAccount.PLACEHOLDER_STRING);
         account.setLastName(StormpathAccount.PLACEHOLDER_STRING);

--- a/app/org/sagebionetworks/bridge/validators/SignInValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/SignInValidator.java
@@ -18,8 +18,8 @@ public class SignInValidator implements Validator {
     public void validate(Object object, Errors errors) {
         SignIn signIn = (SignIn)object;
         
-        if (StringUtils.isBlank(signIn.getUsername())) {
-            errors.rejectValue("username", "required");
+        if (StringUtils.isBlank(signIn.getEmail())) {
+            errors.rejectValue("email", "required");
         }
         if (StringUtils.isBlank(signIn.getPassword())) {
             errors.rejectValue("password", "required");

--- a/app/org/sagebionetworks/bridge/validators/SignUpValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/SignUpValidator.java
@@ -37,9 +37,6 @@ public class SignUpValidator extends DataGroupsValidator {
         } else if (!emailValidator.isValid(signUp.getEmail())){
             errors.rejectValue("email", "must be a valid email address");
         }
-        if (StringUtils.isBlank(signUp.getUsername())) {
-            errors.rejectValue("username", "is required");
-        }
         if (StringUtils.isBlank(signUp.getPassword())) {
             errors.rejectValue("password", "is required");
             return;

--- a/test/org/sagebionetworks/bridge/TestConstants.java
+++ b/test/org/sagebionetworks/bridge/TestConstants.java
@@ -23,7 +23,7 @@ public class TestConstants {
     public static final String STUDIES_URL = API_URL + "/studies/";
 
     public static final String APPLICATION_JSON = "application/json";
-    public static final String USERNAME = "username";
+    public static final String EMAIL = "email";
     public static final String PASSWORD = "password";
     public static final String SESSION_TOKEN = "sessionToken";
 

--- a/test/org/sagebionetworks/bridge/TestUserAdminHelper.java
+++ b/test/org/sagebionetworks/bridge/TestUserAdminHelper.java
@@ -40,7 +40,6 @@ public class TestUserAdminHelper {
     StudyService studyService;
 
     public class TestUser {
-        private final String username;
         private final String email;
         private final String password;
         private final Set<Roles> roles;
@@ -49,7 +48,6 @@ public class TestUserAdminHelper {
         private final UserSession session;
 
         public TestUser(SignUp signUp, Study study, UserSession session) {
-            this.username = signUp.getUsername();
             this.email = signUp.getEmail();
             this.password = signUp.getPassword();
             this.roles = Sets.newHashSet(signUp.getRoles());
@@ -59,13 +57,10 @@ public class TestUserAdminHelper {
             this.session = session;
         }
         public SignUp getSignUp() {
-            return new SignUp(username, email, password, roles, dataGroups);
+            return new SignUp(email, password, roles, dataGroups);
         }
         public SignIn getSignIn() {
-            return new SignIn(username, password);
-        }
-        public String getUsername() {
-            return username;
+            return new SignIn(email, password);
         }
         public String getEmail() {
             return email;
@@ -180,7 +175,7 @@ public class TestUserAdminHelper {
                 study = studyService.getStudy(TEST_STUDY_IDENTIFIER);
             }
             String name = makeRandomUserName(cls);
-            SignUp finalSignUp = (signUp != null) ? signUp : new SignUp(name, name + EMAIL_DOMAIN, PASSWORD, roles, dataGroups);
+            SignUp finalSignUp = (signUp != null) ? signUp : new SignUp(name + EMAIL_DOMAIN, PASSWORD, roles, dataGroups);
             UserSession session = userAdminService.createUser(finalSignUp, study, subpopGuid, signIn, consent);
             
             return new TestUser(finalSignUp, study, session);

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -114,11 +114,7 @@ public class TestUtils {
     }
     
     public static String randomName(Class<?> clazz) {
-        return TestUtils.randomName(clazz.getSimpleName().toLowerCase() + "-");
-    }
-
-    public static String randomName(String midFix) {
-        return "test-" + midFix + RandomStringUtils.randomAlphabetic(5).toLowerCase();
+        return "test-" + clazz.getSimpleName().toLowerCase() + "-" + RandomStringUtils.randomAlphabetic(5).toLowerCase();
     }
 
     public static List<ScheduledActivity> runSchedulerForActivities(List<SchedulePlan> plans, ScheduleContext context) {

--- a/test/org/sagebionetworks/bridge/models/accounts/SignInTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/SignInTest.java
@@ -27,4 +27,14 @@ public class SignInTest {
         assertEquals("aName", signIn.getEmail());
         assertEquals("password", signIn.getPassword());
     }
+    
+    @Test
+    public void preferUsernameOverEmailForBackwardsCompatability() throws Exception {
+        String json = "{\"username\":\"aName\",\"email\":\"email@email.com\",\"password\":\"password\"}";
+
+        SignIn signIn = BridgeObjectMapper.get().readValue(json, SignIn.class);
+
+        assertEquals("aName", signIn.getEmail());
+        assertEquals("password", signIn.getPassword());
+    }
 }

--- a/test/org/sagebionetworks/bridge/models/accounts/SignInTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/SignInTest.java
@@ -29,7 +29,7 @@ public class SignInTest {
     }
     
     @Test
-    public void preferUsernameOverEmailForBackwardsCompatability() throws Exception {
+    public void preferUsernameOverEmailForBackwardsCompatibility() throws Exception {
         String json = "{\"username\":\"aName\",\"email\":\"email@email.com\",\"password\":\"password\"}";
 
         SignIn signIn = BridgeObjectMapper.get().readValue(json, SignIn.class);

--- a/test/org/sagebionetworks/bridge/models/accounts/SignInTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/SignInTest.java
@@ -1,0 +1,30 @@
+package org.sagebionetworks.bridge.models.accounts;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+public class SignInTest {
+
+    @Test
+    public void canDeserializeOldJson() throws Exception {
+        String oldJson = "{\"username\":\"aName\",\"password\":\"password\"}";
+
+        SignIn signIn = BridgeObjectMapper.get().readValue(oldJson, SignIn.class);
+
+        assertEquals("aName", signIn.getEmail());
+        assertEquals("password", signIn.getPassword());
+    }
+    
+    @Test
+    public void canDeserialize() throws Exception {
+        String json = "{\"email\":\"aName\",\"password\":\"password\"}";
+
+        SignIn signIn = BridgeObjectMapper.get().readValue(json, SignIn.class);
+
+        assertEquals("aName", signIn.getEmail());
+        assertEquals("password", signIn.getPassword());
+    }
+}

--- a/test/org/sagebionetworks/bridge/models/accounts/SignUpTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/SignUpTest.java
@@ -28,12 +28,11 @@ public class SignUpTest {
     public void canSerialize() throws Exception {
         Set<Roles> roles = Sets.newHashSet(Roles.ADMIN);
         Set<String> dataGroups = Sets.newHashSet("group1", "group2");
-        SignUp signUp = new SignUp("username", "email@email.com", "password", roles, dataGroups);
+        SignUp signUp = new SignUp("email@email.com", "password", roles, dataGroups);
         
         String json = BridgeObjectMapper.get().writeValueAsString(signUp);
         JsonNode node = BridgeObjectMapper.get().readTree(json);
         
-        assertEquals("username", node.get("username").asText());
         assertEquals("email@email.com", node.get("email").asText());
         assertEquals("password", node.get("password").asText());
         assertEquals("SignUp", node.get("type").asText());
@@ -49,7 +48,7 @@ public class SignUpTest {
         assertTrue(groupNames.contains("group1"));
         assertTrue(groupNames.contains("group2"));
         
-        assertEquals(6, TestUtils.getFieldNamesSet(node).size());
+        assertEquals(5, TestUtils.getFieldNamesSet(node).size());
         
         SignUp newSignUp = BridgeObjectMapper.get().readValue(json, SignUp.class); 
         assertEquals(signUp, newSignUp);
@@ -57,7 +56,7 @@ public class SignUpTest {
     
     @Test
     public void nullParametersBreakNothing() {
-        SignUp signUp = new SignUp("username", "email@email.com", "password", null, null);
+        SignUp signUp = new SignUp("email@email.com", "password", null, null);
         
         assertEquals(0, signUp.getRoles().size());
         assertEquals(0, signUp.getDataGroups().size());

--- a/test/org/sagebionetworks/bridge/models/accounts/SignUpTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/SignUpTest.java
@@ -55,11 +55,21 @@ public class SignUpTest {
     }
     
     @Test
-    public void nullParametersBreakNothing() {
+    public void nullParametersBreakNothing() throws Exception {
         SignUp signUp = new SignUp("email@email.com", "password", null, null);
-        
+
         assertEquals(0, signUp.getRoles().size());
         assertEquals(0, signUp.getDataGroups().size());
+    }
+    
+    @Test
+    public void oldJsonParsesCorrectly() throws Exception {
+        // Old clients will continue to submit a username, this will be ignored.
+        String json = "{\"email\":\"email@email.com\",\"username\":\"username@email.com\",\"password\":\"password\",\"roles\":[],\"dataGroups\":[],\"type\":\"SignUp\"}";
+        
+        SignUp signUp = BridgeObjectMapper.get().readValue(json, SignUp.class);
+        assertEquals("email@email.com", signUp.getEmail());
+        assertEquals("password", signUp.getPassword());
     }
 
 }

--- a/test/org/sagebionetworks/bridge/models/accounts/UserSessionInfoTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/UserSessionInfoTest.java
@@ -34,7 +34,6 @@ public class UserSessionInfoTest {
         user.setSharingScope(SharingScope.ALL_QUALIFIED_RESEARCHERS);
         user.setStudyKey("study-identifier");
         user.getDataGroups().add("foo");
-        user.setUsername("username");
         
         UserSession session = new UserSession();
         session.setAuthenticated(true);
@@ -54,12 +53,11 @@ public class UserSessionInfoTest {
         assertEquals(user.doesConsent(), node.get("consented").asBoolean());
         assertEquals(user.getSharingScope().name(), node.get("sharingScope").asText().toUpperCase());
         assertEquals(session.getSessionToken(), node.get("sessionToken").asText());
-        assertEquals(user.getUsername(), node.get("username").asText());
+        assertEquals(user.getEmail(), node.get("username").asText());
         assertEquals("researcher", node.get("roles").get(0).asText());
         assertEquals("foo", node.get("dataGroups").get(0).asText());
         assertEquals("staging", node.get("environment").asText());
         assertEquals("UserSessionInfo", node.get("type").asText());
-
         JsonNode consentMap = node.get("consentStatuses");
         
         JsonNode consentStatus = consentMap.get("AAA");

--- a/test/org/sagebionetworks/bridge/models/accounts/UserSessionTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/UserSessionTest.java
@@ -28,7 +28,6 @@ public class UserSessionTest {
         
         User user = new User();
         user.setId("id");
-        user.setUsername("username");
         user.setFirstName("firstName");
         user.setLastName("lastName");
         user.setEmail("email");

--- a/test/org/sagebionetworks/bridge/play/controllers/AuthenticationControllerMockTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/AuthenticationControllerMockTest.java
@@ -55,7 +55,7 @@ public class AuthenticationControllerMockTest {
     private static final String TEST_INTERNAL_SESSION_ID = "internal-session-id";
     private static final String TEST_PASSWORD = "password";
     private static final String TEST_USER_STORMPATH_ID = "spId";
-    private static final String TEST_USERNAME = "username";
+    private static final String TEST_EMAIL = "email@email.com";
     private static final String TEST_REQUEST_ID = "request-id";
     private static final String TEST_SESSION_TOKEN = "session-token";
     private static final String TEST_STUDY_ID_STRING = "study-key";
@@ -87,7 +87,7 @@ public class AuthenticationControllerMockTest {
     
     @Test
     public void userCannotAssignRolesToSelfOnSignUp() throws Exception {
-        Context context = TestUtils.mockPlayContextWithJson("{\"study\":\"study-key\",\"username\":\"test\",\"email\":\"bridge-testing+test@sagebase.org\",\"password\":\"P@ssword1\",\"roles\":[\"admin\"]}");
+        Context context = TestUtils.mockPlayContextWithJson("{\"study\":\"study-key\",\"email\":\"bridge-testing+test@sagebase.org\",\"password\":\"P@ssword1\",\"roles\":[\"admin\"]}");
         Http.Context.current.set(context);
         
         Result result = controller.signUp();
@@ -230,7 +230,7 @@ public class AuthenticationControllerMockTest {
 
         // mock request
         String requestJsonString = "{\n" +
-                "   \"username\":\"" + TEST_USERNAME + "\",\n" +
+                "   \"email\":\"" + TEST_EMAIL + "\",\n" +
                 "   \"password\":\"" + TEST_PASSWORD + "\",\n" +
                 "   \"study\":\"" + TEST_STUDY_ID_STRING + "\"\n" +
                 "}";
@@ -249,7 +249,7 @@ public class AuthenticationControllerMockTest {
 
         // validate signIn
         SignIn signIn = signInCaptor.getValue();
-        assertEquals(TEST_USERNAME, signIn.getUsername());
+        assertEquals(TEST_EMAIL, signIn.getEmail());
         assertEquals(TEST_PASSWORD, signIn.getPassword());
     }
 
@@ -288,7 +288,7 @@ public class AuthenticationControllerMockTest {
 
         // mock request
         String requestJsonString = "{\n" +
-                "   \"username\":\"" + TEST_USERNAME + "\",\n" +
+                "   \"email\":\"" + TEST_EMAIL + "\",\n" +
                 "   \"password\":\"" + TEST_PASSWORD + "\",\n" +
                 "   \"study\":\"" + TEST_STUDY_ID_STRING + "\"\n" +
                 "}";
@@ -315,7 +315,7 @@ public class AuthenticationControllerMockTest {
 
         // validate signIn
         SignIn signIn = signInCaptor.getValue();
-        assertEquals(TEST_USERNAME, signIn.getUsername());
+        assertEquals(TEST_EMAIL, signIn.getEmail());
         assertEquals(TEST_PASSWORD, signIn.getPassword());
     }
 
@@ -351,7 +351,7 @@ public class AuthenticationControllerMockTest {
 
         // mock request
         String requestJsonString = "{\n" +
-                "   \"username\":\"" + TEST_USERNAME + "\",\n" +
+                "   \"email\":\"" + TEST_EMAIL + "\",\n" +
                 "   \"password\":\"" + TEST_PASSWORD + "\",\n" +
                 "   \"study\":\"" + TEST_STUDY_ID_STRING + "\"\n" +
                 "}";
@@ -375,7 +375,7 @@ public class AuthenticationControllerMockTest {
 
         // validate signIn
         SignIn signIn = signInCaptor.getValue();
-        assertEquals(TEST_USERNAME, signIn.getUsername());
+        assertEquals(TEST_EMAIL, signIn.getEmail());
         assertEquals(TEST_PASSWORD, signIn.getPassword());
     }
 

--- a/test/org/sagebionetworks/bridge/play/controllers/AuthenticationControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/AuthenticationControllerTest.java
@@ -12,7 +12,7 @@ import static org.sagebionetworks.bridge.TestConstants.SIGN_OUT_URL;
 import static org.sagebionetworks.bridge.TestConstants.STUDIES_URL;
 import static org.sagebionetworks.bridge.TestConstants.TEST_BASE_URL;
 import static org.sagebionetworks.bridge.TestConstants.TIMEOUT;
-import static org.sagebionetworks.bridge.TestConstants.USERNAME;
+import static org.sagebionetworks.bridge.TestConstants.EMAIL;
 import static play.test.Helpers.running;
 import static play.test.Helpers.testServer;
 
@@ -79,7 +79,7 @@ public class AuthenticationControllerTest {
             public void testCode() throws Exception {
                 ObjectNode node = JsonNodeFactory.instance.objectNode();
                 node.put(STUDY_PROPERTY, testUser.getStudyIdentifier().getIdentifier());
-                node.put(USERNAME, testUser.getUsername());
+                node.put(EMAIL, testUser.getEmail());
                 node.put(PASSWORD, testUser.getPassword());
                 
                 WSRequest request = WS.url(TEST_BASE_URL + SIGN_IN_URL);
@@ -115,7 +115,7 @@ public class AuthenticationControllerTest {
                     
                     ObjectNode node = JsonNodeFactory.instance.objectNode();
                     node.put(STUDY_PROPERTY, testUser.getStudy().getIdentifier());
-                    node.put(USERNAME, testUser.getUsername());
+                    node.put(EMAIL, testUser.getEmail());
                     node.put(PASSWORD, testUser.getPassword());
                     
                     WSRequest request = WS.url(TEST_BASE_URL + SIGN_IN_URL);
@@ -147,7 +147,7 @@ public class AuthenticationControllerTest {
                 try {
                     ObjectNode node = JsonNodeFactory.instance.objectNode();
                     node.put(STUDY_PROPERTY, dev.getStudy().getIdentifier());
-                    node.put(USERNAME, dev.getUsername());
+                    node.put(EMAIL, dev.getEmail());
                     node.put(PASSWORD, dev.getPassword());
                     
                     WSRequest request = WS.url(TEST_BASE_URL + SIGN_IN_URL);

--- a/test/org/sagebionetworks/bridge/play/controllers/ConsentControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ConsentControllerTest.java
@@ -10,7 +10,7 @@ import static org.sagebionetworks.bridge.TestConstants.PASSWORD;
 import static org.sagebionetworks.bridge.TestConstants.SIGN_IN_URL;
 import static org.sagebionetworks.bridge.TestConstants.TEST_BASE_URL;
 import static org.sagebionetworks.bridge.TestConstants.TIMEOUT;
-import static org.sagebionetworks.bridge.TestConstants.USERNAME;
+import static org.sagebionetworks.bridge.TestConstants.EMAIL;
 import static play.test.Helpers.running;
 import static play.test.Helpers.testServer;
 
@@ -100,7 +100,7 @@ public class ConsentControllerTest {
             public void testCode() throws Exception {
                 ObjectNode node = JsonNodeFactory.instance.objectNode();
                 node.put(STUDY_PROPERTY, testUser.getStudyIdentifier().getIdentifier());
-                node.put(USERNAME, testUser.getUsername());
+                node.put(EMAIL, testUser.getEmail());
                 node.put(PASSWORD, testUser.getPassword());
                 
                 WSRequest request = WS.url(TEST_BASE_URL + SIGN_IN_URL);

--- a/test/org/sagebionetworks/bridge/play/interceptors/ExceptionInterceptorTest.java
+++ b/test/org/sagebionetworks/bridge/play/interceptors/ExceptionInterceptorTest.java
@@ -69,7 +69,6 @@ public class ExceptionInterceptorTest {
         user.setSharingScope(SharingScope.ALL_QUALIFIED_RESEARCHERS);
         user.setStudyKey("test");
         user.getDataGroups().add("group1");
-        user.setUsername("username");
         
         UserSession session = new UserSession();
         session.setAuthenticated(true);
@@ -92,8 +91,8 @@ public class ExceptionInterceptorTest {
         assertFalse(node.get("signedMostRecentConsent").asBoolean());
         assertEquals("all_qualified_researchers", node.get("sharingScope").asText());
         assertEquals("sessionToken", node.get("sessionToken").asText());
-        assertEquals("username", node.get("username").asText());
         assertEquals("develop", node.get("environment").asText());
+        assertEquals("email@email.com", node.get("username").asText());
         assertTrue(node.get("dataSharing").asBoolean());
         assertEquals("UserSessionInfo", node.get("type").asText());
         ArrayNode array = (ArrayNode)node.get("roles");

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
@@ -86,7 +86,7 @@ public class AuthenticationServiceTest {
     }
 
     @Test(expected = BridgeServiceException.class)
-    public void signInNoUsername() throws Exception {
+    public void signInNoEmail() throws Exception {
         authService.signIn(testUser.getStudy(), ClientInfo.UNKNOWN_CLIENT, new SignIn(null, "bar"));
     }
 
@@ -103,7 +103,7 @@ public class AuthenticationServiceTest {
     @Test
     public void signInCorrectCredentials() throws Exception {
         UserSession newSession = authService.getSession(testUser.getSessionToken());
-        assertEquals("Username is for test2 user", newSession.getUser().getUsername(), testUser.getUsername());
+        assertEquals("Email is for test2 user", newSession.getUser().getEmail(), testUser.getEmail());
         assertTrue("Session token has been assigned", StringUtils.isNotBlank(testUser.getSessionToken()));
     }
 
@@ -111,7 +111,7 @@ public class AuthenticationServiceTest {
     public void signInWhenSignedIn() throws Exception {
         String sessionToken = testUser.getSessionToken();
         UserSession newSession = authService.signIn(testUser.getStudy(), ClientInfo.UNKNOWN_CLIENT, testUser.getSignIn());
-        assertEquals("Username is for test2 user", testUser.getUsername(), newSession.getUser().getUsername());
+        assertEquals("Email is for test2 user", testUser.getEmail(), newSession.getUser().getEmail());
         assertEquals("Should update the existing session instead of creating a new one.",
                 sessionToken, newSession.getSessionToken());
     }
@@ -135,7 +135,7 @@ public class AuthenticationServiceTest {
     public void getSessionWhenAuthenticated() throws Exception {
         UserSession newSession = authService.getSession(testUser.getSessionToken());
 
-        assertEquals("Username is for test2 user", testUser.getUsername(), newSession.getUser().getUsername());
+        assertEquals("Email is for test2 user", testUser.getEmail(), newSession.getUser().getEmail());
         assertTrue("Session token has been assigned", StringUtils.isNotBlank(newSession.getSessionToken()));
     }
 
@@ -223,7 +223,7 @@ public class AuthenticationServiceTest {
         String email = "bridge-testing+"+name+"@sagebase.org";
         
         try {
-            SignUp signUp = new SignUp(name, email, "P@ssword1", null, list);
+            SignUp signUp = new SignUp(email, "P@ssword1", null, list);
 
             authService.signUp(study, signUp, true);
             Account account = accountDao.getAccount(study, email);

--- a/test/org/sagebionetworks/bridge/services/ConsentServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/ConsentServiceMockTest.java
@@ -275,7 +275,6 @@ public class ConsentServiceMockTest {
     }
 
     public static class SimpleAccount implements Account {
-        private String username;
         private String firstName;
         private String lastName;
         private String email;
@@ -284,14 +283,6 @@ public class ConsentServiceMockTest {
         private Map<SubpopulationGuid,List<ConsentSignature>> signatures = Maps.newHashMap();
         private Map<String,String> attributes = Maps.newHashMap();
         private Set<Roles> roles = Sets.newHashSet();
-        @Override
-        public String getUsername() {
-            return username;
-        }
-        @Override
-        public void setUsername(String username) {
-            this.username = username;
-        }
         @Override
         public String getFirstName() {
             return firstName;

--- a/test/org/sagebionetworks/bridge/services/UserAdminServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/UserAdminServiceMockTest.java
@@ -70,7 +70,7 @@ public class UserAdminServiceMockTest {
     @Test
     public void creatingUserConsentsToAllRequiredConsents() {
         Study study = TestUtils.getValidStudy(UserAdminServiceMockTest.class);
-        SignUp signUp = new SignUp("username", "email@email.com", "password", null, null);
+        SignUp signUp = new SignUp("email@email.com", "password", null, null);
         
         UserSession session = service.createUser(signUp, study, null, true, true);
         
@@ -82,7 +82,7 @@ public class UserAdminServiceMockTest {
     @Test
     public void creatingUserWithSubpopulationOnlyConsentsToThatSubpopulation() {
         Study study = TestUtils.getValidStudy(UserAdminServiceMockTest.class);
-        SignUp signUp = new SignUp("username", "email@email.com", "password", null, null);
+        SignUp signUp = new SignUp("email@email.com", "password", null, null);
         SubpopulationGuid consentedGuid = Iterables.getFirst(user.getConsentStatuses().keySet(), null);
         
         UserSession session = service.createUser(signUp, study, consentedGuid, true, true);

--- a/test/org/sagebionetworks/bridge/services/UserAdminServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/UserAdminServiceTest.java
@@ -114,8 +114,7 @@ public class UserAdminServiceTest {
     public void cannotCreateUserWithSameEmail() {
         testUser = userAdminService.createUser(signUp, study, null, true, false).getUser();
         try {
-            SignUp sameWithDifferentEmail = new SignUp(signUp.getEmail(), signUp.getPassword(), null, null);
-            userAdminService.createUser(sameWithDifferentEmail, study, null, false, false);
+            userAdminService.createUser(signUp, study, null, false, false);
             fail("Sign up with email already in use should throw an exception");
         } catch(EntityAlreadyExistsException e) { 
             assertEquals("Account already exists.", e.getMessage());

--- a/test/org/sagebionetworks/bridge/services/UserAdminServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/UserAdminServiceTest.java
@@ -70,7 +70,7 @@ public class UserAdminServiceTest {
     public void before() {
         study = studyService.getStudy(TEST_STUDY_IDENTIFIER);
         String name = bridgeConfig.getUser() + "-admin-" + RandomStringUtils.randomAlphabetic(4);
-        signUp = new SignUp(name, name+"@sagebridge.org", "P4ssword!", null, null);
+        signUp = new SignUp(name+"@sagebridge.org", "P4ssword!", null, null);
 
         SignIn signIn = new SignIn(bridgeConfig.getProperty("admin.email"), bridgeConfig.getProperty("admin.password"));
         authService.signIn(study, ClientInfo.UNKNOWN_CLIENT, signIn).getUser();
@@ -111,22 +111,12 @@ public class UserAdminServiceTest {
     }
     
     @Test
-    public void cannotCreateUserWithSameUsernameOrEmail() {
+    public void cannotCreateUserWithSameEmail() {
         testUser = userAdminService.createUser(signUp, study, null, true, false).getUser();
-        
         try {
-            SignUp sameWithDifferentUsername = new SignUp(RandomStringUtils.randomAlphabetic(8), signUp.getEmail(), signUp.getPassword(), null, null);
-            userAdminService.createUser(sameWithDifferentUsername, study, null, false, false);
-            fail("Sign up with email already in use should throw an exception");
-        } catch(EntityAlreadyExistsException e) {
-            assertEquals("Account already exists.", e.getMessage());
-        }
-        try {
-            String name = bridgeConfig.getUser() + "-admin-" + RandomStringUtils.randomAlphabetic(4);
-            String email = name+"@sagebridge.org";
-            SignUp sameWithDifferentEmail = new SignUp(signUp.getUsername(), email, signUp.getPassword(), null, null);
+            SignUp sameWithDifferentEmail = new SignUp(signUp.getEmail(), signUp.getPassword(), null, null);
             userAdminService.createUser(sameWithDifferentEmail, study, null, false, false);
-            fail("Sign up with username already in use should throw an exception");
+            fail("Sign up with email already in use should throw an exception");
         } catch(EntityAlreadyExistsException e) { 
             assertEquals("Account already exists.", e.getMessage());
         }

--- a/test/org/sagebionetworks/bridge/services/UserDataDownloadViaSqsServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/UserDataDownloadViaSqsServiceTest.java
@@ -46,7 +46,7 @@ public class UserDataDownloadViaSqsServiceTest {
 
         // test inputs
         User user = new User();
-        user.setUsername("test-username");
+        user.setEmail("test-username@email.com");
         DateRange dateRange = new DateRange(LocalDate.parse("2015-08-15"), LocalDate.parse("2015-08-19"));
 
         // execute
@@ -58,7 +58,7 @@ public class UserDataDownloadViaSqsServiceTest {
                 JsonUtils.TYPE_REF_RAW_MAP);
 
         assertEquals("api", sqsMessageMap.get(REQUEST_KEY_STUDY_ID));
-        assertEquals("test-username", sqsMessageMap.get(REQUEST_KEY_USERNAME));
+        assertEquals("test-username@email.com", sqsMessageMap.get(REQUEST_KEY_USERNAME));
         assertEquals("2015-08-15", sqsMessageMap.get(REQUEST_KEY_START_DATE));
         assertEquals("2015-08-19", sqsMessageMap.get(REQUEST_KEY_END_DATE));
     }

--- a/test/org/sagebionetworks/bridge/services/UserProfileServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/UserProfileServiceTest.java
@@ -55,7 +55,6 @@ public class UserProfileServiceTest {
         profile.setAttribute("firstName", "NotTest");
         profile.setAttribute("lastName", "NotPowers");
         profile.setAttribute("email", "NotEmail");
-        profile.setAttribute("username", "NotUsername");
 
         profileService.updateProfile(testUser.getStudy(), testUser.getUser(), profile);
         profile = profileService.getProfile(testUser.getStudy(), testUser.getEmail());
@@ -63,7 +62,6 @@ public class UserProfileServiceTest {
         assertEquals("First name is persisted", "Test", profile.getFirstName());
         assertEquals("Last name is persisted", "Powers", profile.getLastName());
         assertEquals("Email is persisted", testUser.getEmail(), profile.getEmail());
-        assertEquals("Username is persisted", testUser.getUsername(), profile.getUsername());
         assertEquals("Phone is persisted", "123-456-7890", profile.getAttribute("phone"));
         assertEquals("Attribute is persisted", "true", profile.getAttribute("can_be_recontacted"));
         assertNull("Unknown attribute is null", profile.getAttribute("some_unknown_attribute"));

--- a/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoMockTest.java
@@ -140,7 +140,7 @@ public class StormpathAccountDaoMockTest {
         
         String random = RandomStringUtils.randomAlphabetic(5);
         String email = "bridge-testing+"+random+"@sagebridge.org";
-        SignUp signUp = new SignUp(random, email, PASSWORD, null, null);
+        SignUp signUp = new SignUp(email, PASSWORD, null, null);
         Account account = dao.signUp(study, signUp, false);
         assertNotNull(account);
         
@@ -150,7 +150,7 @@ public class StormpathAccountDaoMockTest {
         com.stormpath.sdk.account.Account acct = argument.getValue();
         verify(acct).setSurname("<EMPTY>");
         verify(acct).setGivenName("<EMPTY>");
-        verify(acct).setUsername(random);
+        verify(acct).setUsername(email);
         verify(acct).setEmail(email);
         verify(acct).setPassword(PASSWORD);
     }

--- a/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoTest.java
+++ b/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoTest.java
@@ -92,11 +92,11 @@ public class StormpathAccountDaoTest {
         Account account = null;
         
         try {
-            SignUp signUp = new SignUp(random, email, PASSWORD, Sets.newHashSet(TEST_USERS), null);
+            SignUp signUp = new SignUp(email, PASSWORD, Sets.newHashSet(TEST_USERS), null);
             accountDao.signUp(study, signUp, false);
             
             account = accountDao.authenticate(study, new SignIn(email, PASSWORD));
-            assertEquals(random, account.getUsername());
+            assertEquals(email, account.getEmail());
             assertEquals(1, account.getRoles().size());
         } finally {
             accountDao.deleteAccount(study, email);
@@ -108,7 +108,7 @@ public class StormpathAccountDaoTest {
         String random = RandomStringUtils.randomAlphabetic(5);
         String email = "bridge-testing+"+random+"@sagebridge.org";
         try {
-            SignUp signUp = new SignUp(random, email, PASSWORD, Sets.newHashSet(TEST_USERS), null);
+            SignUp signUp = new SignUp(email, PASSWORD, Sets.newHashSet(TEST_USERS), null);
             accountDao.signUp(study, signUp, false);
             
             try {
@@ -138,7 +138,7 @@ public class StormpathAccountDaoTest {
             ConsentSignature sig = new ConsentSignature.Builder().withName("Test Test").withBirthdate("1970-01-01")
                     .withSignedOn(signedOn).build();
             
-            SignUp signUp = new SignUp(random, email, PASSWORD, Sets.newHashSet(TEST_USERS), null);
+            SignUp signUp = new SignUp(email, PASSWORD, Sets.newHashSet(TEST_USERS), null);
             account = accountDao.signUp(study, signUp, false);
             
             assertNull(account.getFirstName()); // defaults are not visible
@@ -146,7 +146,6 @@ public class StormpathAccountDaoTest {
             account.setEmail(email);
             account.setAttribute("phone", "123-456-7890");
             account.setHealthId("abc");
-            account.setUsername(random);
             account.getConsentSignatureHistory(subpop.getGuid()).add(sig);
             account.setAttribute("attribute_one", "value of attribute one");
             
@@ -160,7 +159,6 @@ public class StormpathAccountDaoTest {
             assertEquals(account.getEmail(), newAccount.getEmail());
             assertEquals(account.getAttribute("phone"), newAccount.getAttribute("phone"));
             assertEquals(account.getHealthId(), newAccount.getHealthId());
-            assertEquals(account.getUsername(), newAccount.getUsername());
             assertEquals(account.getActiveConsentSignature(subpop.getGuid()), 
                     newAccount.getActiveConsentSignature(subpop.getGuid()));
             assertEquals(account.getActiveConsentSignature(subpop.getGuid()).getSignedOn(), 
@@ -198,7 +196,7 @@ public class StormpathAccountDaoTest {
     @Test
     public void canResendEmailVerification() throws Exception {
         String random = RandomStringUtils.randomAlphabetic(5);
-        SignUp signUp = new SignUp(random, "bridge-testing+" + random + "@sagebridge.org", PASSWORD, null, null); 
+        SignUp signUp = new SignUp("bridge-testing+" + random + "@sagebridge.org", PASSWORD, null, null); 
         try {
             accountDao.signUp(study, signUp, false); // don't send email
             
@@ -235,7 +233,7 @@ public class StormpathAccountDaoTest {
                 .build();
 
         String random = RandomStringUtils.randomAlphabetic(5);
-        SignUp signUp = new SignUp(random, "bridge-testing+" + random + "@sagebridge.org", PASSWORD, null, null); 
+        SignUp signUp = new SignUp("bridge-testing+" + random + "@sagebridge.org", PASSWORD, null, null); 
         try {
             Account account = accountDao.signUp(study, signUp, false); // don't send email
             

--- a/test/org/sagebionetworks/bridge/validators/SignUpValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/SignUpValidatorTest.java
@@ -41,19 +41,15 @@ public class SignUpValidatorTest {
     }
     
     private SignUp withPassword(String password) {
-        return new SignUp("username", "email@email.com", password, EMPTY_ROLES, null);
+        return new SignUp("email@email.com", password, EMPTY_ROLES, null);
     }
     
     private SignUp withEmail(String email) {
-        return new SignUp("username", email, "aAz1%_aAz1%", EMPTY_ROLES, null);
-    }
-    
-    private SignUp withUsername(String username) {
-        return new SignUp(username, "email@email.com", "aAz1%_aAz1%", EMPTY_ROLES, null);
+        return new SignUp(email, "aAz1%_aAz1%", EMPTY_ROLES, null);
     }
     
     private SignUp withDataGroup(String dataGroup) {
-        return new SignUp("username", "email@email.com", "aAz1%_aAz1%", EMPTY_ROLES, Sets.newHashSet(dataGroup));
+        return new SignUp("email@email.com", "aAz1%_aAz1%", EMPTY_ROLES, Sets.newHashSet(dataGroup));
     }
     
     @Test
@@ -65,11 +61,6 @@ public class SignUpValidatorTest {
     @Test
     public void emailRequired() {
         assertCorrectMessage(withEmail(null), "email", "email is required");
-    }
-    
-    @Test
-    public void usernameRequired() {
-        assertCorrectMessage(withUsername(""), "username", "username is required");
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
@@ -138,8 +138,8 @@ public class StudyValidatorTest {
     
     @Test
     public void cannotAddConflictingUserProfileAttribute() {
-        study.getUserProfileAttributes().add("username");
-        assertCorrectMessage(study, "userProfileAttributes", "userProfileAttributes 'username' conflicts with existing user profile property");
+        study.getUserProfileAttributes().add("email");
+        assertCorrectMessage(study, "userProfileAttributes", "userProfileAttributes 'email' conflicts with existing user profile property");
     }
     
     @Test


### PR DESCRIPTION
- only email and password now required for sign up/sign in (we use email for username in Stormpath, where it is required information);
- username continues to be accepted silently (on sign up we silently ignore it and use the email address; on sign in, you can submit it and we will treat it as if you submitted the value under the "email" property.... it does need to be the email, so we will have to migrate developer, researcher, and admin accounts);
- user profile, session still have "username" property (it's the email address of the user), in case someone looks at this;
- this fixes the case where an existing username/new email either fails silently, confusing the user, or throws an error that exposes to the caller that the username is in use. Since our apps all already set the username to be people's email addresses, this was not acceptable (it's a session enumeration vulnerability).

This should be backwards compatible IF the username of existing accounts use the email address. Will adjust non-app accounts before we roll this out to each environment.
