### PR TITLE
Repairing incomplete consent records.

### DIFF
--- a/app/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -288,7 +288,7 @@ public class AuthenticationService {
      * DDB. We need to create it.
      */
     private void repairConsent(UserSession session, SubpopulationGuid subpopGuid, ConsentSignature activeSignature) {
-        logger.error("Signature found without a matching user consent record. Adding consent for " + session.getUser().getId());
+        logger.info("Signature found without a matching user consent record. Adding consent for " + session.getUser().getId());
         long signedOn = activeSignature.getSignedOn();
         if (signedOn == 0L) {
             signedOn = DateTimeUtils.currentTimeMillis(); // this is so old we did not record a signing date...

--- a/app/org/sagebionetworks/bridge/stormpath/StormpathAccount.java
+++ b/app/org/sagebionetworks/bridge/stormpath/StormpathAccount.java
@@ -38,7 +38,7 @@ import com.google.common.collect.Maps;
  * updating these values, the version keys will be updated.
  */
 @BridgeTypeName("Account")
-class StormpathAccount implements Account {
+public final class StormpathAccount implements Account {
     
     static final String PLACEHOLDER_STRING = "<EMPTY>";
     
@@ -91,7 +91,7 @@ class StormpathAccount implements Account {
         }
     }
     
-    com.stormpath.sdk.account.Account getAccount() {
+    public com.stormpath.sdk.account.Account getAccount() {
         for (Map.Entry<SubpopulationGuid, List<ConsentSignature>> entry : allSignatures.entrySet()) {
             encryptJSONTo(entry.getKey().getGuid()+CONSENT_SIGNATURES_SUFFIX, entry.getValue());
         }

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
@@ -44,6 +44,7 @@ import org.sagebionetworks.bridge.models.accounts.HealthId;
 import org.sagebionetworks.bridge.models.accounts.PasswordReset;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
 import org.sagebionetworks.bridge.models.accounts.SignUp;
+import org.sagebionetworks.bridge.models.accounts.UserConsent;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.accounts.UserSessionInfo;
 import org.sagebionetworks.bridge.models.studies.Study;
@@ -384,6 +385,8 @@ public class AuthenticationServiceTest {
             // and this person should be recorded as consented...
             for (ConsentStatus status : session.getUser().getConsentStatuses().values()) {
                 assertTrue(!status.isRequired() || status.isConsented());
+                UserConsent consent  = userConsentDao.getActiveUserConsent(session.getUser().getHealthCode(), SubpopulationGuid.create(status.getSubpopulationGuid()));
+                assertTrue(consent.getSignedOn() > 0L);
             }
         } finally {
             helper.deleteUser(user);

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
@@ -35,6 +35,7 @@ import org.sagebionetworks.bridge.dao.UserConsentDao;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
@@ -46,10 +47,13 @@ import org.sagebionetworks.bridge.models.accounts.SignUp;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.accounts.UserSessionInfo;
 import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
 import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
+import org.sagebionetworks.bridge.stormpath.StormpathAccount;
 
 import com.google.common.collect.Sets;
+import com.stormpath.sdk.directory.CustomData;
 
 @ContextConfiguration("classpath:test-context.xml")
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -343,17 +347,35 @@ public class AuthenticationServiceTest {
     }
     
     @Test
-    public void userWithSignatureAndNoDbRecordIsRepaired() {
+    public void userWithSignatureAndNoDbRecordIsRepaired() throws Exception {
         TestUser user = helper.getBuilder(AuthenticationServiceTest.class)
                 .withConsent(true).withSignIn(true).build();
         try {
             authService.signOut(user.getSession());
             
-            // now delete any and all consent records
+            // now delete any and all consent records, and zero out the signed on dates
+            
+            Account account = accountDao.getAccount(testUser.getStudy(), testUser.getEmail());
+            
             List<Subpopulation> subpops = subpopService.getSubpopulations(user.getStudyIdentifier());
             for (Subpopulation subpop : subpops) {
+                // Delete all DDB records
                 userConsentDao.deleteAllConsents(user.getUser().getHealthCode(), subpop.getGuid());
+                
+                // zero out the signed on date
+                ConsentSignature sig = account.getConsentSignatureHistory(subpop.getGuid()).get(0);
+                sig = new ConsentSignature.Builder().withConsentSignature(sig).withSignedOn(0L).build();
+                
+                // alter the customData object so it stores the one signature and no history, as 
+                // was stored in the past when this problem was present
+                com.stormpath.sdk.account.Account stormpathAcct = ((StormpathAccount)account).getAccount();
+                CustomData data = stormpathAcct.getCustomData();
+                data.put(subpop.getGuidString()+"_signature", BridgeObjectMapper.get().writeValueAsString(sig));
+                data.put(subpop.getGuidString()+"_signature_version", 2);
+                data.remove(subpop.getGuidString()+"_signatures");
+                data.remove(subpop.getGuidString()+"_signatures_version");                
             }
+            accountDao.updateAccount(testUser.getStudy(), account);
             
             // Signing in should still work to create a consented user.
             Study study = studyService.getStudy(user.getStudyIdentifier());

--- a/test/org/sagebionetworks/bridge/validators/ScheduleValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/ScheduleValidatorTest.java
@@ -83,7 +83,6 @@ public class ScheduleValidatorTest {
             Validate.entityThrowingException(validator, schedule);
             fail("Should have thrown InvalidEntityException");
         } catch(InvalidEntityException e) {
-            System.out.println(e.getErrors());
             assertEquals("interval and cron expression cannot both be set when a schedule repeats (results are ambiguous)", e.getErrors().get("interval").get(0));
         }
     }


### PR DESCRIPTION
After authentication, look at the user's signatures. If one exists for a valid and active consent, but there's no consent record in DynamoDB, create it. We've seen a small (~5?) number of people from the early days of production where this has been the case.
