### PR TITLE
add Write mPower Visualization API

### DIFF
--- a/app/org/sagebionetworks/bridge/Roles.java
+++ b/app/org/sagebionetworks/bridge/Roles.java
@@ -7,7 +7,8 @@ public enum Roles {
     DEVELOPER,
     RESEARCHER,
     ADMIN,
-    TEST_USERS;
+    TEST_USERS,
+    WORKER;
     
     public static final Set<Roles> ADMINISTRATIVE_ROLES = EnumSet.of(Roles.DEVELOPER, Roles.RESEARCHER, Roles.ADMIN);
 }

--- a/app/org/sagebionetworks/bridge/dao/MpowerVisualizationDao.java
+++ b/app/org/sagebionetworks/bridge/dao/MpowerVisualizationDao.java
@@ -3,6 +3,8 @@ package org.sagebionetworks.bridge.dao;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.joda.time.LocalDate;
 
+import org.sagebionetworks.bridge.models.visualization.MpowerVisualization;
+
 /** Abstract DAO for mPower visualization. */
 public interface MpowerVisualizationDao {
     /**
@@ -23,4 +25,13 @@ public interface MpowerVisualizationDao {
      * @return raw JSON containing visualization data
      */
     JsonNode getVisualization(String healthCode, LocalDate startDate, LocalDate endDate);
+
+    /**
+     * Writes the visualization to the backing store. See for details:
+     * https://sagebionetworks.jira.com/wiki/display/BRIDGE/mPower+Visualization
+     *
+     * @param visualization
+     *         visualization object, which includes visualization JSON data and metadata
+     */
+    void writeVisualization(MpowerVisualization visualization);
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoMpowerVisualization.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoMpowerVisualization.java
@@ -5,7 +5,13 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMarshalling;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.joda.deser.LocalDateDeserializer;
 import org.joda.time.LocalDate;
+
+import org.sagebionetworks.bridge.json.LocalDateToStringSerializer;
+import org.sagebionetworks.bridge.models.visualization.MpowerVisualization;
 
 /**
  * DDB implementation of mPower visualization. Individual data points are stored as raw JSON in the "json" field for
@@ -14,7 +20,7 @@ import org.joda.time.LocalDate;
 // Provisioned throughput set to 1/1, as it seems similar to schedules.
 @DynamoThroughput(readCapacity=1, writeCapacity=1)
 @DynamoDBTable(tableName = "MpowerVisualization")
-public class DynamoMpowerVisualization {
+public class DynamoMpowerVisualization implements MpowerVisualization {
     private LocalDate date;
     private String healthCode;
     private JsonNode visualization;
@@ -22,33 +28,41 @@ public class DynamoMpowerVisualization {
     /** Date for this data point. */
     @DynamoDBMarshalling(marshallerClass = LocalDateMarshaller.class)
     @DynamoDBRangeKey
+    @JsonSerialize(using = LocalDateToStringSerializer.class)
+    @Override
     public LocalDate getDate() {
         return date;
     }
 
     /** @see #getDate */
+    @JsonDeserialize(using = LocalDateDeserializer.class)
+    @Override
     public void setDate(LocalDate date) {
         this.date = date;
     }
 
     /** Health code of user for this data point. */
     @DynamoDBHashKey
+    @Override
     public String getHealthCode() {
         return healthCode;
     }
 
     /** @see #getHealthCode */
+    @Override
     public void setHealthCode(String healthCode) {
         this.healthCode = healthCode;
     }
 
     /** Raw JSON data of this data point. */
     @DynamoDBMarshalling(marshallerClass = JsonNodeMarshaller.class)
+    @Override
     public JsonNode getVisualization() {
         return visualization;
     }
 
     /** @see #getVisualization */
+    @Override
     public void setVisualization(JsonNode visualization) {
         this.visualization = visualization;
     }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoMpowerVisualizationDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoMpowerVisualizationDao.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Component;
 
 import org.sagebionetworks.bridge.dao.MpowerVisualizationDao;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.visualization.MpowerVisualization;
 
 /** DDB implementation of mPower visualization. */
 @Component
@@ -51,5 +52,11 @@ public class DynamoMpowerVisualizationDao implements MpowerVisualizationDao {
             vizColNode.set(oneViz.getDate().toString(), oneViz.getVisualization());
         }
         return vizColNode;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void writeVisualization(MpowerVisualization visualization) {
+        mapper.save(visualization);
     }
 }

