### PR TITLE
Adding a flag to disable email verification for studies

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
@@ -48,6 +48,7 @@ public final class DynamoStudy implements Study {
     private EmailTemplate resetPasswordTemplate;
     private boolean strictUploadValidationEnabled;
     private boolean healthCodeExportEnabled;
+    private boolean emailVerificationEnabled;
     private Map<String, Integer> minSupportedAppVersions;
 
     public DynamoStudy() {
@@ -311,6 +312,18 @@ public final class DynamoStudy implements Study {
     
     /** {@inheritDoc} */
     @Override
+    public boolean isEmailVerificationEnabled() {
+        return emailVerificationEnabled;
+    }
+    
+    /** {@inheritDoc} */
+    @Override
+    public void setEmailVerificationEnabled(boolean enabled) {
+        this.emailVerificationEnabled = enabled;
+    }
+    
+    /** {@inheritDoc} */
+    @Override
     public Map<String,Integer> getMinSupportedAppVersions() {
         return minSupportedAppVersions;
     }
@@ -326,7 +339,7 @@ public final class DynamoStudy implements Study {
                 supportEmail, technicalEmail, consentNotificationEmail, stormpathHref, version, 
                 profileAttributes, taskIdentifiers, dataGroups, passwordPolicy, verifyEmailTemplate, 
                 resetPasswordTemplate, active, strictUploadValidationEnabled, healthCodeExportEnabled, 
-                minSupportedAppVersions, synapseDataAccessTeamId, synapseProjectId);
+                emailVerificationEnabled, minSupportedAppVersions, synapseDataAccessTeamId, synapseProjectId);
     }
 
     @Override
@@ -355,6 +368,7 @@ public final class DynamoStudy implements Study {
                 && Objects.equals(technicalEmail, other.technicalEmail)
                 && Objects.equals(strictUploadValidationEnabled, other.strictUploadValidationEnabled)
                 && Objects.equals(healthCodeExportEnabled, other.healthCodeExportEnabled)
+                && Objects.equals(emailVerificationEnabled, other.emailVerificationEnabled)
                 && Objects.equals(minSupportedAppVersions, other.minSupportedAppVersions);
     }
 
@@ -366,10 +380,10 @@ public final class DynamoStudy implements Study {
                             + "synapseProjectId=%s, technicalEmail=%s, consentNotificationEmail=%s, "
                             + "version=%s, userProfileAttributes=%s, taskIdentifiers=%s, dataGroups=%s, passwordPolicy=%s, "
                             + "verifyEmailTemplate=%s, resetPasswordTemplate=%s, strictUploadValidationEnabled=%s, "
-                            + "healthCodeExportEnabled=%s, minSupportedAppVersions=%s]",
+                            + "healthCodeExportEnabled=%s, emailVerificationEnabled=%s, minSupportedAppVersions=%s]",
             name, active, sponsorName, identifier, stormpathHref, minAgeOfConsent, maxNumOfParticipants,
             supportEmail, synapseDataAccessTeamId, synapseProjectId, technicalEmail, consentNotificationEmail, version,
             profileAttributes, taskIdentifiers, dataGroups, passwordPolicy, verifyEmailTemplate, resetPasswordTemplate,
-            strictUploadValidationEnabled, healthCodeExportEnabled, minSupportedAppVersions);
+            strictUploadValidationEnabled, healthCodeExportEnabled, emailVerificationEnabled, minSupportedAppVersions);
     }
 }

