### PR TITLE
Researcher API for setting Data Groups

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/UserManagementController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/UserManagementController.java
@@ -2,10 +2,12 @@ package org.sagebionetworks.bridge.play.controllers;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.sagebionetworks.bridge.json.JsonUtils;
+import org.sagebionetworks.bridge.models.accounts.DataGroups;
 import org.sagebionetworks.bridge.models.accounts.SignUp;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.services.UserAdminService;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import play.mvc.Result;
@@ -57,4 +59,14 @@ public class UserManagementController extends BaseController {
         return okResult("User deleted.");
     }
 
+    /** Researcher API to set data groups for the given user. Note that this overwrites data groups, not adds. */
+    public Result updateDataGroupForUser(String email) {
+        UserSession session = getAuthenticatedSession(RESEARCHER);
+        Study study = studyService.getStudy(session.getStudyIdentifier());
+
+        DataGroups dataGroups = parseJson(request(), DataGroups.class);
+        userAdminService.updateDataGroupForUser(study, email, dataGroups);
+
+        return okResult("Data groups updated.");
+    }
 }

--- a/app/org/sagebionetworks/bridge/services/UserAdminService.java
+++ b/app/org/sagebionetworks/bridge/services/UserAdminService.java
@@ -12,11 +12,15 @@ import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dao.DistributedLockDao;
 import org.sagebionetworks.bridge.dao.HealthIdDao;
+import org.sagebionetworks.bridge.dao.ParticipantOption;
+import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
+import org.sagebionetworks.bridge.exceptions.NotFoundException;
 import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
+import org.sagebionetworks.bridge.models.accounts.DataGroups;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
 import org.sagebionetworks.bridge.models.accounts.SignUp;
 import org.sagebionetworks.bridge.models.accounts.User;
@@ -25,6 +29,9 @@ import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 import org.sagebionetworks.bridge.redis.RedisKey;
+import org.sagebionetworks.bridge.validators.DataGroupsValidator;
+import org.sagebionetworks.bridge.validators.Validate;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -278,5 +285,39 @@ public class UserAdminService {
             logger.error(e.getMessage(), e);
             return false;
         }
+    }
+
+    /**
+     * Researcher API to update data groups to a given account. Note that this *overwrites* all data groups, not adds.
+     * This is used for bootstrapping test accounts and to correct errors in data groups.
+     *
+     * @param study
+     *         study the account lives in
+     * @param email
+     *         email address of the account to update
+     * @param dataGroups
+     *         new set of data groups
+     */
+    public void updateDataGroupForUser(Study study, String email, DataGroups dataGroups) {
+        // validate user inputs (except study, which isn't user input)
+        if (StringUtils.isBlank(email)) {
+            throw new BadRequestException("Email address must be specified");
+        }
+        Validate.entityThrowingException(new DataGroupsValidator(study.getDataGroups()), dataGroups);
+
+        // Get the user's health code.
+        Account account = accountDao.getAccount(study, email);
+        if (account == null) {
+            throw new NotFoundException("Account not found");
+        }
+
+        String healthCode = healthIdDao.getCode(account.getHealthId());
+        if (healthCode == null) {
+            throw new NotFoundException("Health code not found");
+        }
+
+        // Set data groups.
+        optionsService.setStringSet(study, healthCode, ParticipantOption.DATA_GROUPS,
+                dataGroups.getDataGroups());
     }
 }

--- a/conf/routes
+++ b/conf/routes
@@ -13,6 +13,9 @@ POST   /v3/auth/signUp                  @org.sagebionetworks.bridge.play.control
 POST   /v3/auth/verifyEmail             @org.sagebionetworks.bridge.play.controllers.AuthenticationController.verifyEmail
 POST   /v3/auth/resendEmailVerification @org.sagebionetworks.bridge.play.controllers.AuthenticationController.resendEmailVerification
 
