### PR TITLE
Reuse upload IDs for incomplete duplicate uploads

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/UploadDao.java
+++ b/app/org/sagebionetworks/bridge/dao/UploadDao.java
@@ -20,28 +20,6 @@ public interface UploadDao {
     Upload createUpload(@Nonnull UploadRequest uploadRequest, @Nonnull String healthCode);
 
     /**
-     * <p>
-     * Gets the failed uploads between the specified dates, inclusive, in YYYY-MM-DD format. A failed upload is any
-     * upload with status VALIDATION_FAILED or VALIDATION_IN_PROGRESS (validation crashing  during validation). This is
-     * generally useful for redriving uploads that have failed validation.
-     * </p>
-     * <p>
-     * Note that this method should not be called with an endDate on or after the current date, as this may incorrectly
-     * return uploads that are still validating.
-     * </p>
-     * <p>
-     * Also note that this method doesn't catch uploads that failed to upload to S3.
-     * </p>
-     *
-     * @param startDate
-     *         start date, inclusive, in YYYY-MM-DD format
-     * @param endDate
-     *         end date, inclusive, in YYYY-MM-DD format
-     * @return list of failed uploads
-     */
-    List<? extends Upload> getFailedUploadsForDates(@Nonnull String startDate, @Nonnull String endDate);
-
-    /**
      * Gets the upload metadata associated with this upload.
      *
      * @param uploadId

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadDao.java
@@ -10,10 +10,6 @@ import java.util.List;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBScanExpression;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
-import com.amazonaws.services.dynamodbv2.model.Condition;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.LocalDate;
 
@@ -48,22 +44,6 @@ public class DynamoUploadDao implements UploadDao {
         DynamoUpload2 upload = new DynamoUpload2(uploadRequest, healthCode);
         mapper.save(upload);
         return upload;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public List<? extends Upload> getFailedUploadsForDates(@Nonnull String startDate, @Nonnull String endDate) {
-        // We want upload dates between startDate and endDate (inclusive by default) and with statuses
-        // VALIDATION_IN_PROGRESS or VALIDATION_FAILED
-        DynamoDBScanExpression scan = new DynamoDBScanExpression()
-                .withFilterConditionEntry("uploadDate", new Condition()
-                        .withComparisonOperator(ComparisonOperator.BETWEEN)
-                        .withAttributeValueList(new AttributeValue(startDate), new AttributeValue(endDate)))
-                .withFilterConditionEntry("status", new Condition()
-                        .withComparisonOperator(ComparisonOperator.IN)
-                        .withAttributeValueList(new AttributeValue(UploadStatus.VALIDATION_IN_PROGRESS.name()),
-                                new AttributeValue(UploadStatus.VALIDATION_FAILED.name())));
-        return mapper.scan(DynamoUpload2.class, scan);
     }
 
     // TODO: Cache this, or make it so that calling getUpload() and uploadComplete() in sequence don't cause duplicate


### PR DESCRIPTION
Update UploadService to reuse upload IDs for incomplete duplicate uploads. Also delete some unused and potentially dangerous code.

Testing done:
- updated unit tests
- UploadTest integration tests
- manual tests: new upload, not a dupe, dupe of incomplete upload, dupe of complete upload
