### PR TITLE
implement mPower Visualization, backed by DDB

### DIFF
--- a/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
+++ b/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
@@ -49,6 +49,7 @@ import org.sagebionetworks.bridge.crypto.CmsEncryptorCacheLoader;
 import org.sagebionetworks.bridge.dynamodb.DynamoHealthDataAttachment;
 import org.sagebionetworks.bridge.dynamodb.DynamoHealthDataRecord;
 import org.sagebionetworks.bridge.dynamodb.DynamoIndexHelper;
+import org.sagebionetworks.bridge.dynamodb.DynamoMpowerVisualization;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudyConsent1;
 import org.sagebionetworks.bridge.dynamodb.DynamoSurvey;
 import org.sagebionetworks.bridge.dynamodb.DynamoSurveyElement;
@@ -173,6 +174,11 @@ public class BridgeSpringConfig {
         BridgeConfig bridgeConfig = bridgeConfig();
         return new BasicAWSCredentials(bridgeConfig.getProperty("aws.key"),
                 bridgeConfig.getProperty("aws.secret.key"));
+    }
+
+    @Bean(name = "mpowerVisualizationDdbMapper")
+    public DynamoDBMapper mpowerVisualizationDdbMapper() {
+        return DynamoUtils.getMapper(DynamoMpowerVisualization.class, bridgeConfig(), dynamoDbClient());
     }
 
     @Bean(name = "s3UploadCredentials")

