### PR TITLE
add worker APIs for surveys so Bridge Exporter can get survey questions

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -70,11 +70,9 @@ GET    /v3/surveys                                           @org.sagebionetwork
 POST   /v3/surveys                                           @org.sagebionetworks.bridge.play.controllers.SurveyController.createSurvey
 GET    /v3/surveys/recent                                    @org.sagebionetworks.bridge.play.controllers.SurveyController.getAllSurveysMostRecentVersion
 GET    /v3/surveys/published                                 @org.sagebionetworks.bridge.play.controllers.SurveyController.getAllSurveysMostRecentlyPublishedVersion
-GET    /v3/surveys/published/forStudy/:studyId               @org.sagebionetworks.bridge.play.controllers.SurveyController.getAllSurveysMostRecentlyPublishedVersionForStudy(studyId: String)
 GET    /v3/surveys/:surveyGuid/revisions                     @org.sagebionetworks.bridge.play.controllers.SurveyController.getSurveyAllVersions(surveyGuid: String)
 GET    /v3/surveys/:surveyGuid/revisions/recent              @org.sagebionetworks.bridge.play.controllers.SurveyController.getSurveyMostRecentVersion(surveyGuid: String)
 GET    /v3/surveys/:surveyGuid/revisions/published           @org.sagebionetworks.bridge.play.controllers.SurveyController.getSurveyMostRecentlyPublishedVersion(surveyGuid: String)
-GET    /v3/surveys/:surveyGuid/revisions/:createdOn/forWorker @org.sagebionetworks.bridge.play.controllers.SurveyController.getSurveyForWorker(surveyGuid: String, createdOn: String)
 POST   /v3/surveys/:surveyGuid/revisions/:createdOn/version  @org.sagebionetworks.bridge.play.controllers.SurveyController.versionSurvey(surveyGuid: String, createdOn: String)
 POST   /v3/surveys/:surveyGuid/revisions/:createdOn/publish  @org.sagebionetworks.bridge.play.controllers.SurveyController.publishSurvey(surveyGuid: String, createdOn: String)
 GET    /v3/surveys/:surveyGuid/revisions/:createdOn          @org.sagebionetworks.bridge.play.controllers.SurveyController.getSurvey(surveyGuid: String, createdOn: String)
@@ -128,6 +126,9 @@ POST   /v3/studies/self             @org.sagebionetworks.bridge.play.controllers
 GET    /v3/studies/:identifier      @org.sagebionetworks.bridge.play.controllers.StudyController.getStudy(identifier: String)
 POST   /v3/studies/:identifier      @org.sagebionetworks.bridge.play.controllers.StudyController.updateStudy(identifier: String)
 DELETE /v3/studies/:identifier      @org.sagebionetworks.bridge.play.controllers.StudyController.deleteStudy(identifier: String)
+
+# APIs for getting entities across studies
+GET /v3/studies/:studyId/surveys/published @org.sagebionetworks.bridge.play.controllers.SurveyController.getAllSurveysMostRecentlyPublishedVersionForStudy(studyId: String)
 
 # Backfills
 GET    /v3/backfill/:name          @org.sagebionetworks.bridge.play.controllers.BackfillController.backfill(name: String)

--- a/conf/routes
+++ b/conf/routes
@@ -70,9 +70,11 @@ GET    /v3/surveys                                           @org.sagebionetwork
 POST   /v3/surveys                                           @org.sagebionetworks.bridge.play.controllers.SurveyController.createSurvey
 GET    /v3/surveys/recent                                    @org.sagebionetworks.bridge.play.controllers.SurveyController.getAllSurveysMostRecentVersion
 GET    /v3/surveys/published                                 @org.sagebionetworks.bridge.play.controllers.SurveyController.getAllSurveysMostRecentlyPublishedVersion
+GET    /v3/surveys/published/forStudy/:studyId               @org.sagebionetworks.bridge.play.controllers.SurveyController.getAllSurveysMostRecentlyPublishedVersionForStudy(studyId: String)
 GET    /v3/surveys/:surveyGuid/revisions                     @org.sagebionetworks.bridge.play.controllers.SurveyController.getSurveyAllVersions(surveyGuid: String)
 GET    /v3/surveys/:surveyGuid/revisions/recent              @org.sagebionetworks.bridge.play.controllers.SurveyController.getSurveyMostRecentVersion(surveyGuid: String)
 GET    /v3/surveys/:surveyGuid/revisions/published           @org.sagebionetworks.bridge.play.controllers.SurveyController.getSurveyMostRecentlyPublishedVersion(surveyGuid: String)
+GET    /v3/surveys/:surveyGuid/revisions/:createdOn/forWorker @org.sagebionetworks.bridge.play.controllers.SurveyController.getSurveyForWorker(surveyGuid: String, createdOn: String)
 POST   /v3/surveys/:surveyGuid/revisions/:createdOn/version  @org.sagebionetworks.bridge.play.controllers.SurveyController.versionSurvey(surveyGuid: String, createdOn: String)
 POST   /v3/surveys/:surveyGuid/revisions/:createdOn/publish  @org.sagebionetworks.bridge.play.controllers.SurveyController.publishSurvey(surveyGuid: String, createdOn: String)
 GET    /v3/surveys/:surveyGuid/revisions/:createdOn          @org.sagebionetworks.bridge.play.controllers.SurveyController.getSurvey(surveyGuid: String, createdOn: String)

