### PR TITLE
Split schedule criteria context

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/SubpopulationDao.java
+++ b/app/org/sagebionetworks/bridge/dao/SubpopulationDao.java
@@ -2,7 +2,7 @@ package org.sagebionetworks.bridge.dao;
 
 import java.util.List;
 
-import org.sagebionetworks.bridge.models.schedules.ScheduleContext;
+import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
@@ -50,7 +50,7 @@ public interface SubpopulationDao {
      * @param context
      * @return
      */
-    public List<Subpopulation> getSubpopulationsForUser(ScheduleContext context);
+    public List<Subpopulation> getSubpopulationsForUser(CriteriaContext context);
     
     /**
      * Update a subpopulation.

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDao.java
@@ -15,8 +15,8 @@ import org.sagebionetworks.bridge.dao.StudyConsentDao;
 import org.sagebionetworks.bridge.dao.SubpopulationDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
+import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.CriteriaUtils;
-import org.sagebionetworks.bridge.models.schedules.ScheduleContext;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
@@ -132,11 +132,11 @@ public class DynamoSubpopulationDao implements SubpopulationDao {
     }
 
     @Override
-    public List<Subpopulation> getSubpopulationsForUser(ScheduleContext context) {
+    public List<Subpopulation> getSubpopulationsForUser(CriteriaContext context) {
         List<Subpopulation> subpops = getSubpopulations(context.getStudyIdentifier(), true, false);
         
         return subpops.stream().filter(subpop -> {
-            return CriteriaUtils.matchCriteria(context.getCriteriaContext(), subpop);
+            return CriteriaUtils.matchCriteria(context, subpop);
         }).collect(toImmutableList());
     }
     

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDao.java
@@ -136,7 +136,7 @@ public class DynamoSubpopulationDao implements SubpopulationDao {
         List<Subpopulation> subpops = getSubpopulations(context.getStudyIdentifier(), true, false);
         
         return subpops.stream().filter(subpop -> {
-            return CriteriaUtils.matchCriteria(context, subpop);
+            return CriteriaUtils.matchCriteria(context.getCriteriaContext(), subpop);
         }).collect(toImmutableList());
     }
     

--- a/app/org/sagebionetworks/bridge/models/CriteriaContext.java
+++ b/app/org/sagebionetworks/bridge/models/CriteriaContext.java
@@ -1,16 +1,24 @@
 package org.sagebionetworks.bridge.models;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.Objects;
 import java.util.Set;
+
+import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 
 import com.google.common.collect.ImmutableSet;
 
 public final class CriteriaContext {
     
+    private final StudyIdentifier studyId;
+    private final String healthCode;
     private final ClientInfo clientInfo;
     private final Set<String> userDataGroups;
     
-    private CriteriaContext(ClientInfo clientInfo, Set<String> userDataGroups) {
+    private CriteriaContext(StudyIdentifier studyId, String healthCode, ClientInfo clientInfo, Set<String> userDataGroups) {
+        this.studyId = studyId;
+        this.healthCode = healthCode;
         this.clientInfo = clientInfo;
         this.userDataGroups = (userDataGroups == null) ? ImmutableSet.of() : ImmutableSet.copyOf(userDataGroups);
     }
@@ -26,10 +34,18 @@ public final class CriteriaContext {
     public Set<String> getUserDataGroups() {
         return userDataGroups;
     }
+    
+    public StudyIdentifier getStudyIdentifier() {
+        return studyId;
+    }
+    
+    public String getHealthCode() {
+        return healthCode;
+    }
 
     @Override
     public int hashCode() {
-        return Objects.hash(clientInfo, userDataGroups);
+        return Objects.hash(studyId, healthCode, clientInfo, userDataGroups);
     }
 
     @Override
@@ -39,18 +55,32 @@ public final class CriteriaContext {
         if (obj == null || getClass() != obj.getClass())
             return false;
         CriteriaContext other = (CriteriaContext)obj;
-        return (Objects.equals(clientInfo, other.clientInfo) && Objects.equals(userDataGroups, other.userDataGroups));
+        return (Objects.equals(clientInfo, other.clientInfo) && 
+                Objects.equals(userDataGroups, other.userDataGroups) && 
+                Objects.equals(studyId, other.studyId) && 
+                Objects.equals(healthCode, other.healthCode));
     }
 
     @Override
     public String toString() {
-        return "CriteriaContext [clientInfo=" + clientInfo + ", userDataGroups=" + userDataGroups + "]";
+        return "CriteriaContext [studyId=" + studyId + ", healthCode=" + healthCode + 
+                ", clientInfo=" + clientInfo + ", userDataGroups=" + userDataGroups + "]";
     }
 
     public static class Builder {
+        private StudyIdentifier studyId;
+        private String healthCode;
         private ClientInfo clientInfo;
         private Set<String> userDataGroups;
 
+        public Builder withStudyIdentifier(StudyIdentifier studyId) {
+            this.studyId = studyId;
+            return this;
+        }
+        public Builder withHealthCode(String healthCode) {
+            this.healthCode = healthCode;
+            return this;
+        }
         public Builder withClientInfo(ClientInfo clientInfo) {
             this.clientInfo = clientInfo;
             return this;
@@ -60,16 +90,19 @@ public final class CriteriaContext {
             return this;
         }
         public Builder withContext(CriteriaContext context) {
+            this.studyId = context.studyId;
+            this.healthCode = context.healthCode;
             this.clientInfo = context.clientInfo;
             this.userDataGroups = context.userDataGroups;
             return this;
         }
 
         public CriteriaContext build() {
+            checkNotNull(studyId, "studyId cannot be null");
             if (clientInfo == null) {
                 clientInfo = ClientInfo.UNKNOWN_CLIENT;
             }
-            return new CriteriaContext(clientInfo, userDataGroups);
+            return new CriteriaContext(studyId, healthCode, clientInfo, userDataGroups);
         }
     }
 }

--- a/app/org/sagebionetworks/bridge/models/CriteriaContext.java
+++ b/app/org/sagebionetworks/bridge/models/CriteriaContext.java
@@ -1,0 +1,75 @@
+package org.sagebionetworks.bridge.models;
+
+import java.util.Objects;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
+
+public final class CriteriaContext {
+    
+    private final ClientInfo clientInfo;
+    private final Set<String> userDataGroups;
+    
+    private CriteriaContext(ClientInfo clientInfo, Set<String> userDataGroups) {
+        this.clientInfo = clientInfo;
+        this.userDataGroups = (userDataGroups == null) ? ImmutableSet.of() : ImmutableSet.copyOf(userDataGroups);
+    }
+
+    /**
+    * Client information based on the supplied User-Agent header.
+    * @return
+    */
+    public ClientInfo getClientInfo() {
+        return clientInfo;
+    }
+
+    public Set<String> getUserDataGroups() {
+        return userDataGroups;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(clientInfo, userDataGroups);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null || getClass() != obj.getClass())
+            return false;
+        CriteriaContext other = (CriteriaContext)obj;
+        return (Objects.equals(clientInfo, other.clientInfo) && Objects.equals(userDataGroups, other.userDataGroups));
+    }
+
+    @Override
+    public String toString() {
+        return "CriteriaContext [clientInfo=" + clientInfo + ", userDataGroups=" + userDataGroups + "]";
+    }
+
+    public static class Builder {
+        private ClientInfo clientInfo;
+        private Set<String> userDataGroups;
+
+        public Builder withClientInfo(ClientInfo clientInfo) {
+            this.clientInfo = clientInfo;
+            return this;
+        }
+        public Builder withUserDataGroups(Set<String> userDataGroups) {
+            this.userDataGroups = userDataGroups;
+            return this;
+        }
+        public Builder withContext(CriteriaContext context) {
+            this.clientInfo = context.clientInfo;
+            this.userDataGroups = context.userDataGroups;
+            return this;
+        }
+
+        public CriteriaContext build() {
+            if (clientInfo == null) {
+                clientInfo = ClientInfo.UNKNOWN_CLIENT;
+            }
+            return new CriteriaContext(clientInfo, userDataGroups);
+        }
+    }
+}