--- a/app/org/sagebionetworks/bridge/dao/MpowerVisualizationDao.java
+++ b/app/org/sagebionetworks/bridge/dao/MpowerVisualizationDao.java
@@ -1,0 +1,26 @@
+package org.sagebionetworks.bridge.dao;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.joda.time.LocalDate;
+
+/** Abstract DAO for mPower visualization. */
+public interface MpowerVisualizationDao {
+    /**
+     * <p>
+     * Get the visualization for the given date range. We use raw JSON to allow for rapid development. When we need to
+     * genericize and harden this, we can refactor this class as necessary.
+     * </p>
+     * <p>
+     * See https://sagebionetworks.jira.com/wiki/display/BRIDGE/mPower+Visualization for details.
+     * </p>
+     *
+     * @param healthCode
+     *         user's health code
+     * @param startDate
+     *         start date for visualization
+     * @param endDate
+     *         end date for visualization
+     * @return raw JSON containing visualization data
+     */
+    JsonNode getVisualization(String healthCode, LocalDate startDate, LocalDate endDate);
+}

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoMpowerVisualization.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoMpowerVisualization.java
@@ -1,0 +1,55 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMarshalling;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.joda.time.LocalDate;
+
+/**
+ * DDB implementation of mPower visualization. Individual data points are stored as raw JSON in the "json" field for
+ * rapid development. When we generalize this, we can restructure this class as needed.
+ */
+// Provisioned throughput set to 1/1, as it seems similar to schedules.
+@DynamoThroughput(readCapacity=1, writeCapacity=1)
+@DynamoDBTable(tableName = "MpowerVisualization")
+public class DynamoMpowerVisualization {
+    private LocalDate date;
+    private String healthCode;
+    private JsonNode visualization;
+
+    /** Date for this data point. */
+    @DynamoDBMarshalling(marshallerClass = LocalDateMarshaller.class)
+    @DynamoDBRangeKey
+    public LocalDate getDate() {
+        return date;
+    }
+
+    /** @see #getDate */
+    public void setDate(LocalDate date) {
+        this.date = date;
+    }
+
+    /** Health code of user for this data point. */
+    @DynamoDBHashKey
+    public String getHealthCode() {
+        return healthCode;
+    }
+
+    /** @see #getHealthCode */
+    public void setHealthCode(String healthCode) {
+        this.healthCode = healthCode;
+    }
+
+    /** Raw JSON data of this data point. */
+    @DynamoDBMarshalling(marshallerClass = JsonNodeMarshaller.class)
+    public JsonNode getVisualization() {
+        return visualization;
+    }
+
+    /** @see #getVisualization */
+    public void setVisualization(JsonNode visualization) {
+        this.visualization = visualization;
+    }
+}

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoMpowerVisualizationDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoMpowerVisualizationDao.java
@@ -1,0 +1,55 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import java.util.List;
+import javax.annotation.Resource;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
+import com.amazonaws.services.dynamodbv2.model.Condition;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.joda.time.LocalDate;
+import org.springframework.stereotype.Component;
+
+import org.sagebionetworks.bridge.dao.MpowerVisualizationDao;
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+/** DDB implementation of mPower visualization. */
+@Component
+public class DynamoMpowerVisualizationDao implements MpowerVisualizationDao {
+    private DynamoDBMapper mapper;
+
+    /** DDB mapper for the mPower visualization table. */
+    @Resource(name = "mpowerVisualizationDdbMapper")
+    final void setDdbMapper(DynamoDBMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public JsonNode getVisualization(String healthCode, LocalDate startDate, LocalDate endDate) {
+        // hash key comes from study and health code
+        DynamoMpowerVisualization hashKey = new DynamoMpowerVisualization();
+        hashKey.setHealthCode(healthCode);
+
+        // range key is between start date and end date
+        Condition dateCondition = new Condition().withComparisonOperator(ComparisonOperator.BETWEEN)
+                .withAttributeValueList(new AttributeValue().withS(startDate.toString()),
+                        new AttributeValue().withS(endDate.toString()));
+
+        // query
+        DynamoDBQueryExpression<DynamoMpowerVisualization> query =
+                new DynamoDBQueryExpression<DynamoMpowerVisualization>().withHashKeyValues(hashKey)
+                        .withRangeKeyCondition("date", dateCondition);
+        List<DynamoMpowerVisualization> vizList = mapper.query(DynamoMpowerVisualization.class, query);
+
+        // convert to JSON object
+        ObjectNode vizColNode = BridgeObjectMapper.get().createObjectNode();
+        for (DynamoMpowerVisualization oneViz : vizList) {
+            vizColNode.set(oneViz.getDate().toString(), oneViz.getVisualization());
+        }
+        return vizColNode;
+    }
+}

--- a/app/org/sagebionetworks/bridge/play/controllers/MpowerVisualizationController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/MpowerVisualizationController.java
@@ -1,17 +1,12 @@
 package org.sagebionetworks.bridge.play.controllers;
 
-import java.util.Set;
-
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.collect.ImmutableSet;
-import org.joda.time.LocalDate;
-import org.joda.time.Period;
-import org.joda.time.PeriodType;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import play.mvc.Result;
 
-import org.sagebionetworks.bridge.exceptions.BadRequestException;
-import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.accounts.UserSession;
+import org.sagebionetworks.bridge.services.MpowerVisualizationService;
 
 /**
  * Controller for mPower visualization. This is mPower-specific for now to get things out the door. We'll figure out if
@@ -19,49 +14,20 @@ import org.sagebionetworks.bridge.json.BridgeObjectMapper;
  */
 @Controller
 public class MpowerVisualizationController extends BaseController {
-    public static final Set<String> DATA_KEY_SET = ImmutableSet.of("standingPreMedication", "standingPostMedication",
-            "tappingPreMedication", "tappingPostMedication", "voicePreMedication", "voicePostMedication",
-            "walkingPreMedication", "walkingPostMedication");
+    private MpowerVisualizationService mpowerVisualizationService;
+
+    /** mPower Visualization Service */
+    @Autowired
+    final void setMpowerVisualizationService(MpowerVisualizationService mpowerVisualizationService) {
+        this.mpowerVisualizationService = mpowerVisualizationService;
+    }
 
     /** Gets the mPower visualization for the given start and end dates, inclusive. */
     public Result getVisualization(String startDate, String endDate) {
-        getAuthenticatedAndConsentedSession();
+        UserSession session = getAuthenticatedAndConsentedSession();
+        String healthCode = session.getUser().getHealthCode();
 
-        // parse start and end dates
-        LocalDate startDateObj;
-        try {
-            startDateObj = LocalDate.parse(startDate);
-        } catch (RuntimeException ex) {
-            throw new BadRequestException("Invalid start date " + startDate);
-        }
-
-        LocalDate endDateObj;
-        try {
-            endDateObj = LocalDate.parse(endDate);
-        } catch (RuntimeException ex) {
-            throw new BadRequestException("Invalid end date " + endDate);
-        }
-
-        // To prevent browning out the back end, the date range must be <= 45 days.
-        Period dateRange = new Period(startDateObj, endDateObj, PeriodType.days());
-        if (dateRange.getDays() > 45) {
-            throw new BadRequestException("Date range cannot exceed 45 days, startDate=" + startDate + ", endDate=" +
-                    endDate);
-        }
-
-        // TODO: replace test version with real implementation
-        // Initial dummy implementation just returns random values
-        ObjectNode parentNode = BridgeObjectMapper.get().createObjectNode();
-        for (LocalDate curDate = startDateObj; !curDate.isAfter(endDateObj); curDate = curDate.plusDays(1)) {
-            ObjectNode dateNode = BridgeObjectMapper.get().createObjectNode();
-
-            for (String oneDataKey : DATA_KEY_SET) {
-                dateNode.put(oneDataKey, Math.random());
-            }
-
-            parentNode.set(curDate.toString(), dateNode);
-        }
-
-        return ok(parentNode);
+        JsonNode vizColNode = mpowerVisualizationService.getVisualization(healthCode, startDate, endDate);
+        return ok(vizColNode);
     }
 }

--- a/app/org/sagebionetworks/bridge/services/MpowerVisualizationService.java
+++ b/app/org/sagebionetworks/bridge/services/MpowerVisualizationService.java
@@ -1,0 +1,79 @@
+package org.sagebionetworks.bridge.services;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.commons.lang3.StringUtils;
+import org.joda.time.LocalDate;
+import org.joda.time.Period;
+import org.joda.time.PeriodType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.sagebionetworks.bridge.dao.MpowerVisualizationDao;
+import org.sagebionetworks.bridge.exceptions.BadRequestException;
+import org.sagebionetworks.bridge.json.DateUtils;
+
+/** mPower visualization service. */
+@Component
+public class MpowerVisualizationService {
+    private static final int MAX_RANGE_DAYS = 45;
+
+    private MpowerVisualizationDao mpowerVisualizationDao;
+
+    /** mPower visualization DAO. */
+    @Autowired
+    final void setMpowerVisualizationDao(MpowerVisualizationDao mpowerVisualizationDao) {
+        this.mpowerVisualizationDao = mpowerVisualizationDao;
+    }
+
+    /**
+     * <p>
+     * Get the visualization for the given date range. We use raw JSON to allow for rapid development. When we need to
+     * genericize and harden this, we can refactor this class as necessary.
+     * </p>
+     * <p>
+     * See https://sagebionetworks.jira.com/wiki/display/BRIDGE/mPower+Visualization for details.
+     * </p>
+     *
+     * @param healthCode
+     *         user's health code
+     * @param startDateStr
+     *         start date for visualization
+     * @param endDateStr
+     *         end date for visualization
+     * @return raw JSON containing visualization data
+     */
+    public JsonNode getVisualization(String healthCode, String startDateStr, String endDateStr) {
+        // start date and end date are user input. Must validate them.
+        // Note that we parse the start and end date strings here and not in the controller. This is to consolidate as
+        // much logic as possible into the service, which is much easier to test than the controller.
+        LocalDate startDate = parseDateHelper(startDateStr);
+        LocalDate endDate = parseDateHelper(endDateStr);
+
+        if (startDate.isAfter(endDate)) {
+            throw new BadRequestException("start date " + startDateStr + " can't be after end date " + endDateStr);
+        }
+
+        Period dateRange = new Period(startDate, endDate, PeriodType.days());
+        if (dateRange.getDays() > MAX_RANGE_DAYS) {
+            throw new BadRequestException("Date range cannot exceed " + MAX_RANGE_DAYS + " days, startDate=" +
+                    startDateStr + ", endDate=" + endDateStr);
+        }
+
+        // Don't need to validate study ID or healthCode. Controller takes care of that for us.
+
+        return mpowerVisualizationDao.getVisualization(healthCode, startDate, endDate);
+    }
+
+    // Helper method to parse dates. If the date isn't specified, it defaults to yesterday's date in the local timezone
+    private static LocalDate parseDateHelper(String dateStr) {
+        if (StringUtils.isBlank(dateStr)) {
+            return DateUtils.getCurrentCalendarDateInLocalTime().minusDays(1);
+        } else {
+            try {
+                return DateUtils.parseCalendarDate(dateStr);
+            } catch (RuntimeException ex) {
+                throw new BadRequestException("invalid date " + dateStr);
+            }
+        }
+    }
+}

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoMpowerVisualizationDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoMpowerVisualizationDaoTest.java
@@ -1,0 +1,77 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Resource;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.joda.time.LocalDate;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@ContextConfiguration("classpath:test-context.xml")
+@RunWith(SpringJUnit4ClassRunner.class)
+public class DynamoMpowerVisualizationDaoTest {
+    @Autowired
+    @SuppressWarnings("unused")
+    private DynamoMpowerVisualizationDao dao;
+
+    @Resource(name = "mpowerVisualizationDdbMapper")
+    @SuppressWarnings("unused")
+    private DynamoDBMapper mapper;
+
+    private List<DynamoMpowerVisualization> vizList;
+
+    @Before
+    public void setup() {
+        // Create test data for health code AAA from Feb 1 to Feb 4, test data for health code BBB for Feb 4. This
+        // gives us a nice range of data to play with.
+        // Test data will be strings, even though in production they'll be complex objects.
+        vizList = new ArrayList<>();
+        for (int i = 1; i <= 4; i++) {
+            String dateStr = "2016-02-0" + i;
+
+            DynamoMpowerVisualization viz = new DynamoMpowerVisualization();
+            viz.setDate(LocalDate.parse(dateStr));
+            viz.setHealthCode("AAA");
+            viz.setVisualization(new TextNode("data AAA-" + dateStr));
+
+            vizList.add(viz);
+        }
+
+        {
+            DynamoMpowerVisualization viz = new DynamoMpowerVisualization();
+            viz.setDate(LocalDate.parse("2016-02-04"));
+            viz.setHealthCode("BBB");
+            viz.setVisualization(new TextNode("data BBB-2016-02-04"));
+
+            vizList.add(viz);
+        }
+
+        mapper.batchSave(vizList);
+    }
+
+    @After
+    public void cleanup() {
+        mapper.batchDelete(vizList);
+    }
+
+    @Test
+    public void test() {
+        JsonNode vizColNode = dao.getVisualization("AAA", LocalDate.parse("2016-02-02"),
+                LocalDate.parse("2016-02-04"));
+        assertEquals(3, vizColNode.size());
+        assertEquals("data AAA-2016-02-02", vizColNode.get("2016-02-02").textValue());
+        assertEquals("data AAA-2016-02-03", vizColNode.get("2016-02-03").textValue());
+        assertEquals("data AAA-2016-02-04", vizColNode.get("2016-02-04").textValue());
+    }
+}

--- a/test/org/sagebionetworks/bridge/play/controllers/MpowerVisualizationControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/MpowerVisualizationControllerTest.java
@@ -1,59 +1,52 @@
 package org.sagebionetworks.bridge.play.controllers;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import org.junit.Test;
 import play.mvc.Result;
 import play.test.Helpers;
 
-import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.accounts.User;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
+import org.sagebionetworks.bridge.services.MpowerVisualizationService;
 
-// These are just temporary tests to support the dummy implementation. Replace these with real tests when we write the
-// real implementation.
 public class MpowerVisualizationControllerTest {
+    private static final String DUMMY_HEALTH_CODE = "dummyHealthCode";
+
     @Test
     public void test() throws Exception {
         // Spy controller. Mock session.
+        User user = new User();
+        user.setHealthCode(DUMMY_HEALTH_CODE);
+
+        UserSession session = new UserSession();
+        session.setUser(user);
+
         MpowerVisualizationController controller = spy(new MpowerVisualizationController());
-        doReturn(new UserSession()).when(controller).getAuthenticatedAndConsentedSession();
+        doReturn(session).when(controller).getAuthenticatedAndConsentedSession();
+
+        // mock service - For rapid development and to avoid unnecessary coupling, just mock the visualization with a
+        // dummy string. Check if that dummy string is propagated through the controller.
+        MpowerVisualizationService mockSvc = mock(MpowerVisualizationService.class);
+        JsonNode mockViz = new TextNode("mock visualization");
+        when(mockSvc.getVisualization(DUMMY_HEALTH_CODE, "2016-02-06", "2016-02-08"))
+                .thenReturn(mockViz);
+
+        controller.setMpowerVisualizationService(mockSvc);
 
         // execute and validate
-        Result result = controller.getVisualization("2016-02-01", "2016-02-03");
+        Result result = controller.getVisualization("2016-02-06", "2016-02-08");
         assertEquals(200, result.status());
 
         String resultStr = Helpers.contentAsString(result);
         JsonNode resultNode = BridgeObjectMapper.get().readTree(resultStr);
-        assertEquals(3, resultNode.size());
-
-        for (int i = 1; i <= 3; i++) {
-            JsonNode dateNode = resultNode.get("2016-02-0" + i);
-            assertEquals(8, dateNode.size());
-
-            for (String oneDataKey : MpowerVisualizationController.DATA_KEY_SET) {
-                JsonNode dataValueNode = dateNode.get(oneDataKey);
-                assertTrue(dataValueNode.isDouble());
-
-                double dataValue = dataValueNode.doubleValue();
-                assertTrue(dataValue >= 0.0);
-                assertTrue(dataValue <= 1.0);
-            }
-        }
-    }
-
-    @Test(expected = BadRequestException.class)
-    public void dateRangeTooWide() {
-        // Spy controller. Mock session.
-        MpowerVisualizationController controller = spy(new MpowerVisualizationController());
-        doReturn(new UserSession()).when(controller).getAuthenticatedAndConsentedSession();
-
-        // execute
-        // Not gonna do the exact math, but this is definitely too long.
-        controller.getVisualization("2016-01-01", "2016-03-01");
+        assertEquals("mock visualization", resultNode.textValue());
     }
 }

--- a/test/org/sagebionetworks/bridge/play/controllers/MpowerVisualizationControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/MpowerVisualizationControllerTest.java
@@ -8,10 +8,12 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+import org.joda.time.LocalDate;
 import org.junit.Test;
 import play.mvc.Result;
 import play.test.Helpers;
 
+import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.accounts.User;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
@@ -21,7 +23,62 @@ public class MpowerVisualizationControllerTest {
     private static final String DUMMY_HEALTH_CODE = "dummyHealthCode";
 
     @Test
-    public void test() throws Exception {
+    public void nullStartDate() throws Exception {
+        test(null, "2016-02-08", null, LocalDate.parse("2016-02-08"));
+    }
+
+    @Test
+    public void emptyStartDate() throws Exception {
+        test("", "2016-02-08", null, LocalDate.parse("2016-02-08"));
+    }
+
+    @Test
+    public void blankStartDate() throws Exception {
+        test("   ", "2016-02-08", null, LocalDate.parse("2016-02-08"));
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void malformedStartDate() throws Exception {
+        test("this is not a date", "2016-02-08", null, LocalDate.parse("2016-02-08"));
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void timestampAsStartDate() throws Exception {
+        test("2016-02-06T12:30-0800", "2016-02-08", null, LocalDate.parse("2016-02-08"));
+    }
+
+    @Test
+    public void nullEndDate() throws Exception {
+        test("2016-02-06", null, LocalDate.parse("2016-02-06"), null);
+    }
+
+    @Test
+    public void emptyEndDate() throws Exception {
+        test("2016-02-06", "", LocalDate.parse("2016-02-06"), null);
+    }
+
+    @Test
+    public void blankEndDate() throws Exception {
+        test("2016-02-06", "   ", LocalDate.parse("2016-02-06"), null);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void malformedEndDate() throws Exception {
+        test("2016-02-06", "also not a date", LocalDate.parse("2016-02-06"), null);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void timestampAsEndDate() throws Exception {
+        test("2016-02-06", "2016-02-08T23:45-0800", LocalDate.parse("2016-02-06"), null);
+    }
+
+    @Test
+    public void bothDatesSpecified() throws Exception {
+        test("2016-02-06", "2016-02-08", LocalDate.parse("2016-02-06"), LocalDate.parse("2016-02-08"));
+    }
+
+    private static void test(String startDateStr, String endDateStr, LocalDate expectedStartDate,
+            LocalDate expectedEndDate) throws Exception {
         // Spy controller. Mock session.
         User user = new User();
         user.setHealthCode(DUMMY_HEALTH_CODE);
@@ -36,13 +93,12 @@ public class MpowerVisualizationControllerTest {
         // dummy string. Check if that dummy string is propagated through the controller.
         MpowerVisualizationService mockSvc = mock(MpowerVisualizationService.class);
         JsonNode mockViz = new TextNode("mock visualization");
-        when(mockSvc.getVisualization(DUMMY_HEALTH_CODE, "2016-02-06", "2016-02-08"))
-                .thenReturn(mockViz);
+        when(mockSvc.getVisualization(DUMMY_HEALTH_CODE, expectedStartDate, expectedEndDate)).thenReturn(mockViz);
 
         controller.setMpowerVisualizationService(mockSvc);
 
         // execute and validate
-        Result result = controller.getVisualization("2016-02-06", "2016-02-08");
+        Result result = controller.getVisualization(startDateStr, endDateStr);
         assertEquals(200, result.status());
 
         String resultStr = Helpers.contentAsString(result);

--- a/test/org/sagebionetworks/bridge/services/MpowerVisualizationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/MpowerVisualizationServiceTest.java
@@ -29,7 +29,8 @@ public class MpowerVisualizationServiceTest {
         svc.setMpowerVisualizationDao(mockDao);
 
         // execute and validate
-        JsonNode result = svc.getVisualization(DUMMY_HEALTH_CODE, "2016-02-06", "2016-02-08");
+        JsonNode result = svc.getVisualization(DUMMY_HEALTH_CODE, LocalDate.parse("2016-02-06"),
+                LocalDate.parse("2016-02-08"));
         assertSame(mockViz, result);
     }
 
@@ -58,39 +59,15 @@ public class MpowerVisualizationServiceTest {
     }
 
     @Test(expected = BadRequestException.class)
-    public void malformedStartDate() {
-        new MpowerVisualizationService().getVisualization(DUMMY_HEALTH_CODE, "this is not a date",
-                "2016-02-08");
-    }
-
-    @Test(expected = BadRequestException.class)
-    public void timestampAsStartDate() {
-        new MpowerVisualizationService().getVisualization(DUMMY_HEALTH_CODE,
-                "2016-02-06T18:00-0800", "2016-02-08");
-    }
-
-    @Test(expected = BadRequestException.class)
-    public void malformedEndDate() {
-        new MpowerVisualizationService().getVisualization(DUMMY_HEALTH_CODE, "2016-02-06",
-                "also not a date");
-    }
-
-    @Test(expected = BadRequestException.class)
-    public void timestampAsEndDate() {
-        new MpowerVisualizationService().getVisualization(DUMMY_HEALTH_CODE, "2016-02-06",
-                "2016-02-08T23:00-0800");
-    }
-
-    @Test(expected = BadRequestException.class)
     public void startDateAfterEndDate() {
-        new MpowerVisualizationService().getVisualization(DUMMY_HEALTH_CODE, "2016-02-09",
-                "2016-02-08");
+        new MpowerVisualizationService().getVisualization(DUMMY_HEALTH_CODE, LocalDate.parse("2016-02-09"),
+                LocalDate.parse("2016-02-08"));
     }
 
     @Test(expected = BadRequestException.class)
     public void dateRangeTooWide() {
         // Two months is definitely too wide. Don't need exactly 45 days.
-        new MpowerVisualizationService().getVisualization(DUMMY_HEALTH_CODE, "2016-01-01",
-                "2016-03-01");
+        new MpowerVisualizationService().getVisualization(DUMMY_HEALTH_CODE, LocalDate.parse("2016-01-01"),
+                LocalDate.parse("2016-03-01"));
     }
 }

--- a/test/org/sagebionetworks/bridge/services/MpowerVisualizationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/MpowerVisualizationServiceTest.java
@@ -1,0 +1,96 @@
+package org.sagebionetworks.bridge.services;
+
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeUtils;
+import org.joda.time.LocalDate;
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.dao.MpowerVisualizationDao;
+import org.sagebionetworks.bridge.exceptions.BadRequestException;
+
+public class MpowerVisualizationServiceTest {
+    private static final String DUMMY_HEALTH_CODE = "dummyHealthCode";
+
+    @Test
+    public void specifiedStartAndEndDates() {
+        // mock dao
+        MpowerVisualizationDao mockDao = mock(MpowerVisualizationDao.class);
+        JsonNode mockViz = mock(JsonNode.class);
+        when(mockDao.getVisualization(DUMMY_HEALTH_CODE, LocalDate.parse("2016-02-06"), LocalDate.parse("2016-02-08")))
+                .thenReturn(mockViz);
+
+        // set up service
+        MpowerVisualizationService svc = new MpowerVisualizationService();
+        svc.setMpowerVisualizationDao(mockDao);
+
+        // execute and validate
+        JsonNode result = svc.getVisualization(DUMMY_HEALTH_CODE, "2016-02-06", "2016-02-08");
+        assertSame(mockViz, result);
+    }
+
+    @Test
+    public void defaultStartAndEndDates() {
+        // mock now
+        DateTimeUtils.setCurrentMillisFixed(DateTime.parse("2016-02-08T09:00-0800").getMillis());
+
+        try {
+            // mock dao
+            MpowerVisualizationDao mockDao = mock(MpowerVisualizationDao.class);
+            JsonNode mockViz = mock(JsonNode.class);
+            when(mockDao.getVisualization(DUMMY_HEALTH_CODE, LocalDate.parse("2016-02-07"),
+                    LocalDate.parse("2016-02-07"))).thenReturn(mockViz);
+
+            // set up service
+            MpowerVisualizationService svc = new MpowerVisualizationService();
+            svc.setMpowerVisualizationDao(mockDao);
+
+            // execute and validate
+            JsonNode result = svc.getVisualization(DUMMY_HEALTH_CODE, null, null);
+            assertSame(mockViz, result);
+        } finally {
+            DateTimeUtils.setCurrentMillisSystem();
+        }
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void malformedStartDate() {
+        new MpowerVisualizationService().getVisualization(DUMMY_HEALTH_CODE, "this is not a date",
+                "2016-02-08");
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void timestampAsStartDate() {
+        new MpowerVisualizationService().getVisualization(DUMMY_HEALTH_CODE,
+                "2016-02-06T18:00-0800", "2016-02-08");
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void malformedEndDate() {
+        new MpowerVisualizationService().getVisualization(DUMMY_HEALTH_CODE, "2016-02-06",
+                "also not a date");
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void timestampAsEndDate() {
+        new MpowerVisualizationService().getVisualization(DUMMY_HEALTH_CODE, "2016-02-06",
+                "2016-02-08T23:00-0800");
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void startDateAfterEndDate() {
+        new MpowerVisualizationService().getVisualization(DUMMY_HEALTH_CODE, "2016-02-09",
+                "2016-02-08");
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void dateRangeTooWide() {
+        // Two months is definitely too wide. Don't need exactly 45 days.
+        new MpowerVisualizationService().getVisualization(DUMMY_HEALTH_CODE, "2016-01-01",
+                "2016-03-01");
+    }
+}


### PR DESCRIPTION
Replace the stub implementation with a real implementation, backed by DDB.

I was originally going to gate this on studyId=parkinson, but then I decided to make it easier to test, I'd allow it in any study. healthCodes aren't shared across studies, so this should be fine.

Testing done:
- added new unit tests
- manual tests: specified date range, default date range (yesterday), date range larger than available data
