### PR TITLE
calling upload complete on an already completed upload won't trigger validation again

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/UploadController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/UploadController.java
@@ -8,7 +8,6 @@ import org.sagebionetworks.bridge.models.upload.UploadRequest;
 import org.sagebionetworks.bridge.models.upload.UploadSession;
 import org.sagebionetworks.bridge.models.upload.UploadValidationStatus;
 import org.sagebionetworks.bridge.services.UploadService;
-import org.sagebionetworks.bridge.services.UploadValidationService;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,17 +19,10 @@ import play.mvc.Result;
 public class UploadController extends BaseController {
 
     private UploadService uploadService;
-    private UploadValidationService uploadValidationService;
 
     @Autowired
     public void setUploadService(UploadService uploadService) {
         this.uploadService = uploadService;
-    }
-
-    /** Service handler for upload validation. This is configured by Spring. */
-    @Autowired
-    public void setUploadValidationService(UploadValidationService uploadValidationService) {
-        this.uploadValidationService = uploadValidationService;
     }
 
     /** Gets validation status and messages for the given upload ID. */
@@ -70,10 +62,7 @@ public class UploadController extends BaseController {
 
         // mark upload as complete
         Upload upload = uploadService.getUpload(session.getUser(), uploadId);
-        uploadService.uploadComplete(upload);
-
-        // kick off upload validation
-        uploadValidationService.validateUpload(session.getStudyIdentifier(), upload);
+        uploadService.uploadComplete(session.getStudyIdentifier(), upload);
 
         return okResult("Upload " + uploadId + " complete!");
     }

--- a/test/org/sagebionetworks/bridge/services/UploadServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/UploadServiceTest.java
@@ -98,7 +98,7 @@ public class UploadServiceTest {
         assertEquals(200, reponseCode);
 
         Upload upload = uploadService.getUpload(testUser.getUser(), uploadId);
-        uploadService.uploadComplete(upload);
+        uploadService.uploadComplete(TestConstants.TEST_STUDY, upload);
         long expiration = DateTime.now(DateTimeZone.UTC).plusMinutes(1).getMillis();
         assertTrue(expiration > uploadSession.getExpires());
         ObjectMetadata obj = s3Client.getObjectMetadata(BUCKET, uploadId);

--- a/test/org/sagebionetworks/bridge/services/UploadServiceUploadCompleteMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/UploadServiceUploadCompleteMockTest.java
@@ -1,0 +1,106 @@
+package org.sagebionetworks.bridge.services;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.config.BridgeConfig;
+import org.sagebionetworks.bridge.dao.UploadDao;
+import org.sagebionetworks.bridge.dynamodb.DynamoUpload2;
+import org.sagebionetworks.bridge.exceptions.NotFoundException;
+import org.sagebionetworks.bridge.models.upload.UploadStatus;
+
+@SuppressWarnings("unchecked")
+public class UploadServiceUploadCompleteMockTest {
+    private static final String TEST_BUCKET = "test-bucket";
+    private static final String TEST_UPLOAD_ID = "test-upload";
+
+    private AmazonS3 mockS3Client;
+    private UploadDao mockUploadDao;
+    private UploadValidationService mockUploadValidationService;
+    private UploadService svc;
+
+    @Before
+    public void setup() {
+        // mock config
+        BridgeConfig mockConfig = mock(BridgeConfig.class);
+        when(mockConfig.getProperty(UploadService.CONFIG_KEY_UPLOAD_BUCKET)).thenReturn(TEST_BUCKET);
+
+        // set up mocks - The actual behavior will vary with each test.
+        mockS3Client = mock(AmazonS3.class);
+        mockUploadDao = mock(UploadDao.class);
+        mockUploadValidationService = mock(UploadValidationService.class);
+
+        // Set up service
+        svc = new UploadService();
+        svc.setConfig(mockConfig);
+        svc.setS3Client(mockS3Client);
+        svc.setUploadDao(mockUploadDao);
+        svc.setUploadValidationService(mockUploadValidationService);
+    }
+
+    @Test
+    public void validationInProgress() {
+        // set up input
+        DynamoUpload2 upload = new DynamoUpload2();
+        upload.setUploadId(TEST_UPLOAD_ID);
+        upload.setStatus(UploadStatus.VALIDATION_IN_PROGRESS);
+
+        // execute
+        svc.uploadComplete(TestConstants.TEST_STUDY, upload);
+
+        // Verify upload DAO and validation aren't called. Can skip S3 because we don't want to over-specify our tests.
+        verifyZeroInteractions(mockUploadDao, mockUploadValidationService);
+    }
+
+    @Test
+    public void notFoundInS3() {
+        // set up input
+        DynamoUpload2 upload = new DynamoUpload2();
+        upload.setUploadId(TEST_UPLOAD_ID);
+        upload.setStatus(UploadStatus.REQUESTED);
+
+        // mock S3
+        when(mockS3Client.getObjectMetadata(TEST_BUCKET, TEST_UPLOAD_ID)).thenThrow(AmazonClientException.class);
+
+        // execute
+        try {
+            svc.uploadComplete(TestConstants.TEST_STUDY, upload);
+            fail("expected exception");
+        } catch (NotFoundException ex) {
+            // expected exception
+        }
+
+        // Verify upload DAO and validation aren't called.
+        verifyZeroInteractions(mockUploadDao, mockUploadValidationService);
+    }
+
+    @Test
+    public void normalCase() {
+        // set up input
+        DynamoUpload2 upload = new DynamoUpload2();
+        upload.setUploadId(TEST_UPLOAD_ID);
+        upload.setStatus(UploadStatus.REQUESTED);
+
+        // mock S3
+        ObjectMetadata mockObjMetadata = mock(ObjectMetadata.class);
+        when(mockObjMetadata.getSSEAlgorithm()).thenReturn(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
+        when(mockS3Client.getObjectMetadata(TEST_BUCKET, TEST_UPLOAD_ID)).thenReturn(mockObjMetadata);
+
+        // execute
+        svc.uploadComplete(TestConstants.TEST_STUDY, upload);
+
+        // Verify upload DAO and validation.
+        verify(mockUploadDao).uploadComplete(upload);
+        verify(mockUploadValidationService).validateUpload(TestConstants.TEST_STUDY, upload);
+    }
+}


### PR DESCRIPTION
See https://sagebionetworks.jira.com/browse/BRIDGE-1236

Some apps, notably Diabetes, will create a bunch of duplicate uploads in parallel, then call upload complete on these uploads in parallel. This causes some the validation pipeline to run in parallel for the same records and occasionally causes concurrent modification exceptions in DDB. This is bad because (a) redundant validation (b) errors in the logs.

This change moves validation from the controller to the service, where the "can be validated" gate is being checked and actually being honored.

Testing done:
- updated unit tests
- ran upload integration tests