--- a/app/org/sagebionetworks/bridge/models/studies/Study.java
+++ b/app/org/sagebionetworks/bridge/models/studies/Study.java
@@ -198,6 +198,14 @@ public interface Study extends BridgeEntity, StudyIdentifier {
     /** @see #isHealthCodeExportEnabled(); */
     public void setHealthCodeExportEnabled(boolean enabled);
     
+    /** True if this study requires users to verify their email addresses in order to sign up. 
+     * True by default.
+     */
+    public boolean isEmailVerificationEnabled();
+    
+    /** @see #isEmailVerificationEnabled(); */
+    public void setEmailVerificationEnabled(boolean enabled);
+    
     /**
      * Minimum supported app version number. If set, user app clients pointing to an older version will 
      * fail with an httpResponse status code of 410.

--- a/app/org/sagebionetworks/bridge/services/StudyService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyService.java
@@ -125,6 +125,7 @@ public class StudyService {
 
         study.setActive(true);
         study.setStrictUploadValidationEnabled(true);
+        study.setEmailVerificationEnabled(true);
         setDefaultsIfAbsent(study);
         sanitizeHTML(study);
         Validate.entityThrowingException(validator, study);
@@ -165,6 +166,7 @@ public class StudyService {
         if (!isAdminUpdate) {
             study.setMaxNumOfParticipants(originalStudy.getMaxNumOfParticipants());
             study.setHealthCodeExportEnabled(originalStudy.isHealthCodeExportEnabled());
+            study.setEmailVerificationEnabled(originalStudy.isEmailVerificationEnabled());
         }
         Validate.entityThrowingException(validator, study);
 

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -218,6 +218,7 @@ public class TestUtils {
         study.setDataGroups(Sets.newHashSet("beta_users", "production_users"));
         study.setStrictUploadValidationEnabled(true);
         study.setHealthCodeExportEnabled(true);
+        study.setEmailVerificationEnabled(true);
         return study;
     }
     

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
@@ -65,6 +65,7 @@ public class DynamoStudyTest {
         assertEqualsAndNotNull((Long)study.getVersion(), (Long)node.get("version").asLong());
         assertTrue(node.get("strictUploadValidationEnabled").asBoolean());
         assertTrue(node.get("healthCodeExportEnabled").asBoolean());
+        assertTrue(node.get("emailVerificationEnabled").asBoolean());
         assertEqualsAndNotNull("Study", node.get("type").asText());
         
         JsonNode supportedVersionsNode = JsonUtils.asJsonNode(node, "minSupportedAppVersions");

--- a/test/org/sagebionetworks/bridge/services/StudyServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceTest.java
@@ -106,6 +106,7 @@ public class StudyServiceTest {
         study.setActive(false);
         study.setStrictUploadValidationEnabled(false);
         study.setHealthCodeExportEnabled(true);
+        study.setEmailVerificationEnabled(false);
         study = studyService.createStudy(study);
         
         assertNotNull("Version has been set", study.getVersion());
@@ -125,6 +126,7 @@ public class StudyServiceTest {
         Study newStudy = studyService.getStudy(study.getIdentifier());
         assertTrue(newStudy.isActive());
         assertTrue(newStudy.isStrictUploadValidationEnabled());
+        assertTrue(newStudy.isEmailVerificationEnabled());
         assertEquals(study.getIdentifier(), newStudy.getIdentifier());
         assertEquals("Test Study [StudyServiceTest]", newStudy.getName());
         assertEquals(200, newStudy.getMaxNumOfParticipants());
@@ -238,25 +240,30 @@ public class StudyServiceTest {
     }
     
     @Test
-    public void adminsCanSomeValuesResearchersCannot() {
+    public void adminsCanChangeSomeValuesResearchersCannot() {
         study = TestUtils.getValidStudy(StudyServiceTest.class);
         study.setMaxNumOfParticipants(200);
         study.setHealthCodeExportEnabled(false);
+        study.setEmailVerificationEnabled(true);
         study = studyService.createStudy(study);
         
         // Okay, now that these are set, researchers cannot change them
         study.setMaxNumOfParticipants(1000);
         study.setHealthCodeExportEnabled(true);
+        study.setEmailVerificationEnabled(false);
         study = studyService.updateStudy(study, false); // nope
         assertEquals(200, study.getMaxNumOfParticipants());
-        assertFalse("This should be null", study.isHealthCodeExportEnabled());
+        assertFalse("isHealthCodeExportEnabled should be false", study.isHealthCodeExportEnabled());
+        assertTrue("isEmailVerificationEnabled should be true", study.isEmailVerificationEnabled());
         
         // But administrators can
         study.setMaxNumOfParticipants(1000);
         study.setHealthCodeExportEnabled(true);
+        study.setEmailVerificationEnabled(false);
         study = studyService.updateStudy(study, true); // yep
         assertEquals(1000, study.getMaxNumOfParticipants());
         assertTrue(study.isHealthCodeExportEnabled());
+        assertFalse(study.isEmailVerificationEnabled());
     }
     
     @Test(expected=InvalidEntityException.class)


### PR DESCRIPTION
To be used in studies where users are entered by researchers, possibly even in a lab (pharma studies). Adding the setting only. Will migrate existing studies to set this value to true; in a future update, we'll use it to update AccountCreationPolicy.setVerificationEmailStatus when the Stormpath directory is created/updated.
