### PR TITLE
In cases where an attribute is not paired with a _version attribute

### DIFF
--- a/app/org/sagebionetworks/bridge/stormpath/StormpathAccount.java
+++ b/app/org/sagebionetworks/bridge/stormpath/StormpathAccount.java
@@ -268,7 +268,9 @@ class StormpathAccount implements Account {
             }
         }
         if (version == null) {
-            throw new BridgeServiceException("No version for encryptor found for field " + versionKey);
+            // Get the most recent key. We've only ever used v2 in production so in the rare case where we 
+            // don't have the version of the encryptor saved alongside the attribute, this should be correct.
+            version = encryptors.lastKey();
         }
         return version;
     }

--- a/app/org/sagebionetworks/bridge/stormpath/StormpathAccount.java
+++ b/app/org/sagebionetworks/bridge/stormpath/StormpathAccount.java
@@ -223,8 +223,8 @@ class StormpathAccount implements Account {
         BridgeEncryptor encryptor = encryptors.get(encryptorKey);
 
         String encrypted = encryptor.encrypt(value);
-        acct.getCustomData().put(key, encrypted);
         acct.getCustomData().put(key+VERSION_SUFFIX, encryptor.getVersion());
+        acct.getCustomData().put(key, encrypted);
     }
     
     private String decryptFrom(String key) {

--- a/test/org/sagebionetworks/bridge/stormpath/StormpathAccountTest.java
+++ b/test/org/sagebionetworks/bridge/stormpath/StormpathAccountTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
@@ -377,6 +378,15 @@ public class StormpathAccountTest {
         verifyOneConsentStream(SUBPOP_GUID_2, sig2);
     }
 
+    @Test
+    public void ifEncryptorVersionMissingDefaultToLastEncryptor() {
+        // no _version for this attribute, throws NPE without setting the version
+        data.put("foo", "111"); 
+
+        // Does not throw NPE, it uses last version in sorted map
+        assertEquals("111", acct.getAttribute("foo"));
+    }
+    
     private void verifyOneConsentStream(SubpopulationGuid guid, ConsentSignature sig1)
             throws IOException, JsonParseException, JsonMappingException {
         Integer version = (Integer)data.get(guid.getGuid()+"_consent_signatures_version");


### PR DESCRIPTION
assume the last encryptor in the list of encryptors. This has been version 2 for the lifetime of this application in production.