+# Participants Researcher APIs
+POST /v3/participants/dataGroups @org.sagebionetworks.bridge.play.controllers.UserManagementController.updateDataGroupForUser(email: String ?= null)
+
 # Study Subpopulations
 
 GET    /v3/subpopulations        @org.sagebionetworks.bridge.play.controllers.SubpopulationController.getAllSubpopulations

--- a/test/org/sagebionetworks/bridge/play/controllers/UserManagementControllerUpdateDataGroupsTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/UserManagementControllerUpdateDataGroupsTest.java
@@ -1,0 +1,66 @@
+package org.sagebionetworks.bridge.play.controllers;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import play.mvc.Result;
+
+import org.sagebionetworks.bridge.Roles;
+import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.TestUtils;
+import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
+import org.sagebionetworks.bridge.models.accounts.DataGroups;
+import org.sagebionetworks.bridge.models.accounts.UserSession;
+import org.sagebionetworks.bridge.services.StudyService;
+import org.sagebionetworks.bridge.services.UserAdminService;
+
+public class UserManagementControllerUpdateDataGroupsTest {
+    private static final String TEST_EMAIL = "email@example.com";
+
+    @Test
+    public void test() throws Exception {
+        // Spy controller. Mock session.
+        UserSession mockSession = new UserSession();
+        mockSession.setStudyIdentifier(TestConstants.TEST_STUDY);
+
+        UserManagementController controller = spy(new UserManagementController());
+        doReturn(mockSession).when(controller).getAuthenticatedSession(Roles.RESEARCHER);
+
+        // Mock study service
+        DynamoStudy mockStudy = new DynamoStudy();
+        StudyService mockStudyService = mock(StudyService.class);
+        when(mockStudyService.getStudy(TestConstants.TEST_STUDY)).thenReturn(mockStudy);
+        controller.setStudyService(mockStudyService);
+
+        // Mock request JSON.
+        String requestJsonText = "{\n" +
+                "   \"dataGroups\":[\"foo\", \"bar\", \"baz\"]\n" +
+                "}";
+        TestUtils.mockPlayContextWithJson(requestJsonText);
+
+        // Mock User Admin Service
+        UserAdminService mockUserAdminService = mock(UserAdminService.class);
+        controller.setUserAdminService(mockUserAdminService);
+
+        // execute and validate
+        Result result = controller.updateDataGroupForUser(TEST_EMAIL);
+        assertEquals(200, result.status());
+
+        // verify it called through to the User Admin Service
+        ArgumentCaptor<DataGroups> dataGroupsCaptor = ArgumentCaptor.forClass(DataGroups.class);
+        verify(mockUserAdminService).updateDataGroupForUser(same(mockStudy), eq(TEST_EMAIL),
+                dataGroupsCaptor.capture());
+
+        DataGroups dataGroups = dataGroupsCaptor.getValue();
+        assertEquals(ImmutableSet.of("foo", "bar", "baz"), dataGroups.getDataGroups());
+    }
+}

