### PR TITLE
Add AccountStatus to the update of a user's profile by a researcher

### DIFF
--- a/app/org/sagebionetworks/bridge/json/JsonUtils.java
+++ b/app/org/sagebionetworks/bridge/json/JsonUtils.java
@@ -40,6 +40,18 @@ public class JsonUtils {
      */
     public static final ObjectMapper INTERNAL_OBJECT_MAPPER = new ObjectMapper();
 
+    public static <T extends Enum<T>> T asEnum(JsonNode parent, String property, Class<T> enumType) {
+        String value = asText(parent, property);
+        if (value == null) {
+            return null;
+        }
+        try {
+            return Enum.valueOf(enumType, value.toUpperCase());    
+        } catch(IllegalArgumentException e) {
+            return null;
+        }
+    }
+    
     public static String asText(JsonNode parent, String property) {
         if (parent != null && parent.hasNonNull(property)) {
             return parent.get(property).asText();

--- a/app/org/sagebionetworks/bridge/models/accounts/Account.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/Account.java
@@ -43,6 +43,9 @@ public interface Account extends BridgeEntity {
     
     public String getHealthId();
     public void setHealthId(String healthId);
+    
+    public AccountStatus getStatus();
+    public void setStatus(AccountStatus status);
 
     public StudyIdentifier getStudyIdentifier();
     

--- a/app/org/sagebionetworks/bridge/models/accounts/StudyParticipant.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/StudyParticipant.java
@@ -33,10 +33,12 @@ public class StudyParticipant {
     private final Map<String,List<UserConsentHistory>> consentHistories;
     private final Set<Roles> roles;
     private final LinkedHashSet<String> languages;
+    private final AccountStatus status;
     
-    private StudyParticipant(String firstName, String lastName, String email, String externalId, SharingScope sharingScope,
-            boolean notifyByEmail, Set<String> dataGroups, String healthCode, Map<String,String> attributes, 
-            Map<String,List<UserConsentHistory>> consentHistories, Set<Roles> roles, LinkedHashSet<String> languages) {
+    private StudyParticipant(String firstName, String lastName, String email, String externalId,
+            SharingScope sharingScope, boolean notifyByEmail, Set<String> dataGroups, String healthCode,
+            Map<String, String> attributes, Map<String, List<UserConsentHistory>> consentHistories, Set<Roles> roles,
+            LinkedHashSet<String> languages, AccountStatus status) {
         this.firstName = firstName;
         this.lastName = lastName;
         this.email = email;
@@ -49,6 +51,7 @@ public class StudyParticipant {
         this.consentHistories = consentHistories;
         this.roles = roles;
         this.languages = languages;
+        this.status = status;
     }
     
     public String getFirstName() {
@@ -87,6 +90,9 @@ public class StudyParticipant {
     public LinkedHashSet<String> getLanguages() {
         return languages;
     }
+    public AccountStatus getStatus() {
+        return status;
+    }
     
     public static class Builder {
         private String firstName;
@@ -101,6 +107,7 @@ public class StudyParticipant {
         private Map<String,List<UserConsentHistory>> consentHistories = Maps.newHashMap();
         private Set<Roles> roles = Sets.newHashSet();
         private LinkedHashSet<String> languages = new LinkedHashSet<>();
+        private AccountStatus status;
         
         public Builder withFirstName(String firstName) {
             this.firstName = firstName;
@@ -166,10 +173,14 @@ public class StudyParticipant {
             }
             return this;
         }
+        public Builder withStatus(AccountStatus status) {
+            this.status = status;
+            return this;
+        }
         
         public StudyParticipant build() {
             return new StudyParticipant(firstName, lastName, email, externalId, sharingScope, notifyByEmail, 
-                    dataGroups, healthCode, attributes, consentHistories, roles, languages);
+                    dataGroups, healthCode, attributes, consentHistories, roles, languages, status);
         }
     }
 

--- a/app/org/sagebionetworks/bridge/models/accounts/UserProfile.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/UserProfile.java
@@ -12,6 +12,7 @@ import org.sagebionetworks.bridge.json.JsonUtils;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Sets;
 
@@ -84,6 +85,9 @@ public class UserProfile {
     public void setEmail(String email) {
         this.email = email;
     }
+    // We use this object to capture status from a researcher update, but we never 
+    // show it to users, it is only exposed through the API through StudyParticipant.
+    @JsonIgnore
     public AccountStatus getStatus() {
         return status;
     }

--- a/app/org/sagebionetworks/bridge/models/accounts/UserProfile.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/UserProfile.java
@@ -39,6 +39,7 @@ public class UserProfile {
     private String lastName;
     private String email;
     private Map<String,String> attributes;
+    private AccountStatus status;
 
     public UserProfile() {
         attributes = new HashMap<>();
@@ -48,6 +49,7 @@ public class UserProfile {
         UserProfile profile = new UserProfile();
         profile.setFirstName(JsonUtils.asText(node, FIRST_NAME_FIELD));
         profile.setLastName(JsonUtils.asText(node, LAST_NAME_FIELD));
+        profile.setStatus(JsonUtils.asEnum(node, STATUS_FIELD, AccountStatus.class));
         for (String attribute : attributes) {
             String value = JsonUtils.asText(node, attribute);
             if (value != null) {
@@ -81,6 +83,12 @@ public class UserProfile {
     }
     public void setEmail(String email) {
         this.email = email;
+    }
+    public AccountStatus getStatus() {
+        return status;
+    }
+    public void setStatus(AccountStatus status) {
+        this.status = status;
     }
     public void removeAttribute(String name) {
         if (isNotBlank(name)) {

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -126,6 +126,7 @@ public class ParticipantService {
         participant.withLastName(account.getLastName());
         participant.withEmail(account.getEmail());
         participant.withRoles(account.getRoles());
+        participant.withStatus(account.getStatus());
         
         Map<String,String> attributes = Maps.newHashMap();
         for (String attribute : study.getUserProfileAttributes()) {
@@ -185,6 +186,7 @@ public class ParticipantService {
         Account account = getAccountThrowingException(study, email);
         account.setFirstName(profile.getFirstName());
         account.setLastName(profile.getLastName());
+        account.setStatus(profile.getStatus());
         for(String attribute : study.getUserProfileAttributes()) {
             String value = profile.getAttribute(attribute);
             account.setAttribute(attribute, value);

--- a/app/org/sagebionetworks/bridge/stormpath/StormpathAccount.java
+++ b/app/org/sagebionetworks/bridge/stormpath/StormpathAccount.java
@@ -16,6 +16,7 @@ import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.json.BridgeTypeName;
 import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountStatus;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
@@ -148,6 +149,14 @@ public final class StormpathAccount implements Account {
     @Override
     public void setHealthId(String healthId) {
         encryptTo(healthIdKey, healthId);
+    };
+    @Override
+    public AccountStatus getStatus() {
+        return AccountStatus.valueOf(acct.getStatus().name());
+    };
+    @Override
+    public void setStatus(AccountStatus status) {
+        acct.setStatus(com.stormpath.sdk.account.AccountStatus.valueOf(status.name()));
     };
     @Override
     public List<ConsentSignature> getConsentSignatureHistory(SubpopulationGuid subpopGuid) {

--- a/test/org/sagebionetworks/bridge/models/accounts/StudyParticipantTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/StudyParticipantTest.java
@@ -44,6 +44,7 @@ public class StudyParticipantTest {
                 .withHealthCode("healthCode")
                 .withAttributes(ATTRIBUTES)
                 .withRoles(ROLES)
+                .withStatus(AccountStatus.UNVERIFIED)
                 .withLanguages(LANGS);
         
         List<UserConsentHistory> histories = Lists.newArrayList();
@@ -67,6 +68,7 @@ public class StudyParticipantTest {
         assertEquals("sponsors_and_partners", node.get("sharingScope").asText());
         assertTrue(node.get("notifyByEmail").asBoolean());
         assertEquals("healthCode", node.get("healthCode").asText());
+        assertEquals("unverified", node.get("status").asText());
         assertEquals("StudyParticipant", node.get("type").asText());
 
         Set<String> roleNames = Sets.newHashSet(
@@ -87,7 +89,7 @@ public class StudyParticipantTest {
         assertEquals("B", node.get("attributes").get("A").asText());
         assertEquals("D", node.get("attributes").get("C").asText());
         
-        assertEquals(13, node.size());
+        assertEquals(14, node.size());
         
         StudyParticipant deserParticipant = BridgeObjectMapper.get().readValue(node.toString(), StudyParticipant.class);
         assertEquals("firstName", deserParticipant.getFirstName());
@@ -99,6 +101,7 @@ public class StudyParticipantTest {
         assertEquals(DATA_GROUPS, deserParticipant.getDataGroups());
         assertEquals("healthCode", deserParticipant.getHealthCode());
         assertEquals(ATTRIBUTES, deserParticipant.getAttributes());
+        assertEquals(AccountStatus.UNVERIFIED, deserParticipant.getStatus());
         
         UserConsentHistory deserHistory = deserParticipant.getConsentHistories().get("AAA").get(0);
         assertEquals("2002-02-02", deserHistory.getBirthdate());

--- a/test/org/sagebionetworks/bridge/models/accounts/UserProfileTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/UserProfileTest.java
@@ -13,16 +13,30 @@ import com.google.common.collect.Sets;
 public class UserProfileTest {
 
     @Test
-    public void attributesSerializedCorrrectly() throws Exception {
+    public void canSerialize() {
         UserProfile profile = new UserProfile();
+        profile.setFirstName("firstName");
+        profile.setLastName("lastName");
+        profile.setEmail("email@email.com");
+        profile.setStatus(AccountStatus.UNVERIFIED);
         profile.setAttribute("foo", "bar");
         
-        String json = BridgeObjectMapper.get().writeValueAsString(profile);
-        assertEquals("{\"foo\":\"bar\",\"type\":\"UserProfile\"}", json);
+        JsonNode node = BridgeObjectMapper.get().valueToTree(profile);
+        // Attribute is included as part of profile object
+        assertEquals("bar", node.get("foo").asText());
+        assertEquals("firstName", node.get("firstName").asText());
+        assertEquals("lastName", node.get("lastName").asText());
+        assertEquals("email@email.com", node.get("email").asText());
+        assertEquals("unverified", node.get("status").asText());
+        assertEquals("UserProfile", node.get("type").asText());
         
-        JsonNode node = BridgeObjectMapper.get().readTree(json);
-        profile = UserProfile.fromJson(Sets.newHashSet("foo"), node);
-        assertEquals("bar", profile.getAttribute("foo"));
+        UserProfile deserProfile = UserProfile.fromJson(Sets.newHashSet("foo"), node);
+        assertEquals("bar", deserProfile.getAttribute("foo"));
+        assertEquals("firstName", deserProfile .getFirstName());
+        assertEquals("lastName", deserProfile.getLastName());
+        assertEquals(AccountStatus.UNVERIFIED, deserProfile.getStatus());
+        // Users are never allowed to submit JSON that changes their email:
+        assertNull(deserProfile.getEmail());
     }
 
     @Test

--- a/test/org/sagebionetworks/bridge/models/accounts/UserProfileTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/UserProfileTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 import org.junit.Test;
+
+import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.accounts.UserProfile;
 
@@ -22,21 +24,32 @@ public class UserProfileTest {
         profile.setAttribute("foo", "bar");
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(profile);
+        
         // Attribute is included as part of profile object
         assertEquals("bar", node.get("foo").asText());
         assertEquals("firstName", node.get("firstName").asText());
         assertEquals("lastName", node.get("lastName").asText());
         assertEquals("email@email.com", node.get("email").asText());
-        assertEquals("unverified", node.get("status").asText());
+        assertNull(node.get("status"));
         assertEquals("UserProfile", node.get("type").asText());
         
         UserProfile deserProfile = UserProfile.fromJson(Sets.newHashSet("foo"), node);
         assertEquals("bar", deserProfile.getAttribute("foo"));
         assertEquals("firstName", deserProfile .getFirstName());
         assertEquals("lastName", deserProfile.getLastName());
-        assertEquals(AccountStatus.UNVERIFIED, deserProfile.getStatus());
+        assertNull(deserProfile.getStatus());
         // Users are never allowed to submit JSON that changes their email:
         assertNull(deserProfile.getEmail());
+    }
+    
+    public void willCaptureStatusFromStudyParticipantUpdate() throws Exception {
+        JsonNode node = BridgeObjectMapper.get().readTree(TestUtils.createJson("{'status':'disabled'}"));
+
+        // The StudyParticipantService copies this value over to the StormpathAccount, 
+        // and the UserProfileService doesn't. It's not show in the UserProfle JSON, it is 
+        // shown in the StudyParticipant JSON. We're going to rationalize all of this.
+        UserProfile deserProfile = UserProfile.fromJson(Sets.newHashSet(), node);
+        assertEquals(AccountStatus.DISABLED, deserProfile.getStatus());
     }
 
     @Test

--- a/test/org/sagebionetworks/bridge/play/controllers/UserProfileControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/UserProfileControllerTest.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
@@ -13,7 +14,6 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
@@ -21,17 +21,25 @@ import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 import static org.sagebionetworks.bridge.dao.ParticipantOption.DATA_GROUPS;
 import static org.sagebionetworks.bridge.dao.ParticipantOption.EXTERNAL_IDENTIFIER;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.cache.CacheProvider;
+import org.sagebionetworks.bridge.cache.ViewCache;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.accounts.User;
+import org.sagebionetworks.bridge.models.accounts.UserProfile;
 import org.sagebionetworks.bridge.models.accounts.ParticipantOptionsLookup;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.studies.Study;
@@ -41,6 +49,7 @@ import org.sagebionetworks.bridge.play.controllers.UserProfileController;
 import org.sagebionetworks.bridge.services.ConsentService;
 import org.sagebionetworks.bridge.services.ParticipantOptionsService;
 import org.sagebionetworks.bridge.services.StudyService;
+import org.sagebionetworks.bridge.services.UserProfileService;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -50,22 +59,80 @@ import com.google.common.collect.Sets;
 import play.mvc.Result;
 import play.test.Helpers;
 
+@RunWith(MockitoJUnitRunner.class)
 public class UserProfileControllerTest {
     
     private static final Map<SubpopulationGuid,ConsentStatus> CONSENT_STATUSES_MAP = Maps.newHashMap();
     
+    @Mock
     private ParticipantOptionsService optionsService;
     
+    @Mock
     private ConsentService consentService;
     
+    @Mock
     private UserSession session;
+    
+    @Mock
+    private CacheProvider cacheProvider;
+    
+    @Mock
+    private UserProfileService userProfileService;
+    
+    @Mock
+    private StudyService studyService;
+    
+    @Mock
+    private ViewCache viewCache;
+    
+    @Spy
+    private UserProfileController controller;
+    
+    private User user;
+    
+    private Study study;
+    
+    @Captor
+    private ArgumentCaptor<UserProfile> userProfileCaptor;
+    
+    @Captor
+    private ArgumentCaptor<Set<String>> stringSetCaptor;
+    
+    @Captor
+    private ArgumentCaptor<CriteriaContext> contextCaptor;
+
+    @Before
+    public void before() {
+        study = new DynamoStudy();
+        study.setIdentifier(TEST_STUDY_IDENTIFIER);
+        study.setDataGroups(Sets.newHashSet("group1", "group2"));
+        study.setUserProfileAttributes(Sets.newHashSet("phone"));
+        
+        when(consentService.getConsentStatuses(any())).thenReturn(CONSENT_STATUSES_MAP);
+        when(studyService.getStudy((StudyIdentifier)any())).thenReturn(study);
+        
+        controller.setStudyService(studyService);
+        controller.setParticipantOptionsService(optionsService);
+        controller.setCacheProvider(cacheProvider);
+        controller.setConsentService(consentService);
+        controller.setUserProfileService(userProfileService);
+        controller.setViewCache(viewCache);
+        
+        user = new User();
+        user.setStudyKey(TEST_STUDY.getIdentifier());
+        user.setHealthCode("healthCode");
+        
+        session = mock(UserSession.class);
+        when(session.getUser()).thenReturn(user);
+        when(session.getStudyIdentifier()).thenReturn(TEST_STUDY);
+        
+        doReturn(session).when(controller).getAuthenticatedSession();
+    }
     
     @Test
     public void canSubmitExternalIdentifier() throws Exception {
         TestUtils.mockPlayContextWithJson("{\"identifier\":\"ABC-123-XYZ\"}");
         
-        UserProfileController controller = controllerForExternalIdTests();
-                
         Result result = controller.createExternalIdentifier();
         assertEquals(200, result.status());
         assertEquals("application/json", result.contentType());
@@ -80,21 +147,13 @@ public class UserProfileControllerTest {
         Set<String> dataGroupSet = Sets.newHashSet("group1");
         TestUtils.mockPlayContextWithJson("{\"dataGroups\":[\"group1\"]}");
         
-        UserProfileController controller = controllerForExternalIdTests();
-        
         Result result = controller.updateDataGroups();
         
-        ArgumentCaptor<Set> captor = ArgumentCaptor.forClass(Set.class);
-        ArgumentCaptor<CriteriaContext> contextCaptor = ArgumentCaptor.forClass(CriteriaContext.class);
-        
-        verify(optionsService).setStringSet(eq(TEST_STUDY), eq("healthCode"), eq(DATA_GROUPS), captor.capture());
+        verify(optionsService).setStringSet(eq(TEST_STUDY), eq("healthCode"), eq(DATA_GROUPS), stringSetCaptor.capture());
         verify(consentService).getConsentStatuses(contextCaptor.capture());
         
-        Set<String> dataGroups = (Set<String>)captor.getValue();
-        assertEquals(dataGroupSet, dataGroups);
-        
+        assertEquals(dataGroupSet, stringSetCaptor.getValue());
         assertEquals(dataGroupSet, contextCaptor.getValue().getUserDataGroups());
-        
         assertEquals(dataGroupSet, session.getUser().getDataGroups());
         
         JsonNode node = BridgeObjectMapper.get().readTree(Helpers.contentAsString(result));
@@ -105,7 +164,6 @@ public class UserProfileControllerTest {
     @Test
     public void invalidDataGroupsRejected() throws Exception {
         TestUtils.mockPlayContextWithJson("{\"dataGroups\":[\"completelyInvalidGroup\"]}");
-        UserProfileController controller = controllerForExternalIdTests();
         try {
             controller.updateDataGroups();
             fail("Should have thrown an exception");
@@ -118,8 +176,6 @@ public class UserProfileControllerTest {
     @Test
     public void canGetDataGroups() throws Exception {
         Set<String> dataGroupsSet = Sets.newHashSet("group1","group2");
-        
-        UserProfileController controller = controllerForExternalIdTests();
         
         Map<String,String> map = Maps.newHashMap();
         map.put(DATA_GROUPS.name(), "group1,group2");
@@ -143,52 +199,39 @@ public class UserProfileControllerTest {
     public void evenEmptyJsonActsOK() throws Exception {
         TestUtils.mockPlayContextWithJson("{}");
         
-        UserProfileController controller = controllerForExternalIdTests();
-        
         Result result = controller.updateDataGroups();
         
-        ArgumentCaptor<Set> captor = ArgumentCaptor.forClass(Set.class);
-        verify(optionsService).setStringSet(eq(TEST_STUDY), eq("healthCode"), eq(DATA_GROUPS), captor.capture());
+        verify(optionsService).setStringSet(eq(TEST_STUDY), eq("healthCode"), eq(DATA_GROUPS), stringSetCaptor.capture());
         
-        Set<String> dataGroups = (Set<String>)captor.getValue();
-        assertEquals(Sets.newHashSet(), dataGroups);
+        assertEquals(Sets.newHashSet(), stringSetCaptor.getValue());
         
         JsonNode node = BridgeObjectMapper.get().readTree(Helpers.contentAsString(result));
         assertEquals("Data groups updated.", node.get("message").asText());
     }
     
-    private UserSession mockSession() {
-        User user = new User();
-        user.setStudyKey(TEST_STUDY.getIdentifier());
-        user.setHealthCode("healthCode");
+    @Test
+    public void updateUserProfile() throws Exception {
+        TestUtils.mockPlayContextWithJson(TestUtils.createJson("{'firstName':'firstName',"+
+                "'lastName':'lastName','email':'email@email.com','status':'unverified',"+
+                "'username':'email@email.com','phone':'123-456-7890'}"));
         
-        session = mock(UserSession.class);
-        when(session.getUser()).thenReturn(user);
-        when(session.getStudyIdentifier()).thenReturn(TEST_STUDY);
-        return session;
+        Result result = controller.updateUserProfile();
+        JsonNode node = BridgeObjectMapper.get().readTree(Helpers.contentAsString(result));
+        assertEquals(200, result.status());
+        assertEquals("Profile updated.", node.get("message").asText());
+        
+        verify(userProfileService).updateProfile(eq(study), eq(user), userProfileCaptor.capture());
+        
+        UserProfile profile = userProfileCaptor.getValue();
+        assertEquals("firstName", profile.getFirstName());
+        assertEquals("lastName", profile.getLastName());
+        assertEquals("123-456-7890", profile.getAttribute("phone"));
+        // Users can't submit JSON that changes their status or email
+        assertNull(profile.getStatus());
+        assertNull(profile.getEmail());
+        
+        verify(cacheProvider).setUserSession(session);
+        verify(viewCache).removeView(any());
     }
-    
-    private UserProfileController controllerForExternalIdTests() {
-        Study study = new DynamoStudy();
-        study.setIdentifier(TEST_STUDY_IDENTIFIER);
-        study.setDataGroups(Sets.newHashSet("group1", "group2"));
 
-        CacheProvider cacheProvider = mock(CacheProvider.class);
-        consentService = mock(ConsentService.class);
-        
-        when(consentService.getConsentStatuses(any())).thenReturn(CONSENT_STATUSES_MAP);
-        
-        optionsService = mock(ParticipantOptionsService.class);
-        StudyService studyService = mock(StudyService.class);
-        when(studyService.getStudy((StudyIdentifier)any())).thenReturn(study);
-        
-        UserProfileController controller = spy(new UserProfileController());
-        controller.setStudyService(studyService);
-        controller.setParticipantOptionsService(optionsService);
-        controller.setCacheProvider(cacheProvider);
-        controller.setConsentService(consentService);
-        doReturn(mockSession()).when(controller).getAuthenticatedSession();
-
-        return controller;
-    }
 }

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -33,6 +33,7 @@ import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountStatus;
 import org.sagebionetworks.bridge.models.accounts.HealthId;
 import org.sagebionetworks.bridge.models.accounts.ParticipantOptionsLookup;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
@@ -140,6 +141,7 @@ public class ParticipantServiceTest {
         when(account.getLastName()).thenReturn("lastName");
         when(account.getEmail()).thenReturn("email@email.com");
         when(account.getAttribute("attr2")).thenReturn("anAttribute2");
+        when(account.getStatus()).thenReturn(AccountStatus.ENABLED);
         
         when(healthId.getCode()).thenReturn("healthCode");
         when(accountDao.getAccount(STUDY, email)).thenReturn(account);
@@ -193,6 +195,7 @@ public class ParticipantServiceTest {
         assertEquals("healthCode", participant.getHealthCode());
         assertEquals("email@email.com", participant.getEmail());
         assertEquals(TestUtils.newLinkedHashSet("fr","de"), participant.getLanguages());
+        assertEquals(AccountStatus.ENABLED, participant.getStatus());
         
         assertNull(participant.getAttributes().get("attr1"));
         assertEquals("anAttribute2", participant.getAttributes().get("attr2"));
@@ -270,6 +273,7 @@ public class ParticipantServiceTest {
         profile.setLastName("last name");
         profile.setAttribute("attr1", "new attr1");
         profile.setAttribute("attr2", "new attr2");
+        profile.setStatus(AccountStatus.DISABLED);
 
         // Need an account object on which we can actually set the values...
         Account acct = new SimpleAccount();
@@ -285,6 +289,7 @@ public class ParticipantServiceTest {
         assertEquals("last name", capturedAccount.getLastName());
         assertEquals("new attr1", capturedAccount.getAttribute("attr1"));
         assertEquals("new attr2", capturedAccount.getAttribute("attr2"));
+        assertEquals(AccountStatus.DISABLED, capturedAccount.getStatus());
     }
 
     @Test(expected = EntityNotFoundException.class)

--- a/test/org/sagebionetworks/bridge/services/SimpleAccount.java
+++ b/test/org/sagebionetworks/bridge/services/SimpleAccount.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountStatus;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
@@ -23,6 +24,7 @@ public class SimpleAccount implements Account {
     private Map<SubpopulationGuid,List<ConsentSignature>> signatures = Maps.newHashMap();
     private Map<String,String> attributes = Maps.newHashMap();
     private Set<Roles> roles = Sets.newHashSet();
+    private AccountStatus status;
     @Override
     public String getFirstName() {
         return firstName;
@@ -79,6 +81,14 @@ public class SimpleAccount implements Account {
     @Override
     public Set<Roles> getRoles() {
         return roles;
+    }
+    @Override
+    public void setStatus(AccountStatus status) {
+        this.status = status;
+    }
+    @Override
+    public AccountStatus getStatus() {
+        return status;
     }
     @Override
     public String getId() {

--- a/test/org/sagebionetworks/bridge/services/UserProfileServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/UserProfileServiceTest.java
@@ -11,6 +11,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.sagebionetworks.bridge.TestUserAdminHelper;
 import org.sagebionetworks.bridge.TestUserAdminHelper.TestUser;
+import org.sagebionetworks.bridge.dao.AccountDao;
+import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountStatus;
 import org.sagebionetworks.bridge.models.accounts.UserProfile;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -24,6 +27,9 @@ public class UserProfileServiceTest {
     
     @Resource
     private UserProfileService profileService;
+    
+    @Resource
+    private AccountDao accountDao;
     
     private TestUser testUser;
     
@@ -45,6 +51,8 @@ public class UserProfileServiceTest {
         profile.setAttribute("phone", "123-456-7890");
         profile.setAttribute("can_be_recontacted", "true");
         
+        // this cannot be updated through UserProfileService
+        profile.setStatus(AccountStatus.DISABLED); 
         // You cannot reset a field through the attributes. These should do NOTHING.
         profile.setAttribute("firstName", "NotTest");
         profile.setAttribute("lastName", "NotPowers");
@@ -59,6 +67,11 @@ public class UserProfileServiceTest {
         assertEquals("Phone is persisted", "123-456-7890", profile.getAttribute("phone"));
         assertEquals("Attribute is persisted", "true", profile.getAttribute("can_be_recontacted"));
         assertNull("Unknown attribute is null", profile.getAttribute("some_unknown_attribute"));
+        assertNull(profile.getStatus()); // no status is returned
+        
+        // Verify the status was not changed
+        Account account = accountDao.getAccount(testUser.getStudy(), testUser.getEmail());
+        assertEquals(AccountStatus.ENABLED, account.getStatus());
     }
 
     @Test

--- a/test/org/sagebionetworks/bridge/stormpath/StormpathAccountTest.java
+++ b/test/org/sagebionetworks/bridge/stormpath/StormpathAccountTest.java
@@ -426,6 +426,16 @@ public class StormpathAccountTest {
         assertEquals("lastName", account.getLastName());
         assertEquals(Sets.newHashSet(Roles.DEVELOPER,Roles.ADMIN), account.getRoles());
         assertEquals("123", account.getId());
+        assertEquals(org.sagebionetworks.bridge.models.accounts.AccountStatus.ENABLED, account.getStatus());
+        
+        account.setFirstName("New First Name");
+        account.setLastName("New Last Name");
+        account.setStatus(org.sagebionetworks.bridge.models.accounts.AccountStatus.DISABLED);
+        
+        com.stormpath.sdk.account.Account updatedAcct = account.getAccount();
+        verify(updatedAcct).setGivenName("New First Name");
+        verify(updatedAcct).setSurname("New Last Name");
+        verify(updatedAcct).setStatus(com.stormpath.sdk.account.AccountStatus.DISABLED);
     }
     
     private void verifyOneConsentStream(SubpopulationGuid guid, ConsentSignature sig1)


### PR DESCRIPTION
DON'T MERGE. Going to refactor UserProfile/StudyParticipant first.
- Add AccountStatus to the update of a user's profile by a researcher. 
- Verify that users cannot change their own account status when updating their profile. 
- Test cleanup of UserProfileControllerTest

NOTE: This is messy and we've identified the design reasons as to why. We're going to simplify this code by consolidating all the editable fields of ParticipantOptions and Account on the UserProfile, which will be how you update these values as a user on your own account. Researchers will have further fields they can edit on the StudyParticipant object (status), which is a sub type of UserProfile that includes some read-only information like consent statuses and healthCode (for studies configured to support it).