--- a/app/org/sagebionetworks/bridge/models/visualization/MpowerVisualization.java
+++ b/app/org/sagebionetworks/bridge/models/visualization/MpowerVisualization.java
@@ -1,0 +1,36 @@
+package org.sagebionetworks.bridge.models.visualization;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.joda.time.LocalDate;
+
+import org.sagebionetworks.bridge.dynamodb.DynamoMpowerVisualization;
+import org.sagebionetworks.bridge.json.BridgeTypeName;
+import org.sagebionetworks.bridge.models.BridgeEntity;
+
+/**
+ * Generic interface mPower visualization, for use outside of the DDB layer. Individual data points are stored as raw
+ * JSON in the visualization field for rapid development. When we generalize this, we can restructure this class as
+ * needed.
+ */
+@BridgeTypeName("MpowerVisualization")
+@JsonDeserialize(as = DynamoMpowerVisualization.class)
+public interface MpowerVisualization extends BridgeEntity {
+    /** Date for this data point. */
+    LocalDate getDate();
+
+    /** @see #getDate */
+    void setDate(LocalDate date);
+
+    /** Health code of user for this data point. */
+    String getHealthCode();
+
+    /** @see #getHealthCode */
+    void setHealthCode(String healthCode);
+
+    /** Raw JSON data of this data point. */
+    JsonNode getVisualization();
+
+    /** @see #getVisualization */
+    void setVisualization(JsonNode visualization);
+}

--- a/app/org/sagebionetworks/bridge/play/controllers/MpowerVisualizationController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/MpowerVisualizationController.java
@@ -7,9 +7,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import play.mvc.Result;
 
+import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
+import org.sagebionetworks.bridge.models.visualization.MpowerVisualization;
 import org.sagebionetworks.bridge.services.MpowerVisualizationService;
 
 /**
@@ -52,5 +54,13 @@ public class MpowerVisualizationController extends BaseController {
                 throw new BadRequestException("invalid date " + dateStr);
             }
         }
+    }
+
+    /** Writes the mPower visualization. The request body includes both the visualization data and metadata. */
+    public Result writeVisualization() {
+        getAuthenticatedSession(Roles.WORKER);
+        MpowerVisualization viz = parseJson(request(), MpowerVisualization.class);
+        mpowerVisualizationService.writeVisualization(viz);
+        return created("Visualization created.");
     }
 }

--- a/app/org/sagebionetworks/bridge/services/MpowerVisualizationService.java
+++ b/app/org/sagebionetworks/bridge/services/MpowerVisualizationService.java
@@ -9,7 +9,11 @@ import org.springframework.stereotype.Component;
 
 import org.sagebionetworks.bridge.dao.MpowerVisualizationDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
+import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.json.DateUtils;
+import org.sagebionetworks.bridge.models.visualization.MpowerVisualization;
+import org.sagebionetworks.bridge.validators.MpowerVisualizationValidator;
+import org.sagebionetworks.bridge.validators.Validate;
 
 /** mPower visualization service. */
 @Component
@@ -64,5 +68,23 @@ public class MpowerVisualizationService {
         // Don't need to validate study ID or healthCode. Controller takes care of that for us.
 
         return mpowerVisualizationDao.getVisualization(healthCode, startDate, endDate);
+    }
+
+    /**
+     * Writes the visualization to the backing store. See for details:
+     * https://sagebionetworks.jira.com/wiki/display/BRIDGE/mPower+Visualization
+     *
+     * @param visualization
+     *         visualization object, which includes visualization JSON data and metadata, must be non-null
+     */
+    public void writeVisualization(MpowerVisualization visualization) {
+        // validate visualization
+        if (visualization == null) {
+            throw new InvalidEntityException("visualization must be specified");
+        }
+        Validate.entityThrowingException(MpowerVisualizationValidator.INSTANCE, visualization);
+
+        // call through to DAO
+        mpowerVisualizationDao.writeVisualization(visualization);
     }
 }

