### PR TITLE
Fetch participant

### DIFF
--- a/app/org/sagebionetworks/bridge/models/accounts/StudyParticipant2.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/StudyParticipant2.java
@@ -8,6 +8,7 @@ import org.sagebionetworks.bridge.dao.ParticipantOption.SharingScope;
 import org.sagebionetworks.bridge.json.BridgeTypeName;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 
@@ -16,6 +17,7 @@ import com.google.common.collect.Maps;
  * participant roster (which is also going away).
  */
 @BridgeTypeName("StudyParticipant")
+@JsonDeserialize(builder=StudyParticipant2.Builder.class)
 public class StudyParticipant2 {
 
     private final String firstName;
@@ -131,6 +133,10 @@ public class StudyParticipant2 {
             if (guid != null && history != null) {
                 this.consentHistories.put(guid.getGuid(), history);
             }
+            return this;
+        }
+        public Builder withConsentHistories(Map<String,List<UserConsentHistory>> consentHistories) {
+            this.consentHistories = consentHistories;
             return this;
         }
         

--- a/app/org/sagebionetworks/bridge/models/accounts/StudyParticipant2.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/StudyParticipant2.java
@@ -1,0 +1,143 @@
+package org.sagebionetworks.bridge.models.accounts;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.sagebionetworks.bridge.dao.ParticipantOption.SharingScope;
+import org.sagebionetworks.bridge.json.BridgeTypeName;
+import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+
+/**
+ * This object will replace the existing StudyParticipant object that is used to generate the 
+ * participant roster (which is also going away).
+ */
+@BridgeTypeName("StudyParticipant")
+public class StudyParticipant2 {
+
+    private final String firstName;
+    private final String lastName;
+    private final String email;
+    private final String externalId;
+    private final SharingScope sharingScope;
+    private final boolean notifyByEmail;
+    private final Set<String> dataGoups;
+    private final String healthCode;
+    private final Map<String,String> attributes;
+    private final Map<String,List<UserConsentHistory>> consentHistories;
+    
+    private StudyParticipant2(String firstName, String lastName, String email, String externalId, SharingScope sharingScope,
+            boolean notifyByEmail, Set<String> dataGroups, String healthCode, Map<String,String> attributes, 
+            Map<String,List<UserConsentHistory>> consentHistories) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.email = email;
+        this.externalId = externalId;
+        this.sharingScope = sharingScope;
+        this.notifyByEmail = notifyByEmail;
+        this.dataGoups = dataGroups;
+        this.healthCode = healthCode;
+        this.attributes = attributes;
+        this.consentHistories = consentHistories;
+    }
+    
+    public String getFirstName() {
+        return firstName;
+    }
+    public String getLastName() {
+        return lastName;
+    }
+    public String getEmail() {
+        return email;
+    }
+    public String getExternalId() {
+        return externalId;
+    }
+    public SharingScope getSharingScope() {
+        return sharingScope;
+    }
+    public boolean isNotifyByEmail() {
+        return notifyByEmail;
+    }
+    public Set<String> getDataGroups() {
+        return dataGoups;
+    }
+    public String getHealthCode() {
+        return healthCode;
+    }
+    public Map<String,String> getAttributes() {
+        return attributes;
+    }
+    public Map<String, List<UserConsentHistory>> getConsentHistories() {
+        return consentHistories;
+    }
+    
+    public static class Builder {
+        private String firstName;
+        private String lastName;
+        private String email;
+        private String externalId;
+        private SharingScope sharingScope;
+        private boolean notifyByEmail;
+        private Set<String> dataGroups = ImmutableSet.of();
+        private String healthCode;
+        private Map<String,String> attributes = Maps.newHashMap();
+        private Map<String,List<UserConsentHistory>> consentHistories = Maps.newHashMap();
+        
+        public Builder withFirstName(String firstName) {
+            this.firstName = firstName;
+            return this;
+        }
+        public Builder withLastName(String lastName) {
+            this.lastName = lastName;
+            return this;
+        }
+        public Builder withEmail(String email) {
+            this.email = email;
+            return this;
+        }
+        public Builder withExternalId(String externalId) {
+            this.externalId = externalId;
+            return this;
+        }
+        public Builder withSharingScope(SharingScope sharingScope) {
+            this.sharingScope = sharingScope;
+            return this;
+        }
+        public Builder withNotifyByEmail(boolean notifyByEmail) {
+            this.notifyByEmail = notifyByEmail;
+            return this;
+        }
+        public Builder withDataGroups(Set<String> dataGroups) {
+            if (dataGroups != null) {
+                this.dataGroups = dataGroups;
+            }
+            return this;
+        }
+        public Builder withHealthCode(String healthCode) {
+            this.healthCode = healthCode;
+            return this;
+        }
+        public Builder withAttributes(Map<String,String> attributes) {
+            if (attributes != null) {
+                this.attributes = attributes;
+            }
+            return this;
+        }
+        public Builder addConsentHistory(SubpopulationGuid guid, List<UserConsentHistory> history) {
+            if (guid != null && history != null) {
+                this.consentHistories.put(guid.getGuid(), history);
+            }
+            return this;
+        }
+        
+        public StudyParticipant2 build() {
+            return new StudyParticipant2(firstName, lastName, email, externalId, sharingScope, notifyByEmail, 
+                    dataGroups, healthCode, attributes, consentHistories);
+        }
+    }
+
+}

