### PR TITLE
Do not return a 500 when an Accept-Language header is malformed.

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
@@ -17,7 +17,6 @@ import javax.annotation.Nonnull;
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.config.BridgeConfig;
-import org.sagebionetworks.bridge.config.BridgeProductionSpringConfig;
 import org.sagebionetworks.bridge.exceptions.UnsupportedVersionException;
 import org.sagebionetworks.bridge.exceptions.ConsentRequiredException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
@@ -39,7 +38,6 @@ import org.sagebionetworks.bridge.services.ParticipantOptionsService;
 import org.sagebionetworks.bridge.services.StudyService;
 
 import org.apache.commons.lang3.StringUtils;
-import org.eclipse.jetty.util.log.Log;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/test/org/sagebionetworks/bridge/play/controllers/BaseControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/BaseControllerTest.java
@@ -240,6 +240,19 @@ public class BaseControllerTest {
         assertEquals(ImmutableSet.of("en"), langs);
     }
     
+    // We don't want to throw a BadRequestException due to a malformed header. Just return no languages.
+    @Test
+    public void badAcceptLanguageHeaderSilentlyIgnored() throws Exception {
+        BaseController controller = new SchedulePlanController();
+        
+        mockPlayContext();
+        // This is apparently a bad User-Agent header some browser is sending to us; any failure will do though.
+        mockHeader(ACCEPT_LANGUAGE, "chrome://global/locale/intl.properties");
+        
+        LinkedHashSet<String> langs = controller.getLanguagesFromAcceptLanguageHeader();
+        assertTrue(langs.isEmpty());
+    }
+    
     @Test
     public void canGetLanguagesWhenInSession() {
         BaseController controller = new SchedulePlanController();


### PR DESCRIPTION
 Just log and continue.