--- a/test/org/sagebionetworks/bridge/services/UserAdminServiceUpdateDataGroupsTest.java
+++ b/test/org/sagebionetworks/bridge/services/UserAdminServiceUpdateDataGroupsTest.java
@@ -1,0 +1,119 @@
+package org.sagebionetworks.bridge.services;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.dao.AccountDao;
+import org.sagebionetworks.bridge.dao.HealthIdDao;
+import org.sagebionetworks.bridge.dao.ParticipantOption;
+import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
+import org.sagebionetworks.bridge.exceptions.BadRequestException;
+import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
+import org.sagebionetworks.bridge.exceptions.NotFoundException;
+import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.DataGroups;
+
+public class UserAdminServiceUpdateDataGroupsTest {
+    private static final Set<String> TEST_DATA_GROUP_SET = ImmutableSet.of("foo", "bar");
+    private static final DataGroups TEST_DATA_GROUPS = new DataGroups(TEST_DATA_GROUP_SET);
+    private static final String TEST_EMAIL = "email@example.com";
+    private static final String TEST_HEALTH_ID = "test-health-id";
+    private static final String TEST_HEALTH_CODE = "test-health-code";
+    private static final DynamoStudy TEST_STUDY;
+    static {
+        // Only thing we care about is data groups
+        TEST_STUDY = new DynamoStudy();
+        TEST_STUDY.setDataGroups(ImmutableSet.of("foo", "bar", "extraneous"));
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void nullEmail() {
+        new UserAdminService().updateDataGroupForUser(TEST_STUDY, null, TEST_DATA_GROUPS);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void emptyEmail() {
+        new UserAdminService().updateDataGroupForUser(TEST_STUDY, "", TEST_DATA_GROUPS);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void blankEmail() {
+        new UserAdminService().updateDataGroupForUser(TEST_STUDY, "   ", TEST_DATA_GROUPS);
+    }
+
+    @Test(expected = InvalidEntityException.class)
+    public void invalidDataGroup() {
+        new UserAdminService().updateDataGroupForUser(TEST_STUDY, TEST_EMAIL, new DataGroups(ImmutableSet.of("foo",
+                "bar", "invalid")));
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void noAccount() {
+        // mock account DAO
+        AccountDao mockAccountDao = mock(AccountDao.class);
+        when(mockAccountDao.getAccount(TEST_STUDY, TEST_EMAIL)).thenReturn(null);
+
+        // set up service
+        UserAdminService svc = new UserAdminService();
+        svc.setAccountDao(mockAccountDao);
+
+        // execute
+        svc.updateDataGroupForUser(TEST_STUDY, TEST_EMAIL, TEST_DATA_GROUPS);
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void noHealthCode() {
+        // mock account DAO
+        Account mockAccount = mock(Account.class);
+        when(mockAccount.getHealthId()).thenReturn(TEST_HEALTH_ID);
+
+        AccountDao mockAccountDao = mock(AccountDao.class);
+        when(mockAccountDao.getAccount(TEST_STUDY, TEST_EMAIL)).thenReturn(mockAccount);
+
+        // mock health ID DAO
+        HealthIdDao mockHealthIdDao = mock(HealthIdDao.class);
+        when(mockHealthIdDao.getCode(TEST_HEALTH_ID)).thenReturn(null);
+
+        // set up service
+        UserAdminService svc = new UserAdminService();
+        svc.setAccountDao(mockAccountDao);
+        svc.setHealthIdDao(mockHealthIdDao);
+
+        // execute
+        svc.updateDataGroupForUser(TEST_STUDY, TEST_EMAIL, TEST_DATA_GROUPS);
+    }
+
+    @Test
+    public void normalCase() {
+        // mock account DAO
+        Account mockAccount = mock(Account.class);
+        when(mockAccount.getHealthId()).thenReturn(TEST_HEALTH_ID);
+
+        AccountDao mockAccountDao = mock(AccountDao.class);
+        when(mockAccountDao.getAccount(TEST_STUDY, TEST_EMAIL)).thenReturn(mockAccount);
+
+        // mock health ID DAO
+        HealthIdDao mockHealthIdDao = mock(HealthIdDao.class);
+        when(mockHealthIdDao.getCode(TEST_HEALTH_ID)).thenReturn(TEST_HEALTH_CODE);
+
+        // mock options service
+        ParticipantOptionsService mockOptionsSvc = mock(ParticipantOptionsService.class);
+
+        // set up service
+        UserAdminService svc = new UserAdminService();
+        svc.setAccountDao(mockAccountDao);
+        svc.setHealthIdDao(mockHealthIdDao);
+        svc.setParticipantOptionsService(mockOptionsSvc);
+
+        // execute and validate
+        svc.updateDataGroupForUser(TEST_STUDY, TEST_EMAIL, TEST_DATA_GROUPS);
+        verify(mockOptionsSvc).setStringSet(TEST_STUDY, TEST_HEALTH_CODE, ParticipantOption.DATA_GROUPS,
+                TEST_DATA_GROUP_SET);
+    }
+}


### PR DESCRIPTION
This is needed to bootstrap test accounts. This is also useful if we have to fix data groups as a one-off thing in the future.

Testing done:
- added new unit tests
- manual tests
