### PR TITLE
Limit use of absolute schedule window

### DIFF
--- a/app/org/sagebionetworks/bridge/models/schedules/ActivityScheduler.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/ActivityScheduler.java
@@ -29,9 +29,8 @@ public abstract class ActivityScheduler {
         }
         DateTime eventTime = getFirstEventDateTime(context, eventIdString);
 
-        // An event was specified, but it hasn't happened yet. So no activities are generated.
-        // OR, an event fires, but outside of the window for the schedule, so again, no activities.
-        if (eventTime == null || !isInWindow(eventTime)) {
+        // An event was specified, but it hasn't happened yet.. So no activities are generated.
+        if (eventTime == null) {
             return null;
         }
         if (schedule.getDelay() != null) {
@@ -92,6 +91,7 @@ public abstract class ActivityScheduler {
     private boolean isInWindow(DateTime scheduledTime) {
         DateTime startsOn = schedule.getStartsOn();
         DateTime endsOn = schedule.getEndsOn();
+        
         return (startsOn == null || scheduledTime.isEqual(startsOn) || scheduledTime.isAfter(startsOn)) && 
                (endsOn == null || scheduledTime.isEqual(endsOn) || scheduledTime.isBefore(endsOn));
     }

--- a/test/org/sagebionetworks/bridge/models/schedules/CronActivitySchedulerTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/CronActivitySchedulerTest.java
@@ -154,8 +154,7 @@ public class CronActivitySchedulerTest {
         
         // We'd expect, based on that schedule, to have a task:
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(now.plusDays(4)));
-        // 1 or 2 activities depending on the time of the week (4 day window creates some overlap)
-        assertTrue(scheduledActivities.size() == 1 || scheduledActivities.size() == 2);
+        assertEquals(1, scheduledActivities.size());
         
         DateTimeUtils.setCurrentMillisSystem();
     }
@@ -178,8 +177,7 @@ public class CronActivitySchedulerTest {
         
         // We'd expect, based on that schedule, to have a task:
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(now.plusDays(4)));
-        // 1 or 2 activities depending on the time of the week (4 day window creates some overlap)
-        assertTrue(scheduledActivities.size() == 1 || scheduledActivities.size() == 2);
+        assertEquals(1, scheduledActivities.size());
         
         DateTimeUtils.setCurrentMillisSystem();
     }

--- a/test/org/sagebionetworks/bridge/models/schedules/CronActivitySchedulerTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/CronActivitySchedulerTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.models.schedules;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.sagebionetworks.bridge.models.schedules.ScheduleTestUtils.asDT;
 import static org.sagebionetworks.bridge.models.schedules.ScheduleTestUtils.assertDates;
 import static org.sagebionetworks.bridge.models.schedules.ScheduleType.ONCE;
@@ -55,9 +56,10 @@ public class CronActivitySchedulerTest {
     @Test
     public void onceStartsOnCronScheduleWorks() {
         Schedule schedule = createScheduleWith(ONCE);
+        // This is the day after the event will be scheduled, based on enrollment date
         schedule.setStartsOn(asDT("2015-03-31 00:00"));
         
-        scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusWeeks(2)));
+        scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusWeeks(1)));
         assertEquals(0, scheduledActivities.size());
     }
     @Test
