### PR TITLE
add study to dedupe log message

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/UploadController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/UploadController.java
@@ -45,7 +45,8 @@ public class UploadController extends BaseController {
     public Result upload() throws Exception {
         UserSession session = getAuthenticatedAndConsentedSession();
         UploadRequest uploadRequest = UploadRequest.fromJson(requestToJSON(request()));
-        UploadSession uploadSession = uploadService.createUpload(session.getUser(), uploadRequest);
+        UploadSession uploadSession = uploadService.createUpload(session.getStudyIdentifier(), session.getUser(),
+                uploadRequest);
         final Metrics metrics = getMetrics();
         if (metrics != null) {
             metrics.setUploadSize(uploadRequest.getContentLength());

--- a/app/org/sagebionetworks/bridge/services/UploadService.java
+++ b/app/org/sagebionetworks/bridge/services/UploadService.java
@@ -23,6 +23,7 @@ import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.models.accounts.User;
 import org.sagebionetworks.bridge.models.healthdata.HealthDataRecord;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.upload.Upload;
 import org.sagebionetworks.bridge.models.upload.UploadRequest;
 import org.sagebionetworks.bridge.models.upload.UploadSession;
@@ -93,7 +94,7 @@ public class UploadService {
         this.validator = validator;
     }
 
-    public UploadSession createUpload(User user, UploadRequest uploadRequest) {
+    public UploadSession createUpload(StudyIdentifier studyId, User user, UploadRequest uploadRequest) {
         Validate.entityThrowingException(validator, uploadRequest);
 
         // For all new uploads, the upload ID in DynamoDB is the same as the S3 Object ID
@@ -109,7 +110,8 @@ public class UploadService {
             String originalUploadId = uploadDedupeDao.getDuplicate(healthCode, uploadMd5, uploadRequestedOn);
             if (originalUploadId != null) {
                 // Is a dupe. We're in observation mode, so for now, just log.
-                logger.info("Detected dupe: Upload " + uploadId + " is a dupe of " + originalUploadId);
+                logger.info("Detected dupe: Study " + studyId.getIdentifier() + ", upload " + uploadId +
+                        " is a dupe of " + originalUploadId);
             } else {
                 // Not a dupe. Register this dupe so we can detect dupes of this.
                 uploadDedupeDao.registerUpload(healthCode, uploadMd5, uploadRequestedOn, uploadId);

--- a/test/org/sagebionetworks/bridge/services/UploadServiceCreateUploadMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/UploadServiceCreateUploadMockTest.java
@@ -22,6 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dao.UploadDao;
 import org.sagebionetworks.bridge.dao.UploadDedupeDao;
 import org.sagebionetworks.bridge.dynamodb.DynamoUpload2;
@@ -167,7 +168,7 @@ public class UploadServiceCreateUploadMockTest {
 
     private void testUpload() {
         // execute and validate
-        UploadSession uploadSession = svc.createUpload(TEST_USER, uploadRequest);
+        UploadSession uploadSession = svc.createUpload(TestConstants.TEST_STUDY, TEST_USER, uploadRequest);
         assertEquals(TEST_UPLOAD_ID, uploadSession.getId());
         assertEquals(TEST_PRESIGNED_URL, uploadSession.getUrl());
 

--- a/test/org/sagebionetworks/bridge/services/UploadServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/UploadServiceTest.java
@@ -25,6 +25,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUserAdminHelper;
 import org.sagebionetworks.bridge.TestUserAdminHelper.TestUser;
 import org.sagebionetworks.bridge.config.BridgeConfigFactory;
@@ -88,7 +90,8 @@ public class UploadServiceTest {
     @Test
     public void test() throws Exception {
         UploadRequest uploadRequest = createUploadRequest();
-        UploadSession uploadSession = uploadService.createUpload(testUser.getUser(), uploadRequest);
+        UploadSession uploadSession = uploadService.createUpload(TestConstants.TEST_STUDY, testUser.getUser(),
+                uploadRequest);
         final String uploadId = uploadSession.getId();
         objectsToRemove.add(uploadId);
         int reponseCode = upload(uploadSession.getUrl(), uploadRequest);


### PR DESCRIPTION
When analyzing dedupe messages, all dupes were either integration tests or diabetes study. This log change allows us to break down dupes by study, allowing for a better analysis.
