### PR TITLE
Adding task events

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/ActivityEventDao.java
+++ b/app/org/sagebionetworks/bridge/dao/ActivityEventDao.java
@@ -10,7 +10,6 @@ public interface ActivityEventDao {
     /**
      * Publish an event into this user's event stream. This event becomes available 
      * for scheduling activities for this user.
-     * @param event
      */
     public void publishEvent(ActivityEvent event);
     
@@ -20,8 +19,6 @@ public interface ActivityEventDao {
      * "two_weeks_before_enrollment".
      * 
      * @see org.sagebionetworks.bridge.models.activities.ActivityEventObjectType
-     * @param healthCode
-     * @return
      */
     public Map<String, DateTime> getActivityEventMap(String healthCode);
     
@@ -29,8 +26,6 @@ public interface ActivityEventDao {
      * Delete all activity events for this user. This should only be called when physically 
      * deleting test users; users in production take too many server resources to completely 
      * delete this way.
-     * 
-     * @param healthCode
      */
     public void deleteActivityEvents(String healthCode);
 }

--- a/app/org/sagebionetworks/bridge/dao/ActivityEventDao.java
+++ b/app/org/sagebionetworks/bridge/dao/ActivityEventDao.java
@@ -7,9 +7,30 @@ import org.sagebionetworks.bridge.models.activities.ActivityEvent;
 
 public interface ActivityEventDao {
 
+    /**
+     * Publish an event into this user's event stream. This event becomes available 
+     * for scheduling activities for this user.
+     * @param event
+     */
     public void publishEvent(ActivityEvent event);
     
+    /**
+     * Get a map of events, where the string key is an event identifier, and the value 
+     * is the timestamp of the event. This map will include calculated events like 
+     * "two_weeks_before_enrollment".
+     * 
+     * @see org.sagebionetworks.bridge.models.activities.ActivityEventObjectType
+     * @param healthCode
+     * @return
+     */
     public Map<String, DateTime> getActivityEventMap(String healthCode);
     
+    /**
+     * Delete all activity events for this user. This should only be called when physically 
+     * deleting test users; users in production take too many server resources to completely 
+     * delete this way.
+     * 
+     * @param healthCode
+     */
     public void deleteActivityEvents(String healthCode);
 }

--- a/app/org/sagebionetworks/bridge/models/activities/ActivityEventObjectType.java
+++ b/app/org/sagebionetworks/bridge/models/activities/ActivityEventObjectType.java
@@ -1,8 +1,49 @@
 package org.sagebionetworks.bridge.models.activities;
 
 public enum ActivityEventObjectType {
+    /**
+     * An enrollment event. The eventId will be "enrollment".
+     */
     ENROLLMENT,
+    /**
+     * Event for when a question has been answered. An event record is created for each answer 
+     * submitted to the survey response API (NOTE: No application as of 2/9/2016 uses this 
+     * API for historical reasons, so we can't schedule based on the answers to survey questions).
+     * Event IDs take the format "question:<guid>:answered=<answer_values>".
+     */
     QUESTION,
+    /**
+     * Event for when a survey has been finished. This event is recorded when we have received an 
+     * answer (or a declined to answer) for every question in a survey through the survey response 
+     * API. (NOTE: No application as of 2/9/2016 uses this API for historical reasons, so we can't 
+     * schedule based on users finishing a survey). Event IDs take the format 
+     * "survey:<guid>:finished".
+     */
     SURVEY,
-    ACTIVITY;
+    /**
+     * Event for when any activity has been finished. An event is published every time the client 
+     * updates a scheduled activity record with a finishedOn timestamp. Clients that use the scheduled 
+     * events API do send these updates and we can schedule against the completion of a survey or task. 
+     * Event IDs take the format "activity:<guid>:finished" (The guid is the guid of the activity as 
+     * saved in a schedule plan).
+     */
+    ACTIVITY,
+    /** 
+     * This is a calculated event timestamp based on enrollment. It allows us to create schedules
+     * where the participant joins scheduling "mid-stream". For example, in FPHS, activities are 
+     * all scheduled from Saturday to Saturday using a cron expression, and a user, when they join, 
+     * get the tasks assigned the previous Saturday. This event can be used for periodic tasks 
+     * that happen weekly or biweekly.
+     * @see org.sagebionetworks.bridge.dao.ActivityEventDao#getActivityEventMap 
+     */
+    TWO_WEEKS_BEFORE_ENROLLMENT,
+    /** 
+     * This is a calculated event timestamp based on enrollment. It allows us to create schedules
+     * where the participant joins scheduling "mid-stream". For example, in FPHS, activities are 
+     * all scheduled from Saturday to Saturday using a cron expression, and a user, when they join, 
+     * get the tasks assigned the previous Saturday. This event can be used for periodic tasks 
+     * that happen monthly or bimonthly.
+     * @see org.sagebionetworks.bridge.dao.ActivityEventDao#getActivityEventMap 
+     */
+    TWO_MONTHS_BEFORE_ENROLLMENT;
 }

--- a/app/org/sagebionetworks/bridge/models/activities/ActivityEventObjectType.java
+++ b/app/org/sagebionetworks/bridge/models/activities/ActivityEventObjectType.java
@@ -14,7 +14,7 @@ public enum ActivityEventObjectType {
     QUESTION,
     /**
      * Event for when a survey has been finished. This event is recorded when we have received an 
-     * answer (or a declined to answer) for every question in a survey through the survey response 
+     * answer (or a declined-to-answer) for every question in a survey through the survey response 
      * API. (NOTE: No application as of 2/9/2016 uses this API for historical reasons, so we can't 
      * schedule based on users finishing a survey). Event IDs take the format 
      * "survey:<guid>:finished".

--- a/app/org/sagebionetworks/bridge/models/activities/ActivityEventObjectType.java
+++ b/app/org/sagebionetworks/bridge/models/activities/ActivityEventObjectType.java
@@ -33,7 +33,8 @@ public enum ActivityEventObjectType {
      * where the participant joins scheduling "mid-stream". For example, in FPHS, activities are 
      * all scheduled from Saturday to Saturday using a cron expression, and a user, when they join, 
      * get the tasks assigned the previous Saturday. This event can be used for periodic tasks 
-     * that happen weekly or biweekly.
+     * that happen weekly or biweekly. The eventId will be "two_weeks_before_enrollment".
+     * 
      * @see org.sagebionetworks.bridge.dao.ActivityEventDao#getActivityEventMap 
      */
     TWO_WEEKS_BEFORE_ENROLLMENT,
@@ -42,7 +43,8 @@ public enum ActivityEventObjectType {
      * where the participant joins scheduling "mid-stream". For example, in FPHS, activities are 
      * all scheduled from Saturday to Saturday using a cron expression, and a user, when they join, 
      * get the tasks assigned the previous Saturday. This event can be used for periodic tasks 
-     * that happen monthly or bimonthly.
+     * that happen monthly or bimonthly. The eventId will be "two_months_before_enrollment".
+     * 
      * @see org.sagebionetworks.bridge.dao.ActivityEventDao#getActivityEventMap 
      */
     TWO_MONTHS_BEFORE_ENROLLMENT;


### PR DESCRIPTION
Adding a couple of events to begin scheduling before a user's enrollment, in order to meet an unusual scheduling requirement in FPHS.

Specifically they want to have tasks run from Saturday to Saturday, regardless of when a user joins, and new users should see the tasks for a given week. We are going to support this by creating a "fire on Sunday" cron schedule, coupled with scheduling from one of these events that will go far enough back in time to pick up the Saturday before whatever day the user joined the study. 

Right now I can't think of another use for these... it might be possible to add others that would be useful with interval-based scheduling, but I haven't come up with anything convincing.