--- a/app/org/sagebionetworks/bridge/models/accounts/StudyParticipant2.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/StudyParticipant2.java
@@ -136,7 +136,9 @@ public class StudyParticipant2 {
             return this;
         }
         public Builder withConsentHistories(Map<String,List<UserConsentHistory>> consentHistories) {
-            this.consentHistories = consentHistories;
+            if (consentHistories != null) {
+                this.consentHistories = consentHistories;    
+            }
             return this;
         }
         

--- a/app/org/sagebionetworks/bridge/models/accounts/UserConsentHistory.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/UserConsentHistory.java
@@ -7,6 +7,7 @@ import org.sagebionetworks.bridge.json.DateTimeToLongSerializer;
 import org.sagebionetworks.bridge.json.DateTimeToPrimitiveLongDeserializer;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
@@ -47,6 +48,7 @@ public final class UserConsentHistory {
         this.hasSignedActiveConsent = hasSignedActiveConsent;
     }
 
+    @JsonIgnore
     public String getHealthCode() {
         return healthCode;
     }

--- a/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Controller;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.accounts.AccountSummary;
+import org.sagebionetworks.bridge.models.accounts.StudyParticipant2;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.services.ParticipantService;
@@ -25,6 +26,15 @@ public class ParticipantController extends BaseController {
     @Autowired
     final void setParticipantService(ParticipantService participantService) {
         this.participantService = participantService;
+    }
+    
+    public Result getParticipant(String email) {
+        UserSession session = getAuthenticatedSession(RESEARCHER);
+        
+        Study study = studyService.getStudy(session.getStudyIdentifier());
+        
+        StudyParticipant2 participant = participantService.getParticipant(study, email);
+        return okResult(participant);
     }
     
     public Result getParticipants(String offsetByString, String pageSizeString) {

--- a/app/org/sagebionetworks/bridge/services/ConsentService.java
+++ b/app/org/sagebionetworks/bridge/services/ConsentService.java
@@ -280,15 +280,16 @@ public class ConsentService {
      * signed to join the study.
      * @param study
      * @param subpopGuid
-     * @param user
+     * @param healthCode
+     * @param email
      */
-    public List<UserConsentHistory> getUserConsentHistory(Study study, SubpopulationGuid subpopGuid, User user) {
-        Account account = accountDao.getAccount(study, user.getEmail());
+    public List<UserConsentHistory> getUserConsentHistory(Study study, SubpopulationGuid subpopGuid, String healthCode, String email) {
+        Account account = accountDao.getAccount(study, email);
         
         return account.getConsentSignatureHistory(subpopGuid).stream().map(signature -> {
             UserConsent consent = userConsentDao.getUserConsent(
-                    user.getHealthCode(), subpopGuid, signature.getSignedOn());
-            boolean hasSignedActiveConsent = hasUserSignedActiveConsent(user.getHealthCode(), subpopGuid);
+                    healthCode, subpopGuid, signature.getSignedOn());
+            boolean hasSignedActiveConsent = hasUserSignedActiveConsent(healthCode, subpopGuid);
             
             UserConsentHistory.Builder builder = new UserConsentHistory.Builder();
             builder.withName(signature.getName())
@@ -297,7 +298,7 @@ public class ConsentService {
                 .withImageData(signature.getImageData())
                 .withImageMimeType(signature.getImageMimeType())
                 .withSignedOn(signature.getSignedOn())
-                .withHealthCode(user.getHealthCode())
+                .withHealthCode(healthCode)
                 .withWithdrewOn(consent.getWithdrewOn())
                 .withConsentCreatedOn(consent.getConsentCreatedOn())
                 .withHasSignedActiveConsent(hasSignedActiveConsent);

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -1,28 +1,122 @@
 package org.sagebionetworks.bridge.services;
 
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
+import static org.sagebionetworks.bridge.dao.ParticipantOption.DATA_GROUPS;
+import static org.sagebionetworks.bridge.dao.ParticipantOption.EMAIL_NOTIFICATIONS;
+import static org.sagebionetworks.bridge.dao.ParticipantOption.EXTERNAL_IDENTIFIER;
+import static org.sagebionetworks.bridge.dao.ParticipantOption.SHARING_SCOPE;
+
+import java.util.List;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import org.sagebionetworks.bridge.dao.AccountDao;
+import org.sagebionetworks.bridge.dao.ParticipantOption.SharingScope;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.models.PagedResourceList;
+import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountSummary;
+import org.sagebionetworks.bridge.models.accounts.HealthId;
+import org.sagebionetworks.bridge.models.accounts.ParticipantOptionsLookup;
+import org.sagebionetworks.bridge.models.accounts.StudyParticipant2;
+import org.sagebionetworks.bridge.models.accounts.UserConsentHistory;
 import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
 
 @Component
 public class ParticipantService {
 
     private static final String PAGE_SIZE_ERROR = "pageSize must be from "+API_MINIMUM_PAGE_SIZE+"-"+API_MAXIMUM_PAGE_SIZE+" records";
     
+    private static final List<UserConsentHistory> NO_HISTORY = ImmutableList.of();
+    
     private AccountDao accountDao;
+    
+    private ParticipantOptionsService optionsService;
+    
+    private SubpopulationService subpopService;
+    
+    private HealthCodeService healthCodeService;
+    
+    private ConsentService consentService;
     
     @Autowired
     final void setAccountDao(AccountDao accountDao) {
         this.accountDao = accountDao;
+    }
+    
+    @Autowired
+    final void setParticipantOptionsService(ParticipantOptionsService optionsService) {
+        this.optionsService = optionsService;
+    }
+    
+    @Autowired
+    final void setSubpopulationService(SubpopulationService subpopService) {
+        this.subpopService = subpopService;
+    }
+    
+    @Autowired
+    final void setHealthCodeService(HealthCodeService healthCodeService) {
+        this.healthCodeService = healthCodeService;
+    }
+    
+    @Autowired
+    final void setUserConsent(ConsentService consentService) {
+        this.consentService = consentService;
+    }
+    
+    // This code is functionally very similar to the ParticipantRosterGenerator, which it will replace.
+    public StudyParticipant2 getParticipant(Study study, String email) {
+        checkNotNull(study);
+        checkArgument(isNotBlank(email));
+        
+        StudyParticipant2.Builder participant = new StudyParticipant2.Builder();
+        
+        Account account = accountDao.getAccount(study, email);
+        String healthCode = getHealthCode(account);
+
+        List<Subpopulation> subpopulations = subpopService.getSubpopulations(study.getStudyIdentifier());
+        for (Subpopulation subpop : subpopulations) {
+            // Create an empty history if there's no health Code.
+            List<UserConsentHistory> history = NO_HISTORY;
+            if (healthCode != null) {
+                history = consentService.getUserConsentHistory(study, subpop.getGuid(), healthCode, email);
+            }
+            participant.addConsentHistory(subpop.getGuid(), history);
+        }
+        // Accounts exist that have signatures but no health codes. This may only be from testing, 
+        // but still, do not want roster generation to fail because of this. So we check for this.
+        if (healthCode != null) {
+            ParticipantOptionsLookup lookup = optionsService.getOptions(healthCode);
+            participant.withSharingScope(lookup.getEnum(SHARING_SCOPE, SharingScope.class));
+            participant.withNotifyByEmail(lookup.getBoolean(EMAIL_NOTIFICATIONS));
+            participant.withExternalId(lookup.getString(EXTERNAL_IDENTIFIER));
+            participant.withDataGroups(lookup.getStringSet(DATA_GROUPS));
+        }
+        participant.withFirstName(account.getFirstName());
+        participant.withLastName(account.getLastName());
+        participant.withEmail(account.getEmail());
+        
+        Map<String,String> attributes = Maps.newHashMap();
+        for (String attribute : study.getUserProfileAttributes()) {
+            String value = account.getAttribute(attribute);
+            attributes.put(attribute, value);
+        }
+        participant.withAttributes(attributes);
+        
+        if (study.isHealthCodeExportEnabled()) {
+            participant.withHealthCode(healthCode);
+        }
+        return participant.build();
     }
     
     public PagedResourceList<AccountSummary> getPagedAccountSummaries(Study study, int offsetBy, int pageSize) {
@@ -36,4 +130,15 @@ public class ParticipantService {
         }
         return accountDao.getPagedAccountSummaries(study, offsetBy, pageSize);
     }
+    
+    private String getHealthCode(Account account) {
+        if (account.getHealthId() != null) {
+            HealthId healthId = healthCodeService.getMapping(account.getHealthId());
+            if (healthId != null && healthId.getCode() != null) {
+                return healthId.getCode();
+            }
+        }
+        return null;
+    }
+    
 }

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -86,12 +86,14 @@ public class ParticipantService {
 
         List<Subpopulation> subpopulations = subpopService.getSubpopulations(study.getStudyIdentifier());
         for (Subpopulation subpop : subpopulations) {
-            // Create an empty history if there's no health Code.
-            List<UserConsentHistory> history = NO_HISTORY;
             if (healthCode != null) {
-                history = consentService.getUserConsentHistory(study, subpop.getGuid(), healthCode, email);
+                // always returns a list, even if empty
+                List<UserConsentHistory> history = consentService.getUserConsentHistory(study, subpop.getGuid(), healthCode, email);
+                participant.addConsentHistory(subpop.getGuid(), history);
+            } else {
+                // Create an empty history if there's no health Code.
+                participant.addConsentHistory(subpop.getGuid(), NO_HISTORY);
             }
-            participant.addConsentHistory(subpop.getGuid(), history);
         }
         // Accounts exist that have signatures but no health codes. This may only be from testing, 
         // but still, do not want roster generation to fail because of this. So we check for this.

--- a/conf/routes
+++ b/conf/routes
@@ -15,6 +15,7 @@ POST   /v3/auth/resendEmailVerification @org.sagebionetworks.bridge.play.control
 
 # Participants Researcher APIs
 GET  /v3/participants		     @org.sagebionetworks.bridge.play.controllers.ParticipantController.getParticipants(offsetBy: String ?= null, pageSize: String ?= null)
+GET  /v3/participants/:email     @org.sagebionetworks.bridge.play.controllers.ParticipantController.getParticipant(email: String)
 POST /v3/participants/dataGroups @org.sagebionetworks.bridge.play.controllers.UserManagementController.updateDataGroupForUser(email: String ?= null)
 
 # Study Subpopulations

--- a/test/org/sagebionetworks/bridge/models/accounts/StudyParticipant2Test.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/StudyParticipant2Test.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.joda.time.DateTime;
 import org.junit.Test;
 
 import org.sagebionetworks.bridge.dao.ParticipantOption.SharingScope;
@@ -18,7 +17,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
 public class StudyParticipant2Test {

--- a/test/org/sagebionetworks/bridge/models/accounts/StudyParticipant2Test.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/StudyParticipant2Test.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.joda.time.DateTime;
 import org.junit.Test;
 
 import org.sagebionetworks.bridge.dao.ParticipantOption.SharingScope;
@@ -15,6 +16,7 @@ import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -22,11 +24,9 @@ import com.google.common.collect.Sets;
 public class StudyParticipant2Test {
 
     private static final Set<String> DATA_GROUPS = Sets.newHashSet("group1","group2");
-    private static final Map<String,String> ATTRIBUTES = Maps.newHashMap();
-    static {
-        ATTRIBUTES.put("A", "B");
-        ATTRIBUTES.put("C", "D");
-    }
+    private static final Map<String,String> ATTRIBUTES = ImmutableMap.<String,String>builder()
+            .put("A", "B")
+            .put("C", "D").build();
     
     @Test
     public void canSerialize() throws Exception {

--- a/test/org/sagebionetworks/bridge/models/accounts/StudyParticipant2Test.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/StudyParticipant2Test.java
@@ -1,0 +1,78 @@
+package org.sagebionetworks.bridge.models.accounts;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.dao.ParticipantOption.SharingScope;
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+
+public class StudyParticipant2Test {
+
+    private static final Set<String> DATA_GROUPS = Sets.newHashSet("group1","group2");
+    private static final Map<String,String> ATTRIBUTES = Maps.newHashMap();
+    static {
+        ATTRIBUTES.put("A", "B");
+        ATTRIBUTES.put("C", "D");
+    }
+    
+    @Test
+    public void canSerialize() throws Exception {
+        StudyParticipant2.Builder builder = new StudyParticipant2.Builder()
+                .withFirstName("firstName")
+                .withLastName("lastName")
+                .withEmail("email@email.com")
+                .withExternalId("externalId")
+                .withSharingScope(SharingScope.SPONSORS_AND_PARTNERS)
+                .withNotifyByEmail(true)
+                .withDataGroups(DATA_GROUPS)
+                .withHealthCode("healthCode")
+                .withAttributes(ATTRIBUTES);
+        
+        List<UserConsentHistory> histories = Lists.newArrayList();
+        UserConsentHistory history = new UserConsentHistory.Builder()
+                .withBirthdate("2002-02-02")
+                .withConsentCreatedOn(1000000L)
+                .withSignedOn(2000000L)
+                .withName("Test User")
+                .withSubpopulationGuid(SubpopulationGuid.create("AAA"))
+                .withWithdrewOn(3000000L).build();
+        histories.add(history);
+        builder.addConsentHistory(SubpopulationGuid.create("AAA"), histories);
+
+        StudyParticipant2 participant = builder.build();
+
+        JsonNode node = BridgeObjectMapper.get().valueToTree(participant);
+        assertEquals("firstName", node.get("firstName").asText());
+        assertEquals("lastName", node.get("lastName").asText());
+        assertEquals("email@email.com", node.get("email").asText());
+        assertEquals("externalId", node.get("externalId").asText());
+        assertEquals("sponsors_and_partners", node.get("sharingScope").asText());
+        assertTrue(node.get("notifyByEmail").asBoolean());
+        assertEquals("healthCode", node.get("healthCode").asText());
+
+        assertEquals("StudyParticipant", node.get("type").asText());
+        
+        ArrayNode dataGroupsArray = (ArrayNode)node.get("dataGroups");
+        
+        assertTrue(DATA_GROUPS.contains(dataGroupsArray.get(0).asText()));
+        assertTrue(DATA_GROUPS.contains(dataGroupsArray.get(1).asText()));
+
+        assertEquals("B", node.get("attributes").get("A").asText());
+        assertEquals("D", node.get("attributes").get("C").asText());
+        
+        assertEquals(11, node.size());
+    }
+}

--- a/test/org/sagebionetworks/bridge/models/accounts/StudyParticipant2Test.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/StudyParticipant2Test.java
@@ -74,5 +74,25 @@ public class StudyParticipant2Test {
         assertEquals("D", node.get("attributes").get("C").asText());
         
         assertEquals(11, node.size());
+        
+        StudyParticipant2 deserParticipant = BridgeObjectMapper.get().readValue(node.toString(), StudyParticipant2.class);
+        assertEquals("firstName", deserParticipant.getFirstName());
+        assertEquals("lastName", deserParticipant.getLastName());
+        assertEquals("email@email.com", deserParticipant.getEmail());
+        assertEquals("externalId", deserParticipant.getExternalId());
+        assertEquals(SharingScope.SPONSORS_AND_PARTNERS, deserParticipant.getSharingScope());
+        assertTrue(deserParticipant.isNotifyByEmail());
+        assertEquals(DATA_GROUPS, deserParticipant.getDataGroups());
+        assertEquals("healthCode", deserParticipant.getHealthCode());
+        assertEquals(ATTRIBUTES, deserParticipant.getAttributes());
+        
+        UserConsentHistory deserHistory = deserParticipant.getConsentHistories().get("AAA").get(0);
+        assertEquals("2002-02-02", deserHistory.getBirthdate());
+        assertEquals(1000000L, deserHistory.getConsentCreatedOn());
+        assertEquals(2000000L, deserHistory.getSignedOn());
+        assertEquals("Test User", deserHistory.getName());
+        assertEquals("AAA", deserHistory.getSubpopulationGuid());
+        assertEquals(new Long(3000000L), deserHistory.getWithdrewOn());
+
     }
 }

--- a/test/org/sagebionetworks/bridge/models/accounts/UserConsentHistoryTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/UserConsentHistoryTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.models.accounts;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -8,6 +9,7 @@ import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
@@ -46,7 +48,7 @@ public class UserConsentHistoryTest {
         String json = BridgeObjectMapper.get().writeValueAsString(history);
         JsonNode node = BridgeObjectMapper.get().readTree(json);
         
-        assertEquals("AAA", node.get("healthCode").asText());
+        assertNull(node.get("healthCode"));
         assertEquals("BBB", node.get("subpopulationGuid").asText());
         assertEquals("2015-10-29T16:29:24.293Z", node.get("consentCreatedOn").asText());
         assertEquals("image/png", node.get("imageMimeType").asText());
@@ -55,7 +57,10 @@ public class UserConsentHistoryTest {
         assertEquals(true, node.get("hasSignedActiveConsent").asBoolean());
         assertEquals("UserConsentHistory", node.get("type").asText());
         
-        UserConsentHistory newHistory = BridgeObjectMapper.get().readValue(json, UserConsentHistory.class);
+        // This has to be added for the deserialized version to be equal to original
+        ((ObjectNode)node).put("healthCode", "AAA");
+        
+        UserConsentHistory newHistory = BridgeObjectMapper.get().readValue(node.toString(), UserConsentHistory.class);
         assertEquals(history, newHistory);
     }
 }

--- a/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
@@ -26,6 +26,7 @@ import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.accounts.AccountStatus;
 import org.sagebionetworks.bridge.models.accounts.AccountSummary;
+import org.sagebionetworks.bridge.models.accounts.StudyParticipant2;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.services.ParticipantService;
@@ -101,6 +102,21 @@ public class ParticipantControllerTest {
         
         // paging with defaults
         verify(participantService).getPagedAccountSummaries(STUDY, 0, BridgeConstants.API_DEFAULT_PAGE_SIZE);
+    }
+    
+    @Test
+    public void getParticipant() throws Exception {
+        StudyParticipant2 studyParticipant = new StudyParticipant2.Builder().withFirstName("Test").build();
+        
+        when(participantService.getParticipant(STUDY, "email@email.com")).thenReturn(studyParticipant);
+        
+        Result result = controller.getParticipant("email@email.com");
+        String string = Helpers.contentAsString(result);
+        StudyParticipant2 retrievedParticipant = BridgeObjectMapper.get().readValue(string, StudyParticipant2.class);
+        // Verify that there's a field, full serialization tested in StudyParticipant2Test
+        assertEquals("Test", retrievedParticipant.getFirstName());
+        
+        verify(participantService).getParticipant(STUDY, "email@email.com");
     }
     
     public void nullParametersUseDefaults() throws Exception {

--- a/test/org/sagebionetworks/bridge/services/ConsentServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ConsentServiceTest.java
@@ -127,7 +127,7 @@ public class ConsentServiceTest {
         assertNotConsented(statuses);
         
         List<UserConsentHistory> histories = consentService.getUserConsentHistory(testUser.getStudy(),
-                defaultSubpopulation.getGuid(), testUser.getUser());
+                defaultSubpopulation.getGuid(), testUser.getUser().getHealthCode(), testUser.getUser().getEmail());
         assertTrue(histories.isEmpty());
         
         try {
@@ -189,7 +189,7 @@ public class ConsentServiceTest {
         // However we have a historical record of the consent, including a revocation date
         // data is exported with the sharing status set at the time it was exported
         List<UserConsentHistory> histories = consentService.getUserConsentHistory(testUser.getStudy(),
-                defaultSubpopulation.getGuid(), testUser.getUser());
+                defaultSubpopulation.getGuid(), testUser.getUser().getHealthCode(), testUser.getUser().getEmail());
         assertEquals(1, histories.size());
         assertNotNull(histories.get(0).getWithdrewOn());
     }
@@ -311,7 +311,7 @@ public class ConsentServiceTest {
         
         // Finally, verify there is a history for this user.
         List<UserConsentHistory> history = consentService.getUserConsentHistory(testUser.getStudy(),
-                defaultSubpopulation.getGuid(), testUser.getUser());
+                defaultSubpopulation.getGuid(), testUser.getUser().getHealthCode(), testUser.getUser().getEmail());
         assertEquals(2, history.size());
         
         UserConsentHistory withdrawnConsent = history.get(0);

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -1,6 +1,16 @@
 package org.sagebionetworks.bridge.services;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.sagebionetworks.bridge.dao.ParticipantOption.DATA_GROUPS;
+import static org.sagebionetworks.bridge.dao.ParticipantOption.EMAIL_NOTIFICATIONS;
+import static org.sagebionetworks.bridge.dao.ParticipantOption.EXTERNAL_IDENTIFIER;
+import static org.sagebionetworks.bridge.dao.ParticipantOption.SHARING_SCOPE;
+
+import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -8,25 +18,66 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dao.AccountDao;
+import org.sagebionetworks.bridge.dao.ParticipantOption.SharingScope;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
+import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.HealthId;
+import org.sagebionetworks.bridge.models.accounts.ParticipantOptionsLookup;
+import org.sagebionetworks.bridge.models.accounts.StudyParticipant2;
+import org.sagebionetworks.bridge.models.accounts.UserConsentHistory;
 import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ParticipantServiceTest {
 
     private static final Study STUDY = new DynamoStudy();
+    static {
+        STUDY.setIdentifier("test-study");
+        STUDY.setHealthCodeExportEnabled(true);
+        STUDY.setUserProfileAttributes(Sets.newHashSet("attr1","attr2"));        
+    }
     
     private ParticipantService participantService;
     
     @Mock
     private AccountDao accountDao;
     
+    @Mock
+    private ParticipantOptionsService optionsService;
+    
+    @Mock
+    private SubpopulationService subpopService;
+    
+    @Mock
+    private HealthCodeService healthCodeService;
+    
+    @Mock
+    private ConsentService consentService;
+    
+    @Mock
+    private Account account;
+    
+    @Mock
+    private HealthId healthId;
+    
+    @Mock
+    private ParticipantOptionsLookup lookup;
+    
     @Before
     public void before() {
         participantService = new ParticipantService();
         participantService.setAccountDao(accountDao);
+        participantService.setParticipantOptionsService(optionsService);
+        participantService.setSubpopulationService(subpopService);
+        participantService.setHealthCodeService(healthCodeService);
+        participantService.setUserConsent(consentService);
     }
     
     @Test
@@ -54,5 +105,79 @@ public class ParticipantServiceTest {
     @Test(expected = BadRequestException.class)
     public void limitToCannotBeGreaterThan250() {
         participantService.getPagedAccountSummaries(STUDY, 0, 251);
+    }
+    
+    @Test
+    public void getStudyParticipant() {
+        // A lot of mocks have to be set up first, this call aggregates almost everything we know about the user
+        String email = "email@email.com";
+        
+        when(account.getHealthId()).thenReturn("healthId");
+        when(account.getFirstName()).thenReturn("firstName");
+        when(account.getLastName()).thenReturn("lastName");
+        when(account.getEmail()).thenReturn("email@email.com");
+        when(account.getAttribute("attr2")).thenReturn("anAttribute2");
+        
+        when(healthId.getCode()).thenReturn("healthCode");
+        when(accountDao.getAccount(STUDY, email)).thenReturn(account);
+        when(healthCodeService.getMapping("healthId")).thenReturn(healthId);
+        
+        List<Subpopulation> subpopulations = Lists.newArrayList();
+        // Two subpopulations for mocking.
+        Subpopulation subpop1 = Subpopulation.create();
+        subpop1.setGuidString("guid1");
+        subpopulations.add(subpop1);
+        
+        Subpopulation subpop2 = Subpopulation.create();
+        subpop2.setGuidString("guid2");
+        subpopulations.add(subpop2);
+        when(subpopService.getSubpopulations(STUDY.getStudyIdentifier())).thenReturn(subpopulations);
+        
+        List<UserConsentHistory> histories1 = Lists.newArrayList();
+        UserConsentHistory history1 = new UserConsentHistory.Builder()
+                .withBirthdate("2002-02-02")
+                .withConsentCreatedOn(1L)
+                .withName("Test User")
+                .withSubpopulationGuid(subpop1.getGuid())
+                .withWithdrewOn(2L).build();
+        histories1.add(history1);
+        
+        // Add another one, we don't need to test that it is the same.
+        UserConsentHistory history2 = new UserConsentHistory.Builder().build();
+        histories1.add(history2);
+        
+        List<UserConsentHistory> histories2 = Lists.newArrayList();
+        
+        when(consentService.getUserConsentHistory(STUDY, subpop1.getGuid(), "healthCode", "email@email.com")).thenReturn(histories1);
+        when(consentService.getUserConsentHistory(STUDY, subpop2.getGuid(), "healthCode", "email@email.com")).thenReturn(histories2);
+        
+        when(lookup.getEnum(SHARING_SCOPE, SharingScope.class)).thenReturn(SharingScope.ALL_QUALIFIED_RESEARCHERS);
+        when(lookup.getBoolean(EMAIL_NOTIFICATIONS)).thenReturn(true);
+        when(lookup.getString(EXTERNAL_IDENTIFIER)).thenReturn("externalId");
+        when(lookup.getStringSet(DATA_GROUPS)).thenReturn(TestUtils.newLinkedHashSet("group1","group2"));
+        when(optionsService.getOptions("healthCode")).thenReturn(lookup);
+        
+        // Get the participant
+        StudyParticipant2 participant = participantService.getParticipant(STUDY, email);
+        
+        assertEquals("firstName", participant.getFirstName());
+        assertEquals("lastName", participant.getLastName());
+        assertTrue(participant.isNotifyByEmail());
+        assertEquals(Sets.newHashSet("group1","group2"), participant.getDataGroups());
+        assertEquals("externalId", participant.getExternalId());
+        assertEquals(SharingScope.ALL_QUALIFIED_RESEARCHERS, participant.getSharingScope());
+        assertEquals("healthCode", participant.getHealthCode());
+        assertEquals("email@email.com", participant.getEmail());
+        
+        assertNull(participant.getAttributes().get("attr1"));
+        assertEquals("anAttribute2", participant.getAttributes().get("attr2"));
+        
+        List<UserConsentHistory> retrievedHistory1 = participant.getConsentHistories().get(subpop1.getGuidString());
+        assertEquals(2, retrievedHistory1.size());
+        assertEquals(history1, retrievedHistory1.get(0));
+        assertEquals(history2, retrievedHistory1.get(1));
+        
+        List<UserConsentHistory> retrievedHistory2 = participant.getConsentHistories().get(subpop2.getGuidString());
+        assertTrue(retrievedHistory2.isEmpty());
     }
 }


### PR DESCRIPTION
Retrieve an individual participant by email address. Along with the paged access to participant email addresses, this is going to replace the participant roster, and the service code in this PR is adapted from the ParticipantRoster generator code. However this version also includes a complete consent history for the user.

The roster code will be removed once this is completely deployed and I have scripts to user it to produce a roster, or we have a UI to do it, or something like that.