--- a/app/org/sagebionetworks/bridge/validators/MpowerVisualizationValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/MpowerVisualizationValidator.java
@@ -1,0 +1,52 @@
+package org.sagebionetworks.bridge.validators;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+
+import org.sagebionetworks.bridge.models.visualization.MpowerVisualization;
+
+/** Validator for mPower visualization. */
+public class MpowerVisualizationValidator implements Validator {
+    /** Singleton instance of this validator. */
+    public static final MpowerVisualizationValidator INSTANCE = new MpowerVisualizationValidator();
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean supports(Class<?> clazz) {
+        return MpowerVisualization.class.isAssignableFrom(clazz);
+    }
+
+    /**
+     * Simple validation. It the visualization object must have a date, must have a health code, and must have
+     * visualization data. To allow rapid development, we don't validate deeply into the visualization data, only that
+     * it exists
+     *
+     * @see org.springframework.validation.Validator#validate
+     */
+    @Override
+    public void validate(Object target, Errors errors) {
+        if (target == null) {
+            errors.rejectValue("visualization", "cannot be null");
+        } else if (!(target instanceof MpowerVisualization)) {
+            errors.rejectValue("visualization", "is the wrong type");
+        } else {
+            MpowerVisualization viz = (MpowerVisualization) target;
+
+            // date
+            if (viz.getDate() == null) {
+                errors.rejectValue("date", "must be specified");
+            }
+
+            // health code
+            if (StringUtils.isBlank(viz.getHealthCode())) {
+                errors.rejectValue("healthCode", "must be specified");
+            }
+
+            // visualization
+            if (viz.getVisualization() == null || viz.getVisualization().isNull()) {
+                errors.rejectValue("visualization", "must be specified");
+            }
+        }
+    }
+}

--- a/conf/routes
+++ b/conf/routes
@@ -140,6 +140,7 @@ POST   /fphs/externalIds  @org.sagebionetworks.bridge.play.controllers.FPHSContr
 
 # Visualization
 GET /parkinson/visualization @org.sagebionetworks.bridge.play.controllers.MpowerVisualizationController.getVisualization(startDate: String ?= null, endDate: String ?= null)
+POST /parkinson/visualization @org.sagebionetworks.bridge.play.controllers.MpowerVisualizationController.writeVisualization
 
 # OLD API ----------------------------------------------------------------------------------------------------
 

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge;
 
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -18,6 +19,7 @@ import org.joda.time.Period;
 
 import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
+import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.schedules.ABTestScheduleStrategy;
@@ -61,6 +63,14 @@ public class TestUtils {
             }
         }
     }
+
+    // Helper metod to extract and assert on validator error messages.
+    public static void assertValidatorMessage(InvalidEntityException e, String propName, String error) {
+        Map<String,List<String>> errors = e.getErrors();
+        List<String> messages = errors.get(propName);
+        assertTrue(messages.get(0).contains(propName + error));
+    }
+
     public static Map<SubpopulationGuid,ConsentStatus> toMap(ConsentStatus... statuses) {
         return TestUtils.toMap(Lists.newArrayList(statuses));
     }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoMpowerVisualizationDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoMpowerVisualizationDaoTest.java
@@ -56,8 +56,6 @@ public class DynamoMpowerVisualizationDaoTest {
 
             vizList.add(viz);
         }
-
-        mapper.batchSave(vizList);
     }
 
     @After