--- a/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.play.controllers;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
@@ -21,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
@@ -28,6 +30,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.Roles;
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.cache.ViewCache;
@@ -38,18 +41,20 @@ import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolder;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolderImpl;
+import org.sagebionetworks.bridge.models.ResourceList;
 import org.sagebionetworks.bridge.models.accounts.User;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.surveys.Survey;
 import org.sagebionetworks.bridge.models.surveys.TestSurvey;
-import org.sagebionetworks.bridge.play.controllers.SurveyController;
 import org.sagebionetworks.bridge.services.SurveyService;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import play.mvc.Result;
+import play.test.Helpers;
 
 /**
  * We know this controller works given the integration tests. Here I'm interested in finding a way 
@@ -57,6 +62,8 @@ import com.google.common.collect.Sets;
  * etc. through integration tests is very slow.
  */
 public class SurveyControllerTest {
+    private static final TypeReference<ResourceList<Survey>> TYPE_REF_SURVEY_LIST =
+            new TypeReference<ResourceList<Survey>>(){};
 
     private SurveyController controller;
     
@@ -145,7 +152,8 @@ public class SurveyControllerTest {
         verify(service, times(1)).getSurveyMostRecentlyPublishedVersion(eq(studyId), eq("bbb"));
         verifyNoMoreInteractions(service);
     }
-    
+
+    @Test
     public void getAllSurveysMostRecentVersion() throws Exception {
         setContext();
         when(service.getAllSurveysMostRecentVersion(any(StudyIdentifier.class))).thenReturn(getSurveys(3, false));
@@ -181,7 +189,29 @@ public class SurveyControllerTest {
         verify(service).getAllSurveysMostRecentlyPublishedVersion(any(StudyIdentifier.class));
         verifyNoMoreInteractions(service);
     }
-    
+
+    @Test
+    public void getAllSurveysMostRecentlyPublishedVersionForStudy() throws Exception {
+        setContext();
+
+        // make surveys
+        List<Survey> surveyList = getSurveys(2, false);
+        surveyList.get(0).setGuid("survey-0");
+        surveyList.get(1).setGuid("survey-1");
+        when(service.getAllSurveysMostRecentlyPublishedVersion(TestConstants.TEST_STUDY)).thenReturn(surveyList);
+
+        // execute and validate
+        Result result = controller.getAllSurveysMostRecentlyPublishedVersionForStudy(
+                TestConstants.TEST_STUDY_IDENTIFIER);
+        String resultStr = Helpers.contentAsString(result);
+        ResourceList<Survey> resultSurveyResourceList = BridgeObjectMapper.get().readValue(resultStr,
+                TYPE_REF_SURVEY_LIST);
+        List<Survey> resultSurveyList = resultSurveyResourceList.getItems();
+        assertEquals(2, resultSurveyList.size());
+        assertEquals("survey-0", resultSurveyList.get(0).getGuid());
+        assertEquals("survey-1", resultSurveyList.get(1).getGuid());
+    }
+
     @Test
     public void cannotGetAllSurveysMostRecentlyPublishedVersionInOtherStudy() throws Exception {
         setContext();
@@ -289,7 +319,29 @@ public class SurveyControllerTest {
             verifyNoMoreInteractions(service);
         }
     }
-    
+
+    @Test
+    public void getSurveyForWorker() throws Exception {
+        setContext();
+
+        // set up inputs
+        String guid = "BBB";
+        String dateString = DateTime.now().toString();
+        GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl(guid, DateTime.parse(dateString)
+                .getMillis());
+
+        // make survey
+        Survey survey = getSurvey(false);
+        survey.setGuid("test-survey");
+        when(service.getSurvey(keys)).thenReturn(survey);
+
+        // execute and validate
+        Result result = controller.getSurvey(guid, dateString);
+        String resultStr = Helpers.contentAsString(result);
+        Survey resultSurvey = BridgeObjectMapper.get().readValue(resultStr, Survey.class);
+        assertEquals("test-survey", resultSurvey.getGuid());
+    }
+
     @Test
     public void getSurveyMostRecentVersion() throws Exception {
         StudyIdentifier studyId = new StudyIdentifierImpl("api");

--- a/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.collect.ImmutableSet;
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
@@ -193,6 +194,7 @@ public class SurveyControllerTest {
     @Test
     public void getAllSurveysMostRecentlyPublishedVersionForStudy() throws Exception {
         setContext();
+        setUserSession("secondstudy");
 
         // make surveys
         List<Survey> surveyList = getSurveys(2, false);
@@ -323,6 +325,8 @@ public class SurveyControllerTest {
     @Test
     public void getSurveyForWorker() throws Exception {
         setContext();
+        setUserSession("secondstudy");
+        session.getUser().setRoles(ImmutableSet.of(Roles.WORKER));
 
         // set up inputs
         String guid = "BBB";


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-1095

We want Bridge-EX to export Survey questions to Synapse. In order to do this, we need a worker API so Bridge-EX can get survey questions. We don't want to configure Bridge-EX with a new worker account for every study, so we want the worker API to be able to access surveys in any study.

Testing done:
- added unit tests
- manual tests
- ran SurveyTest integration tests locally to make sure old APIs weren't broken
