### PR TITLE
Anti-ResearchKit hack: unconvert ints back into strings

### DIFF
--- a/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2.java
+++ b/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2.java
@@ -506,6 +506,12 @@ public class IosSchemaValidationHandler2 implements UploadValidationHandler {
                 logger.warn(warnMsg);
                 context.addMessage(warnMsg);
             }
+        } else if (fieldDef.getType().equals(UploadFieldType.STRING) && !fieldValue.isTextual()) {
+            // Research Kit "helpfully" converts strings that look like ints into actual ints (example: "80" into 80).
+            // This breaks Strict Validation later down the line, so we need to un-convert them back strings.
+            // Note that we do it here, as this is an iOS-specific behavior, rather than in StrictValidation, which is
+            // intended to be more global.
+            dataMap.put(fieldName, fieldValue.toString());
         } else {
             dataMap.set(fieldName, fieldValue);
         }

--- a/test/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2Test.java
+++ b/test/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2Test.java
@@ -92,6 +92,8 @@ public class IosSchemaValidationHandler2Test {
         jsonDataSchema.setFieldDefinitions(ImmutableList.<UploadFieldDefinition>of(
                 new DynamoUploadFieldDefinition.Builder().withName("string.json.string")
                         .withType(UploadFieldType.STRING).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("string.json.intAsString")
+                        .withType(UploadFieldType.STRING).build(),
                 new DynamoUploadFieldDefinition.Builder().withName("blob.json.blob")
                         .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build(),
                 new DynamoUploadFieldDefinition.Builder().withName("date.json.date")
@@ -380,7 +382,8 @@ public class IosSchemaValidationHandler2Test {
         JsonNode infoJsonNode = BridgeObjectMapper.get().readTree(infoJsonText);
 
         String stringJsonText = "{\n" +
-                "   \"string\":\"This is a string\"\n" +
+                "   \"string\":\"This is a string\",\n" +
+                "   \"intAsString\":42\n" +
                 "}";
         JsonNode stringJsonNode = BridgeObjectMapper.get().readTree(stringJsonText);
 
@@ -414,8 +417,10 @@ public class IosSchemaValidationHandler2Test {
         assertEquals(1, recordBuilder.getSchemaRevision());
 
         JsonNode dataNode = recordBuilder.getData();
-        assertEquals(3, dataNode.size());
+        assertEquals(4, dataNode.size());
         assertEquals("This is a string", dataNode.get("string.json.string").textValue());
+        assertTrue(dataNode.get("string.json.intAsString").isTextual());
+        assertEquals("42", dataNode.get("string.json.intAsString").textValue());
         assertEquals("2015-12-25", dataNode.get("date.json.date").textValue());
         assertEquals("2015-12-25", dataNode.get("date.json.timestampAsDate").textValue());
 


### PR DESCRIPTION
Research Kit "helpfully" converts strings that look like ints into actual ints (example: "80" into 80). This breaks Strict Validation later down the line, so we need to un-convert them back strings.

Note that we do it in IosSchemaValidationHandler, as this is an iOS-specific behavior, rather than in StrictValidation, which is intended to be more global.

Testing done:
- updated unit tests
- manually tested with int 42 as a string, verified in the DDB record that 42 was converted into string "42".
- UploadTest integration tests
