### PR TITLE
Using a concrete set implementation in signatures

### DIFF
--- a/app/org/sagebionetworks/bridge/models/CriteriaContext.java
+++ b/app/org/sagebionetworks/bridge/models/CriteriaContext.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge.models;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
 
@@ -15,19 +16,16 @@ public final class CriteriaContext {
     private final String healthCode;
     private final ClientInfo clientInfo;
     private final Set<String> userDataGroups;
-    // This set is ordered from most preferred to least preferred language. It is not a SortedSet because 
-    // that type includes a comparator for sorting the items in the set, and this preference order was 
-    // determined externally from the LanguageRange objects (it's not in the language string).
-    private final Set<String> languages;
+    // This set has ordered keys (most to least preferential)
+    private final LinkedHashSet<String> languages;
     
     private CriteriaContext(StudyIdentifier studyId, String healthCode, ClientInfo clientInfo,
-            Set<String> userDataGroups, Set<String> languages) {
+            Set<String> userDataGroups, LinkedHashSet<String> languages) {
         this.studyId = studyId;
         this.healthCode = healthCode;
         this.clientInfo = clientInfo;
         this.userDataGroups = (userDataGroups == null) ? ImmutableSet.of() : ImmutableSet.copyOf(userDataGroups);
-        // ImmutableSet says its items are kept "in order"
-        this.languages = (languages == null) ? ImmutableSet.of() : ImmutableSet.copyOf(languages);
+        this.languages = (languages == null) ? new LinkedHashSet<>() : languages;
     }
 
     /**
@@ -57,7 +55,7 @@ public final class CriteriaContext {
      * the third, etc. However, this isn't a SortedSet, because it is sorted by something 
      * (LanguageRange quality) that is external to the contents of the Set.
      */
-    public Set<String> getLanguages() {
+    public LinkedHashSet<String> getLanguages() {
         return languages;
     }
 
@@ -91,7 +89,7 @@ public final class CriteriaContext {
         private String healthCode;
         private ClientInfo clientInfo;
         private Set<String> userDataGroups;
-        private Set<String> languages;
+        private LinkedHashSet<String> languages;
 
         public Builder withStudyIdentifier(StudyIdentifier studyId) {
             this.studyId = studyId;
@@ -109,7 +107,7 @@ public final class CriteriaContext {
             this.userDataGroups = userDataGroups;
             return this;
         }
-        public Builder withLanguages(Set<String> languages) {
+        public Builder withLanguages(LinkedHashSet<String> languages) {
             this.languages = languages;
             return this;
         }

--- a/app/org/sagebionetworks/bridge/models/schedules/ScheduleContext.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/ScheduleContext.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.models.schedules;
 
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -154,7 +155,7 @@ public final class ScheduleContext {
             this.now = now;
             return this;
         }
-        public Builder withLanguages(Set<String> languages) {
+        public Builder withLanguages(LinkedHashSet<String> languages) {
             contextBuilder.withLanguages(languages);
             return this;
         }

--- a/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
@@ -8,7 +8,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Set;
 import java.util.Locale.LanguageRange;
 import java.util.stream.Collectors;
 
@@ -51,7 +50,6 @@ import com.amazonaws.util.Throwables;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableSet;
 
 public abstract class BaseController extends Controller {
 
@@ -166,18 +164,21 @@ public abstract class BaseController extends Controller {
         }
     }
 
-    Set<String> getLanguagesFromAcceptLanguageHeader() {
+    /**
+     * Returns languages in the order of their quality rating in the original LanguageRange objects 
+     * that are created from the Accept-Language header (first item in ordered set is the most-preferred 
+     * language option).
+     * @return
+     */
+    LinkedHashSet<String> getLanguagesFromAcceptLanguageHeader() {
         String acceptLanguageHeader = request().getHeader(ACCEPT_LANGUAGE);
         if (isNotBlank(acceptLanguageHeader)) {
-            // This parse method returns LanguageRange objects in descending order of their quality 
-            // value (so most-desirable language first). We extract language only and de-duplicate 
-            // them using a LinkedHashSet which retains the order the languages are added to the set.
             List<LanguageRange> ranges = Locale.LanguageRange.parse(acceptLanguageHeader);
             return ranges.stream().map(range -> {
                 return Locale.forLanguageTag(range.getRange()).getLanguage();
             }).collect(Collectors.toCollection(LinkedHashSet::new));
         }
-        return ImmutableSet.of();
+        return new LinkedHashSet<>();
     }
     
     ClientInfo getClientInfoFromUserAgentHeader() {

--- a/test/org/sagebionetworks/bridge/play/controllers/BaseControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/BaseControllerTest.java
@@ -5,6 +5,7 @@ import static org.apache.http.HttpHeaders.USER_AGENT;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -12,8 +13,8 @@ import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.TestUtils.mockPlayContext;
 
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
-import java.util.Set;
 
 import org.junit.Test;
 
@@ -197,14 +198,16 @@ public class BaseControllerTest {
         mockPlayContext();
         
         // with no accept language header at all, things don't break;
-        Set<String> langs = controller.getLanguagesFromAcceptLanguageHeader();
+        LinkedHashSet<String> langs = controller.getLanguagesFromAcceptLanguageHeader();
+        // testing this because the rest of these tests will use ImmutableSet.of()
+        assertTrue(langs instanceof LinkedHashSet); 
         assertEquals(ImmutableSet.of(), langs);
         
         mockHeader(ACCEPT_LANGUAGE, "de-de;q=0.4,de;q=0.2,en-ca,en;q=0.8,en-us;q=0.6");
         
         langs = controller.getLanguagesFromAcceptLanguageHeader();
             
-        Set<String> set = Sets.newLinkedHashSet();
+        LinkedHashSet<String> set = Sets.newLinkedHashSet();
         set.add("en");
         set.add("de");
         assertEquals(set, langs);


### PR DESCRIPTION
That explicitly has user-ordered keys, because the order of the keys in this property is important. This documents it a little more clearly.
