### PR TITLE
Making changes so it's easier to determine what test is leaving a survey in the db

### DIFF
--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -38,8 +38,6 @@ import org.sagebionetworks.bridge.models.studies.MimeType;
 import org.sagebionetworks.bridge.models.studies.PasswordPolicy;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
-import org.sagebionetworks.bridge.models.surveys.Survey;
-import org.sagebionetworks.bridge.models.surveys.TestSurvey;
 
 import play.mvc.Http;
 
@@ -282,15 +280,6 @@ public class TestUtils {
         plan.setStrategy(strategy);
         
         return plan;
-    }
-    
-    /**
-     * A convenience for finding a completed survey object for tests.
-     * @param makeNew
-     * @return
-     */
-    public static Survey getSurvey(boolean makeNew) {
-        return new TestSurvey(makeNew);
     }
     
     public static Schedule getSchedule(String label) {

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoTest.java
@@ -21,6 +21,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.exceptions.ConcurrentModificationException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
@@ -60,7 +62,7 @@ public class DynamoSurveyDaoTest {
 
     @Before
     public void before() {
-        testSurvey = new TestSurvey(true);
+        testSurvey = new TestSurvey(DynamoSurveyDaoTest.class, true);
         // remove all but two questions to reduce DDB usage.
         testSurvey.setElements(testSurvey.getElements().subList(0, 2));
         surveysToDelete = new HashSet<>();
@@ -100,7 +102,7 @@ public class DynamoSurveyDaoTest {
     private class SimpleSurvey extends DynamoSurvey {
         public SimpleSurvey(String name) {
             setName(name);
-            setIdentifier("bloodpressure");
+            setIdentifier(TestUtils.randomName(DynamoSurveyDaoTest.class));
             setStudyIdentifier(TEST_STUDY_IDENTIFIER);
         }
     }
@@ -456,12 +458,12 @@ public class DynamoSurveyDaoTest {
     @Test
     public void canGetAllSurveys() throws Exception {
         Set<GuidCreatedOnVersionHolderImpl> mostRecentVersionSurveys = new HashSet<>();
-        mostRecentVersionSurveys.add(new GuidCreatedOnVersionHolderImpl(createSurvey(new TestSurvey(true))));
-        mostRecentVersionSurveys.add(new GuidCreatedOnVersionHolderImpl(createSurvey(new TestSurvey(true))));
-        mostRecentVersionSurveys.add(new GuidCreatedOnVersionHolderImpl(createSurvey(new TestSurvey(true))));
-        mostRecentVersionSurveys.add(new GuidCreatedOnVersionHolderImpl(createSurvey(new TestSurvey(true))));
+        mostRecentVersionSurveys.add(new GuidCreatedOnVersionHolderImpl(createSurvey(new TestSurvey(DynamoSurveyDaoTest.class, true))));
+        mostRecentVersionSurveys.add(new GuidCreatedOnVersionHolderImpl(createSurvey(new TestSurvey(DynamoSurveyDaoTest.class, true))));
+        mostRecentVersionSurveys.add(new GuidCreatedOnVersionHolderImpl(createSurvey(new TestSurvey(DynamoSurveyDaoTest.class, true))));
+        mostRecentVersionSurveys.add(new GuidCreatedOnVersionHolderImpl(createSurvey(new TestSurvey(DynamoSurveyDaoTest.class, true))));
 
-        Survey survey = createSurvey(new TestSurvey(true));
+        Survey survey = createSurvey(new TestSurvey(DynamoSurveyDaoTest.class, true));
 
         versionSurvey(survey);
 
@@ -489,7 +491,7 @@ public class DynamoSurveyDaoTest {
     @Test
     public void canRetrieveMostRecentlyPublishedSurveysWithManyVersions() throws Exception {
         // Version 1.
-        Survey survey1 = createSurvey(new TestSurvey(true));
+        Survey survey1 = createSurvey(new TestSurvey(DynamoSurveyDaoTest.class, true));
 
         // Version 2.
         Survey survey2 = versionSurvey(survey1);
@@ -536,13 +538,13 @@ public class DynamoSurveyDaoTest {
 
     @Test
     public void canRetrieveMostRecentPublishedSurveysWithManySurveys() throws Exception {
-        Survey survey1 = createSurvey(new TestSurvey(true));
+        Survey survey1 = createSurvey(new TestSurvey(DynamoSurveyDaoTest.class, true));
         publishSurvey(TEST_STUDY, survey1);
 
-        Survey survey2 = createSurvey(new TestSurvey(true));
+        Survey survey2 = createSurvey(new TestSurvey(DynamoSurveyDaoTest.class, true));
         publishSurvey(TEST_STUDY, survey2);
 
-        Survey survey3 = createSurvey(new TestSurvey(true));
+        Survey survey3 = createSurvey(new TestSurvey(DynamoSurveyDaoTest.class, true));
         publishSurvey(TEST_STUDY, survey3);
 
         // We must wait here because the above getter uses a secondary global index, and consistent

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyResponseDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyResponseDaoTest.java
@@ -60,7 +60,7 @@ public class DynamoSurveyResponseDaoTest {
 
     @Before
     public void before() throws Exception {
-        survey = new TestSurvey(true);
+        survey = new TestSurvey(DynamoSurveyResponseDaoTest.class, true);
         survey = surveyDao.createSurvey(survey);
     }
 

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyTest.java
@@ -147,7 +147,7 @@ public class DynamoSurveyTest {
 
     private static DynamoSurvey makeTestSurvey() {
         // Make survey. Modify a few fields to make testing easier.
-        DynamoSurvey survey = new TestSurvey(false);
+        DynamoSurvey survey = new TestSurvey(DynamoSurveyTest.class, false);
         survey.setGuid("test-survey-guid");
         survey.setCreatedOn(TEST_CREATED_ON_MILLIS);
         survey.setModifiedOn(TEST_MODIFIED_ON_MILLIS);

--- a/test/org/sagebionetworks/bridge/models/schedules/ScheduleTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/ScheduleTest.java
@@ -114,7 +114,7 @@ public class ScheduleTest {
         Schedule schedule = new Schedule();
         assertFalse(schedule.getPersistent()); // safe to do this before anything else.
         
-        Survey survey = new TestSurvey(false);
+        Survey survey = new TestSurvey(ScheduleTest.class, false);
         Activity activity = new Activity.Builder().withLabel("Test").withSurvey(survey.getIdentifier(),
                         survey.getGuid(), new DateTime(survey.getCreatedOn())).build();
         schedule.addActivity(activity);
@@ -140,7 +140,7 @@ public class ScheduleTest {
     @Test
     public void scheduleWithDelayNotPersistent() {
         Schedule schedule = new Schedule();
-        Survey survey = new TestSurvey(false);
+        Survey survey = new TestSurvey(ScheduleTest.class, false);
         Activity activity = new Activity.Builder().withLabel("Test").withSurvey(survey.getIdentifier(),
                         survey.getGuid(), new DateTime(survey.getCreatedOn())).build();
         schedule.addActivity(activity);

--- a/test/org/sagebionetworks/bridge/models/surveys/TestSurvey.java
+++ b/test/org/sagebionetworks/bridge/models/surveys/TestSurvey.java
@@ -165,10 +165,10 @@ public class TestSurvey extends DynamoSurvey {
         }
     };
     
-    public TestSurvey(boolean makeNew) {
+    public TestSurvey(Class<?> cls, boolean makeNew) {
         setGuid(UUID.randomUUID().toString());
         setName("General Blood Pressure Survey");
-        setIdentifier(TestUtils.randomName(TestSurvey.class));
+        setIdentifier(TestUtils.randomName(cls));
         setModifiedOn(DateUtils.getCurrentMillisFromEpoch());
         setCreatedOn(DateUtils.getCurrentMillisFromEpoch());
         setVersion(2L);

--- a/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
@@ -803,8 +803,8 @@ public class SurveyControllerTest {
     }
     
     private Survey getSurvey(boolean makeNew) {
-        Survey survey = new TestSurvey(makeNew);
-        survey.setName("bloodpressure " + survey.getGuid());
+        Survey survey = new TestSurvey(SurveyControllerTest.class, makeNew);
+        survey.setName(TestUtils.randomName(SurveyControllerTest.class));
         return survey;
     }
     

--- a/test/org/sagebionetworks/bridge/play/controllers/SurveyResponseControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SurveyResponseControllerTest.java
@@ -97,7 +97,7 @@ public class SurveyResponseControllerTest {
     
     @Test
     public void createSurveyResponse() throws Exception {
-        Survey survey = new TestSurvey(false);
+        Survey survey = new TestSurvey(SurveyResponseControllerTest.class, false);
         SurveyResponse response = mockSurveyResponse();
         SurveyResponseView view = new SurveyResponseView(response, survey);
         setContext(response);
@@ -124,7 +124,7 @@ public class SurveyResponseControllerTest {
     @SuppressWarnings("unchecked")
     @Test
     public void createSurveyResponseWithoutAnIdentifier() throws Exception {
-        Survey survey = new TestSurvey(false);
+        Survey survey = new TestSurvey(SurveyResponseControllerTest.class, false);
         SurveyResponse response = mockSurveyResponse();
         response.setIdentifier(null);
         setContext(response);
@@ -140,7 +140,7 @@ public class SurveyResponseControllerTest {
     
     @Test
     public void getSurveyResponse() throws Exception {
-        Survey survey = new TestSurvey(false);
+        Survey survey = new TestSurvey(SurveyResponseControllerTest.class, false);
         SurveyResponse response = mockSurveyResponse();
         SurveyResponseView view = new SurveyResponseView(response, survey);
         
@@ -156,7 +156,7 @@ public class SurveyResponseControllerTest {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
     public void appendAnswersToSurveyResponse() throws Exception {
-        Survey survey = new TestSurvey(false);
+        Survey survey = new TestSurvey(SurveyResponseControllerTest.class, false);
         SurveyResponse response = mockSurveyResponse();
         SurveyResponseView view = new SurveyResponseView(response, survey);
         setContext(response);

--- a/test/org/sagebionetworks/bridge/services/SchedulePlanServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/SchedulePlanServiceMockTest.java
@@ -34,6 +34,7 @@ import org.sagebionetworks.bridge.models.schedules.ScheduleType;
 import org.sagebionetworks.bridge.models.schedules.SimpleScheduleStrategy;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.surveys.Survey;
+import org.sagebionetworks.bridge.models.surveys.TestSurvey;
 
 import com.google.common.collect.Sets;
 
@@ -61,9 +62,9 @@ public class SchedulePlanServiceMockTest {
         service.setSchedulePlanDao(mockSchedulePlanDao);
         service.setSurveyService(mockSurveyService);
         
-        Survey survey1 = TestUtils.getSurvey(false);
+        Survey survey1 = new TestSurvey(SchedulePlanServiceMockTest.class, false);
         survey1.setIdentifier("identifier1");
-        Survey survey2 = TestUtils.getSurvey(false);
+        Survey survey2 = new TestSurvey(SchedulePlanServiceMockTest.class, false);
         survey2.setIdentifier("identifier2");
         when(mockSurveyService.getSurveyMostRecentlyPublishedVersion(any(), any())).thenReturn(survey1);
         when(mockSurveyService.getSurvey(any())).thenReturn(survey2);

--- a/test/org/sagebionetworks/bridge/services/SurveyServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SurveyServiceTest.java
@@ -60,7 +60,7 @@ public class SurveyServiceTest {
 
     @Before
     public void before() {
-        testSurvey = new TestSurvey(true);
+        testSurvey = new TestSurvey(SurveyServiceTest.class, true);
         surveysToDelete = new HashSet<>();
     }
 
@@ -304,12 +304,12 @@ public class SurveyServiceTest {
     @Test
     public void canGetAllSurveys() throws Exception {
         Set<GuidCreatedOnVersionHolderImpl> mostRecentVersionSurveys = new HashSet<>();
-        mostRecentVersionSurveys.add(new GuidCreatedOnVersionHolderImpl(surveyService.createSurvey(new TestSurvey(true))));
-        mostRecentVersionSurveys.add(new GuidCreatedOnVersionHolderImpl(surveyService.createSurvey(new TestSurvey(true))));
-        mostRecentVersionSurveys.add(new GuidCreatedOnVersionHolderImpl(surveyService.createSurvey(new TestSurvey(true))));
-        mostRecentVersionSurveys.add(new GuidCreatedOnVersionHolderImpl(surveyService.createSurvey(new TestSurvey(true))));
+        mostRecentVersionSurveys.add(new GuidCreatedOnVersionHolderImpl(surveyService.createSurvey(new TestSurvey(SurveyServiceTest.class, true))));
+        mostRecentVersionSurveys.add(new GuidCreatedOnVersionHolderImpl(surveyService.createSurvey(new TestSurvey(SurveyServiceTest.class, true))));
+        mostRecentVersionSurveys.add(new GuidCreatedOnVersionHolderImpl(surveyService.createSurvey(new TestSurvey(SurveyServiceTest.class, true))));
+        mostRecentVersionSurveys.add(new GuidCreatedOnVersionHolderImpl(surveyService.createSurvey(new TestSurvey(SurveyServiceTest.class, true))));
 
-        Survey survey = surveyService.createSurvey(new TestSurvey(true));
+        Survey survey = surveyService.createSurvey(new TestSurvey(SurveyServiceTest.class, true));
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(survey));
 
         Survey nextVersion = surveyService.versionSurvey(survey);
@@ -339,7 +339,7 @@ public class SurveyServiceTest {
     @Test
     public void canRetrieveMostRecentlyPublishedSurveysWithManyVersions() throws Exception {
         // Version 1.
-        Survey survey1 = surveyService.createSurvey(new TestSurvey(true));
+        Survey survey1 = surveyService.createSurvey(new TestSurvey(SurveyServiceTest.class, true));
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(survey1));
 
         // Version 2.
@@ -387,15 +387,15 @@ public class SurveyServiceTest {
 
     @Test
     public void canRetrieveMostRecentPublishedSurveysWithManySurveys() throws Exception {
-        Survey survey1 = surveyService.createSurvey(new TestSurvey(true));
+        Survey survey1 = surveyService.createSurvey(new TestSurvey(SurveyServiceTest.class, true));
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(survey1));
         surveyService.publishSurvey(TEST_STUDY, survey1);
 
-        Survey survey2 = surveyService.createSurvey(new TestSurvey(true));
+        Survey survey2 = surveyService.createSurvey(new TestSurvey(SurveyServiceTest.class, true));
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(survey2));
         surveyService.publishSurvey(TEST_STUDY, survey2);
 
-        Survey survey3 = surveyService.createSurvey(new TestSurvey(true));
+        Survey survey3 = surveyService.createSurvey(new TestSurvey(SurveyServiceTest.class, true));
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(survey3));
         surveyService.publishSurvey(TEST_STUDY, survey3);
 
@@ -411,7 +411,7 @@ public class SurveyServiceTest {
 
     @Test
     public void validationInfoScreen() {
-        Survey survey = new TestSurvey(true);
+        Survey survey = new TestSurvey(SurveyServiceTest.class, true);
         
         DynamoSurveyInfoScreen screen = new DynamoSurveyInfoScreen();
         screen.setImage(new Image("/path/to/source.gif", 0, 0)); // very wrong

--- a/test/org/sagebionetworks/bridge/validators/SurveyValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/SurveyValidatorTest.java
@@ -40,7 +40,7 @@ public class SurveyValidatorTest {
 
     @Before
     public void before() {
-        survey = new TestSurvey(true);
+        survey = new TestSurvey(SurveyValidatorTest.class, true);
         // because this is set by the service before validation
         survey.setGuid("AAA");
         validator = new SurveyValidator();
@@ -118,7 +118,7 @@ public class SurveyValidatorTest {
     @Test
     public void preventsDuplicateElementIdentfiers() {
         try {
-            survey = new TestSurvey(true);
+            survey = new TestSurvey(SurveyValidatorTest.class, true);
             String identifier = survey.getElements().get(0).getIdentifier();
             survey.getElements().get(1).setIdentifier(identifier);
             Validate.entityThrowingException(validator, survey);
@@ -131,7 +131,7 @@ public class SurveyValidatorTest {
     @Test
     public void infoScreenIdentifierRequired() {
         try {
-            survey = new TestSurvey(true);
+            survey = new TestSurvey(SurveyValidatorTest.class, true);
             survey.getElements().add(createSurveyInfoScreen());
             SurveyInfoScreen screen = (SurveyInfoScreen) last(survey);
             screen.setIdentifier("");
@@ -146,7 +146,7 @@ public class SurveyValidatorTest {
     @Test
     public void infoScreenTitleRequired() {
         try {
-            survey = new TestSurvey(true);
+            survey = new TestSurvey(SurveyValidatorTest.class, true);
             survey.getElements().add(createSurveyInfoScreen());
             SurveyInfoScreen screen = (SurveyInfoScreen) last(survey);
             screen.setTitle("");
@@ -161,7 +161,7 @@ public class SurveyValidatorTest {
     @Test
     public void infoScreenPromptRequired() {
         try {
-            survey = new TestSurvey(true);
+            survey = new TestSurvey(SurveyValidatorTest.class, true);
             survey.getElements().add(createSurveyInfoScreen());
             SurveyInfoScreen screen = (SurveyInfoScreen) last(survey);
             screen.setPrompt("");
@@ -176,7 +176,7 @@ public class SurveyValidatorTest {
     @Test
     public void ifPresentAllFieldsOfSurveyScreenImageRequired() {
         try {
-            survey = new TestSurvey(false);
+            survey = new TestSurvey(SurveyValidatorTest.class, false);
             survey.getElements().add(createSurveyInfoScreen());
             SurveyInfoScreen screen = (SurveyInfoScreen) last(survey);
             screen.setImage(new Image("", 0, 0));
@@ -193,7 +193,7 @@ public class SurveyValidatorTest {
     @Test
     public void questionIdentifierRequired() {
         try {
-            survey = new TestSurvey(false);
+            survey = new TestSurvey(SurveyValidatorTest.class, false);
             survey.getElements().get(0).setIdentifier("");
 
             Validate.entityThrowingException(validator, survey);
@@ -206,7 +206,7 @@ public class SurveyValidatorTest {
     @Test
     public void questionUiHintRequired() {
         try {
-            survey = new TestSurvey(false);
+            survey = new TestSurvey(SurveyValidatorTest.class, false);
             survey.getUnmodifiableQuestionList().get(0).setUiHint(null);
 
             Validate.entityThrowingException(validator, survey);
@@ -219,7 +219,7 @@ public class SurveyValidatorTest {
     @Test
     public void questionPromptRequired() {
         try {
-            survey = new TestSurvey(false);
+            survey = new TestSurvey(SurveyValidatorTest.class, false);
             survey.getUnmodifiableQuestionList().get(0).setPrompt("");
 
             Validate.entityThrowingException(validator, survey);
@@ -232,7 +232,7 @@ public class SurveyValidatorTest {
     @Test
     public void questionConstraintsRequired() {
         try {
-            survey = new TestSurvey(false);
+            survey = new TestSurvey(SurveyValidatorTest.class, false);
             survey.getUnmodifiableQuestionList().get(0).setConstraints(null);
 
             Validate.entityThrowingException(validator, survey);
@@ -249,7 +249,7 @@ public class SurveyValidatorTest {
     @Test
     public void constraintDataTypeRequired() {
         try {
-            survey = new TestSurvey(false);
+            survey = new TestSurvey(SurveyValidatorTest.class, false);
             survey.getUnmodifiableQuestionList().get(0).getConstraints().setDataType(null);
 
             Validate.entityThrowingException(validator, survey);
@@ -262,7 +262,7 @@ public class SurveyValidatorTest {
     @Test
     public void uiHintMustBeSupportedByConstraintsType() {
         try {
-            survey = new TestSurvey(false);
+            survey = new TestSurvey(SurveyValidatorTest.class, false);
             // Boolean constraints do not jive with lists (which are normally for select multiple)
             survey.getUnmodifiableQuestionList().get(0).setUiHint(UIHint.LIST);
 
@@ -277,7 +277,7 @@ public class SurveyValidatorTest {
     @Test
     public void multiValueWithComboboxLimitsConstraints() {
         try {
-            survey = new TestSurvey(false);
+            survey = new TestSurvey(SurveyValidatorTest.class, false);
             SurveyQuestion question = ((TestSurvey) survey).getMultiValueQuestion();
             question.setUiHint(UIHint.COMBOBOX);
             ((MultiValueConstraints) question.getConstraints()).setAllowMultiple(true);
@@ -289,7 +289,7 @@ public class SurveyValidatorTest {
                             errorFor(e, "elements[7].constraints.uiHint"));
         }
         try {
-            survey = new TestSurvey(false);
+            survey = new TestSurvey(SurveyValidatorTest.class, false);
             SurveyQuestion question = ((TestSurvey) survey).getMultiValueQuestion();
             question.setUiHint(UIHint.COMBOBOX);
             ((MultiValueConstraints) question.getConstraints()).setAllowOther(false);
@@ -305,7 +305,7 @@ public class SurveyValidatorTest {
     @Test
     public void multiValueWithMultipleAnswersLimitsConstraints() {
         try {
-            survey = new TestSurvey(false);
+            survey = new TestSurvey(SurveyValidatorTest.class, false);
             SurveyQuestion question = ((TestSurvey) survey).getMultiValueQuestion();
             question.setUiHint(UIHint.SLIDER);
             ((MultiValueConstraints) question.getConstraints()).setAllowMultiple(true);
@@ -321,7 +321,7 @@ public class SurveyValidatorTest {
     @Test
     public void multiValueWithOneAnswerLimitsConstraints() {
         try {
-            survey = new TestSurvey(false);
+            survey = new TestSurvey(SurveyValidatorTest.class, false);
             SurveyQuestion question = ((TestSurvey) survey).getMultiValueQuestion();
             question.setUiHint(UIHint.CHECKBOX);
             ((MultiValueConstraints) question.getConstraints()).setAllowMultiple(false);
@@ -337,7 +337,7 @@ public class SurveyValidatorTest {
     @Test
     public void stringConstraintsMustHaveValidRegularExpressionPattern() {
         try {
-            survey = new TestSurvey(false);
+            survey = new TestSurvey(SurveyValidatorTest.class, false);
             SurveyQuestion question = ((TestSurvey) survey).getStringQuestion();
             ((StringConstraints) question.getConstraints()).setPattern("?");
 
@@ -382,7 +382,7 @@ public class SurveyValidatorTest {
     @Test
     public void willValidateStringMaxLengthNotLowerThanMinLength() {
         try {
-            survey = new TestSurvey(false);
+            survey = new TestSurvey(SurveyValidatorTest.class, false);
             SurveyQuestion question = ((TestSurvey) survey).getStringQuestion();
             StringConstraints constraints = (StringConstraints)question.getConstraints();
             constraints.setMaxLength(2);
@@ -398,7 +398,7 @@ public class SurveyValidatorTest {
     @Test
     public void willValidateMaxValueNotLowerThanMinValueForInteger() {
         try {
-            survey = new TestSurvey(false);
+            survey = new TestSurvey(SurveyValidatorTest.class, false);
             SurveyQuestion question = ((TestSurvey) survey).getIntegerQuestion();
             IntegerConstraints constraints = (IntegerConstraints)question.getConstraints();
             constraints.setMaxValue(2d);
@@ -414,7 +414,7 @@ public class SurveyValidatorTest {
     @Test
     public void willValidateMaxValueNotLowerThanMinValueForDecimal() {
         try {
-            survey = new TestSurvey(false);
+            survey = new TestSurvey(SurveyValidatorTest.class, false);
             SurveyQuestion question = ((TestSurvey) survey).getDecimalQuestion();
             DecimalConstraints constraints = (DecimalConstraints)question.getConstraints();
             constraints.setMaxValue(2d);
@@ -430,7 +430,7 @@ public class SurveyValidatorTest {
     @Test
     public void willValidateMaxValueNotLowerThanMinValueForDuration() {
         try {
-            survey = new TestSurvey(false);
+            survey = new TestSurvey(SurveyValidatorTest.class, false);
             SurveyQuestion question = ((TestSurvey) survey).getDurationQuestion();
             DurationConstraints constraints = (DurationConstraints)question.getConstraints();
             constraints.setMaxValue(2d);
@@ -446,7 +446,7 @@ public class SurveyValidatorTest {
     @Test
     public void willValidateStepValueNotHigherThanRangeOfInteger() {
         try {
-            survey = new TestSurvey(false);
+            survey = new TestSurvey(SurveyValidatorTest.class, false);
             SurveyQuestion question = ((TestSurvey) survey).getIntegerQuestion();
             IntegerConstraints constraints = (IntegerConstraints)question.getConstraints();
             constraints.setMinValue(2d);
@@ -463,7 +463,7 @@ public class SurveyValidatorTest {
     @Test
     public void willValidateStepValueNotHigherThanRangeOfDecimal() {
         try {
-            survey = new TestSurvey(false);
+            survey = new TestSurvey(SurveyValidatorTest.class, false);
             SurveyQuestion question = ((TestSurvey) survey).getDecimalQuestion();
             DecimalConstraints constraints = (DecimalConstraints)question.getConstraints();
             constraints.setMinValue(2d);
@@ -480,7 +480,7 @@ public class SurveyValidatorTest {
     @Test
     public void willValidateStepValueNotHigherThanRangeOfDuration() {
         try {
-            survey = new TestSurvey(false);
+            survey = new TestSurvey(SurveyValidatorTest.class, false);
             SurveyQuestion question = ((TestSurvey) survey).getDurationQuestion();
             DurationConstraints constraints = (DurationConstraints)question.getConstraints();
             constraints.setMinValue(2d);
@@ -497,7 +497,7 @@ public class SurveyValidatorTest {
     @Test
     public void willValidateEarliestLocalDateIsNotAfterLatestLocalDate() {
         try {
-            survey = new TestSurvey(false);
+            survey = new TestSurvey(SurveyValidatorTest.class, false);
             SurveyQuestion question = ((TestSurvey) survey).getDateTimeQuestion();
             DateTimeConstraints constraints = (DateTimeConstraints)question.getConstraints();
             constraints.setEarliestValue(DateTime.parse("2010-10-10T10:10:00.000Z"));
@@ -513,7 +513,7 @@ public class SurveyValidatorTest {
     @Test
     public void willValidateEarliestDateTimeIsNotAfterLatestDateTime() {
         try {
-            survey = new TestSurvey(false);
+            survey = new TestSurvey(SurveyValidatorTest.class, false);
             SurveyQuestion question = ((TestSurvey) survey).getDateQuestion();
             DateConstraints constraints = (DateConstraints)question.getConstraints();
             constraints.setEarliestValue(LocalDate.parse("2010-10-11"));


### PR DESCRIPTION
And not cleaning up correctly (I found a lot of "blood pressure" surveys in the UAT tables, so this will replace that with IDs that can be traced back to a specific test).
