### PR TITLE
Add Accept-Language information to CriteriaContext

### DIFF
--- a/app/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/app/org/sagebionetworks/bridge/BridgeConstants.java
@@ -13,10 +13,6 @@ public class BridgeConstants {
     public static final String BRIDGE_STUDY_HEADER = "Bridge-Study";
 
     public static final String BRIDGE_HOST_HEADER = "Bridge-Host";
-    
-    public static final String ACCEPT_LANGUAGE_HEADER = "Accept-Language";
-    
-    public static final String USER_AGENT_HEADER = "User-Agent";
 
     /** Used by Heroku to pass in the request ID */
     public static final String X_REQUEST_ID_HEADER = "X-Request-Id";

--- a/app/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/app/org/sagebionetworks/bridge/BridgeConstants.java
@@ -14,6 +14,8 @@ public class BridgeConstants {
 
     public static final String BRIDGE_HOST_HEADER = "Bridge-Host";
     
+    public static final String ACCEPT_LANGUAGE_HEADER = "Accept-Language";
+    
     public static final String USER_AGENT_HEADER = "User-Agent";
 
     /** Used by Heroku to pass in the request ID */

--- a/app/org/sagebionetworks/bridge/models/CriteriaContext.java
+++ b/app/org/sagebionetworks/bridge/models/CriteriaContext.java
@@ -23,7 +23,7 @@ public final class CriteriaContext {
         this.healthCode = healthCode;
         this.clientInfo = clientInfo;
         this.userDataGroups = (userDataGroups == null) ? ImmutableSet.of() : ImmutableSet.copyOf(userDataGroups);
-        // ImmutableSet says its items are kept "in order" and this set is ordered, but not a SortedSet
+        // ImmutableSet says its items are kept "in order" and this set is ordered (but not sorted as in SortedSet)
         this.languages = (languages == null) ? ImmutableSet.of() : ImmutableSet.copyOf(languages);
     }
 
@@ -115,6 +115,7 @@ public final class CriteriaContext {
             this.healthCode = context.healthCode;
             this.clientInfo = context.clientInfo;
             this.userDataGroups = context.userDataGroups;
+            this.languages = context.languages;
             return this;
         }
 

--- a/app/org/sagebionetworks/bridge/models/CriteriaContext.java
+++ b/app/org/sagebionetworks/bridge/models/CriteriaContext.java
@@ -15,12 +15,16 @@ public final class CriteriaContext {
     private final String healthCode;
     private final ClientInfo clientInfo;
     private final Set<String> userDataGroups;
+    private final Set<String> languages;
     
-    private CriteriaContext(StudyIdentifier studyId, String healthCode, ClientInfo clientInfo, Set<String> userDataGroups) {
+    private CriteriaContext(StudyIdentifier studyId, String healthCode, ClientInfo clientInfo,
+            Set<String> userDataGroups, Set<String> languages) {
         this.studyId = studyId;
         this.healthCode = healthCode;
         this.clientInfo = clientInfo;
         this.userDataGroups = (userDataGroups == null) ? ImmutableSet.of() : ImmutableSet.copyOf(userDataGroups);
+        // ImmutableSet says its items are kept "in order" and this set is ordered, but not a SortedSet
+        this.languages = (languages == null) ? ImmutableSet.of() : ImmutableSet.copyOf(languages);
     }
 
     /**
@@ -42,10 +46,21 @@ public final class CriteriaContext {
     public String getHealthCode() {
         return healthCode;
     }
+    
+    /**
+     * Languages are sorted in order of descending preference of the LanguageRange objects 
+     * submitted by the request via the Accept-Language HTTP header. That is to say, the 
+     * client prefers the first language more than the second language, the second more than 
+     * the third, etc. However, this isn't a SortedSet, which sorts the items according to 
+     * some ordering that in this case, is external to the string itself.
+     */
+    public Set<String> getLanguages() {
+        return languages;
+    }
 
     @Override
     public int hashCode() {
-        return Objects.hash(studyId, healthCode, clientInfo, userDataGroups);
+        return Objects.hash(studyId, healthCode, clientInfo, userDataGroups, languages);
     }
 
     @Override
@@ -58,13 +73,14 @@ public final class CriteriaContext {
         return (Objects.equals(clientInfo, other.clientInfo) && 
                 Objects.equals(userDataGroups, other.userDataGroups) && 
                 Objects.equals(studyId, other.studyId) && 
-                Objects.equals(healthCode, other.healthCode));
+                Objects.equals(healthCode, other.healthCode) && 
+                Objects.equals(languages, other.languages));
     }
 
     @Override
     public String toString() {
-        return "CriteriaContext [studyId=" + studyId + ", healthCode=" + healthCode + 
-                ", clientInfo=" + clientInfo + ", userDataGroups=" + userDataGroups + "]";
+        return "CriteriaContext [studyId=" + studyId + ", healthCode=" + healthCode + ", clientInfo=" + clientInfo
+                + ", userDataGroups=" + userDataGroups + ", languages=" + languages + "]";
     }
 
     public static class Builder {
@@ -72,6 +88,7 @@ public final class CriteriaContext {
         private String healthCode;
         private ClientInfo clientInfo;
         private Set<String> userDataGroups;
+        private Set<String> languages;
 
         public Builder withStudyIdentifier(StudyIdentifier studyId) {
             this.studyId = studyId;
@@ -89,6 +106,10 @@ public final class CriteriaContext {
             this.userDataGroups = userDataGroups;
             return this;
         }
+        public Builder withLanguages(Set<String> languages) {
+            this.languages = languages;
+            return this;
+        }
         public Builder withContext(CriteriaContext context) {
             this.studyId = context.studyId;
             this.healthCode = context.healthCode;
@@ -102,7 +123,7 @@ public final class CriteriaContext {
             if (clientInfo == null) {
                 clientInfo = ClientInfo.UNKNOWN_CLIENT;
             }
-            return new CriteriaContext(studyId, healthCode, clientInfo, userDataGroups);
+            return new CriteriaContext(studyId, healthCode, clientInfo, userDataGroups, languages);
         }
     }
 }

--- a/app/org/sagebionetworks/bridge/models/CriteriaContext.java
+++ b/app/org/sagebionetworks/bridge/models/CriteriaContext.java
@@ -15,10 +15,9 @@ public final class CriteriaContext {
     private final String healthCode;
     private final ClientInfo clientInfo;
     private final Set<String> userDataGroups;
-    // This set is ordered (but not a SortedSet, as this set implies a sort order based on its contents, 
-    // and we are storing the language string here, without the quality indicator from the LanguageRange
-    // in the Accept-Language header that told us the preferential order of the languages in the first 
-    // place.
+    // This set is ordered from most preferred to least preferred language. It is not a SortedSet because 
+    // that type includes a comparator for sorting the items in the set, and this preference order was 
+    // determined externally from the LanguageRange objects (it's not in the language string).
     private final Set<String> languages;
     
     private CriteriaContext(StudyIdentifier studyId, String healthCode, ClientInfo clientInfo,

--- a/app/org/sagebionetworks/bridge/models/CriteriaContext.java
+++ b/app/org/sagebionetworks/bridge/models/CriteriaContext.java
@@ -15,6 +15,10 @@ public final class CriteriaContext {
     private final String healthCode;
     private final ClientInfo clientInfo;
     private final Set<String> userDataGroups;
+    // This set is ordered (but not a SortedSet, as this set implies a sort order based on its contents, 
+    // and we are storing the language string here, without the quality indicator from the LanguageRange
+    // in the Accept-Language header that told us the preferential order of the languages in the first 
+    // place.
     private final Set<String> languages;
     
     private CriteriaContext(StudyIdentifier studyId, String healthCode, ClientInfo clientInfo,
@@ -23,7 +27,7 @@ public final class CriteriaContext {
         this.healthCode = healthCode;
         this.clientInfo = clientInfo;
         this.userDataGroups = (userDataGroups == null) ? ImmutableSet.of() : ImmutableSet.copyOf(userDataGroups);
-        // ImmutableSet says its items are kept "in order" and this set is ordered (but not sorted as in SortedSet)
+        // ImmutableSet says its items are kept "in order"
         this.languages = (languages == null) ? ImmutableSet.of() : ImmutableSet.copyOf(languages);
     }
 
@@ -51,8 +55,8 @@ public final class CriteriaContext {
      * Languages are sorted in order of descending preference of the LanguageRange objects 
      * submitted by the request via the Accept-Language HTTP header. That is to say, the 
      * client prefers the first language more than the second language, the second more than 
-     * the third, etc. However, this isn't a SortedSet, which sorts the items according to 
-     * some ordering that in this case, is external to the string itself.
+     * the third, etc. However, this isn't a SortedSet, because it is sorted by something 
+     * (LanguageRange quality) that is external to the contents of the Set.
      */
     public Set<String> getLanguages() {
         return languages;

--- a/app/org/sagebionetworks/bridge/models/schedules/ScheduleContext.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/ScheduleContext.java
@@ -154,6 +154,10 @@ public final class ScheduleContext {
             this.now = now;
             return this;
         }
+        public Builder withLanguages(Set<String> languages) {
+            contextBuilder.withLanguages(languages);
+            return this;
+        }
         public Builder withContext(ScheduleContext context) {
             this.zone = context.zone;
             this.endsOn = context.endsOn;

--- a/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
@@ -106,7 +106,6 @@ public class AuthenticationController extends BaseController {
             SignIn signIn = parseJson(request(), SignIn.class);
             Study study = getStudyOrThrowException(json);
 
-            // No session by definition
             CriteriaContext context = getCriteriaContext(study.getStudyIdentifier());
             
             try {

--- a/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
@@ -9,7 +9,7 @@ import org.sagebionetworks.bridge.exceptions.ConcurrentModificationException;
 import org.sagebionetworks.bridge.exceptions.ConsentRequiredException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.json.JsonUtils;
-import org.sagebionetworks.bridge.models.ClientInfo;
+import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.accounts.Email;
 import org.sagebionetworks.bridge.models.accounts.EmailVerification;
 import org.sagebionetworks.bridge.models.accounts.PasswordReset;
@@ -56,9 +56,10 @@ public class AuthenticationController extends BaseController {
         JsonNode json = requestToJSON(request());
         EmailVerification emailVerification = parseJson(request(), EmailVerification.class);
         Study study = getStudyOrThrowException(json);
-        ClientInfo clientInfo = getClientInfoFromUserAgentHeader();
 
-        UserSession session = authenticationService.verifyEmail(study, clientInfo, emailVerification);
+        CriteriaContext context = getCriteriaContext();
+        
+        UserSession session = authenticationService.verifyEmail(study, context, emailVerification);
         writeSessionInfoToMetrics(session);
         setSessionToken(session.getSessionToken());
 
@@ -104,10 +105,11 @@ public class AuthenticationController extends BaseController {
             JsonNode json = requestToJSON(request());
             SignIn signIn = parseJson(request(), SignIn.class);
             Study study = getStudyOrThrowException(json);
-            ClientInfo clientInfo = getClientInfoFromUserAgentHeader();
 
+            CriteriaContext context = getCriteriaContext(session);
+            
             try {
-                session = authenticationService.signIn(study, clientInfo, signIn);
+                session = authenticationService.signIn(study, context, signIn);
             } catch (ConcurrentModificationException e) {
                 if (retryCounter > 0) {
                     final long retryDelayInMillis = 200;

--- a/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
@@ -57,7 +57,7 @@ public class AuthenticationController extends BaseController {
         EmailVerification emailVerification = parseJson(request(), EmailVerification.class);
         Study study = getStudyOrThrowException(json);
 
-        CriteriaContext context = getCriteriaContext();
+        CriteriaContext context = getCriteriaContext(study.getStudyIdentifier());
         
         UserSession session = authenticationService.verifyEmail(study, context, emailVerification);
         writeSessionInfoToMetrics(session);
@@ -106,7 +106,8 @@ public class AuthenticationController extends BaseController {
             SignIn signIn = parseJson(request(), SignIn.class);
             Study study = getStudyOrThrowException(json);
 
-            CriteriaContext context = getCriteriaContext(session);
+            // No session by definition
+            CriteriaContext context = getCriteriaContext(study.getStudyIdentifier());
             
             try {
                 session = authenticationService.signIn(study, context, signIn);

--- a/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
@@ -1,10 +1,16 @@
 package org.sagebionetworks.bridge.play.controllers;
 
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS;
 import static org.sagebionetworks.bridge.BridgeConstants.SESSION_TOKEN_HEADER;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.Locale.LanguageRange;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 
@@ -19,6 +25,7 @@ import org.sagebionetworks.bridge.exceptions.NotAuthenticatedException;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.ClientInfo;
+import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.Metrics;
 import org.sagebionetworks.bridge.models.ResourceList;
 import org.sagebionetworks.bridge.models.StatusMessage;
@@ -44,6 +51,7 @@ import com.amazonaws.util.Throwables;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSet;
 
 public abstract class BaseController extends Controller {
 
@@ -158,12 +166,43 @@ public abstract class BaseController extends Controller {
         }
     }
 
+    Set<String> getLanguagesFromAcceptLanguageHeader() {
+        String acceptLanguageHeader = request().getHeader(BridgeConstants.ACCEPT_LANGUAGE_HEADER);
+        if (isNotBlank(acceptLanguageHeader)) {
+            // This parse method returns LanguageRange objects in descending order of their quality 
+            // value (so most-desirable language first). We extract language only and de-duplicate 
+            // them using a LinkedHashSet which retains the order the languages are added to the set.
+            List<LanguageRange> ranges = Locale.LanguageRange.parse(acceptLanguageHeader);
+            return ranges.stream().map(range -> {
+                return Locale.forLanguageTag(range.getRange()).getLanguage();
+            }).collect(Collectors.toCollection(LinkedHashSet::new));
+        }
+        return ImmutableSet.of();
+    }
+    
     ClientInfo getClientInfoFromUserAgentHeader() {
         String userAgentHeader = request().getHeader(BridgeConstants.USER_AGENT_HEADER);
         ClientInfo info = ClientInfo.fromUserAgentCache(userAgentHeader);
         
         Logger.debug("User agent: '"+userAgentHeader+"' converted to " + info);
     	return info;
+    }
+    
+    CriteriaContext getCriteriaContext() {
+        return new CriteriaContext.Builder()
+            .withLanguages(getLanguagesFromAcceptLanguageHeader())
+            .withClientInfo(getClientInfoFromUserAgentHeader())
+            .build();
+    }
+    
+    CriteriaContext getCriteriaContext(UserSession session) {
+        return new CriteriaContext.Builder()
+            .withLanguages(getLanguagesFromAcceptLanguageHeader())
+            .withClientInfo(getClientInfoFromUserAgentHeader())
+            .withHealthCode(session.getUser().getHealthCode())
+            .withUserDataGroups(session.getUser().getDataGroups())
+            .withStudyIdentifier(session.getStudyIdentifier())
+            .build();
     }
     
     Result okResult(String message) {

--- a/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
@@ -1,10 +1,8 @@
 package org.sagebionetworks.bridge.play.controllers;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static org.sagebionetworks.bridge.BridgeConstants.ACCEPT_LANGUAGE_HEADER;
 import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS;
 import static org.sagebionetworks.bridge.BridgeConstants.SESSION_TOKEN_HEADER;
-import static org.sagebionetworks.bridge.BridgeConstants.USER_AGENT_HEADER;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.LinkedHashSet;
@@ -169,7 +167,7 @@ public abstract class BaseController extends Controller {
     }
 
     Set<String> getLanguagesFromAcceptLanguageHeader() {
-        String acceptLanguageHeader = request().getHeader(ACCEPT_LANGUAGE_HEADER);
+        String acceptLanguageHeader = request().getHeader(ACCEPT_LANGUAGE);
         if (isNotBlank(acceptLanguageHeader)) {
             // This parse method returns LanguageRange objects in descending order of their quality 
             // value (so most-desirable language first). We extract language only and de-duplicate 
@@ -183,7 +181,7 @@ public abstract class BaseController extends Controller {
     }
     
     ClientInfo getClientInfoFromUserAgentHeader() {
-        String userAgentHeader = request().getHeader(USER_AGENT_HEADER);
+        String userAgentHeader = request().getHeader(USER_AGENT);
         ClientInfo info = ClientInfo.fromUserAgentCache(userAgentHeader);
         
         Logger.debug("User agent: '"+userAgentHeader+"' converted to " + info);

--- a/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
@@ -1,8 +1,10 @@
 package org.sagebionetworks.bridge.play.controllers;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.sagebionetworks.bridge.BridgeConstants.ACCEPT_LANGUAGE_HEADER;
 import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS;
 import static org.sagebionetworks.bridge.BridgeConstants.SESSION_TOKEN_HEADER;
+import static org.sagebionetworks.bridge.BridgeConstants.USER_AGENT_HEADER;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.LinkedHashSet;
@@ -14,7 +16,6 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 
-import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.config.BridgeConfig;
@@ -32,6 +33,7 @@ import org.sagebionetworks.bridge.models.StatusMessage;
 import org.sagebionetworks.bridge.models.accounts.User;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.play.interceptors.RequestUtils;
 import org.sagebionetworks.bridge.services.AuthenticationService;
 import org.sagebionetworks.bridge.services.StudyService;
@@ -167,7 +169,7 @@ public abstract class BaseController extends Controller {
     }
 
     Set<String> getLanguagesFromAcceptLanguageHeader() {
-        String acceptLanguageHeader = request().getHeader(BridgeConstants.ACCEPT_LANGUAGE_HEADER);
+        String acceptLanguageHeader = request().getHeader(ACCEPT_LANGUAGE_HEADER);
         if (isNotBlank(acceptLanguageHeader)) {
             // This parse method returns LanguageRange objects in descending order of their quality 
             // value (so most-desirable language first). We extract language only and de-duplicate 
@@ -181,15 +183,16 @@ public abstract class BaseController extends Controller {
     }
     
     ClientInfo getClientInfoFromUserAgentHeader() {
-        String userAgentHeader = request().getHeader(BridgeConstants.USER_AGENT_HEADER);
+        String userAgentHeader = request().getHeader(USER_AGENT_HEADER);
         ClientInfo info = ClientInfo.fromUserAgentCache(userAgentHeader);
         
         Logger.debug("User agent: '"+userAgentHeader+"' converted to " + info);
     	return info;
     }
     
-    CriteriaContext getCriteriaContext() {
+    CriteriaContext getCriteriaContext(StudyIdentifier studyId) {
         return new CriteriaContext.Builder()
+            .withStudyIdentifier(studyId)
             .withLanguages(getLanguagesFromAcceptLanguageHeader())
             .withClientInfo(getClientInfoFromUserAgentHeader())
             .build();

--- a/app/org/sagebionetworks/bridge/play/controllers/FPHSController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/FPHSController.java
@@ -68,12 +68,7 @@ public class FPHSController extends BaseController {
         dataGroups.add("football_player");
         user.setDataGroups(dataGroups);
         
-        CriteriaContext context = new CriteriaContext.Builder()
-                .withClientInfo(getClientInfoFromUserAgentHeader())
-                .withHealthCode(user.getHealthCode())
-                .withUserDataGroups(user.getDataGroups())
-                .withStudyIdentifier(session.getStudyIdentifier())
-                .build();
+        CriteriaContext context = getCriteriaContext(session);
         Map<SubpopulationGuid,ConsentStatus> statuses = consentService.getConsentStatuses(context);
         user.setConsentStatuses(statuses);
         updateSessionUser(session, user);

--- a/app/org/sagebionetworks/bridge/play/controllers/ScheduleController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ScheduleController.java
@@ -71,6 +71,7 @@ public class ScheduleController extends BaseController {
         ClientInfo clientInfo = getClientInfoFromUserAgentHeader();
 
         ScheduleContext context = new ScheduleContext.Builder()
+                .withLanguages(getLanguagesFromAcceptLanguageHeader())
                 .withStudyIdentifier(studyId)
                 .withHealthCode(session.getUser()
                 .getHealthCode()).withClientInfo(clientInfo).build();

--- a/app/org/sagebionetworks/bridge/play/controllers/ScheduledActivityController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ScheduledActivityController.java
@@ -98,6 +98,7 @@ public class ScheduledActivityController extends BaseController {
         ClientInfo clientInfo = getClientInfoFromUserAgentHeader();
 
         ScheduleContext context = new ScheduleContext.Builder()
+                .withLanguages(getLanguagesFromAcceptLanguageHeader())
                 .withHealthCode(session.getUser().getHealthCode())
                 .withStudyIdentifier(session.getStudyIdentifier())
                 .withClientInfo(clientInfo)

--- a/app/org/sagebionetworks/bridge/play/controllers/ScheduledActivityController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ScheduledActivityController.java
@@ -96,7 +96,7 @@ public class ScheduledActivityController extends BaseController {
             throw new BadRequestException("Supply either 'until' parameter, or 'daysAhead' and 'offset' parameters.");
         }
         ClientInfo clientInfo = getClientInfoFromUserAgentHeader();
-
+        
         ScheduleContext context = new ScheduleContext.Builder()
                 .withLanguages(getLanguagesFromAcceptLanguageHeader())
                 .withHealthCode(session.getUser().getHealthCode())

--- a/app/org/sagebionetworks/bridge/play/controllers/UserProfileController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/UserProfileController.java
@@ -118,14 +118,8 @@ public class UserProfileController extends BaseController {
         
         User user = session.getUser();
         user.setDataGroups(dataGroups.getDataGroups());
-
-        CriteriaContext context = new CriteriaContext.Builder()
-                .withHealthCode(user.getHealthCode())
-                .withLanguages(getLanguagesFromAcceptLanguageHeader())
-                .withStudyIdentifier(study.getStudyIdentifier())
-                .withClientInfo(getClientInfoFromUserAgentHeader())
-                .withUserDataGroups(dataGroups.getDataGroups())
-                .build();
+        
+        CriteriaContext context = getCriteriaContext(session);
         Map<SubpopulationGuid,ConsentStatus> statuses = consentService.getConsentStatuses(context);
         user.setConsentStatuses(statuses);
                 

--- a/app/org/sagebionetworks/bridge/play/controllers/UserProfileController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/UserProfileController.java
@@ -121,6 +121,7 @@ public class UserProfileController extends BaseController {
 
         CriteriaContext context = new CriteriaContext.Builder()
                 .withHealthCode(user.getHealthCode())
+                .withLanguages(getLanguagesFromAcceptLanguageHeader())
                 .withStudyIdentifier(study.getStudyIdentifier())
                 .withClientInfo(getClientInfoFromUserAgentHeader())
                 .withUserDataGroups(dataGroups.getDataGroups())

--- a/app/org/sagebionetworks/bridge/services/UserAdminService.java
+++ b/app/org/sagebionetworks/bridge/services/UserAdminService.java
@@ -14,7 +14,7 @@ import org.sagebionetworks.bridge.dao.DistributedLockDao;
 import org.sagebionetworks.bridge.dao.HealthIdDao;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.json.DateUtils;
-import org.sagebionetworks.bridge.models.ClientInfo;
+import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
@@ -126,9 +126,13 @@ public class UserAdminService {
 
         authenticationService.signUp(study, signUp, false);
 
+        // We don't filter users by any of these filtering criteria in the admin API.
+        CriteriaContext context = new CriteriaContext.Builder()
+                .withStudyIdentifier(study.getStudyIdentifier()).build();
+        
         try {
             SignIn signIn = new SignIn(signUp.getEmail(), signUp.getPassword());
-            UserSession newUserSession = authenticationService.signIn(study, ClientInfo.UNKNOWN_CLIENT, signIn);
+            UserSession newUserSession = authenticationService.signIn(study, context, signIn);
 
             if (consentUser) {
                 String name = String.format("[Signature for %s]", signUp.getEmail());

--- a/test/org/sagebionetworks/bridge/TestConstants.java
+++ b/test/org/sagebionetworks/bridge/TestConstants.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge;
 
 import org.joda.time.DateTime;
 import org.sagebionetworks.bridge.config.BridgeConfigFactory;
+import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.schedules.Activity;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
@@ -13,6 +14,9 @@ public class TestConstants {
 
     public static final String TEST_STUDY_IDENTIFIER = "api";
     public static final StudyIdentifier TEST_STUDY = new StudyIdentifierImpl(TEST_STUDY_IDENTIFIER);
+    public static final CriteriaContext TEST_CONTEXT = new CriteriaContext.Builder()
+            .withStudyIdentifier(TestConstants.TEST_STUDY).build();
+
     public static final int TIMEOUT = 10000;
     public static final String TEST_BASE_URL = "http://localhost:3333";
     public static final String API_URL = "/v3";

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -88,7 +88,8 @@ public class TestUtils {
 
         when(request.getHeader(anyString())).thenAnswer(invocation -> {
             Object[] args = invocation.getArguments();
-            return headers.get(args[0])[0];
+            String[] values = headers.get(args[0]);
+            return (values == null || values.length == 0) ? null : values[0];
         });
         when(request.headers()).thenReturn(headers);
         when(request.body()).thenReturn(body);

--- a/test/org/sagebionetworks/bridge/models/CriteriaContextTest.java
+++ b/test/org/sagebionetworks/bridge/models/CriteriaContextTest.java
@@ -8,12 +8,13 @@ import org.junit.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class CriteriaContextTest {
-
+    
     private static final ClientInfo CLIENT_INFO = ClientInfo.parseUserAgentString("app/20");
     private static final Set<String> USER_DATA_GROUPS = Sets.newHashSet("a","b");
     
@@ -27,6 +28,7 @@ public class CriteriaContextTest {
         CriteriaContext context = new CriteriaContext.Builder()
                 .withStudyIdentifier(TestConstants.TEST_STUDY).build();
         assertEquals(ClientInfo.UNKNOWN_CLIENT, context.getClientInfo());
+        assertEquals(ImmutableSet.of(), context.getLanguages());
     }
     
     @Test(expected = NullPointerException.class)
@@ -49,5 +51,4 @@ public class CriteriaContextTest {
         assertEquals(CLIENT_INFO, copy.getClientInfo());
         assertEquals(USER_DATA_GROUPS, copy.getUserDataGroups());
     }
-
 }

--- a/test/org/sagebionetworks/bridge/play/controllers/AuthenticationControllerMockTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/AuthenticationControllerMockTest.java
@@ -33,6 +33,7 @@ import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
 import org.sagebionetworks.bridge.exceptions.ConsentRequiredException;
 import org.sagebionetworks.bridge.exceptions.NotAuthenticatedException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.Metrics;
 import org.sagebionetworks.bridge.models.accounts.EmailVerification;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
@@ -225,6 +226,10 @@ public class AuthenticationControllerMockTest {
         // mock getSessionToken and getMetrics
         doReturn(null).when(controller).getSessionToken();
 
+        CriteriaContext context = new CriteriaContext.Builder()
+                .withStudyIdentifier(TEST_STUDY_ID).build();
+        doReturn(context).when(controller).getCriteriaContext(any(StudyIdentifier.class));
+        
         Metrics metrics = new Metrics(TEST_REQUEST_ID);
         doReturn(metrics).when(controller).getMetrics();
 
@@ -234,8 +239,8 @@ public class AuthenticationControllerMockTest {
                 "   \"password\":\"" + TEST_PASSWORD + "\",\n" +
                 "   \"study\":\"" + TEST_STUDY_ID_STRING + "\"\n" +
                 "}";
-        Context context = TestUtils.mockPlayContextWithJson(requestJsonString);
-        Http.Context.current.set(context);
+        Context playContext = TestUtils.mockPlayContextWithJson(requestJsonString);
+        Http.Context.current.set(playContext);
 
         // mock AuthenticationService
         UserSession session = createSession();
@@ -283,6 +288,10 @@ public class AuthenticationControllerMockTest {
         // mock getSessionToken and getMetrics
         doReturn(null).when(controller).getSessionToken();
 
+        CriteriaContext context = new CriteriaContext.Builder()
+                .withStudyIdentifier(TEST_STUDY_ID).build();
+        doReturn(context).when(controller).getCriteriaContext(any(StudyIdentifier.class));
+        
         Metrics metrics = new Metrics(TEST_REQUEST_ID);
         doReturn(metrics).when(controller).getMetrics();
 
@@ -292,8 +301,8 @@ public class AuthenticationControllerMockTest {
                 "   \"password\":\"" + TEST_PASSWORD + "\",\n" +
                 "   \"study\":\"" + TEST_STUDY_ID_STRING + "\"\n" +
                 "}";
-        Context context = TestUtils.mockPlayContextWithJson(requestJsonString);
-        Http.Context.current.set(context);
+        Context playContext = TestUtils.mockPlayContextWithJson(requestJsonString);
+        Http.Context.current.set(playContext);
 
         // mock AuthenticationService
         User user = new User();
@@ -343,6 +352,10 @@ public class AuthenticationControllerMockTest {
 
     @Test
     public void signInNewSessionUnconsentedAdmin() throws Exception {
+        CriteriaContext context = new CriteriaContext.Builder()
+                .withStudyIdentifier(TEST_STUDY_ID).build();
+        doReturn(context).when(controller).getCriteriaContext(any(StudyIdentifier.class));
+
         // mock getSessionToken and getMetrics
         doReturn(null).when(controller).getSessionToken();
 
@@ -355,8 +368,8 @@ public class AuthenticationControllerMockTest {
                 "   \"password\":\"" + TEST_PASSWORD + "\",\n" +
                 "   \"study\":\"" + TEST_STUDY_ID_STRING + "\"\n" +
                 "}";
-        Context context = TestUtils.mockPlayContextWithJson(requestJsonString);
-        Http.Context.current.set(context);
+        Context playContext = TestUtils.mockPlayContextWithJson(requestJsonString);
+        Http.Context.current.set(playContext);
 
         // mock AuthenticationService
         User user = new User();
@@ -419,19 +432,23 @@ public class AuthenticationControllerMockTest {
         // mock getMetrics
         Metrics metrics = new Metrics(TEST_REQUEST_ID);
         doReturn(metrics).when(controller).getMetrics();
-
+        
         // mock request
         String requestJsonString = "{\n" +
                 "   \"sptoken\":\"" + TEST_VERIFY_EMAIL_TOKEN + "\",\n" +
                 "   \"study\":\"" + TEST_STUDY_ID_STRING + "\"\n" +
                 "}";
-        Context context = TestUtils.mockPlayContextWithJson(requestJsonString);
-        Http.Context.current.set(context);
+        Context playContext = TestUtils.mockPlayContextWithJson(requestJsonString);
+        Http.Context.current.set(playContext);
 
         // mock AuthenticationService
         UserSession session = createSession();
         ArgumentCaptor<EmailVerification> emailVerifyCaptor = ArgumentCaptor.forClass(EmailVerification.class);
         when(authenticationService.verifyEmail(same(study), any(), emailVerifyCaptor.capture())).thenReturn(session);
+
+        CriteriaContext context = new CriteriaContext.Builder()
+                .withStudyIdentifier(TEST_STUDY_ID).build();
+        doReturn(context).when(controller).getCriteriaContext(any(StudyIdentifier.class));
 
         // execute and validate
         Result result = controller.verifyEmail();
@@ -445,6 +462,10 @@ public class AuthenticationControllerMockTest {
 
     @Test
     public void verifyEmailUnconsented() throws Exception {
+        CriteriaContext context = new CriteriaContext.Builder()
+                .withStudyIdentifier(TEST_STUDY_ID).build();
+        doReturn(context).when(controller).getCriteriaContext(any(StudyIdentifier.class));
+        
         // mock getMetrics
         Metrics metrics = new Metrics(TEST_REQUEST_ID);
         doReturn(metrics).when(controller).getMetrics();
@@ -454,8 +475,8 @@ public class AuthenticationControllerMockTest {
                 "   \"sptoken\":\"" + TEST_VERIFY_EMAIL_TOKEN + "\",\n" +
                 "   \"study\":\"" + TEST_STUDY_ID_STRING + "\"\n" +
                 "}";
-        Context context = TestUtils.mockPlayContextWithJson(requestJsonString);
-        Http.Context.current.set(context);
+        Context playContext = TestUtils.mockPlayContextWithJson(requestJsonString);
+        Http.Context.current.set(playContext);
 
         // mock AuthenticationService
         User user = new User();

--- a/test/org/sagebionetworks/bridge/play/controllers/AuthenticationControllerMockTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/AuthenticationControllerMockTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.sagebionetworks.bridge.TestConstants.TEST_CONTEXT;
 
 import java.util.EnumSet;
 
@@ -33,7 +34,6 @@ import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
 import org.sagebionetworks.bridge.exceptions.ConsentRequiredException;
 import org.sagebionetworks.bridge.exceptions.NotAuthenticatedException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
-import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.Metrics;
 import org.sagebionetworks.bridge.models.accounts.EmailVerification;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
@@ -226,9 +226,7 @@ public class AuthenticationControllerMockTest {
         // mock getSessionToken and getMetrics
         doReturn(null).when(controller).getSessionToken();
 
-        CriteriaContext context = new CriteriaContext.Builder()
-                .withStudyIdentifier(TEST_STUDY_ID).build();
-        doReturn(context).when(controller).getCriteriaContext(any(StudyIdentifier.class));
+        doReturn(TEST_CONTEXT).when(controller).getCriteriaContext(any(StudyIdentifier.class));
         
         Metrics metrics = new Metrics(TEST_REQUEST_ID);
         doReturn(metrics).when(controller).getMetrics();
@@ -288,9 +286,7 @@ public class AuthenticationControllerMockTest {
         // mock getSessionToken and getMetrics
         doReturn(null).when(controller).getSessionToken();
 
-        CriteriaContext context = new CriteriaContext.Builder()
-                .withStudyIdentifier(TEST_STUDY_ID).build();
-        doReturn(context).when(controller).getCriteriaContext(any(StudyIdentifier.class));
+        doReturn(TEST_CONTEXT).when(controller).getCriteriaContext(any(StudyIdentifier.class));
         
         Metrics metrics = new Metrics(TEST_REQUEST_ID);
         doReturn(metrics).when(controller).getMetrics();
@@ -352,9 +348,7 @@ public class AuthenticationControllerMockTest {
 
     @Test
     public void signInNewSessionUnconsentedAdmin() throws Exception {
-        CriteriaContext context = new CriteriaContext.Builder()
-                .withStudyIdentifier(TEST_STUDY_ID).build();
-        doReturn(context).when(controller).getCriteriaContext(any(StudyIdentifier.class));
+        doReturn(TEST_CONTEXT).when(controller).getCriteriaContext(any(StudyIdentifier.class));
 
         // mock getSessionToken and getMetrics
         doReturn(null).when(controller).getSessionToken();
@@ -446,9 +440,7 @@ public class AuthenticationControllerMockTest {
         ArgumentCaptor<EmailVerification> emailVerifyCaptor = ArgumentCaptor.forClass(EmailVerification.class);
         when(authenticationService.verifyEmail(same(study), any(), emailVerifyCaptor.capture())).thenReturn(session);
 
-        CriteriaContext context = new CriteriaContext.Builder()
-                .withStudyIdentifier(TEST_STUDY_ID).build();
-        doReturn(context).when(controller).getCriteriaContext(any(StudyIdentifier.class));
+        doReturn(TEST_CONTEXT).when(controller).getCriteriaContext(any(StudyIdentifier.class));
 
         // execute and validate
         Result result = controller.verifyEmail();
@@ -462,9 +454,7 @@ public class AuthenticationControllerMockTest {
 
     @Test
     public void verifyEmailUnconsented() throws Exception {
-        CriteriaContext context = new CriteriaContext.Builder()
-                .withStudyIdentifier(TEST_STUDY_ID).build();
-        doReturn(context).when(controller).getCriteriaContext(any(StudyIdentifier.class));
+        doReturn(TEST_CONTEXT).when(controller).getCriteriaContext(any(StudyIdentifier.class));
         
         // mock getMetrics
         Metrics metrics = new Metrics(TEST_REQUEST_ID);

--- a/test/org/sagebionetworks/bridge/play/controllers/BaseControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/BaseControllerTest.java
@@ -193,11 +193,20 @@ public class BaseControllerTest {
     
     @Test
     public void canRetrieveLanguagesFromAcceptHeader() throws Exception {
-        mockHeader(ACCEPT_LANGUAGE, "de-de;q=0.4,de;q=0.2,en-ca,en;q=0.8,en-us;q=0.6");
-        
         BaseController controller = new SchedulePlanController();
         
+        Http.Request mockRequest = mock(Http.Request.class);
+        Http.Context context = mockPlayContext();
+        when(context.request()).thenReturn(mockRequest);
+        Http.Context.current.set(context);
+        
+        // with no accept language header at all, things don't break;
         Set<String> langs = controller.getLanguagesFromAcceptLanguageHeader();
+        assertEquals(ImmutableSet.of(), langs);
+        
+        mockHeader(ACCEPT_LANGUAGE, "de-de;q=0.4,de;q=0.2,en-ca,en;q=0.8,en-us;q=0.6");
+        
+        langs = controller.getLanguagesFromAcceptLanguageHeader();
             
         Set<String> set = Sets.newLinkedHashSet();
         set.add("en");

--- a/test/org/sagebionetworks/bridge/play/controllers/BaseControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/BaseControllerTest.java
@@ -1,5 +1,8 @@
 package org.sagebionetworks.bridge.play.controllers;
 
+import static org.apache.http.HttpHeaders.ACCEPT_LANGUAGE;
+import static org.apache.http.HttpHeaders.USER_AGENT;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.doReturn;
@@ -16,7 +19,6 @@ import org.junit.Test;
 
 import play.mvc.Http;
 
-import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
@@ -90,8 +92,7 @@ public class BaseControllerTest {
     
     @Test
     public void canRetrieveClientInfoObject() throws Exception {
-        mockHeader(BridgeConstants.USER_AGENT_HEADER, 
-                "Asthma/26 (Unknown iPhone; iPhone OS 9.0.2) BridgeSDK/4");
+        mockHeader(USER_AGENT, "Asthma/26 (Unknown iPhone; iPhone OS 9.0.2) BridgeSDK/4");
         
         ClientInfo info = new SchedulePlanController().getClientInfoFromUserAgentHeader();
         assertEquals("Asthma", info.getAppName());
@@ -104,7 +105,7 @@ public class BaseControllerTest {
     
     @Test
     public void doesNotThrowErrorWhenUserAgentStringInvalid() throws Exception {
-        mockHeader(BridgeConstants.USER_AGENT_HEADER, 
+        mockHeader(USER_AGENT, 
                 "Amazon Route 53 Health Check Service; ref:c97cd53f-2272-49d6-a8cd-3cd658d9d020; report http://amzn.to/1vsZADi");
         
         ClientInfo info = new SchedulePlanController().getClientInfoFromUserAgentHeader();
@@ -118,8 +119,7 @@ public class BaseControllerTest {
     
     @Test (expected = UnsupportedVersionException.class)
     public void testInvalidSupportedVersionThrowsException() throws Exception {
-        mockHeader(BridgeConstants.USER_AGENT_HEADER, 
-                "Asthma/26 (Unknown iPhone; iPhone OS 9.0.2) BridgeSDK/4");
+        mockHeader(USER_AGENT, "Asthma/26 (Unknown iPhone; iPhone OS 9.0.2) BridgeSDK/4");
         
         HashMap<String, Integer> map =new HashMap<>();
         map.put("iPhone OS", 28);
@@ -134,8 +134,7 @@ public class BaseControllerTest {
     
     @Test
     public void testValidSupportedVersionDoesNotThrowException() throws Exception {
-        mockHeader(BridgeConstants.USER_AGENT_HEADER, 
-                "Asthma/26 (Unknown iPhone; iPhone OS 9.0.2) BridgeSDK/4");
+        mockHeader(USER_AGENT, "Asthma/26 (Unknown iPhone; iPhone OS 9.0.2) BridgeSDK/4");
         
         HashMap<String, Integer> map =new HashMap<>();
         map.put("iPhone OS", 25);
@@ -149,8 +148,7 @@ public class BaseControllerTest {
     
     @Test
     public void testNullSupportedVersionDoesNotThrowException() throws Exception {
-        mockHeader(BridgeConstants.USER_AGENT_HEADER, 
-            "Asthma/26 (Unknown iPhone; iPhone OS 9.0.2) BridgeSDK/4");
+        mockHeader(USER_AGENT, "Asthma/26 (Unknown iPhone; iPhone OS 9.0.2) BridgeSDK/4");
         
         HashMap<String, Integer> map =new HashMap<>();
         
@@ -163,7 +161,7 @@ public class BaseControllerTest {
     
     @Test
     public void testUnknownOSDoesNotThrowException() throws Exception {
-        mockHeader(BridgeConstants.USER_AGENT_HEADER, "Asthma/26 BridgeSDK/4");
+        mockHeader(USER_AGENT, "Asthma/26 BridgeSDK/4");
         
         HashMap<String, Integer> map =new HashMap<>();
         map.put("iPhone OS", 25);
@@ -195,8 +193,7 @@ public class BaseControllerTest {
     
     @Test
     public void canRetrieveLanguagesFromAcceptHeader() throws Exception {
-        mockHeader(BridgeConstants.ACCEPT_LANGUAGE_HEADER, 
-                "de-de;q=0.4,de;q=0.2,en-ca,en;q=0.8,en-us;q=0.6");
+        mockHeader(ACCEPT_LANGUAGE, "de-de;q=0.4,de;q=0.2,en-ca,en;q=0.8,en-us;q=0.6");
         
         BaseController controller = new SchedulePlanController();
         
@@ -207,19 +204,19 @@ public class BaseControllerTest {
         set.add("de");
         assertEquals(set, langs);
 
-        mockHeader(BridgeConstants.ACCEPT_LANGUAGE_HEADER, null);
+        mockHeader(ACCEPT_LANGUAGE, null);
         langs = controller.getLanguagesFromAcceptLanguageHeader();
         assertEquals(ImmutableSet.of(), langs);
             
-        mockHeader(BridgeConstants.ACCEPT_LANGUAGE_HEADER, "");
+        mockHeader(ACCEPT_LANGUAGE, "");
         langs = controller.getLanguagesFromAcceptLanguageHeader();
         assertEquals(ImmutableSet.of(), langs);
             
-        mockHeader(BridgeConstants.ACCEPT_LANGUAGE_HEADER, "en-US");
+        mockHeader(ACCEPT_LANGUAGE, "en-US");
         langs = controller.getLanguagesFromAcceptLanguageHeader();
         assertEquals(ImmutableSet.of("en"), langs);
             
-        mockHeader(BridgeConstants.ACCEPT_LANGUAGE_HEADER, "FR,en-US");
+        mockHeader(ACCEPT_LANGUAGE, "FR,en-US");
         langs = controller.getLanguagesFromAcceptLanguageHeader();
         assertEquals(ImmutableSet.of("fr","en"), langs);
     }

--- a/test/org/sagebionetworks/bridge/play/controllers/ConsentControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ConsentControllerTest.java
@@ -4,7 +4,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_API_STATUS_HEADER;
 import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_DEPRECATED_STATUS;
+import static org.sagebionetworks.bridge.BridgeConstants.SESSION_TOKEN_HEADER;
 import static org.sagebionetworks.bridge.BridgeConstants.STUDY_PROPERTY;
 import static org.sagebionetworks.bridge.TestConstants.PASSWORD;
 import static org.sagebionetworks.bridge.TestConstants.SIGN_IN_URL;
@@ -20,7 +22,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.TestUserAdminHelper;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.TestUserAdminHelper.TestUser;
@@ -68,23 +69,23 @@ public class ConsentControllerTest {
                 // First, verify this header isn't on *every* endpoint
                 WSRequest request = WS.url(TEST_BASE_URL + "/v3/users/self");
                 WSResponse response = request.post(node).get(TIMEOUT);
-                String headerValue = response.getHeader(BridgeConstants.BRIDGE_API_STATUS_HEADER);
+                String headerValue = response.getHeader(BRIDGE_API_STATUS_HEADER);
                 assertNull(headerValue);
                 
                 // Now verify it's on the intended endpoints
                 request = WS.url(TEST_BASE_URL + "/api/v1/consent/dataSharing/suspend");
                 response = request.post(node).get(TIMEOUT);
-                headerValue = response.getHeader(BridgeConstants.BRIDGE_API_STATUS_HEADER);
+                headerValue = response.getHeader(BRIDGE_API_STATUS_HEADER);
                 assertEquals(BRIDGE_DEPRECATED_STATUS, headerValue);
                 
                 request = WS.url(TEST_BASE_URL + "/api/v1/consent/dataSharing/resume");
                 response = request.post(node).get(TIMEOUT);
-                headerValue = response.getHeader(BridgeConstants.BRIDGE_API_STATUS_HEADER);
+                headerValue = response.getHeader(BRIDGE_API_STATUS_HEADER);
                 assertEquals(BRIDGE_DEPRECATED_STATUS, headerValue);
                 
                 request = WS.url(TEST_BASE_URL + "/api/v1/consent");
                 response = request.post(node).get(TIMEOUT);
-                headerValue = response.getHeader(BridgeConstants.BRIDGE_API_STATUS_HEADER);
+                headerValue = response.getHeader(BRIDGE_API_STATUS_HEADER);
                 assertEquals(BRIDGE_DEPRECATED_STATUS, headerValue);
             }
         });
@@ -106,7 +107,7 @@ public class ConsentControllerTest {
                 WSRequest request = WS.url(TEST_BASE_URL + SIGN_IN_URL);
                 WSResponse response = request.post(node).get(TIMEOUT);
 
-                WSCookie cookie = response.getCookie(BridgeConstants.SESSION_TOKEN_HEADER);
+                WSCookie cookie = response.getCookie(SESSION_TOKEN_HEADER);
                 String sessionToken = cookie.getValue();
 
                 node = JsonNodeFactory.instance.objectNode();

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.sagebionetworks.bridge.TestConstants.TEST_CONTEXT;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 import static org.sagebionetworks.bridge.dao.ParticipantOption.DATA_GROUPS;
 
@@ -33,7 +34,6 @@ import org.sagebionetworks.bridge.dao.ParticipantOption.SharingScope;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
-import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.accounts.Email;
@@ -51,7 +51,7 @@ import com.google.common.collect.Sets;
 @ContextConfiguration("classpath:test-context.xml")
 @RunWith(SpringJUnit4ClassRunner.class)
 public class AuthenticationServiceTest {
-
+    
     @Resource
     private CacheProvider cacheProvider;
 
@@ -72,7 +72,7 @@ public class AuthenticationServiceTest {
 
     @Resource
     private TestUserAdminHelper helper;
-
+    
     private TestUser testUser;
 
     @Before
@@ -87,17 +87,17 @@ public class AuthenticationServiceTest {
 
     @Test(expected = BridgeServiceException.class)
     public void signInNoEmail() throws Exception {
-        authService.signIn(testUser.getStudy(), ClientInfo.UNKNOWN_CLIENT, new SignIn(null, "bar"));
+        authService.signIn(testUser.getStudy(), TEST_CONTEXT, new SignIn(null, "bar"));
     }
 
     @Test(expected = BridgeServiceException.class)
     public void signInNoPassword() throws Exception {
-        authService.signIn(testUser.getStudy(), ClientInfo.UNKNOWN_CLIENT, new SignIn("foobar", null));
+        authService.signIn(testUser.getStudy(), TEST_CONTEXT, new SignIn("foobar", null));
     }
 
     @Test(expected = EntityNotFoundException.class)
     public void signInInvalidCredentials() throws Exception {
-        authService.signIn(testUser.getStudy(), ClientInfo.UNKNOWN_CLIENT, new SignIn("foobar", "bar"));
+        authService.signIn(testUser.getStudy(), TEST_CONTEXT, new SignIn("foobar", "bar"));
     }
 
     @Test
@@ -110,7 +110,7 @@ public class AuthenticationServiceTest {
     @Test
     public void signInWhenSignedIn() throws Exception {
         String sessionToken = testUser.getSessionToken();
-        UserSession newSession = authService.signIn(testUser.getStudy(), ClientInfo.UNKNOWN_CLIENT, testUser.getSignIn());
+        UserSession newSession = authService.signIn(testUser.getStudy(), TEST_CONTEXT, testUser.getSignIn());
         assertEquals("Email is for test2 user", testUser.getEmail(), newSession.getUser().getEmail());
         assertEquals("Should update the existing session instead of creating a new one.",
                 sessionToken, newSession.getSessionToken());
@@ -118,7 +118,7 @@ public class AuthenticationServiceTest {
 
     @Test
     public void signInSetsSharingScope() { 
-        UserSession newSession = authService.signIn(testUser.getStudy(), ClientInfo.UNKNOWN_CLIENT, testUser.getSignIn());
+        UserSession newSession = authService.signIn(testUser.getStudy(), TEST_CONTEXT, testUser.getSignIn());
         assertEquals(SharingScope.NO_SHARING, newSession.getUser().getSharingScope()); // this is the default.
     }
 
@@ -172,7 +172,7 @@ public class AuthenticationServiceTest {
         TestUser researcher = helper.getBuilder(AuthenticationServiceTest.class)
                 .withConsent(false).withSignIn(false).withRoles(Roles.RESEARCHER).build();
         try {
-            authService.signIn(researcher.getStudy(), ClientInfo.UNKNOWN_CLIENT, researcher.getSignIn());
+            authService.signIn(researcher.getStudy(), TEST_CONTEXT, researcher.getSignIn());
             // no exception should have been thrown.
         } finally {
             helper.deleteUser(researcher);
@@ -184,7 +184,7 @@ public class AuthenticationServiceTest {
         TestUser researcher = helper.getBuilder(AuthenticationServiceTest.class)
                 .withConsent(false).withSignIn(false).withRoles(Roles.ADMIN).build();
         try {
-            authService.signIn(researcher.getStudy(), ClientInfo.UNKNOWN_CLIENT, researcher.getSignIn());
+            authService.signIn(researcher.getStudy(), TEST_CONTEXT, researcher.getSignIn());
             // no exception should have been thrown.
         } finally {
             helper.deleteUser(researcher);
@@ -245,7 +245,7 @@ public class AuthenticationServiceTest {
         TestUser user = helper.getBuilder(AuthenticationServiceTest.class).withConsent(true)
                 .withDataGroups(DefaultStudyBootstrapper.TEST_DATA_GROUPS).build();
         try {
-            UserSession session = authService.signIn(user.getStudy(), ClientInfo.UNKNOWN_CLIENT, user.getSignIn());
+            UserSession session = authService.signIn(user.getStudy(), TEST_CONTEXT, user.getSignIn());
             // Verify we created a list and the anticipated group was not null
             assertEquals(numOfGroups, session.getUser().getDataGroups().size()); 
             assertEquals(DefaultStudyBootstrapper.TEST_DATA_GROUPS, session.getUser().getDataGroups());

--- a/test/org/sagebionetworks/bridge/services/UserAdminServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/UserAdminServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
+import static org.sagebionetworks.bridge.TestConstants.TEST_CONTEXT;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 
 import javax.annotation.Resource;
@@ -22,7 +23,6 @@ import org.sagebionetworks.bridge.dynamodb.DynamoTestUtil;
 import org.sagebionetworks.bridge.dynamodb.DynamoUserConsent3;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
-import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
 import org.sagebionetworks.bridge.models.accounts.SignUp;
 import org.sagebionetworks.bridge.models.accounts.User;
@@ -74,7 +74,7 @@ public class UserAdminServiceTest {
         signUp = new SignUp(name+"@sagebridge.org", "P4ssword!", null, null);
 
         SignIn signIn = new SignIn(bridgeConfig.getProperty("admin.email"), bridgeConfig.getProperty("admin.password"));
-        authService.signIn(study, ClientInfo.UNKNOWN_CLIENT, signIn).getUser();
+        authService.signIn(study, TEST_CONTEXT, signIn).getUser();
     }
 
     @After
@@ -91,7 +91,7 @@ public class UserAdminServiceTest {
         userAdminService.deleteUser(study, testUser.getEmail());
 
         // This should fail with a 404.
-        authService.signIn(study, ClientInfo.UNKNOWN_CLIENT, new SignIn(signUp.getEmail(), signUp.getPassword()));
+        authService.signIn(study, TEST_CONTEXT, new SignIn(signUp.getEmail(), signUp.getPassword()));
     }
 
     @Test
@@ -99,7 +99,7 @@ public class UserAdminServiceTest {
         UserSession session1 = userAdminService.createUser(signUp, study, null, false, false);
         assertNull("No session", session1);
 
-        UserSession session = authService.signIn(study, ClientInfo.UNKNOWN_CLIENT, new SignIn(signUp.getEmail(),
+        UserSession session = authService.signIn(study, TEST_CONTEXT, new SignIn(signUp.getEmail(),
                 signUp.getPassword()));
         testUser = session.getUser();
         assertFalse(testUser.doesConsent());


### PR DESCRIPTION
In order to filter based on the users's language, parse the Accept-Language header and add this information to the CriteriaContext. 

We're not using this information yet, we're not persisting it anywhere, we're just gathering it from the request.
