### PR TITLE
Fixing issue where repair consents code gets a context that is constr…

### DIFF
--- a/app/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -158,7 +158,6 @@ public class AuthenticationService {
             Account account = accountDao.authenticate(study, signIn);
             
             UserSession session = getSessionFromAccount(study, context, account);
-            repairConsents(account, session, context);
             cacheProvider.setUserSession(session);
             
             return session;
@@ -331,6 +330,8 @@ public class AuthenticationService {
 
         user.setConsentStatuses(consentService.getConsentStatuses(newContext));
         session.setUser(user);
+        
+        repairConsents(account, session, newContext);
         
         return session;
     }

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
@@ -38,7 +38,6 @@ import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dao.ParticipantOption;
 import org.sagebionetworks.bridge.dao.ParticipantOption.SharingScope;
 import org.sagebionetworks.bridge.dao.UserConsentDao;
-import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
@@ -336,28 +335,14 @@ public class AuthenticationServiceTest {
     
     @Test
     public void resendEmailVerificationLooksSuccessfulWhenNoAccount() throws Exception {
-        // In particular, it must not throw an EntityNotFoundException
-        TestUser testUser = helper.getBuilder(AuthenticationServiceTest.class)
-                .withConsent(false).withSignIn(false).build();
-        try {
-            Email email = new Email(testUser.getStudyIdentifier(), "notarealaccount@sagebase.org");
-            authService.resendEmailVerification(testUser.getStudyIdentifier(), email);
-        } finally {
-            helper.deleteUser(testUser);
-        }
+        Email email = new Email(TEST_STUDY_IDENTIFIER, "notarealaccount@sagebase.org");
+        authService.resendEmailVerification(study, email);
     }
     
     @Test
     public void requestResetPasswordLooksSuccessfulWhenNoAccount() throws Exception {
-        // In particular, it must not throw an EntityNotFoundException
-        TestUser testUser = helper.getBuilder(AuthenticationServiceTest.class)
-                .withConsent(false).withSignIn(false).build();
-        try {
-            Email email = new Email(testUser.getStudyIdentifier(), "notarealaccount@sagebase.org");
-            authService.requestResetPassword(testUser.getStudy(), email);
-        } finally {
-            helper.deleteUser(testUser);
-        }
+        Email email = new Email(TEST_STUDY_IDENTIFIER, "notarealaccount@sagebase.org");
+        authService.requestResetPassword(study, email);
     }
     
     // Consent statuses passed on to sessionInfo

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
@@ -40,6 +40,7 @@ import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
@@ -384,7 +385,14 @@ public class AuthenticationServiceTest {
             
             // Signing in should still work to create a consented user.
             Study study = studyService.getStudy(user.getStudyIdentifier());
-            CriteriaContext context = testUser.getCriteriaContext();
+            
+            // Create the context you would get for an unauthenticated user, don't use the now 
+            // fully-initialized testUser.getCriteriaContext()
+            CriteriaContext context =  new CriteriaContext.Builder()
+                    .withStudyIdentifier(study.getStudyIdentifier())
+                    .withLanguages(TestUtils.newLinkedHashSet("en"))
+                    .withClientInfo(ClientInfo.UNKNOWN_CLIENT)
+                    .build();
             
             UserSession session = authService.signIn(study, context, user.getSignIn());
             

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
@@ -199,13 +199,13 @@ public class AuthenticationServiceTest {
 
     @Test
     public void canResendEmailVerification() throws Exception {
-        TestUser user = helper.getBuilder(AuthenticationServiceTest.class)
+        TestUser testUser = helper.getBuilder(AuthenticationServiceTest.class)
                 .withConsent(false).withSignIn(false).build();
         try {
-            Email email = new Email(user.getStudyIdentifier(), user.getEmail());
-            authService.resendEmailVerification(user.getStudyIdentifier(), email);
+            Email email = new Email(testUser.getStudyIdentifier(), testUser.getEmail());
+            authService.resendEmailVerification(testUser.getStudyIdentifier(), email);
         } finally {
-            helper.deleteUser(user);
+            helper.deleteUser(testUser);
         }
     }
 


### PR DESCRIPTION
…ucted before user has signed in.

Just moved this method to later in execution after the user is signed in and has a complete context. Changed the test so the signIn() method is called with a context that contains only what the signIn context will contain (which caused the repairConsents test to fail, as desired, so it could be verified fixed).
