### PR TITLE
Validate user profile extension attributes

### DIFF
--- a/app/org/sagebionetworks/bridge/models/accounts/UserProfile.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/UserProfile.java
@@ -1,11 +1,13 @@
 package org.sagebionetworks.bridge.models.accounts;
 
+
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.sagebionetworks.bridge.dao.ParticipantOption;
 import org.sagebionetworks.bridge.json.JsonUtils;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
@@ -15,23 +17,20 @@ import com.google.common.collect.Sets;
 
 public class UserProfile {
     
-    public static final String FIRST_NAME_FIELD = "firstName";
-    public static final String LAST_NAME_FIELD = "lastName";
-    public static final String EMAIL_FIELD = "email";
-    public static final String HEALTH_CODE_FIELD = "healthCode";
-    public static final String SUBPOPULATION_NAMES_FIELD = "subpopulations";
-    public static final String EXTERNAL_ID_FIELD = "externalId";
-    public static final String DATA_GROUPS_FIELD = "dataGroups";
+    private static final String FIRST_NAME_FIELD = "firstName";
+    private static final String LAST_NAME_FIELD = "lastName";
+    private static final String EMAIL_FIELD = "email";
     
-    /**
-     * These fields are not part of the profile, but they are used on export to expose the participant option values, so
-     * studies cannot override these values as extended user profile attributes.
-     */
-    public static final String SHARING_SCOPE_FIELD = "sharing";
-    public static final String NOTIFY_BY_EMAIL_FIELD = "notifyByEmail";
-    
-    public static final Set<String> FIXED_PROPERTIES = Sets.newHashSet(FIRST_NAME_FIELD, LAST_NAME_FIELD,
-            EMAIL_FIELD, SHARING_SCOPE_FIELD);
+    // These fields are potentially present in some exports of user profile data, 
+    // coming from the StudyParticipant or AccountSummary classes. Custom attributes 
+    // cannot be any of these field names so they won't conflict or be confusing.
+    public static final Set<String> RESERVED_ATTR_NAMES = Sets.newHashSet(
+            FIRST_NAME_FIELD,LAST_NAME_FIELD,EMAIL_FIELD,"roles","status");
+    static {
+        for (ParticipantOption option : ParticipantOption.values()) {
+            RESERVED_ATTR_NAMES.add(option.getFieldName());
+        }
+    }
     
     private String firstName;
     private String lastName;
@@ -86,7 +85,7 @@ public class UserProfile {
         }
     }
     public void setAttribute(String name, String value) {
-        if (isNotBlank(name) && isNotBlank(value) && !UserProfile.FIXED_PROPERTIES.contains(name)) {
+        if (isNotBlank(name) && isNotBlank(value) && !UserProfile.RESERVED_ATTR_NAMES.contains(name)) {
             attributes.put(name, value);
         }
     }

--- a/app/org/sagebionetworks/bridge/models/accounts/UserProfile.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/UserProfile.java
@@ -20,12 +20,15 @@ public class UserProfile {
     private static final String FIRST_NAME_FIELD = "firstName";
     private static final String LAST_NAME_FIELD = "lastName";
     private static final String EMAIL_FIELD = "email";
+    private static final String ROLES_FIELD = "roles";
+    private static final String STATUS_FIELD = "status";
+    private static final String HEALTH_CODE_FIELD = "healthCode";
     
     // These fields are potentially present in some exports of user profile data, 
     // coming from the StudyParticipant or AccountSummary classes. Custom attributes 
     // cannot be any of these field names so they won't conflict or be confusing.
     public static final Set<String> RESERVED_ATTR_NAMES = Sets.newHashSet(
-            FIRST_NAME_FIELD,LAST_NAME_FIELD,EMAIL_FIELD,"roles","status");
+            FIRST_NAME_FIELD,LAST_NAME_FIELD,EMAIL_FIELD,ROLES_FIELD,STATUS_FIELD,HEALTH_CODE_FIELD);
     static {
         for (ParticipantOption option : ParticipantOption.values()) {
             RESERVED_ATTR_NAMES.add(option.getFieldName());

--- a/test/org/sagebionetworks/bridge/models/accounts/UserProfileTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/UserProfileTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.models.accounts;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import org.junit.Test;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
@@ -22,6 +23,16 @@ public class UserProfileTest {
         JsonNode node = BridgeObjectMapper.get().readTree(json);
         profile = UserProfile.fromJson(Sets.newHashSet("foo"), node);
         assertEquals("bar", profile.getAttribute("foo"));
+    }
+
+    @Test
+    public void cannotSetReservedWordAttribute() {
+        String reservedField = UserProfile.RESERVED_ATTR_NAMES.iterator().next();
+        
+        UserProfile profile = new UserProfile();
+        profile.setAttribute(reservedField, "bar");
+        
+        assertNull(profile.getAttribute(reservedField));
     }
     
 }

--- a/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
@@ -137,9 +137,45 @@ public class StudyValidatorTest {
     }
     
     @Test
-    public void cannotAddConflictingUserProfileAttribute() {
+    public void cannotAddConflictingEmailAttribute() {
         study.getUserProfileAttributes().add("email");
         assertCorrectMessage(study, "userProfileAttributes", "userProfileAttributes 'email' conflicts with existing user profile property");
+    }
+    
+    @Test
+    public void cannotAddConflictingExternalIdAttribute() {
+        study.getUserProfileAttributes().add("externalId");
+        assertCorrectMessage(study, "userProfileAttributes", "userProfileAttributes 'externalId' conflicts with existing user profile property");
+    }
+    
+    @Test
+    public void userProfileAttributesCannotStartWithDash() {
+        study.getUserProfileAttributes().add("-illegal");
+        assertCorrectMessage(study, "userProfileAttributes", "userProfileAttributes '-illegal' must contain only digits, letters, underscores and dashes, and cannot start with a dash");
+    }
+    
+    @Test
+    public void userProfileAttributesCannotContainSpaces() {
+        study.getUserProfileAttributes().add("Game Points");
+        assertCorrectMessage(study, "userProfileAttributes", "userProfileAttributes 'Game Points' must contain only digits, letters, underscores and dashes, and cannot start with a dash");
+    }
+    
+    @Test
+    public void userProfileAttributesCanBeJustADash() {
+        study.getUserProfileAttributes().add("_");
+        Validate.entityThrowingException(StudyValidator.INSTANCE, study);
+    }
+    
+    @Test
+    public void userProfileAttributesCanBeJustADashAndLetter() {
+        study.getUserProfileAttributes().add("_A");
+        Validate.entityThrowingException(StudyValidator.INSTANCE, study);
+    }
+    
+    @Test
+    public void userProfileAttributesCannotBeEmpty() {
+        study.getUserProfileAttributes().add("");
+        assertCorrectMessage(study, "userProfileAttributes", "userProfileAttributes '' must contain only digits, letters, underscores and dashes, and cannot start with a dash");
     }
     
     @Test


### PR DESCRIPTION
BRIDGE-1242

These attributes must meet Stormpath's criteria for userData key values, in order to avoid Stormpath errors when adding these fields to a user's profile. Also cleaned up the profile's list of attributes we don't want defined as extension attributes, because they would be confusing in some contexts (they clash with fields we use to describe the user).