@@ -131,6 +133,54 @@ public class CronActivitySchedulerTest {
         // Ultimate result: It's the 23rd, and right at enrollment, you see this task from the 21st.
         assertDates(scheduledActivities, "2015-03-21 06:00");
         assertEquals(ScheduledActivityStatus.AVAILABLE, scheduledActivities.get(0).getStatus());
+        DateTimeUtils.setCurrentMillisSystem();
+    }
+    @Test
+    // All the dates in this test are derived from BRIDGE-1211.
+    public void recurringCronScheduleWithStartEndTimeWindowWorks() {
+        DateTime now = DateTime.parse("2016-03-15T17:13:13.044Z");
+        DateTimeUtils.setCurrentMillisFixed(now.getMillis());
+        
+        Schedule schedule = createScheduleWith(RECURRING);
+        schedule.setCronTrigger("0 0 0 ? * MON *");
+        schedule.setEventId("two_weeks_before_enrollment");
+        schedule.setStartsOn(DateTime.parse("2016-03-14T00:00:00.000Z"));
+        schedule.setEndsOn(DateTime.parse("2016-03-20T23:59:00.000Z"));
+        schedule.setExpires("P7D");
+        
+        events.clear();
+        events.put("enrollment", DateTime.parse("2016-03-02T00:04:37.000Z"));
+        events.put("two_weeks_before_enrollment", events.get("enrollment").minusWeeks(2));
+        
+        // We'd expect, based on that schedule, to have a task:
+        scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(now.plusDays(4)));
+        // 1 or 2 activities depending on the time of the week (4 day window creates some overlap)
+        assertTrue(scheduledActivities.size() == 1 || scheduledActivities.size() == 2);
+        
+        DateTimeUtils.setCurrentMillisSystem();
+    }
+    
+    @Test
+    // All the dates in this test are derived from BRIDGE-1211.
+    public void recurringCronScheduleWithStartTimeWindowWorks() {
+        DateTime now = DateTime.parse("2016-03-15T17:13:13.044Z");
+        DateTimeUtils.setCurrentMillisFixed(now.getMillis());
+        
+        Schedule schedule = createScheduleWith(RECURRING);
+        schedule.setCronTrigger("0 0 0 ? * MON *");
+        schedule.setEventId("two_weeks_before_enrollment");
+        schedule.setEndsOn(DateTime.parse("2016-03-15T00:00:00.000Z"));
+        schedule.setExpires("P7D");
+        
+        events.clear();
+        events.put("enrollment", DateTime.parse("2016-03-15T00:04:37.000Z"));
+        events.put("two_weeks_before_enrollment", events.get("enrollment").minusWeeks(2));
+        
+        // We'd expect, based on that schedule, to have a task:
+        scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(now.plusDays(4)));
+        // 1 or 2 activities depending on the time of the week (4 day window creates some overlap)
+        assertTrue(scheduledActivities.size() == 1 || scheduledActivities.size() == 2);
+        
         DateTimeUtils.setCurrentMillisSystem();
     }
     

--- a/test/org/sagebionetworks/bridge/models/schedules/IntervalActivitySchedulerTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/IntervalActivitySchedulerTest.java
@@ -33,7 +33,7 @@ public class IntervalActivitySchedulerTest {
     @Before
     public void before() {
         plan.setGuid("BBB");
-        
+
         // Day of tests is 2015-04-06T10:10:10.000-07:00 for purpose of calculating expiration
         DateTimeUtils.setCurrentMillisFixed(1428340210000L);
         events = Maps.newHashMap();
@@ -447,13 +447,12 @@ public class IntervalActivitySchedulerTest {
         Schedule schedule = createScheduleWith(RECURRING);
         schedule.setEventId("survey:AAA:completedOn");
         schedule.setDelay("P4D");
-        schedule.setStartsOn(asDT("2015-04-02 00:00"));
+        schedule.setStartsOn(asDT("2015-04-10 00:00"));
 
         // The delay doesn't mean the schedule fires on this event
         events.put("survey:AAA:completedOn", asDT("2015-04-01 09:22"));
-        scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusWeeks(2)));
-
-        assertEquals(0, scheduledActivities.size());
+        scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusWeeks(3)));
+        assertDates(scheduledActivities, "2015-04-11 09:40", "2015-04-11 13:40", "2015-04-13 09:40", "2015-04-13 13:40");
     }
     @Test
     public void recurringEventDelayEndsOnScheduleWorks() {
@@ -477,7 +476,9 @@ public class IntervalActivitySchedulerTest {
         // This is outside the window, so when this happens, even if it recurs, it shouldn't fire
         events.put("survey:AAA:completedOn", asDT("2015-04-02 09:22"));
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusWeeks(3)));
-        assertEquals(0, scheduledActivities.size());
+        
+        assertDates(scheduledActivities, 
+                "2015-04-07 09:40", "2015-04-07 13:40", "2015-04-09 09:40", "2015-04-09 13:40");
     }
 
     private ScheduleContext getContext(DateTime endsOn) {


### PR DESCRIPTION
Do not use the absolute scheduling window to winnow out tasks based on their event timestamp, only use it to filter tasks by their scheduledOn timestamp.

This is being used by FPHS now, and the behavior was very counter-intuitive because it was filtering tasks out if a) the event timestamp was outside the window or b) the scheduled start time was outside the window. Just options (b) is more useful and easier to use, so switching to that.