--- a/app/org/sagebionetworks/bridge/models/CriteriaUtils.java
+++ b/app/org/sagebionetworks/bridge/models/CriteriaUtils.java
@@ -6,8 +6,6 @@ import java.util.Set;
 
 import org.springframework.validation.Errors;
 
-import org.sagebionetworks.bridge.models.schedules.ScheduleContext;
-
 import com.google.common.collect.Sets;
 
 /**
@@ -29,7 +27,7 @@ public class CriteriaUtils {
      * @param maxAppVersion
      * @return
      */
-    public static boolean matchCriteria(ScheduleContext context, Criteria criteria) {
+    public static boolean matchCriteria(CriteriaContext context, Criteria criteria) {
         checkNotNull(context);
         checkNotNull(context.getClientInfo());
         checkNotNull(context.getUserDataGroups());

--- a/app/org/sagebionetworks/bridge/models/schedules/ABTestScheduleStrategy.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/ABTestScheduleStrategy.java
@@ -33,7 +33,7 @@ public final class ABTestScheduleStrategy implements ScheduleStrategy {
         // Randomly assign to a group, weighted based on the percentage representation of the group.
         ABTestGroup group = null;
         long seed = UUID.fromString(plan.getGuid()).getLeastSignificantBits()
-                + UUID.fromString(context.getHealthCode()).getLeastSignificantBits();        
+                + UUID.fromString(context.getCriteriaContext().getHealthCode()).getLeastSignificantBits();        
         
         int i = 0;
         int perc = (int)(seed % 100.0) + 1;

--- a/app/org/sagebionetworks/bridge/models/schedules/ActivityScheduler.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/ActivityScheduler.java
@@ -68,7 +68,7 @@ public abstract class ActivityScheduler {
                     ScheduledActivity schActivity = ScheduledActivity.create();
                     schActivity.setSchedulePlanGuid(plan.getGuid());
                     schActivity.setTimeZone(context.getZone());
-                    schActivity.setHealthCode(context.getHealthCode());
+                    schActivity.setHealthCode(context.getCriteriaContext().getHealthCode());
                     schActivity.setActivity(activity);
                     schActivity.setScheduledOn(scheduledTime);
                     schActivity.setGuid(activity.getGuid() + ":" + scheduledTime.toLocalDateTime().toString());

--- a/app/org/sagebionetworks/bridge/models/schedules/CriteriaScheduleStrategy.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/CriteriaScheduleStrategy.java
@@ -43,7 +43,7 @@ public final class CriteriaScheduleStrategy implements ScheduleStrategy {
     @Override
     public Schedule getScheduleForUser(SchedulePlan plan, ScheduleContext context) {
         for (ScheduleCriteria criteria : scheduleCriteria) {
-            if (CriteriaUtils.matchCriteria(context, criteria)) {
+            if (CriteriaUtils.matchCriteria(context.getCriteriaContext(), criteria)) {
                 return criteria.getSchedule();
             }
         }

--- a/app/org/sagebionetworks/bridge/play/controllers/FPHSController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/FPHSController.java
@@ -7,12 +7,12 @@ import java.util.Map;
 import java.util.Set;
 
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.accounts.ExternalIdentifier;
 import org.sagebionetworks.bridge.models.accounts.FPHSExternalIdentifier;
 import org.sagebionetworks.bridge.models.accounts.User;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
-import org.sagebionetworks.bridge.models.schedules.ScheduleContext;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 import org.sagebionetworks.bridge.services.ConsentService;
 import org.sagebionetworks.bridge.services.FPHSService;
@@ -68,7 +68,7 @@ public class FPHSController extends BaseController {
         dataGroups.add("football_player");
         user.setDataGroups(dataGroups);
         
-        ScheduleContext context = new ScheduleContext.Builder()
+        CriteriaContext context = new CriteriaContext.Builder()
                 .withClientInfo(getClientInfoFromUserAgentHeader())
                 .withHealthCode(user.getHealthCode())
                 .withUserDataGroups(user.getDataGroups())

--- a/app/org/sagebionetworks/bridge/play/controllers/ScheduleController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ScheduleController.java
@@ -71,7 +71,9 @@ public class ScheduleController extends BaseController {
         ClientInfo clientInfo = getClientInfoFromUserAgentHeader();
 
         ScheduleContext context = new ScheduleContext.Builder()
-                .withUser(session.getUser()).withClientInfo(clientInfo).build();
+                .withStudyIdentifier(studyId)
+                .withHealthCode(session.getUser()
+                .getHealthCode()).withClientInfo(clientInfo).build();
         
         List<SchedulePlan> plans = schedulePlanService.getSchedulePlans(clientInfo, studyId);
 

--- a/app/org/sagebionetworks/bridge/play/controllers/ScheduledActivityController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ScheduledActivityController.java
@@ -98,7 +98,8 @@ public class ScheduledActivityController extends BaseController {
         ClientInfo clientInfo = getClientInfoFromUserAgentHeader();
 
         ScheduleContext context = new ScheduleContext.Builder()
-                .withUser(session.getUser())
+                .withHealthCode(session.getUser().getHealthCode())
+                .withStudyIdentifier(session.getStudyIdentifier())
                 .withClientInfo(clientInfo)
                 .withTimeZone(zone)
                 .withEndsOn(endsOn).build();

--- a/app/org/sagebionetworks/bridge/play/controllers/UserProfileController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/UserProfileController.java
@@ -9,13 +9,13 @@ import java.util.Set;
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.cache.ViewCache;
 import org.sagebionetworks.bridge.cache.ViewCache.ViewCacheKey;
+import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.accounts.DataGroups;
 import org.sagebionetworks.bridge.models.accounts.ExternalIdentifier;
 import org.sagebionetworks.bridge.models.accounts.User;
 import org.sagebionetworks.bridge.models.accounts.UserProfile;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
-import org.sagebionetworks.bridge.models.schedules.ScheduleContext;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 import org.sagebionetworks.bridge.services.ConsentService;
@@ -119,8 +119,9 @@ public class UserProfileController extends BaseController {
         User user = session.getUser();
         user.setDataGroups(dataGroups.getDataGroups());
 
-        ScheduleContext context = new ScheduleContext.Builder()
-                .withUser(user)
+        CriteriaContext context = new CriteriaContext.Builder()
+                .withHealthCode(user.getHealthCode())
+                .withStudyIdentifier(study.getStudyIdentifier())
                 .withClientInfo(getClientInfoFromUserAgentHeader())
                 .withUserDataGroups(dataGroups.getDataGroups())
                 .build();

--- a/app/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -18,6 +18,7 @@ import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.StudyLimitExceededException;
 import org.sagebionetworks.bridge.models.ClientInfo;
+import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.accounts.Email;
@@ -28,7 +29,6 @@ import org.sagebionetworks.bridge.models.accounts.SignIn;
 import org.sagebionetworks.bridge.models.accounts.SignUp;
 import org.sagebionetworks.bridge.models.accounts.User;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
-import org.sagebionetworks.bridge.models.schedules.ScheduleContext;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
@@ -254,11 +254,11 @@ public class AuthenticationService {
         user.setDataGroups(optionsService.getStringSet(healthCode, DATA_GROUPS));
 
         // now that we know more about this user, we can expand on the request context.
-        ScheduleContext context = new ScheduleContext.Builder()
+        CriteriaContext context = new CriteriaContext.Builder()
                 .withClientInfo(clientInfo)
                 .withHealthCode(healthCode)
                 .withUserDataGroups(user.getDataGroups())
-                .withStudyIdentifier(study.getIdentifier()) // probably already set
+                .withStudyIdentifier(study.getStudyIdentifier()) // probably already set
                 .build();
         
         Map<SubpopulationGuid,ConsentStatus> statuses = consentService.getConsentStatuses(context);

--- a/app/org/sagebionetworks/bridge/services/ConsentService.java
+++ b/app/org/sagebionetworks/bridge/services/ConsentService.java
@@ -19,13 +19,13 @@ import org.sagebionetworks.bridge.dao.UserConsentDao;
 import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.StudyLimitExceededException;
+import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.accounts.User;
 import org.sagebionetworks.bridge.models.accounts.UserConsent;
 import org.sagebionetworks.bridge.models.accounts.UserConsentHistory;
 import org.sagebionetworks.bridge.models.accounts.Withdrawal;
-import org.sagebionetworks.bridge.models.schedules.ScheduleContext;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
 import org.sagebionetworks.bridge.models.subpopulations.StudyConsentView;
@@ -200,7 +200,7 @@ public class ConsentService {
      * @param context
      * @return
      */
-    public Map<SubpopulationGuid,ConsentStatus> getConsentStatuses(ScheduleContext context) {
+    public Map<SubpopulationGuid,ConsentStatus> getConsentStatuses(CriteriaContext context) {
         checkNotNull(context);
         checkNotNull(context.getHealthCode());
         

--- a/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
+++ b/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
@@ -220,7 +220,7 @@ public class ScheduledActivityService {
     private List<ScheduledActivity> scheduleActivitiesForPlans(ScheduleContext context) {
         List<ScheduledActivity> scheduledActivities = Lists.newArrayList();
         
-        List<SchedulePlan> plans = schedulePlanService.getSchedulePlans(context.getClientInfo(),
+        List<SchedulePlan> plans = schedulePlanService.getSchedulePlans(context.getCriteriaContext().getClientInfo(),
                 context.getStudyIdentifier());
         for (SchedulePlan plan : plans) {
             Schedule schedule = plan.getStrategy().getScheduleForUser(plan, context);

--- a/app/org/sagebionetworks/bridge/services/SubpopulationService.java
+++ b/app/org/sagebionetworks/bridge/services/SubpopulationService.java
@@ -14,7 +14,7 @@ import org.springframework.validation.Validator;
 
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.dao.SubpopulationDao;
-import org.sagebionetworks.bridge.models.schedules.ScheduleContext;
+import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.subpopulations.StudyConsentForm;
@@ -140,7 +140,7 @@ public class SubpopulationService {
      * @param context
      * @return
      */
-    public List<Subpopulation> getSubpopulationForUser(ScheduleContext context) {
+    public List<Subpopulation> getSubpopulationForUser(CriteriaContext context) {
         checkNotNull(context);
         
         return subpopDao.getSubpopulationsForUser(context);

--- a/app/org/sagebionetworks/bridge/services/UserAdminService.java
+++ b/app/org/sagebionetworks/bridge/services/UserAdminService.java
@@ -30,8 +30,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import com.google.common.base.Preconditions;
-
 @Component("userAdminService")
 public class UserAdminService {
 

--- a/app/org/sagebionetworks/bridge/validators/ScheduleContextValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/ScheduleContextValidator.java
@@ -27,7 +27,7 @@ public class ScheduleContextValidator implements Validator {
         if (context.getZone() == null) {
             errors.rejectValue("offset", "must set a time zone offset in format '±HH:MM'");
         }
-        if (context.getHealthCode() == null) {
+        if (context.getCriteriaContext().getHealthCode() == null) {
             errors.rejectValue("healthCode", "is required");
         }
         // Very the ending timestamp is not invalid.

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -133,7 +133,7 @@ public class TestUtils {
     }
     
     public static List<ScheduledActivity> runSchedulerForActivities(ScheduleContext context) {
-        return runSchedulerForActivities(getSchedulePlans(context.getStudyIdentifier()), context);
+        return runSchedulerForActivities(getSchedulePlans(context.getCriteriaContext().getStudyIdentifier()), context);
     }
     
     public static List<SchedulePlan> getSchedulePlans(StudyIdentifier studyId) {

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -120,7 +120,7 @@ public class TestUtils {
     public static List<ScheduledActivity> runSchedulerForActivities(List<SchedulePlan> plans, ScheduleContext context) {
         List<ScheduledActivity> scheduledActivities = Lists.newArrayList();
         for (SchedulePlan plan : plans) {
-            if (context.getClientInfo().isTargetedAppVersion(plan.getMinAppVersion(), plan.getMaxAppVersion())) {
+            if (context.getCriteriaContext().getClientInfo().isTargetedAppVersion(plan.getMinAppVersion(), plan.getMaxAppVersion())) {
                 Schedule schedule = plan.getStrategy().getScheduleForUser(plan, context);
                 // It's become possible for a user to match no schedule
                 if (schedule != null) {

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDaoTest.java
@@ -106,7 +106,8 @@ public class DynamoScheduledActivityDaoTest {
         DateTime endsOn = DateTime.now().plus(Period.parse("P4D"));
         
         ScheduleContext context = new ScheduleContext.Builder()
-            .withUser(user)
+            .withHealthCode(user.getHealthCode())
+            .withStudyIdentifier(TEST_STUDY_IDENTIFIER)
             .withClientInfo(ClientInfo.UNKNOWN_CLIENT)
             .withTimeZone(MSK)
             .withEndsOn(endsOn)
@@ -124,7 +125,8 @@ public class DynamoScheduledActivityDaoTest {
         assertEquals(MSK, ((DynamoScheduledActivity)savedActivities.get(0)).getTimeZone());
         
         // Verify getActivity() works
-        ScheduledActivity savedActivity = activityDao.getActivity(context.getZone(), context.getHealthCode(), savedActivities.get(0).getGuid());
+        ScheduledActivity savedActivity = activityDao.getActivity(context.getZone(),
+                context.getCriteriaContext().getHealthCode(), savedActivities.get(0).getGuid());
         assertEquals(savedActivities.get(0), savedActivity);
         assertEquals(context.getZone(), savedActivity.getTimeZone());
         assertEquals(MSK, savedActivity.getScheduledOn().getZone());

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDaoTest.java
@@ -22,7 +22,7 @@ import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.ClientInfo;
-import org.sagebionetworks.bridge.models.schedules.ScheduleContext;
+import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.subpopulations.StudyConsent;
@@ -162,19 +162,19 @@ public class DynamoSubpopulationDaoTest {
         Subpopulation subpop4 = createSubpop(SUBPOP_4, null, null, null); // match anything, specificity 0
         
         // version 12, no tags == Subpop 4
-        List<Subpopulation> results = dao.getSubpopulationsForUser(scheduleContext(12, null));
+        List<Subpopulation> results = dao.getSubpopulationsForUser(criteriaContext(12, null));
         assertEquals(Sets.newHashSet(subpop4), Sets.newHashSet(results));
         
         // version 12, tag group1 == Subpops 3, 4
-        results = dao.getSubpopulationsForUser(scheduleContext(12, "group1"));
+        results = dao.getSubpopulationsForUser(criteriaContext(12, "group1"));
         assertEquals(Sets.newHashSet(subpop3, subpop4), Sets.newHashSet(results));
         
         // version 4, no tag == Subpops 2, 4
-        results = dao.getSubpopulationsForUser(scheduleContext(4, null));
+        results = dao.getSubpopulationsForUser(criteriaContext(4, null));
         assertEquals(Sets.newHashSet(subpop2, subpop4), Sets.newHashSet(results));
         
         // version 4, tag group1 == Subpops 1,2,3,4, returns 1 in this case (most specific)
-        results = dao.getSubpopulationsForUser(scheduleContext(4, "group1"));
+        results = dao.getSubpopulationsForUser(criteriaContext(4, "group1"));
         assertEquals(Sets.newHashSet(subpop1, subpop2, subpop3, subpop4), Sets.newHashSet(results));
     }
     
@@ -248,9 +248,9 @@ public class DynamoSubpopulationDaoTest {
      */
     @Test
     public void getSubpopulationsForUserReturnsNoSubpopulations() {
-        ScheduleContext context = new ScheduleContext.Builder()
+        CriteriaContext context = new CriteriaContext.Builder()
                 .withClientInfo(ClientInfo.UNKNOWN_CLIENT)
-                .withStudyIdentifier(studyId.getIdentifier())
+                .withStudyIdentifier(studyId)
                 .build();
         List<Subpopulation> results = dao.getSubpopulationsForUser(context);
         
@@ -265,9 +265,9 @@ public class DynamoSubpopulationDaoTest {
     @Test
     public void getSubpopulationsForUserDoesNotMatchSubpopulationReturnsNull() {
         createSubpop("Name of unmatcheable subpopulation", null, null, "unmatcheableGroup");
-        ScheduleContext context = new ScheduleContext.Builder()
+        CriteriaContext context = new CriteriaContext.Builder()
                 .withClientInfo(ClientInfo.UNKNOWN_CLIENT)
-                .withStudyIdentifier(studyId.getIdentifier())
+                .withStudyIdentifier(studyId)
                 .build();
         List<Subpopulation> results = dao.getSubpopulationsForUser(context);
         assertTrue(results.isEmpty());
@@ -344,10 +344,10 @@ public class DynamoSubpopulationDaoTest {
         return dao.createSubpopulation(subpop);
     }
     
-    private ScheduleContext scheduleContext(int version, String tag) {
-        ScheduleContext.Builder builder = new ScheduleContext.Builder()
+    private CriteriaContext criteriaContext(int version, String tag) {
+        CriteriaContext.Builder builder = new CriteriaContext.Builder()
                 .withClientInfo(ClientInfo.fromUserAgentCache("app/"+version))
-                .withStudyIdentifier(studyId.getIdentifier());
+                .withStudyIdentifier(studyId);
         if (tag != null) {
             builder.withUserDataGroups(Sets.newHashSet(tag));    
         }

--- a/test/org/sagebionetworks/bridge/models/CriteriaContextTest.java
+++ b/test/org/sagebionetworks/bridge/models/CriteriaContextTest.java
@@ -1,0 +1,53 @@
+package org.sagebionetworks.bridge.models;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Set;
+
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.TestConstants;
+
+import com.google.common.collect.Sets;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+public class CriteriaContextTest {
+
+    private static final ClientInfo CLIENT_INFO = ClientInfo.parseUserAgentString("app/20");
+    private static final Set<String> USER_DATA_GROUPS = Sets.newHashSet("a","b");
+    
+    @Test
+    public void equalsHashCode() {
+        EqualsVerifier.forClass(CriteriaContext.class).allFieldsShouldBeUsed().verify();
+    }
+    
+    @Test
+    public void defaultsClientInfo() {
+        CriteriaContext context = new CriteriaContext.Builder()
+                .withStudyIdentifier(TestConstants.TEST_STUDY).build();
+        assertEquals(ClientInfo.UNKNOWN_CLIENT, context.getClientInfo());
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void requiresStudyIdentifier() {
+        new CriteriaContext.Builder().build();
+    }
+    
+    @Test
+    public void builderWorks() {
+        CriteriaContext context = new CriteriaContext.Builder()
+                .withStudyIdentifier(TestConstants.TEST_STUDY)
+                .withClientInfo(CLIENT_INFO)
+                .withUserDataGroups(USER_DATA_GROUPS).build();
+        
+        // There are defaults
+        assertEquals(CLIENT_INFO, context.getClientInfo());
+        assertEquals(USER_DATA_GROUPS, context.getUserDataGroups());
+        
+        CriteriaContext copy = new CriteriaContext.Builder().withContext(context).build();
+        assertEquals(CLIENT_INFO, copy.getClientInfo());
+        assertEquals(USER_DATA_GROUPS, copy.getUserDataGroups());
+    }
+
+}

--- a/test/org/sagebionetworks/bridge/models/CriteriaUtilsTest.java
+++ b/test/org/sagebionetworks/bridge/models/CriteriaUtilsTest.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import org.junit.Test;
 import org.springframework.validation.Errors;
 
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.validators.Validate;
 
 import com.google.common.collect.Sets;
@@ -96,6 +97,7 @@ public class CriteriaUtilsTest {
     @Test
     public void matchingWithMinimalContextDoesNotCrash() {
         CriteriaContext context = new CriteriaContext.Builder()
+                .withStudyIdentifier(TestConstants.TEST_STUDY)
                 .withClientInfo(ClientInfo.UNKNOWN_CLIENT).build();
         assertTrue(CriteriaUtils.matchCriteria(context, new SimpleCriteria(EMPTY_SET, EMPTY_SET, null, null)));
         assertFalse(CriteriaUtils.matchCriteria(context, new SimpleCriteria(Sets.newHashSet("group1"), EMPTY_SET, null, null)));
@@ -159,6 +161,7 @@ public class CriteriaUtilsTest {
     
     private CriteriaContext getContext() {
         return new CriteriaContext.Builder()
+            .withStudyIdentifier(TestConstants.TEST_STUDY)
             .withClientInfo(ClientInfo.fromUserAgentCache("app/4"))
             .withUserDataGroups(Sets.newHashSet("group1", "group2")).build();
     }

--- a/test/org/sagebionetworks/bridge/models/CriteriaUtilsTest.java
+++ b/test/org/sagebionetworks/bridge/models/CriteriaUtilsTest.java
@@ -9,8 +9,6 @@ import java.util.Set;
 import org.junit.Test;
 import org.springframework.validation.Errors;
 
-import org.sagebionetworks.bridge.TestConstants;
-import org.sagebionetworks.bridge.models.schedules.ScheduleContext;
 import org.sagebionetworks.bridge.validators.Validate;
 
 import com.google.common.collect.Sets;
@@ -51,14 +49,14 @@ public class CriteriaUtilsTest {
     
     @Test
     public void matchesAgainstNothing() {
-        ScheduleContext context = getContext();
+        CriteriaContext context = getContext();
         
         assertTrue(CriteriaUtils.matchCriteria(context, new SimpleCriteria(EMPTY_SET, EMPTY_SET, null, null)));
     }
     
     @Test
     public void matchesAppRange() {
-        ScheduleContext context = getContext();
+        CriteriaContext context = getContext();
         assertTrue(CriteriaUtils.matchCriteria(context, new SimpleCriteria(EMPTY_SET, EMPTY_SET, null, 4)));
         assertTrue(CriteriaUtils.matchCriteria(context, new SimpleCriteria(EMPTY_SET, EMPTY_SET, 1, null)));
         assertTrue(CriteriaUtils.matchCriteria(context, new SimpleCriteria(EMPTY_SET, EMPTY_SET, 1, 4)));
@@ -66,7 +64,7 @@ public class CriteriaUtilsTest {
     
     @Test
     public void filtersAppRange() {
-        ScheduleContext context = getContext();
+        CriteriaContext context = getContext();
         assertFalse(CriteriaUtils.matchCriteria(context, new SimpleCriteria(EMPTY_SET, EMPTY_SET, null, 2)));
         assertFalse(CriteriaUtils.matchCriteria(context, new SimpleCriteria(EMPTY_SET, EMPTY_SET, 5, null)));
         assertFalse(CriteriaUtils.matchCriteria(context, new SimpleCriteria(EMPTY_SET, EMPTY_SET, 6, 11)));
@@ -74,7 +72,7 @@ public class CriteriaUtilsTest {
     
     @Test
     public void allOfGroupsMatch() {
-        ScheduleContext context = getContext(); // has group1, and group2
+        CriteriaContext context = getContext(); // has group1, and group2
         assertTrue(CriteriaUtils.matchCriteria(context, new SimpleCriteria(Sets.newHashSet("group1"), EMPTY_SET, null, null)));
         // Two groups are required, that still matches
         assertTrue(CriteriaUtils.matchCriteria(context, new SimpleCriteria(Sets.newHashSet("group1", "group2"), EMPTY_SET, null, null)));
@@ -84,21 +82,20 @@ public class CriteriaUtilsTest {
     
     @Test
     public void noneOfGroupsMatch() {
-        ScheduleContext context = getContext(); // has group1, and group2
+        CriteriaContext context = getContext(); // has group1, and group2
         // Here, any group at all prevents a match.
         assertFalse(CriteriaUtils.matchCriteria(context, new SimpleCriteria(EMPTY_SET, Sets.newHashSet("group3", "group1"), null, null)));
     }
 
     @Test
     public void noneOfGroupsDefinedButDontPreventMatch() {
-        ScheduleContext context = getContext(); // does not have group3, so it is matched
+        CriteriaContext context = getContext(); // does not have group3, so it is matched
         assertTrue(CriteriaUtils.matchCriteria(context, new SimpleCriteria(EMPTY_SET, Sets.newHashSet("group3"), null, null)));
     }
     
     @Test
     public void matchingWithMinimalContextDoesNotCrash() {
-        ScheduleContext context = new ScheduleContext.Builder()
-                .withStudyIdentifier("api")
+        CriteriaContext context = new CriteriaContext.Builder()
                 .withClientInfo(ClientInfo.UNKNOWN_CLIENT).build();
         assertTrue(CriteriaUtils.matchCriteria(context, new SimpleCriteria(EMPTY_SET, EMPTY_SET, null, null)));
         assertFalse(CriteriaUtils.matchCriteria(context, new SimpleCriteria(Sets.newHashSet("group1"), EMPTY_SET, null, null)));
@@ -160,10 +157,9 @@ public class CriteriaUtilsTest {
         assertTrue(errors.getFieldErrors("allOfGroups").get(0).getCode().contains("group3"));
     }
     
-    private ScheduleContext getContext() {
-        return new ScheduleContext.Builder()
+    private CriteriaContext getContext() {
+        return new CriteriaContext.Builder()
             .withClientInfo(ClientInfo.fromUserAgentCache("app/4"))
-            .withStudyIdentifier(TestConstants.TEST_STUDY_IDENTIFIER)
             .withUserDataGroups(Sets.newHashSet("group1", "group2")).build();
     }
 

--- a/test/org/sagebionetworks/bridge/models/schedules/ABTestScheduleStrategyTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/ABTestScheduleStrategyTest.java
@@ -95,7 +95,9 @@ public class ABTestScheduleStrategyTest {
 
         List<Schedule> schedules = Lists.newArrayList();
         for (User user : users) {
-            ScheduleContext context = new ScheduleContext.Builder().withUser(user).build();
+            ScheduleContext context = new ScheduleContext.Builder()
+                    .withStudyIdentifier(study.getStudyIdentifier())
+                    .withHealthCode(user.getHealthCode()).build();
             Schedule schedule = plan.getStrategy().getScheduleForUser(plan, context);
             schedules.add(schedule);
         }

--- a/test/org/sagebionetworks/bridge/models/schedules/CriteriaScheduleStrategyTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/CriteriaScheduleStrategyTest.java
@@ -196,11 +196,11 @@ public class CriteriaScheduleStrategyTest {
         setUpStrategyWithAppVersions();
         setUpStrategyWithProhibitedDataGroups();
         
-        User user = getUser();
-        user.setDataGroups(Sets.newHashSet("group1"));
         ScheduleContext context = new ScheduleContext.Builder()
+                .withStudyIdentifier(TestConstants.TEST_STUDY)
                 .withClientInfo(ClientInfo.fromUserAgentCache("app/44"))
-                .withUser(user).build();
+                .withUserDataGroups(Sets.newHashSet("group1"))
+                .withHealthCode("BBB").build();
 
         Schedule schedule = strategy.getScheduleForUser(PLAN, context);
         assertNull(schedule);
@@ -215,8 +215,9 @@ public class CriteriaScheduleStrategyTest {
         User user = getUser();
         user.setDataGroups(Sets.newHashSet("group3"));
         ScheduleContext context = new ScheduleContext.Builder()
+                .withStudyIdentifier(TestConstants.TEST_STUDY)
                 .withClientInfo(ClientInfo.fromUserAgentCache("app/44"))
-                .withUser(user).build();
+                .withHealthCode(user.getHealthCode()).build();
         
         // First two ScheduleCriteria don't match; the first because the app version is wrong 
         // and the second because the user does not have a required data group. The last ScheduleCriteria 
@@ -230,11 +231,11 @@ public class CriteriaScheduleStrategyTest {
         setUpStrategyWithAllRequirements();
         setUpStrategyWithAppVersions(); // certainly should not match this one, although criteria are valid
         
-        User user = getUser();
-        user.setDataGroups(Sets.newHashSet("req1", "req2")); // both are required
         ScheduleContext context = new ScheduleContext.Builder()
+                .withUserDataGroups(Sets.newHashSet("req1", "req2"))
+                .withStudyIdentifier(TestConstants.TEST_STUDY)
                 .withClientInfo(ClientInfo.fromUserAgentCache("app/6")) // in range
-                .withUser(user).build();
+                .withHealthCode("AAA").build();
         
         // Matches the first schedule, not the second schedule (although it also matches)
         Schedule schedule = strategy.getScheduleForUser(PLAN, context);

--- a/test/org/sagebionetworks/bridge/models/schedules/ScheduleContextTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/ScheduleContextTest.java
@@ -50,7 +50,7 @@ public class ScheduleContextTest {
     public void defaultsTimeZoneAndClientInfo() {
         ScheduleContext context = new ScheduleContext.Builder().withStudyIdentifier(TestConstants.TEST_STUDY).build();
         
-        assertEquals(ClientInfo.UNKNOWN_CLIENT, context.getClientInfo());
+        assertEquals(ClientInfo.UNKNOWN_CLIENT, context.getCriteriaContext().getClientInfo());
         assertNotNull(context.getNow());
     }
     
@@ -67,10 +67,10 @@ public class ScheduleContextTest {
         assertEquals(user.getStudyKey(), context.getStudyIdentifier().getIdentifier());
         assertEquals(user.getId(), context.getUserId());
         assertEquals(user.getHealthCode(), context.getHealthCode());
-        assertEquals(user.getDataGroups(), context.getUserDataGroups());
+        assertEquals(user.getDataGroups(), context.getCriteriaContext().getUserDataGroups());
         
         // There are defaults
-        assertEquals(ClientInfo.UNKNOWN_CLIENT, context.getClientInfo());
+        assertEquals(ClientInfo.UNKNOWN_CLIENT, context.getCriteriaContext().getClientInfo());
         assertNotNull(context.getNow());
         
         ClientInfo clientInfo = ClientInfo.fromUserAgentCache("app/5");
@@ -96,12 +96,12 @@ public class ScheduleContextTest {
                 .withNow(now).build();
         assertEquals(studyId, context.getStudyIdentifier());
         assertEquals("userId", context.getUserId());
-        assertEquals(clientInfo, context.getClientInfo());
+        assertEquals(clientInfo, context.getCriteriaContext().getClientInfo());
         assertEquals(PST, context.getZone());
         assertEquals(endsOn, context.getEndsOn());
         assertEquals(events.get("enrollment"), context.getEvent("enrollment"));
         assertEquals("healthCode", context.getHealthCode());
-        assertEquals(dataGroups, context.getUserDataGroups());
+        assertEquals(dataGroups, context.getCriteriaContext().getUserDataGroups());
         assertEquals(now, context.getNow());
 
         // and the other studyId setter

--- a/test/org/sagebionetworks/bridge/models/schedules/ScheduleContextTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/ScheduleContextTest.java
@@ -17,7 +17,6 @@ import org.junit.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.models.ClientInfo;
-import org.sagebionetworks.bridge.models.accounts.User;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 
@@ -25,6 +24,8 @@ import com.google.common.collect.Sets;
 
 public class ScheduleContextTest {
 
+    private static final Set<String> USER_DATA_GROUPS = Sets.newHashSet("A","B");
+    
     @Test
     public void equalsHashCode() {
         EqualsVerifier.forClass(ScheduleContext.class).allFieldsShouldBeUsed().verify();
@@ -56,57 +57,37 @@ public class ScheduleContextTest {
     
     @Test
     public void builderWorks() {
-        // User works
-        User user = new User();
-        user.setStudyKey("test-study");
-        user.setHealthCode("AAA");
-        user.setId("aUserId");
-        user.setDataGroups(Sets.newHashSet("A","B"));
-        
-        ScheduleContext context = new ScheduleContext.Builder().withUser(user).build();
-        assertEquals(user.getStudyKey(), context.getStudyIdentifier().getIdentifier());
-        assertEquals(user.getId(), context.getUserId());
-        assertEquals(user.getHealthCode(), context.getHealthCode());
-        assertEquals(user.getDataGroups(), context.getCriteriaContext().getUserDataGroups());
-        
-        // There are defaults
-        assertEquals(ClientInfo.UNKNOWN_CLIENT, context.getCriteriaContext().getClientInfo());
-        assertNotNull(context.getNow());
-        
         ClientInfo clientInfo = ClientInfo.fromUserAgentCache("app/5");
         StudyIdentifier studyId = new StudyIdentifierImpl("study-key");
         DateTimeZone PST = DateTimeZone.forOffsetHours(-7);
         DateTime endsOn = DateTime.now();
-        Set<String> dataGroups = Sets.newHashSet("A","B");
         DateTime now = DateTime.now();
         
         Map<String,DateTime> events = new HashMap<>();
         events.put("enrollment", DateTime.now());
         
         // All the individual fields work
-        context = new ScheduleContext.Builder()
+        ScheduleContext context = new ScheduleContext.Builder()
                 .withClientInfo(clientInfo)
-                .withUserId("userId")
                 .withStudyIdentifier(studyId)
                 .withTimeZone(PST)
                 .withEndsOn(endsOn)
                 .withEvents(events)
                 .withHealthCode("healthCode")
-                .withUserDataGroups(dataGroups)
+                .withUserDataGroups(USER_DATA_GROUPS)
                 .withNow(now).build();
-        assertEquals(studyId, context.getStudyIdentifier());
-        assertEquals("userId", context.getUserId());
+        assertEquals(studyId, context.getCriteriaContext().getStudyIdentifier());
         assertEquals(clientInfo, context.getCriteriaContext().getClientInfo());
         assertEquals(PST, context.getZone());
         assertEquals(endsOn, context.getEndsOn());
         assertEquals(events.get("enrollment"), context.getEvent("enrollment"));
-        assertEquals("healthCode", context.getHealthCode());
-        assertEquals(dataGroups, context.getCriteriaContext().getUserDataGroups());
+        assertEquals("healthCode", context.getCriteriaContext().getHealthCode());
+        assertEquals(USER_DATA_GROUPS, context.getCriteriaContext().getUserDataGroups());
         assertEquals(now, context.getNow());
 
         // and the other studyId setter
         context = new ScheduleContext.Builder().withStudyIdentifier("study-key").build();
-        assertEquals(studyId, context.getStudyIdentifier());
+        assertEquals(studyId, context.getCriteriaContext().getStudyIdentifier());
     }
     
 }

--- a/test/org/sagebionetworks/bridge/play/controllers/FPHSControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/FPHSControllerTest.java
@@ -24,11 +24,11 @@ import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.exceptions.NotAuthenticatedException;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.accounts.ExternalIdentifier;
 import org.sagebionetworks.bridge.models.accounts.FPHSExternalIdentifier;
 import org.sagebionetworks.bridge.models.accounts.User;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
-import org.sagebionetworks.bridge.models.schedules.ScheduleContext;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.services.AuthenticationService;
 import org.sagebionetworks.bridge.services.ConsentService;
@@ -161,7 +161,7 @@ public class FPHSControllerTest {
         assertEquals("External identifier added to user profile.", node.get("message").asText());
 
         assertEquals(Sets.newHashSet("football_player"), user.getDataGroups());
-        verify(consentService).getConsentStatuses(any(ScheduleContext.class));
+        verify(consentService).getConsentStatuses(any(CriteriaContext.class));
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/play/controllers/ScheduledActivityControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ScheduledActivityControllerTest.java
@@ -142,7 +142,7 @@ public class ScheduledActivityControllerTest {
         verifyNoMoreInteractions(scheduledActivityService);
         assertEquals(expectedEndsOn, argument.getValue().getEndsOn().withMillisOfSecond(0));
         assertEquals(expectedEndsOn.getZone(), argument.getValue().getZone());
-        assertEquals(clientInfo, argument.getValue().getClientInfo());
+        assertEquals(clientInfo, argument.getValue().getCriteriaContext().getClientInfo());
     }
     
     @SuppressWarnings("unchecked")

--- a/test/org/sagebionetworks/bridge/play/controllers/ScheduledActivityControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ScheduledActivityControllerTest.java
@@ -70,6 +70,7 @@ public class ScheduledActivityControllerTest {
         user.setHealthCode("BBB");
         user.setStudyKey(TestConstants.TEST_STUDY_IDENTIFIER);
         session.setUser(user);
+        session.setStudyIdentifier(TestConstants.TEST_STUDY);
         
         scheduledActivityService = mock(ScheduledActivityService.class);
         when(scheduledActivityService.getScheduledActivities(any(User.class), any(ScheduleContext.class))).thenReturn(list);

--- a/test/org/sagebionetworks/bridge/play/controllers/UserProfileControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/UserProfileControllerTest.java
@@ -93,7 +93,7 @@ public class UserProfileControllerTest {
         Set<String> dataGroups = (Set<String>)captor.getValue();
         assertEquals(dataGroupSet, dataGroups);
         
-        assertEquals(dataGroupSet, contextCaptor.getValue().getUserDataGroups());
+        assertEquals(dataGroupSet, contextCaptor.getValue().getCriteriaContext().getUserDataGroups());
         
         assertEquals(dataGroupSet, session.getUser().getDataGroups());
         

--- a/test/org/sagebionetworks/bridge/play/controllers/UserProfileControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/UserProfileControllerTest.java
@@ -29,10 +29,10 @@ import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.accounts.User;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
-import org.sagebionetworks.bridge.models.schedules.ScheduleContext;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
@@ -85,7 +85,7 @@ public class UserProfileControllerTest {
         Result result = controller.updateDataGroups();
         
         ArgumentCaptor<Set> captor = ArgumentCaptor.forClass(Set.class);
-        ArgumentCaptor<ScheduleContext> contextCaptor = ArgumentCaptor.forClass(ScheduleContext.class);
+        ArgumentCaptor<CriteriaContext> contextCaptor = ArgumentCaptor.forClass(CriteriaContext.class);
         
         verify(optionsService).setStringSet(eq(TEST_STUDY), eq("healthCode"), eq(DATA_GROUPS), captor.capture());
         verify(consentService).getConsentStatuses(contextCaptor.capture());
@@ -93,7 +93,7 @@ public class UserProfileControllerTest {
         Set<String> dataGroups = (Set<String>)captor.getValue();
         assertEquals(dataGroupSet, dataGroups);
         
-        assertEquals(dataGroupSet, contextCaptor.getValue().getCriteriaContext().getUserDataGroups());
+        assertEquals(dataGroupSet, contextCaptor.getValue().getUserDataGroups());
         
         assertEquals(dataGroupSet, session.getUser().getDataGroups());
         

--- a/test/org/sagebionetworks/bridge/services/ConsentServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ConsentServiceTest.java
@@ -32,12 +32,12 @@ import org.sagebionetworks.bridge.dao.UserConsentDao;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.json.DateUtils;
+import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.accounts.UserConsent;
 import org.sagebionetworks.bridge.models.accounts.UserConsentHistory;
 import org.sagebionetworks.bridge.models.accounts.Withdrawal;
-import org.sagebionetworks.bridge.models.schedules.ScheduleContext;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
 import org.sagebionetworks.bridge.models.subpopulations.StudyConsent;
@@ -84,7 +84,7 @@ public class ConsentServiceTest {
     
     private Subpopulation defaultSubpopulation;
     
-    private ScheduleContext context;
+    private CriteriaContext context;
     
     @Value("classpath:study-defaults/consent-body.xhtml")
     public void setDefaultConsentDocument(org.springframework.core.io.Resource resource) throws IOException {
@@ -105,7 +105,10 @@ public class ConsentServiceTest {
         
         testUser = helper.getBuilder(ConsentServiceTest.class).withStudy(study).withConsent(false).build();
         
-        context = new ScheduleContext.Builder().withUser(testUser.getUser()).build();
+        context = new CriteriaContext.Builder()
+                .withHealthCode(testUser.getUser().getHealthCode())
+                .withStudyIdentifier(testUser.getStudyIdentifier())
+                .withUserDataGroups(testUser.getUser().getDataGroups()).build();
     }
 
     @After

--- a/test/org/sagebionetworks/bridge/services/SubpopulationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SubpopulationServiceTest.java
@@ -30,8 +30,9 @@ import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudyConsent1;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.models.ClientInfo;
-import org.sagebionetworks.bridge.models.schedules.ScheduleContext;
+import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.subpopulations.StudyConsentForm;
 import org.sagebionetworks.bridge.models.subpopulations.StudyConsentView;
 import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
@@ -216,8 +217,8 @@ public class SubpopulationServiceTest {
         List<Subpopulation> subpops = ImmutableList.of(Subpopulation.create());
         // We test the matching logic in CriteriaUtilsTest as well as in the DAO. Here we just want
         // to verify it is being carried through.
-        ScheduleContext context = new ScheduleContext.Builder()
-                .withStudyIdentifier("test-key")
+        CriteriaContext context = new CriteriaContext.Builder()
+                .withStudyIdentifier(new StudyIdentifierImpl("test-key"))
                 .withClientInfo(ClientInfo.fromUserAgentCache("app/4")).build();
         
         when(dao.getSubpopulationsForUser(context)).thenReturn(subpops);

--- a/test/org/sagebionetworks/bridge/stormpath/StormpathAccountTest.java
+++ b/test/org/sagebionetworks/bridge/stormpath/StormpathAccountTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;


### PR DESCRIPTION
Pulling out the parameters that are for criteria matching from ScheduleContext. Using CriteriaContext where we're only concerned with criteria matching. The criteria context is part of the schedule context (we do matching of criteria when schedule matching).
