### PR TITLE
Use the verifyEmailEnabled status flag to enable/disable the workflow…

### DIFF
--- a/app/org/sagebionetworks/bridge/services/StudyService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyService.java
@@ -223,7 +223,8 @@ public class StudyService {
                 !study.getTechnicalEmail().equals(originalStudy.getTechnicalEmail()) ||
                 !study.getPasswordPolicy().equals(originalStudy.getPasswordPolicy()) || 
                 !study.getVerifyEmailTemplate().equals(originalStudy.getVerifyEmailTemplate()) || 
-                !study.getResetPasswordTemplate().equals(originalStudy.getResetPasswordTemplate()));
+                !study.getResetPasswordTemplate().equals(originalStudy.getResetPasswordTemplate()) || 
+                study.isEmailVerificationEnabled() != originalStudy.isEmailVerificationEnabled());
     }
     
     /**

--- a/app/org/sagebionetworks/bridge/stormpath/StormpathDirectoryDao.java
+++ b/app/org/sagebionetworks/bridge/stormpath/StormpathDirectoryDao.java
@@ -201,7 +201,8 @@ public class StormpathDirectoryDao implements DirectoryDao {
         ModeledEmailTemplate template = policy.getAccountVerificationEmailTemplates().single();
         updateTemplate(study, template, study.getVerifyEmailTemplate(), "verifyEmail");
 
-        policy.setVerificationEmailStatus(EmailStatus.ENABLED);
+        EmailStatus verifyEmailStatus = study.isEmailVerificationEnabled() ? EmailStatus.ENABLED : EmailStatus.DISABLED;
+        policy.setVerificationEmailStatus(verifyEmailStatus);
         policy.setVerificationSuccessEmailStatus(EmailStatus.DISABLED);
         policy.setWelcomeEmailStatus(EmailStatus.DISABLED);
         policy.save();

--- a/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
@@ -133,6 +133,11 @@ public class StudyServiceMockTest {
     }
 
     @Test
+    public void changingEmailVerificationEnabledUpdatesDirectory() {
+        assertDirectoryUpdated(study -> study.setEmailVerificationEnabled(false));
+    }
+    
+    @Test
     public void newStudyVerifiesSupportEmail() {
         Study study = getTestStudy();
         when(emailVerificationService.verifyEmailAddress(study.getSupportEmail()))

--- a/test/org/sagebionetworks/bridge/services/StudyServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceTest.java
@@ -187,11 +187,9 @@ public class StudyServiceTest {
         study.setVerifyEmailTemplate(new EmailTemplate("subject *", "body ${url} *", MimeType.TEXT));
         study.setResetPasswordTemplate(new EmailTemplate("subject **", "body ${url} **", MimeType.TEXT));
         
-        study.setEmailVerificationEnabled(false);
-        
         study = studyService.updateStudy(study, true);
         policy = study.getPasswordPolicy();
-        assertFalse(study.isEmailVerificationEnabled());
+        assertTrue(study.isEmailVerificationEnabled());
         assertEquals(6, policy.getMinLength());
         assertTrue(policy.isNumericRequired());
         assertFalse(policy.isSymbolRequired());

--- a/test/org/sagebionetworks/bridge/services/StudyServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceTest.java
@@ -187,8 +187,11 @@ public class StudyServiceTest {
         study.setVerifyEmailTemplate(new EmailTemplate("subject *", "body ${url} *", MimeType.TEXT));
         study.setResetPasswordTemplate(new EmailTemplate("subject **", "body ${url} **", MimeType.TEXT));
         
+        study.setEmailVerificationEnabled(false);
+        
         study = studyService.updateStudy(study, true);
         policy = study.getPasswordPolicy();
+        assertFalse(study.isEmailVerificationEnabled());
         assertEquals(6, policy.getMinLength());
         assertTrue(policy.isNumericRequired());
         assertFalse(policy.isSymbolRequired());

--- a/test/org/sagebionetworks/bridge/stormpath/StormpathDirectoryDaoTest.java
+++ b/test/org/sagebionetworks/bridge/stormpath/StormpathDirectoryDaoTest.java
@@ -73,6 +73,8 @@ public class StormpathDirectoryDaoTest {
         
         Directory newDirectory = directoryDao.getDirectoryForStudy(study);
         assertDirectoriesAreEqual(study, "subject", "subject", directory, newDirectory);
+        // This is enabled, by default.
+        assertEquals(EmailStatus.ENABLED, newDirectory.getAccountCreationPolicy().getVerificationEmailStatus());
         
         // Verify that we can update the directory.
         study.setPasswordPolicy(new PasswordPolicy(3, true, true, true, true));
@@ -84,6 +86,14 @@ public class StormpathDirectoryDaoTest {
         newDirectory = directoryDao.getDirectoryForStudy(study);
         assertDirectoriesAreEqual(study, "new rp subject", "new ve subject", directory, newDirectory);
 
+        // disable email verification
+        study.setEmailVerificationEnabled(false);
+        directoryDao.updateDirectoryForStudy(study);
+        
+        newDirectory = directoryDao.getDirectoryForStudy(study);
+        // This has been disabled.
+        assertEquals(EmailStatus.DISABLED, newDirectory.getAccountCreationPolicy().getVerificationEmailStatus());
+        
         directoryDao.deleteDirectoryForStudy(study);
         newDirectory = directoryDao.getDirectoryForStudy(study);
         assertNull("Directory has been deleted", newDirectory);


### PR DESCRIPTION
… in Stormpath.

We've already verified setting/updating the property in the study, and we verify that we update Stormpath when the value changes. I have manually changed the value and verified that it is changed in Stormpath (this changes workflow outside the application that we have no way to test).
