### PR TITLE
Add a flag to turn stricter external ID validation on or off

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
@@ -13,7 +13,6 @@ import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIgnore;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMarshalling;
@@ -49,6 +48,7 @@ public final class DynamoStudy implements Study {
     private boolean strictUploadValidationEnabled;
     private boolean healthCodeExportEnabled;
     private boolean emailVerificationEnabled;
+    private boolean externalIdValidationEnabled;
     private Map<String, Integer> minSupportedAppVersions;
 
     public DynamoStudy() {
@@ -60,7 +60,6 @@ public final class DynamoStudy implements Study {
 
     /** {@inheritDoc} */
     @Override
-    @DynamoDBAttribute
     public String getSponsorName() {
         return sponsorName;
     }
@@ -72,7 +71,6 @@ public final class DynamoStudy implements Study {
 
     /** {@inheritDoc} */
     @Override
-    @DynamoDBAttribute
     public String getName() {
         return name;
     }
@@ -324,6 +322,18 @@ public final class DynamoStudy implements Study {
     
     /** {@inheritDoc} */
     @Override
+    public boolean isExternalIdValidationEnabled() {
+        return externalIdValidationEnabled;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setExternalIdValidationEnabled(boolean externalIdValidationEnabled) {
+        this.externalIdValidationEnabled = externalIdValidationEnabled;
+    }
+    
+    /** {@inheritDoc} */
+    @Override
     public Map<String,Integer> getMinSupportedAppVersions() {
         return minSupportedAppVersions;
     }
@@ -335,11 +345,11 @@ public final class DynamoStudy implements Study {
 
     @Override
     public int hashCode() {
-        return Objects.hash(identifier, maxNumOfParticipants, minAgeOfConsent, name, sponsorName, 
-                supportEmail, technicalEmail, consentNotificationEmail, stormpathHref, version, 
-                profileAttributes, taskIdentifiers, dataGroups, passwordPolicy, verifyEmailTemplate, 
-                resetPasswordTemplate, active, strictUploadValidationEnabled, healthCodeExportEnabled, 
-                emailVerificationEnabled, minSupportedAppVersions, synapseDataAccessTeamId, synapseProjectId);
+        return Objects.hash(identifier, maxNumOfParticipants, minAgeOfConsent, name, sponsorName, supportEmail,
+                technicalEmail, consentNotificationEmail, stormpathHref, version, profileAttributes, taskIdentifiers,
+                dataGroups, passwordPolicy, verifyEmailTemplate, resetPasswordTemplate, active,
+                strictUploadValidationEnabled, healthCodeExportEnabled, emailVerificationEnabled,
+                externalIdValidationEnabled, minSupportedAppVersions, synapseDataAccessTeamId, synapseProjectId);
     }
 
     @Override
@@ -368,6 +378,7 @@ public final class DynamoStudy implements Study {
                 && Objects.equals(technicalEmail, other.technicalEmail)
                 && Objects.equals(strictUploadValidationEnabled, other.strictUploadValidationEnabled)
                 && Objects.equals(healthCodeExportEnabled, other.healthCodeExportEnabled)
+                && Objects.equals(externalIdValidationEnabled, other.externalIdValidationEnabled)
                 && Objects.equals(emailVerificationEnabled, other.emailVerificationEnabled)
                 && Objects.equals(minSupportedAppVersions, other.minSupportedAppVersions);
     }
@@ -380,10 +391,12 @@ public final class DynamoStudy implements Study {
                             + "synapseProjectId=%s, technicalEmail=%s, consentNotificationEmail=%s, "
                             + "version=%s, userProfileAttributes=%s, taskIdentifiers=%s, dataGroups=%s, passwordPolicy=%s, "
                             + "verifyEmailTemplate=%s, resetPasswordTemplate=%s, strictUploadValidationEnabled=%s, "
-                            + "healthCodeExportEnabled=%s, emailVerificationEnabled=%s, minSupportedAppVersions=%s]",
-            name, active, sponsorName, identifier, stormpathHref, minAgeOfConsent, maxNumOfParticipants,
-            supportEmail, synapseDataAccessTeamId, synapseProjectId, technicalEmail, consentNotificationEmail, version,
-            profileAttributes, taskIdentifiers, dataGroups, passwordPolicy, verifyEmailTemplate, resetPasswordTemplate,
-            strictUploadValidationEnabled, healthCodeExportEnabled, emailVerificationEnabled, minSupportedAppVersions);
+                            + "healthCodeExportEnabled=%s, emailVerificationEnabled=%s, externalIdValidationEnabled=%s, "
+                            + "minSupportedAppVersions=%s]",
+                name, active, sponsorName, identifier, stormpathHref, minAgeOfConsent, maxNumOfParticipants,
+                supportEmail, synapseDataAccessTeamId, synapseProjectId, technicalEmail, consentNotificationEmail,
+                version, profileAttributes, taskIdentifiers, dataGroups, passwordPolicy, verifyEmailTemplate,
+                resetPasswordTemplate, strictUploadValidationEnabled, healthCodeExportEnabled, emailVerificationEnabled,
+                externalIdValidationEnabled, minSupportedAppVersions);
     }
 }

--- a/app/org/sagebionetworks/bridge/models/studies/Study.java
+++ b/app/org/sagebionetworks/bridge/models/studies/Study.java
@@ -207,6 +207,18 @@ public interface Study extends BridgeEntity, StudyIdentifier {
     public void setEmailVerificationEnabled(boolean enabled);
     
     /**
+     * True if this study will enforce constraints on the external identifier. The ID will have 
+     * to be an ID entered into Bridge, it will be assigned to one and only one user, and a user's 
+     * ID cannot be changed after it is set. Otherwise, the external ID is just a string field 
+     * that can be freely updated.
+     * @return
+     */
+    public boolean isExternalIdValidationEnabled();
+    
+    /** @see #isExternalIdValidationEnabled(); */
+    public void setExternalIdValidationEnabled(boolean externalIdValidationEnabled);
+    
+    /**
      * Minimum supported app version number. If set, user app clients pointing to an older version will 
      * fail with an httpResponse status code of 410.
      */

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -265,6 +265,7 @@ public class TestUtils {
         study.setStrictUploadValidationEnabled(true);
         study.setHealthCodeExportEnabled(true);
         study.setEmailVerificationEnabled(true);
+        study.setExternalIdValidationEnabled(true);
         return study;
     }
     

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
@@ -66,6 +66,7 @@ public class DynamoStudyTest {
         assertTrue(node.get("strictUploadValidationEnabled").asBoolean());
         assertTrue(node.get("healthCodeExportEnabled").asBoolean());
         assertTrue(node.get("emailVerificationEnabled").asBoolean());
+        assertTrue(node.get("externalIdValidationEnabled").asBoolean());
         assertEqualsAndNotNull("Study", node.get("type").asText());
         
         JsonNode supportedVersionsNode = JsonUtils.asJsonNode(node, "minSupportedAppVersions");


### PR DESCRIPTION
Prelude to refactoring of external ID tables. This is just a flag, which we'll use to ignore all the additional external validation stuff for studies that don't need or use it (which includes all but FPHS and Lilly right now).