@@ -67,6 +65,12 @@ public class DynamoMpowerVisualizationDaoTest {
 
     @Test
     public void test() {
+        // write statuses
+        for (DynamoMpowerVisualization oneViz : vizList) {
+            dao.writeVisualization(oneViz);
+        }
+
+        // Read statuses back. Read only a subset to make sure query logic works.
         JsonNode vizColNode = dao.getVisualization("AAA", LocalDate.parse("2016-02-02"),
                 LocalDate.parse("2016-02-04"));
         assertEquals(3, vizColNode.size());

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoMpowerVisualizationTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoMpowerVisualizationTest.java
@@ -1,0 +1,49 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.joda.time.LocalDate;
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.visualization.MpowerVisualization;
+
+public class DynamoMpowerVisualizationTest {
+    @Test
+    public void jsonSerialization() throws Exception {
+        // Start with JSON. Test visualization will be strings, even though in production they'll be complex objects.
+        String jsonText = "{\n" +
+                "   \"date\":\"2016-02-08\",\n" +
+                "   \"healthCode\":\"dummyHealthCode\",\n" +
+                "   \"visualization\":\"test-viz\"\n" +
+                "}";
+
+        // convert to POJO
+        MpowerVisualization viz = BridgeObjectMapper.get().readValue(jsonText, MpowerVisualization.class);
+        assertEquals(LocalDate.parse("2016-02-08"), viz.getDate());
+        assertEquals("dummyHealthCode", viz.getHealthCode());
+        assertEquals("test-viz", viz.getVisualization().textValue());
+
+        // convert back into JSON
+        String convertedJsonText = BridgeObjectMapper.get().writeValueAsString(viz);
+
+        // Convert into a JSON node so we can validate it
+        JsonNode convertedJsonNode = BridgeObjectMapper.get().readTree(convertedJsonText);
+        assertEquals(4, convertedJsonNode.size());
+        assertEquals("2016-02-08", convertedJsonNode.get("date").textValue());
+        assertEquals("dummyHealthCode", convertedJsonNode.get("healthCode").textValue());
+        assertEquals("test-viz", convertedJsonNode.get("visualization").textValue());
+        assertEquals("MpowerVisualization", convertedJsonNode.get("type").textValue());
+    }
+
+    // Helper method to make a valid mPower visualization, public in case other tests need it.
+    public static MpowerVisualization makeValidMpowerVisualization() {
+        MpowerVisualization viz = new DynamoMpowerVisualization();
+        viz.setDate(LocalDate.parse("2016-02-08"));
+        viz.setHealthCode("dummyHealthCode");
+        viz.setVisualization(new TextNode("test-viz"));
+        return viz;
+    }
+}

--- a/test/org/sagebionetworks/bridge/play/controllers/MpowerVisualizationControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/MpowerVisualizationControllerTest.java
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.databind.node.TextNode;
 import org.joda.time.LocalDate;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import play.mvc.Http;
 import play.mvc.Result;
 import play.test.Helpers;
 
@@ -128,7 +127,7 @@ public class MpowerVisualizationControllerTest {
         String requestJsonText = "{\n" +
                 "   \"visualization\":\"strictly for controller test\"\n" +
                 "}";
-        Http.Context.current.set(TestUtils.mockPlayContextWithJson(requestJsonText));
+        TestUtils.mockPlayContextWithJson(requestJsonText);
 
         // execute
         Result result = controller.writeVisualization();

--- a/test/org/sagebionetworks/bridge/validators/MpowerVisualizationValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/MpowerVisualizationValidatorTest.java
@@ -1,0 +1,112 @@
+package org.sagebionetworks.bridge.validators;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.HashMap;
+
+import com.fasterxml.jackson.databind.node.NullNode;
+import org.junit.Test;
+import org.springframework.validation.MapBindingResult;
+
+import org.sagebionetworks.bridge.TestUtils;
+import org.sagebionetworks.bridge.dynamodb.DynamoMpowerVisualization;
+import org.sagebionetworks.bridge.dynamodb.DynamoMpowerVisualizationTest;
+import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
+import org.sagebionetworks.bridge.models.visualization.MpowerVisualization;
+
+public class MpowerVisualizationValidatorTest {
+    // branch coverage
+    @Test
+    public void supportsClass() {
+        assertTrue(MpowerVisualizationValidator.INSTANCE.supports(MpowerVisualization.class));
+    }
+
+    // branch coverage
+    @Test
+    public void supportsSubclass() {
+        assertTrue(MpowerVisualizationValidator.INSTANCE.supports(DynamoMpowerVisualization.class));
+    }
+
+    // branch coverage
+    @Test
+    public void doesntSupportsWrongClass() {
+        assertFalse(MpowerVisualizationValidator.INSTANCE.supports(String.class));
+    }
+
+    // branch coverage
+    // we call the validator directly, since Validate.validateThrowingException filters out nulls and wrong types
+    @Test
+    public void nullValue() {
+        MapBindingResult errors = new MapBindingResult(new HashMap<>(), "MpowerVisualization");
+        MpowerVisualizationValidator.INSTANCE.validate(null, errors);
+        assertTrue(errors.hasErrors());
+    }
+
+    // branch coverage
+    // we call the validator directly, since Validate.validateThrowingException filters out nulls and wrong types
+    @Test
+    public void wrongClass() {
+        MapBindingResult errors = new MapBindingResult(new HashMap<>(), "MpowerVisualization");
+        MpowerVisualizationValidator.INSTANCE.validate("this is the wrong class", errors);
+        assertTrue(errors.hasErrors());
+    }
+
+    @Test
+    public void validCase() {
+        Validate.entityThrowingException(MpowerVisualizationValidator.INSTANCE,
+                DynamoMpowerVisualizationTest.makeValidMpowerVisualization());
+    }
+
+    @Test
+    public void invalidCase() {
+        try {
+            Validate.entityThrowingException(MpowerVisualizationValidator.INSTANCE, new DynamoMpowerVisualization());
+            fail("expected exception");
+        } catch (InvalidEntityException ex) {
+            TestUtils.assertValidatorMessage(ex, "date", " must be specified");
+            TestUtils.assertValidatorMessage(ex, "healthCode", " must be specified");
+            TestUtils.assertValidatorMessage(ex, "visualization", " must be specified");
+        }
+    }
+
+    @Test
+    public void emptyHealthCode() {
+        MpowerVisualization viz = DynamoMpowerVisualizationTest.makeValidMpowerVisualization();
+        viz.setHealthCode("");
+
+        try {
+            Validate.entityThrowingException(MpowerVisualizationValidator.INSTANCE, viz);
+            fail("expected exception");
+        } catch (InvalidEntityException ex) {
+            TestUtils.assertValidatorMessage(ex, "healthCode", " must be specified");
+        }
+    }
+
+    @Test
+    public void blankHealthCode() {
+        MpowerVisualization viz = DynamoMpowerVisualizationTest.makeValidMpowerVisualization();
+        viz.setHealthCode("   ");
+
+        try {
+            Validate.entityThrowingException(MpowerVisualizationValidator.INSTANCE, viz);
+            fail("expected exception");
+        } catch (InvalidEntityException ex) {
+            TestUtils.assertValidatorMessage(ex, "healthCode", " must be specified");
+        }
+    }
+
+    @Test
+    public void vizJsonNull() {
+        MpowerVisualization viz = DynamoMpowerVisualizationTest.makeValidMpowerVisualization();
+        viz.setVisualization(NullNode.instance);
+
+        try {
+            Validate.entityThrowingException(MpowerVisualizationValidator.INSTANCE, viz);
+            fail("expected exception");
+        } catch (InvalidEntityException ex) {
+            TestUtils.assertValidatorMessage(ex, "visualization", " must be specified");
+        }
+    }
+}


### PR DESCRIPTION
Add write API, because the Nightly Precompute Job will need it.

Testing done:
- added unit tests
- manual testing: write visualization, verify it in DDB, then get it back through the API
