### PR TITLE
Eagerly fetch account when authenticating

### DIFF
--- a/app/org/sagebionetworks/bridge/stormpath/StormpathAccountDao.java
+++ b/app/org/sagebionetworks/bridge/stormpath/StormpathAccountDao.java
@@ -193,7 +193,7 @@ public class StormpathAccountDao implements AccountDao {
             AuthenticationRequest<?,?> request = UsernamePasswordRequest.builder()
                     .setUsernameOrEmail(signIn.getEmail())
                     .setPassword(signIn.getPassword())
-                    //.withResponseOptions(UsernamePasswordRequest.options().withAccount())
+                    .withResponseOptions(UsernamePasswordRequest.options().withAccount())
                     .inAccountStore(directory).build();
             
             AuthenticationResult result = application.authenticateAccount(request);

--- a/app/org/sagebionetworks/bridge/stormpath/StormpathAccountDao.java
+++ b/app/org/sagebionetworks/bridge/stormpath/StormpathAccountDao.java
@@ -193,6 +193,7 @@ public class StormpathAccountDao implements AccountDao {
             AuthenticationRequest<?,?> request = UsernamePasswordRequest.builder()
                     .setUsernameOrEmail(signIn.getEmail())
                     .setPassword(signIn.getPassword())
+                    //.withResponseOptions(UsernamePasswordRequest.options().withAccount())
                     .inAccountStore(directory).build();
             
             AuthenticationResult result = application.authenticateAccount(request);

--- a/app/org/sagebionetworks/bridge/stormpath/StormpathAccountDao.java
+++ b/app/org/sagebionetworks/bridge/stormpath/StormpathAccountDao.java
@@ -234,8 +234,13 @@ public class StormpathAccountDao implements AccountDao {
                     .inAccountStore(directory).build();
             
             AuthenticationResult result = application.authenticateAccount(request);
-            if (result.getAccount() != null) {
-                return new StormpathAccount(study.getStudyIdentifier(), subpopGuids, result.getAccount(), encryptors);
+            com.stormpath.sdk.account.Account acct = result.getAccount();
+            if (acct != null) {
+                // eagerly fetch remaining data with further calls to Stormpath (these are not retrieved in authentication 
+                // call, this has been verified with Stormpath). If we fail to fully initialize the user, we want it to 
+                // happen here, not later in the call where we don't expect it.
+                acct.getCustomData();
+                return new StormpathAccount(study.getStudyIdentifier(), subpopGuids, acct, encryptors);
             }
         } catch (ResourceException e) {
             rethrowResourceException(e, null);

--- a/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoMockTest.java
@@ -164,37 +164,46 @@ public class StormpathAccountDaoMockTest {
     @SuppressWarnings("rawtypes")
     @Test
     public void authenticate() {
-        // mock stormpath client
+        // mock stormpath director
         Directory mockDirectory = mock(Directory.class);
+        
+        // mock stormpath client
         Client mockClient = mock(Client.class);
         when(mockClient.getResource(study.getStormpathHref(), Directory.class)).thenReturn(mockDirectory);
 
+        // mock subpopulation service
         SubpopulationService mockSubpopService = mock(SubpopulationService.class);
         
+        // mock stormpath account
         com.stormpath.sdk.account.Account mockAcct = mock(com.stormpath.sdk.account.Account.class);
         when(mockAcct.getGivenName()).thenReturn("Test");
         when(mockAcct.getSurname()).thenReturn("User");
         when(mockAcct.getEmail()).thenReturn("email@email.com");
         
+        // mock authentication result
         AuthenticationResult mockResult = mock(AuthenticationResult.class);
         when(mockResult.getAccount()).thenReturn(mockAcct);
         
+        // mock stormpath application
         Application mockApplication = mock(Application.class);
         when(mockApplication.authenticateAccount(any())).thenReturn(mockResult);
         
+        // wire up DAO
         StormpathAccountDao dao = new StormpathAccountDao();
         dao.setStormpathClient(mockClient);
         dao.setStormpathApplication(mockApplication);
         dao.setSubpopulationService(mockSubpopService);
         
-        // Just verify a few fields, the full object initialization is tested elsewhere.
+        // authenticate
         Account account = dao.authenticate(study, new SignIn("dummy-user", PASSWORD));
+        
+        // Just verify a few fields, the full object initialization is tested elsewhere.
         assertEquals("Test", account.getFirstName());
         assertEquals("User", account.getLastName());
         assertEquals("email@email.com", account.getEmail());
         
-        // eager fetch occurring. Can verify AuthenticationRequest configuration because you can set it but
-        // settings themselves are hidden in implementation. 
+        // verify eager fetch occurring. Can't verify AuthenticationRequest configuration because 
+        // you can set it but settings themselves are hidden in implementation. 
         verify(mockResult).getAccount();
         verify(mockAcct).getCustomData();
         verify(mockAcct).getGroups();

--- a/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoMockTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -31,6 +32,10 @@ import org.sagebionetworks.bridge.services.SubpopulationService;
 
 import com.google.common.collect.Lists;
 import com.stormpath.sdk.application.Application;
+import com.stormpath.sdk.authc.AuthenticationOptions;
+import com.stormpath.sdk.authc.AuthenticationRequest;
+import com.stormpath.sdk.authc.AuthenticationResult;
+import com.stormpath.sdk.authc.BasicAuthenticationOptions;
 import com.stormpath.sdk.client.Client;
 import com.stormpath.sdk.directory.CustomData;
 import com.stormpath.sdk.directory.Directory;
@@ -154,6 +159,45 @@ public class StormpathAccountDaoMockTest {
         verify(acct).setUsername(email);
         verify(acct).setEmail(email);
         verify(acct).setPassword(PASSWORD);
+    }
+    
+    @SuppressWarnings("rawtypes")
+    @Test
+    public void authenticate() {
+        // mock stormpath client
+        Directory mockDirectory = mock(Directory.class);
+        Client mockClient = mock(Client.class);
+        when(mockClient.getResource(study.getStormpathHref(), Directory.class)).thenReturn(mockDirectory);
+
+        SubpopulationService mockSubpopService = mock(SubpopulationService.class);
+        
+        com.stormpath.sdk.account.Account mockAcct = mock(com.stormpath.sdk.account.Account.class);
+        when(mockAcct.getGivenName()).thenReturn("Test");
+        when(mockAcct.getSurname()).thenReturn("User");
+        when(mockAcct.getEmail()).thenReturn("email@email.com");
+        
+        AuthenticationResult mockResult = mock(AuthenticationResult.class);
+        when(mockResult.getAccount()).thenReturn(mockAcct);
+        
+        Application mockApplication = mock(Application.class);
+        when(mockApplication.authenticateAccount(any())).thenReturn(mockResult);
+        
+        StormpathAccountDao dao = new StormpathAccountDao();
+        dao.setStormpathClient(mockClient);
+        dao.setStormpathApplication(mockApplication);
+        dao.setSubpopulationService(mockSubpopService);
+        
+        // Just verify a few fields, the full object initialization is tested elsewhere.
+        Account account = dao.authenticate(study, new SignIn("dummy-user", PASSWORD));
+        assertEquals("Test", account.getFirstName());
+        assertEquals("User", account.getLastName());
+        assertEquals("email@email.com", account.getEmail());
+        
+        // eager fetch occurring. Can verify AuthenticationRequest configuration because you can set it but
+        // settings themselves are hidden in implementation. 
+        verify(mockResult).getAccount();
+        verify(mockAcct).getCustomData();
+        verify(mockAcct).getGroups();
     }
 
     @Test


### PR DESCRIPTION
May close this out. Tried an alternative to the API as well that involved pre-fetching as much as possible, this seemed to take about 10+ seconds from our regular test cycle. Couldn't verify with wireshark that fewer requests were being made to Stormpath though.
