### PR TITLE
Worker accounts shouldn't 412; Authentication Controller unit tests

### DIFF
--- a/app/org/sagebionetworks/bridge/Roles.java
+++ b/app/org/sagebionetworks/bridge/Roles.java
@@ -9,6 +9,6 @@ public enum Roles {
     ADMIN,
     TEST_USERS,
     WORKER;
-    
-    public static final Set<Roles> ADMINISTRATIVE_ROLES = EnumSet.of(Roles.DEVELOPER, Roles.RESEARCHER, Roles.ADMIN);
+
+    public static final Set<Roles> ADMINISTRATIVE_ROLES = EnumSet.of(DEVELOPER, RESEARCHER, ADMIN, WORKER);
 }


### PR DESCRIPTION
Change 1: Worker accounts shouldn't throw 412s on sign in, similar to how we treat Admin, Developer, and Researcher accounts. This change is as simple as adding Worker to the set of admin roles.

Manual Testing Done:
- Before the change, log in with a test account that's in the Worker group and no other group. Verify that Bridge throws a 412.
- After the change, log in with the same account. Verify that Bridge returns 200.
## 

Change 2: Updated AuthenticationControllerMockTest to more thoroughly test all the groups and consents. It might be easier to read the new AuthenticationControllerMockTest than to try to read the diff.
