### PR TITLE
Extid service

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/ExternalIdDao.java
+++ b/app/org/sagebionetworks/bridge/dao/ExternalIdDao.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge.dao;
 import java.util.List;
 
 import org.sagebionetworks.bridge.models.PagedResourceList;
+import org.sagebionetworks.bridge.models.accounts.ExternalIdentifierInfo;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 
 /**
@@ -11,6 +12,9 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
  * or re-assigned to another user if assigned.
  */
 public interface ExternalIdDao {
+    
+    public static final String CONFIG_KEY_ADD_LIMIT = "external.id.add.limit";
+    public static final String CONFIG_KEY_LOCK_DURATION = "external.id.lock.duration";
 
     /**
      * Retrieve external IDs that match the ID and/or assignment filters. These records are returned in pages of pageSize 
@@ -32,7 +36,7 @@ public interface ExternalIdDao {
      *      an optional boolean (can be null). If TRUE, all records returned will be assigned. More usefully, if FALSE,
      *      will return unassigned external identifiers. 
      */
-    PagedResourceList<String> getExternalIds(StudyIdentifier studyId, String offsetKey, int pageSize, String idFilter, Boolean assignmentFilter);
+    PagedResourceList<ExternalIdentifierInfo> getExternalIds(StudyIdentifier studyId, String offsetKey, int pageSize, String idFilter, Boolean assignmentFilter);
     
     /**
      * Add one or more external IDs. Existing IDs are left alone without changing the assignment status of the ID.

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoExternalIdDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoExternalIdDao.java
@@ -123,7 +123,7 @@ public class DynamoExternalIdDao implements ExternalIdDao {
         checkNotNull(studyId);
         checkNotNull(externalIds);
 
-        // We validate a range of issues in the service not, but check size again because this is 
+        // We validate a wider range of issues in the service, but check size again because this is 
         // specifically a database capacity issue.
         if (externalIds.size() > addLimit) {
             throw new BadRequestException("List of externalIds is too large; size=" + externalIds.size() + ", limit=" + addLimit);
@@ -312,7 +312,7 @@ public class DynamoExternalIdDao implements ExternalIdDao {
     }
     
     private ExternalIdentifierInfo createInfo(ExternalIdentifier id, long lockDuration) {
-        // This calculation is done a couple of times, it's not accurate to the millisecond, but it's good enough
+        // This calculation is done a couple of times, it does not need to be accurate to the millisecond
         long reservationStartTime = DateTimeUtils.currentTimeMillis() - lockDuration;
         boolean isAssigned = (id.getHealthCode() != null || id.getReservation() >= reservationStartTime);
         return new ExternalIdentifierInfo(id.getIdentifier(), isAssigned);

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoExternalIdDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoExternalIdDao.java
@@ -20,7 +20,6 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Resource;
 
-import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTimeUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -34,6 +33,7 @@ import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.accounts.ExternalIdentifier;
+import org.sagebionetworks.bridge.models.accounts.ExternalIdentifierInfo;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
@@ -54,8 +54,6 @@ import com.google.common.collect.Maps;
 public class DynamoExternalIdDao implements ExternalIdDao {
     
     static final String PAGE_SIZE_ERROR = "pageSize must be from 1-"+API_MAXIMUM_PAGE_SIZE+" records";
-    static final String CONFIG_KEY_ADD_LIMIT = "external.id.add.limit";
-    static final String CONFIG_KEY_LOCK_DURATION = "external.id.lock.duration";
     
     private static final String RESERVATION = "reservation";
     private static final String HEALTH_CODE = "healthCode";
@@ -81,7 +79,7 @@ public class DynamoExternalIdDao implements ExternalIdDao {
     }
 
     @Override
-    public PagedResourceList<String> getExternalIds(StudyIdentifier studyId, String offsetKey, 
+    public PagedResourceList<ExternalIdentifierInfo> getExternalIds(StudyIdentifier studyId, String offsetKey, 
             int pageSize, String idFilter, Boolean assignmentFilter) {
         checkNotNull(studyId);
         
@@ -89,23 +87,30 @@ public class DynamoExternalIdDao implements ExternalIdDao {
         if (pageSize < 1 || pageSize > API_MAXIMUM_PAGE_SIZE) {
             throw new BadRequestException(PAGE_SIZE_ERROR);
         }
+        // The offset key is applied after the range key filter. If the offsetKey doesn't match the beginning
+        // of the range key filter, DDB throws a validation exception. So when providing a filter and an offset, 
+        // if the offset is not the valid prefix of the range key filter, set it to null (go back to first page).
+        if (offsetKey != null && idFilter != null && idFilter.indexOf(offsetKey) != 0) {
+            offsetKey = null;
+        }
         PaginatedQueryList<DynamoExternalIdentifier> list = mapper.query(DynamoExternalIdentifier.class,
                 createGetQuery(studyId, offsetKey, pageSize, idFilter, assignmentFilter));
         
         int total = mapper.count(DynamoExternalIdentifier.class, createCountQuery(studyId, idFilter, assignmentFilter));
         
-        List<String> identifiers = Lists.newArrayListWithCapacity(pageSize);
+        List<ExternalIdentifierInfo> identifiers = Lists.newArrayListWithCapacity(pageSize);
         
         Iterator<? extends ExternalIdentifier> iterator = list.iterator();
         while(iterator.hasNext() && identifiers.size() < pageSize) {
-            identifiers.add(iterator.next().getIdentifier());
+            ExternalIdentifier id = iterator.next();
+            identifiers.add( createInfo(id, lockDuration) );
         }
         // This is the last key, not the next key of the next page of records. It only exists if there's a record
         // beyond the records we've converted to a page. Then get the last key in the list.
-        String lastKey = (iterator.hasNext()) ? last(identifiers) : null;
+        String nextPageOffsetKey = (iterator.hasNext()) ? last(identifiers).getIdentifier() : null;
         
-        PagedResourceList<String> resourceList = new PagedResourceList<String>(identifiers, null, pageSize, total)
-                .withLastKey(lastKey)
+        PagedResourceList<ExternalIdentifierInfo> resourceList = new PagedResourceList<ExternalIdentifierInfo>(identifiers, null, pageSize, total)
+                .withOffsetKey(nextPageOffsetKey)
                 .withFilter(ID_FILTER, idFilter);
         if (assignmentFilter != null) {
             resourceList = resourceList.withFilter(ASSIGNMENT_FILTER, assignmentFilter.toString());
@@ -118,25 +123,20 @@ public class DynamoExternalIdDao implements ExternalIdDao {
         checkNotNull(studyId);
         checkNotNull(externalIds);
 
+        // We validate a range of issues in the service not, but check size again because this is 
+        // specifically a database capacity issue.
         if (externalIds.size() > addLimit) {
             throw new BadRequestException("List of externalIds is too large; size=" + externalIds.size() + ", limit=" + addLimit);
         }
-        for (String id : externalIds) {
-            if (StringUtils.isBlank(id)) {
-                throw new BadRequestException("List of externalIds contains an empty value");
-            }
-        }
-        if (!externalIds.isEmpty()) {
-            List<DynamoExternalIdentifier> idsToSave = externalIds.stream().map(id -> {
-                return new DynamoExternalIdentifier(studyId, id);
-            }).filter(externalId -> {
-                return mapper.load(externalId) == null;
-            }).collect(Collectors.toList());
-            
-            if (!idsToSave.isEmpty()) {
-                List<FailedBatch> failures = mapper.batchSave(idsToSave);
-                BridgeUtils.ifFailuresThrowException(failures);
-            }
+        List<DynamoExternalIdentifier> idsToSave = externalIds.stream().map(id -> {
+            return new DynamoExternalIdentifier(studyId, id);
+        }).filter(externalId -> {
+            return mapper.load(externalId) == null;
+        }).collect(Collectors.toList());
+        
+        if (!idsToSave.isEmpty()) {
+            List<FailedBatch> failures = mapper.batchSave(idsToSave);
+            BridgeUtils.ifFailuresThrowException(failures);
         }
     }
     
@@ -309,6 +309,13 @@ public class DynamoExternalIdDao implements ExternalIdDao {
         DynamoDBSaveExpression saveExpression = new DynamoDBSaveExpression();
         saveExpression.setExpected(map);
         return saveExpression;
+    }
+    
+    private ExternalIdentifierInfo createInfo(ExternalIdentifier id, long lockDuration) {
+        // This calculation is done a couple of times, it's not accurate to the millisecond, but it's good enough
+        long reservationStartTime = DateTimeUtils.currentTimeMillis() - lockDuration;
+        boolean isAssigned = (id.getHealthCode() != null || id.getReservation() >= reservationStartTime);
+        return new ExternalIdentifierInfo(id.getIdentifier(), isAssigned);
     }
     
     private <T> T last(List<T> items) {

--- a/app/org/sagebionetworks/bridge/models/PagedResourceList.java
+++ b/app/org/sagebionetworks/bridge/models/PagedResourceList.java
@@ -23,7 +23,7 @@ import com.google.common.collect.Maps;
  */
 public class PagedResourceList<T> {
 
-    public static final String LAST_KEY_FILTER = "lastKey";
+    public static final String OFFSET_KEY_FILTER = "offsetKey";
     
     private final List<T> items;
     /**
@@ -61,8 +61,8 @@ public class PagedResourceList<T> {
      * Convenience method for adding the DDB key as a filter. The key must be returned to retrieve 
      * the next page of DDB records.
      */
-    public PagedResourceList<T> withLastKey(String lastKey) {
-        return withFilter(LAST_KEY_FILTER, lastKey);
+    public PagedResourceList<T> withOffsetKey(String offsetKey) {
+        return withFilter(OFFSET_KEY_FILTER, offsetKey);
     }
     public List<T> getItems() {
         return items;
@@ -70,8 +70,8 @@ public class PagedResourceList<T> {
     public Integer getOffsetBy() {
         return offsetBy;
     }
-    public String getLastKey() {
-        return filters.get(LAST_KEY_FILTER);
+    public String getOffsetKey() {
+        return filters.get(OFFSET_KEY_FILTER);
     }
     public int getPageSize() {
         return pageSize;

--- a/app/org/sagebionetworks/bridge/models/accounts/ExternalIdentifierInfo.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/ExternalIdentifierInfo.java
@@ -1,0 +1,52 @@
+package org.sagebionetworks.bridge.models.accounts;
+
+import java.util.Objects;
+
+import org.sagebionetworks.bridge.json.BridgeTypeName;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * We expose only limited information about this entity.
+ */
+@BridgeTypeName("ExternalIdentifier")
+public final class ExternalIdentifierInfo {
+
+    private final String identifier;
+    private final boolean isAssigned;
+
+    @JsonCreator
+    public ExternalIdentifierInfo(@JsonProperty("identifier") String identifier, @JsonProperty("assigned") boolean isAssigned) {
+        this.identifier = identifier;
+        this.isAssigned = isAssigned;
+    }
+    
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public boolean isAssigned() {
+        return isAssigned;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(identifier, isAssigned);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null || getClass() != obj.getClass())
+            return false;
+        ExternalIdentifierInfo other = (ExternalIdentifierInfo) obj;
+        return Objects.equals(identifier, other.identifier) && Objects.equals(isAssigned, other.isAssigned);
+    }
+
+    @Override
+    public String toString() {
+        return "ExternalIdentifierInfo [identifier=" + identifier + ", isAssigned=" + isAssigned + "]";
+    }
+}

--- a/app/org/sagebionetworks/bridge/play/controllers/ExternalIdController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ExternalIdController.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 
 import org.sagebionetworks.bridge.models.PagedResourceList;
+import org.sagebionetworks.bridge.models.accounts.ExternalIdentifierInfo;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.services.ExternalIdService;
@@ -31,12 +32,12 @@ public class ExternalIdController extends BaseController {
     public Result getExternalIds(String offsetKey, String pageSizeString, String idFilter, String assignmentFilterString) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
         Study study = studyService.getStudy(session.getStudyIdentifier());
-        
+
         // Play will not convert these to null if they are not included in the query string, so we must do the conversion.
         Integer pageSize = (pageSizeString != null) ? Integer.parseInt(pageSizeString,10) : null;
         Boolean assignmentFilter = (assignmentFilterString != null) ? Boolean.valueOf(assignmentFilterString) : null;
         
-        PagedResourceList<String> page = externalIdService.getExternalIds(study, offsetKey, pageSize, idFilter, assignmentFilter);
+        PagedResourceList<ExternalIdentifierInfo> page = externalIdService.getExternalIds(study, offsetKey, pageSize, idFilter, assignmentFilter);
         return okResult(page);
     }
     

--- a/app/org/sagebionetworks/bridge/play/controllers/ExternalIdController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ExternalIdController.java
@@ -37,7 +37,8 @@ public class ExternalIdController extends BaseController {
         Integer pageSize = (pageSizeString != null) ? Integer.parseInt(pageSizeString,10) : null;
         Boolean assignmentFilter = (assignmentFilterString != null) ? Boolean.valueOf(assignmentFilterString) : null;
         
-        PagedResourceList<ExternalIdentifierInfo> page = externalIdService.getExternalIds(study, offsetKey, pageSize, idFilter, assignmentFilter);
+        PagedResourceList<ExternalIdentifierInfo> page = externalIdService.getExternalIds(
+                study, offsetKey, pageSize, idFilter, assignmentFilter);
         return okResult(page);
     }
     

--- a/app/org/sagebionetworks/bridge/services/ExternalIdService.java
+++ b/app/org/sagebionetworks/bridge/services/ExternalIdService.java
@@ -32,6 +32,8 @@ public class ExternalIdService {
     
     private ParticipantOptionsService optionsService;
     
+    private ExternalIdsValidator validator;
+    
     @Autowired
     final void setExternalIdDao(ExternalIdDao externalIdDao) {
         this.externalIdDao = externalIdDao;
@@ -41,12 +43,9 @@ public class ExternalIdService {
     final void setParticipantOptionsService(ParticipantOptionsService optionsService) {
         this.optionsService = optionsService;
     }
-    
-    private ExternalIdsValidator validator;
 
-    /** Gets the add limit and lock duration from Config. */
     @Autowired
-    public final void setConfig(Config config) {
+    final void setConfig(Config config) {
         validator = new ExternalIdsValidator(config.getInt(ExternalIdDao.CONFIG_KEY_ADD_LIMIT));
     }
     

--- a/app/org/sagebionetworks/bridge/validators/ExternalIdsValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/ExternalIdsValidator.java
@@ -2,12 +2,15 @@ package org.sagebionetworks.bridge.validators;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
 import org.sagebionetworks.bridge.models.BridgeEntity;
+
+import com.google.common.collect.Sets;
 
 /**
  * A list of identifiers must consist entirely of valid identifiers.
@@ -50,9 +53,15 @@ public class ExternalIdsValidator implements Validator {
         } else if (identifiers.size() > addLimit) {
             errors.reject("contains too many elements; size=" + identifiers.size() + ", limit=" + addLimit);
         } else {
+            Set<String> contents = Sets.newHashSet();
             for (int i=0; i < identifiers.size(); i++) {
                 String id = identifiers.get(i);
                 String path = "ids["+i+"]";
+                
+                if (contents.contains(id)) {
+                    errors.rejectValue(path, "is a duplicate value");
+                }
+                contents.add(id);
                 if (StringUtils.isBlank(id)) {
                     errors.rejectValue(path, "cannot be null or blank");
                 } else if (!id.matches(IDENTIFIER_PATTERN)) {

--- a/app/org/sagebionetworks/bridge/validators/ExternalIdsValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/ExternalIdsValidator.java
@@ -22,8 +22,8 @@ public class ExternalIdsValidator implements Validator {
     
     /**
      * Really the only purpose of this class is to provide a comprehensible name for the 
-     * array that was submitted by the user, as "ArrayList" or somesuch is in Java-land, 
-     * it's not JSON.
+     * array that was submitted by the user, as "ArrayList" doesn't mean much to client 
+     * submitting JSON.
      */
     @SuppressWarnings("serial")
     public static class ExternalIdList extends ArrayList<String> implements BridgeEntity {

--- a/app/org/sagebionetworks/bridge/validators/ExternalIdsValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/ExternalIdsValidator.java
@@ -1,0 +1,66 @@
+package org.sagebionetworks.bridge.validators;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+
+import org.sagebionetworks.bridge.models.BridgeEntity;
+
+/**
+ * A list of identifiers must consist entirely of valid identifiers.
+ *
+ */
+public class ExternalIdsValidator implements Validator {
+    
+    /**
+     * Really the only purpose of this class is to provide a comprehensible name for the 
+     * array that was submitted by the user, as "ArrayList" or somesuch is in Java-land, 
+     * it's not JSON.
+     */
+    @SuppressWarnings("serial")
+    public static class ExternalIdList extends ArrayList<String> implements BridgeEntity {
+        public ExternalIdList(List<String> members) {
+            super(members);
+        }
+    }
+
+    private static final String SYNAPSE_IDENTIFIER_PATTERN = "^[a-zA-Z0-9_-]+$";
+    
+    private final int addLimit;
+    
+    public ExternalIdsValidator(int addLimit) {
+        this.addLimit = addLimit;
+    }
+    
+    @Override
+    public boolean supports(Class<?> clazz) {
+        return ExternalIdList.class.isAssignableFrom(clazz);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void validate(Object object, Errors errors) {
+        ExternalIdList identifiers = (ExternalIdList) object;
+
+        if (identifiers.isEmpty()) {
+            errors.reject("contains no elements");
+        }
+        if (identifiers.size() > addLimit) {
+            errors.reject("contains too many elements; size=" + identifiers.size() + ", limit=" + addLimit);
+        } else {
+            for (int i=0; i < identifiers.size(); i++) {
+                String id = identifiers.get(i);
+                String path = "ids["+i+"]";
+                if (StringUtils.isBlank(id)) {
+                    errors.rejectValue(path, "cannot be null or blank");
+                } else if (!id.matches(SYNAPSE_IDENTIFIER_PATTERN)) {
+                    String msg = String.format("'%s' must contain only digits, letters, underscores and dashes", id);
+                    errors.rejectValue(path, msg);
+                }
+            }
+        }
+     }
+}

--- a/app/org/sagebionetworks/bridge/validators/ExternalIdsValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/ExternalIdsValidator.java
@@ -14,6 +14,8 @@ import org.sagebionetworks.bridge.models.BridgeEntity;
  *
  */
 public class ExternalIdsValidator implements Validator {
+
+    private static final String IDENTIFIER_PATTERN = "^[a-zA-Z0-9_-]+$";
     
     /**
      * Really the only purpose of this class is to provide a comprehensible name for the 
@@ -26,8 +28,6 @@ public class ExternalIdsValidator implements Validator {
             super(members);
         }
     }
-
-    private static final String SYNAPSE_IDENTIFIER_PATTERN = "^[a-zA-Z0-9_-]+$";
     
     private final int addLimit;
     
@@ -47,8 +47,7 @@ public class ExternalIdsValidator implements Validator {
 
         if (identifiers.isEmpty()) {
             errors.reject("contains no elements");
-        }
-        if (identifiers.size() > addLimit) {
+        } else if (identifiers.size() > addLimit) {
             errors.reject("contains too many elements; size=" + identifiers.size() + ", limit=" + addLimit);
         } else {
             for (int i=0; i < identifiers.size(); i++) {
@@ -56,7 +55,7 @@ public class ExternalIdsValidator implements Validator {
                 String path = "ids["+i+"]";
                 if (StringUtils.isBlank(id)) {
                     errors.rejectValue(path, "cannot be null or blank");
-                } else if (!id.matches(SYNAPSE_IDENTIFIER_PATTERN)) {
+                } else if (!id.matches(IDENTIFIER_PATTERN)) {
                     String msg = String.format("'%s' must contain only digits, letters, underscores and dashes", id);
                     errors.rejectValue(path, msg);
                 }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoExternalIdDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoExternalIdDaoTest.java
@@ -269,7 +269,8 @@ public class DynamoExternalIdDaoTest {
         }
     }
     
-    // This currently doesn't, you get this error: ValidationException...The provided starting key does not match the range key predicate
+    // This did give a ValidationException...The provided starting key does not match the range key 
+    // predicate. Now the offset key is reset to null (the first page)
     @Test
     public void pagingWithAFilterWorks() {
         PagedResourceList<ExternalIdentifierInfo> page = dao.getExternalIds(studyId, "B", 5, "C", null);

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoExternalIdDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoExternalIdDaoTest.java
@@ -4,12 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -26,12 +21,12 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import org.sagebionetworks.bridge.TestUtils;
-import org.sagebionetworks.bridge.config.BridgeConfig;
 import org.sagebionetworks.bridge.config.Config;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.PagedResourceList;
+import org.sagebionetworks.bridge.models.accounts.ExternalIdentifierInfo;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 
@@ -53,16 +48,13 @@ public class DynamoExternalIdDaoTest {
     @Resource(name = "externalIdDdbMapper")
     private DynamoDBMapper mapper;
     
-    @Resource
-    private BridgeConfig config;
-    
     private StudyIdentifier studyId;
 
     @Before
     public void before() {
         studyId = new StudyIdentifierImpl(TestUtils.randomName(DynamoExternalIdDaoTest.class));
-        
-        dao.setConfig(config);
+
+        dao.setConfig(makeConfig(10, 30000));
         dao.addExternalIds(studyId, EXT_IDS);
     }
     
@@ -105,32 +97,6 @@ public class DynamoExternalIdDaoTest {
         DynamoExternalIdentifier keyObject = new DynamoExternalIdentifier(studyId, "AAA");
         DynamoExternalIdentifier identifier = mapper.load(keyObject);
         assertEquals("healthCode", identifier.getHealthCode());
-    }
-    
-    @SuppressWarnings("unchecked")
-    @Test
-    public void cannotAddNullValues() {
-        mapper = spy(mapper);
-        dao.setMapper(mapper);
-        try {
-            dao.addExternalIds(studyId, Lists.newArrayList("DDD", null));
-            fail("Should have thrown exception");
-        } catch(BadRequestException e) {}
-        verify(mapper, never()).load(any());
-        verify(mapper, never()).batchSave((List<DynamoExternalIdentifier>)any());
-    }
-    
-    @SuppressWarnings("unchecked")
-    @Test
-    public void cannotAddEmptyValues() {
-        mapper = spy(mapper);
-        dao.setMapper(mapper);
-        try {
-            dao.addExternalIds(studyId, Lists.newArrayList("DDD", "  \t"));
-            fail("Should have thrown exception");
-        } catch(BadRequestException e) {}
-        verify(mapper, never()).load(any());
-        verify(mapper, never()).batchSave((List<DynamoExternalIdentifier>)any());
     }
     
     @Test
@@ -234,7 +200,7 @@ public class DynamoExternalIdDaoTest {
     
     @Test
     public void canGetIds() {
-        PagedResourceList<String> page = dao.getExternalIds(studyId, null, 10, null, null);
+        PagedResourceList<ExternalIdentifierInfo> page = dao.getExternalIds(studyId, null, 10, null, null);
         
         assertEquals(3, page.getItems().size());
         assertEquals(10, page.getPageSize());
@@ -248,7 +214,7 @@ public class DynamoExternalIdDaoTest {
             dao.addExternalIds(studyId, moreIds);
             
             // AAA, AEE, AFF
-            PagedResourceList<String> page = dao.getExternalIds(studyId, null, 10, "A", null);
+            PagedResourceList<ExternalIdentifierInfo> page = dao.getExternalIds(studyId, null, 10, "A", null);
             assertEquals(3, page.getItems().size());
             assertEquals(10, page.getPageSize());
             assertEquals("A", page.getFilters().get("idFilter"));
@@ -266,7 +232,7 @@ public class DynamoExternalIdDaoTest {
 
             page = dao.getExternalIds(studyId, null, 10, null, Boolean.TRUE);
             assertEquals(2, page.getItems().size());
-            assertEquals(Sets.newHashSet("AAA", "BBB"), Sets.newHashSet(page.getItems()));
+            assertEquals(toSet(true, "AAA", "BBB"), Sets.newHashSet(page.getItems()));
         } finally {
             dao.deleteExternalIds(studyId, moreIds);
         }
@@ -280,26 +246,34 @@ public class DynamoExternalIdDaoTest {
         try {
             dao.addExternalIds(studyId, moreIds);
 
-            PagedResourceList<String> page = dao.getExternalIds(studyId, null, 5, null, null);
+            PagedResourceList<ExternalIdentifierInfo> page = dao.getExternalIds(studyId, null, 5, null, null);
             assertEquals(5, page.getItems().size());
             assertEquals(26, page.getTotal());
-            assertEquals("EEE", page.getLastKey());
-            assertEquals(Sets.newHashSet("AAA","BBB","CCC","DDD","EEE"), Sets.newHashSet(page.getItems()));
+            assertEquals("EEE", page.getOffsetKey());
+            assertEquals(toSet(false, "AAA","BBB","CCC","DDD","EEE"), Sets.newHashSet(page.getItems()));
             
-            page = dao.getExternalIds(studyId, page.getLastKey(), 5, null, null);
-            assertEquals(Sets.newHashSet("FFF","GGG","HHH","III","JJJ"), Sets.newHashSet(page.getItems()));
+            page = dao.getExternalIds(studyId, page.getOffsetKey(), 5, null, null);
+            assertEquals(toSet(false, "FFF","GGG","HHH","III","JJJ"), Sets.newHashSet(page.getItems()));
             
-            page = dao.getExternalIds(studyId, page.getLastKey(), 5, null, null);
-            assertEquals(Sets.newHashSet("KKK","LLL","MMM","NNN","OOO"), Sets.newHashSet(page.getItems()));
+            page = dao.getExternalIds(studyId, page.getOffsetKey(), 5, null, null);
+            assertEquals(toSet(false, "KKK","LLL","MMM","NNN","OOO"), Sets.newHashSet(page.getItems()));
             
-            page = dao.getExternalIds(studyId, page.getLastKey(), 15, null, null);
-            assertEquals(Sets.newHashSet("PPP","QQQ","RRR","SSS","TTT","UUU","VVV","WWW","XXX","YYY","ZZZ"), Sets.newHashSet(page.getItems()));
+            page = dao.getExternalIds(studyId, page.getOffsetKey(), 15, null, null);
+            assertEquals(toSet(false, "PPP", "QQQ", "RRR", "SSS", "TTT", "UUU", "VVV", "WWW", "XXX", "YYY", "ZZZ"),
+                    Sets.newHashSet(page.getItems()));
             assertEquals(26, page.getTotal());
-            assertNull(page.getLastKey());
+            assertNull(page.getOffsetKey());
             
         } finally {
             dao.deleteExternalIds(studyId, moreIds);
         }
+    }
+    
+    // This currently doesn't, you get this error: ValidationException...The provided starting key does not match the range key predicate
+    @Test
+    public void pagingWithAFilterWorks() {
+        PagedResourceList<ExternalIdentifierInfo> page = dao.getExternalIds(studyId, "B", 5, "C", null);
+        assertEquals(new ExternalIdentifierInfo("CCC", false), page.getItems().get(0));
     }
     
     // Sometimes paging fails when the total records divided by the page has no remainder. 
@@ -310,15 +284,15 @@ public class DynamoExternalIdDaoTest {
         try {
             dao.addExternalIds(studyId, moreIds);
             
-            PagedResourceList<String> page = dao.getExternalIds(studyId, null, 3, null, null);
+            PagedResourceList<ExternalIdentifierInfo> page = dao.getExternalIds(studyId, null, 3, null, null);
             assertEquals(6, page.getTotal());
             assertEquals(3, page.getItems().size());
-            assertNotNull(page.getLastKey());
+            assertNotNull(page.getOffsetKey());
             
-            page = dao.getExternalIds(studyId, page.getLastKey(), 3, null, null);
+            page = dao.getExternalIds(studyId, page.getOffsetKey(), 3, null, null);
             assertEquals(6, page.getTotal());
             assertEquals(3, page.getItems().size());
-            assertNull(page.getLastKey());
+            assertNull(page.getOffsetKey());
         } finally {
             dao.deleteExternalIds(studyId, moreIds);
         }
@@ -331,15 +305,15 @@ public class DynamoExternalIdDaoTest {
         dao.assignExternalId(studyId, "AAA", "healthCode1");
         dao.reserveExternalId(studyId, "BBB"); // only reserved
         
-        PagedResourceList<String> page = dao.getExternalIds(studyId, null, 5, null, Boolean.FALSE);
+        PagedResourceList<ExternalIdentifierInfo> page = dao.getExternalIds(studyId, null, 5, null, Boolean.FALSE);
         assertEquals(1, page.getItems().size());
-        assertEquals("CCC", page.getItems().get(0));
+        assertEquals(new ExternalIdentifierInfo("CCC", false), page.getItems().get(0));
         
-        Thread.sleep(1000);
+        Thread.sleep(2000);
         page = dao.getExternalIds(studyId, null, 5, null, Boolean.FALSE);
         assertEquals(2, page.getItems().size());
-        assertTrue(page.getItems().contains("BBB"));
-        assertTrue(page.getItems().contains("CCC"));
+        assertTrue(page.getItems().contains(new ExternalIdentifierInfo("BBB", false)));
+        assertTrue(page.getItems().contains(new ExternalIdentifierInfo("CCC", false)));
     }
     
     @Test
@@ -349,16 +323,16 @@ public class DynamoExternalIdDaoTest {
         dao.assignExternalId(studyId, "AAA", "healthCode");
         dao.reserveExternalId(studyId, "BBB");
         
-        PagedResourceList<String> page = dao.getExternalIds(studyId, null, 5, null, Boolean.TRUE);
+        PagedResourceList<ExternalIdentifierInfo> page = dao.getExternalIds(studyId, null, 5, null, Boolean.TRUE);
         assertEquals(2, page.getItems().size());
-        assertTrue(page.getItems().contains("AAA"));
-        assertTrue(page.getItems().contains("BBB"));
+        assertTrue(page.getItems().contains(new ExternalIdentifierInfo("AAA", true)));
+        assertTrue(page.getItems().contains(new ExternalIdentifierInfo("BBB", true)));
         
         // Wait until lock is released, item is no longer in results that are considered assigned.
         Thread.sleep(10000);
         page = dao.getExternalIds(studyId, null, 5, null, Boolean.TRUE);
         assertEquals(1, page.getItems().size());
-        assertTrue(page.getItems().contains("AAA"));
+        assertTrue(page.getItems().contains(new ExternalIdentifierInfo("AAA", true)));
     }
     
     @Test
@@ -367,10 +341,18 @@ public class DynamoExternalIdDaoTest {
         dao.assignExternalId(studyId, "AAA", "healthCode");
         dao.reserveExternalId(studyId, "BBB");
         
-        PagedResourceList<String> ids = dao.getExternalIds(studyId, null, 1, null, Boolean.FALSE);
+        PagedResourceList<ExternalIdentifierInfo> ids = dao.getExternalIds(studyId, null, 1, null, Boolean.FALSE);
         
         assertEquals(1, ids.getItems().size());
-        assertEquals("CCC", ids.getItems().get(0));
+        assertEquals("CCC", ids.getItems().get(0).getIdentifier());
+    }
+
+    private Set<ExternalIdentifierInfo> toSet(boolean isAssigned, String... infos) {
+        Set<ExternalIdentifierInfo> set = Sets.newHashSetWithExpectedSize(infos.length);
+        for (String identifier : infos) {
+            set.add(new ExternalIdentifierInfo(identifier, isAssigned));
+        }
+        return set; 
     }
     
 }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoExternalIdDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoExternalIdDaoTest.java
@@ -275,6 +275,7 @@ public class DynamoExternalIdDaoTest {
     public void pagingWithAFilterWorks() {
         PagedResourceList<ExternalIdentifierInfo> page = dao.getExternalIds(studyId, "B", 5, "C", null);
         assertEquals(new ExternalIdentifierInfo("CCC", false), page.getItems().get(0));
+        assertNull(page.getOffsetKey());
     }
     
     // Sometimes paging fails when the total records divided by the page has no remainder. 

--- a/test/org/sagebionetworks/bridge/models/PagedResourceListTest.java
+++ b/test/org/sagebionetworks/bridge/models/PagedResourceListTest.java
@@ -73,7 +73,7 @@ public class PagedResourceListTest {
     // DynamoDB, that was easily incorporated into this implementation. This test verifies
     // that the results are the same as before.
     @Test
-    public void canSerializeWithDynamoLastKey() throws Exception {
+    public void canSerializeWithDynamoOffsetKey() throws Exception {
         List<String> accounts = Lists.newArrayListWithCapacity(2);
         accounts.add("value1");
         accounts.add("value2");
@@ -101,8 +101,8 @@ public class PagedResourceListTest {
         
         assertEquals(page.getTotal(), serPage.getTotal());
         assertEquals(page.getPageSize(), serPage.getPageSize());
-        assertEquals(page.getFilters().get("lastKey"), serPage.getFilters().get("lastKey"));
-        assertEquals(page.getLastKey(), serPage.getLastKey());
+        assertEquals(page.getFilters().get("offsetKey"), serPage.getFilters().get("offsetKey"));
+        assertEquals(page.getOffsetKey(), serPage.getOffsetKey());
         assertEquals(page.getFilters().get("idFilter"), serPage.getFilters().get("idFilter"));
         assertEquals(page.getFilters().get("assignmentFilter"), serPage.getFilters().get("assignmentFilter"));
         assertEquals(page.getItems(), serPage.getItems());

--- a/test/org/sagebionetworks/bridge/models/accounts/ExternalIdentifierInfoTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/ExternalIdentifierInfoTest.java
@@ -1,0 +1,34 @@
+package org.sagebionetworks.bridge.models.accounts;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+public class ExternalIdentifierInfoTest {
+
+    @Test
+    public void hashCodeEquals() {
+        EqualsVerifier.forClass(ExternalIdentifierInfo.class).allFieldsShouldBeUsed().verify();
+    }
+
+    @Test
+    public void canSerialize() throws Exception {
+        ExternalIdentifierInfo info = new ExternalIdentifierInfo("AAA", true);
+        
+        JsonNode node = BridgeObjectMapper.get().valueToTree(info);
+        assertEquals("AAA", node.get("identifier").asText());
+        assertEquals(true, node.get("assigned").asBoolean());
+        assertEquals("ExternalIdentifier", node.get("type").asText());
+        assertEquals(3, node.size());
+        
+        ExternalIdentifierInfo resInfo = BridgeObjectMapper.get().treeToValue(node, ExternalIdentifierInfo.class);
+        assertEquals(info, resInfo);
+    }
+    
+}

--- a/test/org/sagebionetworks/bridge/play/controllers/ExternalIdControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ExternalIdControllerTest.java
@@ -91,8 +91,6 @@ public class ExternalIdControllerTest {
         Result result = controller.getExternalIds(null, null, null, null);
         String content = Helpers.contentAsString(result);
         
-        System.out.println(content);
-        
         PagedResourceList<ExternalIdentifierInfo> deserPage =  MAPPER.readValue(content, PAGE_REF);
         assertEquals(EXT_IDS, deserPage.getItems());
         assertEquals("CCC", deserPage.getOffsetKey());

--- a/test/org/sagebionetworks/bridge/services/ExternalIdServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ExternalIdServiceTest.java
@@ -2,9 +2,11 @@ package org.sagebionetworks.bridge.services;
 
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.dao.ParticipantOption.EXTERNAL_IDENTIFIER;
 
 import java.util.List;
@@ -16,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import org.sagebionetworks.bridge.BridgeConstants;
+import org.sagebionetworks.bridge.config.Config;
 import org.sagebionetworks.bridge.dao.ExternalIdDao;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
@@ -45,9 +48,13 @@ public class ExternalIdServiceTest {
     
     @Before
     public void before() {
+        Config config = mock(Config.class);
+        when(config.getInt(ExternalIdDao.CONFIG_KEY_ADD_LIMIT)).thenReturn(10);
+        
         externalIdService = new ExternalIdService();
         externalIdService.setExternalIdDao(externalIdDao);
         externalIdService.setParticipantOptionsService(optionsService);
+        externalIdService.setConfig(config);
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/validators/ExternalIdValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/ExternalIdValidatorTest.java
@@ -85,4 +85,17 @@ public class ExternalIdValidatorTest {
         }        
     }
     
+    @Test
+    public void rejectsDuplicateElement() {
+        ExternalIdList list = new ExternalIdList(Lists.newArrayList("AAA","BBB","AAA"));
+
+        try {
+            Validate.entityThrowingException(validator, list);
+            fail("Should have thrown exception");
+        } catch(InvalidEntityException e) {
+            assertEquals("ids[2] is a duplicate value", e.getErrors().get("ids[2]").get(0));
+        }        
+    }
+    
+    
 }

--- a/test/org/sagebionetworks/bridge/validators/ExternalIdValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/ExternalIdValidatorTest.java
@@ -96,6 +96,4 @@ public class ExternalIdValidatorTest {
             assertEquals("ids[2] is a duplicate value", e.getErrors().get("ids[2]").get(0));
         }        
     }
-    
-    
 }

--- a/test/org/sagebionetworks/bridge/validators/ExternalIdValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/ExternalIdValidatorTest.java
@@ -1,0 +1,88 @@
+package org.sagebionetworks.bridge.validators;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
+import org.sagebionetworks.bridge.validators.ExternalIdsValidator.ExternalIdList;
+
+import com.google.common.collect.Lists;
+
+public class ExternalIdValidatorTest {
+
+    private ExternalIdsValidator validator;
+    
+    @Before
+    public void before() {
+        validator = new ExternalIdsValidator(5);
+    }
+    
+    @Test
+    public void rejectsOverLimit() {
+        ExternalIdList list = new ExternalIdList(Lists.newArrayList("A","B","C","D","E","F"));
+        
+        try {
+            Validate.entityThrowingException(validator, list);
+            fail("Should have thrown exception");
+        } catch(InvalidEntityException e) {
+            assertTrue(e.getMessage().contains("ExternalIdList contains too many elements; size=6, limit=5"));
+        }
+    }
+    
+    @Test
+    public void rejectsEmpty() {
+        ExternalIdList list = new ExternalIdList(Lists.newArrayList());
+        
+        try {
+            Validate.entityThrowingException(validator, list);
+            fail("Should have thrown exception");
+        } catch(InvalidEntityException e) {
+            assertTrue(e.getMessage().contains("ExternalIdList contains no elements"));
+        }
+    }
+    
+    @Test
+    public void rejectsEmptyElement() {
+        ExternalIdList list = new ExternalIdList(Lists.newArrayList("AAA","","CCC"));
+
+        try {
+            Validate.entityThrowingException(validator, list);
+            fail("Should have thrown exception");
+        } catch(InvalidEntityException e) {
+            assertEquals("ids[1] cannot be null or blank", e.getErrors().get("ids[1]").get(0));
+            assertTrue(e.getMessage().contains("ids[1] cannot be null or blank"));
+        }
+    }
+    
+    @Test
+    public void rejectsNullElement() {
+        ExternalIdList list = new ExternalIdList(Lists.newArrayList("AAA",null,"CCC"));
+
+        try {
+            Validate.entityThrowingException(validator, list);
+            fail("Should have thrown exception");
+        } catch(InvalidEntityException e) {
+            assertEquals("ids[1] cannot be null or blank", e.getErrors().get("ids[1]").get(0));
+            assertTrue(e.getMessage().contains("ids[1] cannot be null or blank"));
+        }
+    }
+    
+    @Test
+    public void rejectsInvalidElement() {
+        ExternalIdList list = new ExternalIdList(Lists.newArrayList("Two Words","<Funky>Markup","And a \ttab character"));
+
+        try {
+            Validate.entityThrowingException(validator, list);
+            fail("Should have thrown exception");
+        } catch(InvalidEntityException e) {
+            assertEquals("ids[0] 'Two Words' must contain only digits, letters, underscores and dashes", e.getErrors().get("ids[0]").get(0));
+            assertEquals("ids[1] '<Funky>Markup' must contain only digits, letters, underscores and dashes", e.getErrors().get("ids[1]").get(0));
+            assertEquals("ids[2] 'And a \ttab character' must contain only digits, letters, underscores and dashes", e.getErrors().get("ids[2]").get(0));
+        }        
+    }
+    
+}


### PR DESCRIPTION
- consistently use "offsetKey" and get rid of "lastKey" synonym
- validate that the external IDs contain alphanumeric characters (only). no spaces, for example
- validate that the new list of IDS doesn't contain duplicates, because AWS throws an interesting error over this (submitting IDs that have already been saved just works, which we want, so users can re-import lists if they succeed only partially)
- switch to using a validator for all this stuff
- return an identifier object that includes the assignment status of the code
- fixed bug where the offsetKey does not match the rangeKey, throwing a DDB validation exception
