### PR TITLE
Delete external IDs

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoExternalIdDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoExternalIdDao.java
@@ -87,10 +87,10 @@ public class DynamoExternalIdDao implements ExternalIdDao {
         if (pageSize < 1 || pageSize > API_MAXIMUM_PAGE_SIZE) {
             throw new BadRequestException(PAGE_SIZE_ERROR);
         }
-        // The offset key is applied after the range key filter. If the offsetKey doesn't match the beginning
-        // of the range key filter, DDB throws a validation exception. So when providing a filter and an offset, 
-        // if the offset is not the valid prefix of the range key filter, set it to null (go back to first page).
-        if (offsetKey != null && idFilter != null && idFilter.indexOf(offsetKey) != 0) {
+        // The offset key is applied after the idFilter. If the offsetKey doesn't match the beginning
+        // of the idFilter, the AWS SDK throws a validation exception. So when providing an idFilter and 
+        // a paging offset, clear the offset (go back to the first page) if they don't match.
+        if (offsetKey != null && idFilter != null && !offsetKey.startsWith(idFilter)) {
             offsetKey = null;
         }
         PaginatedQueryList<DynamoExternalIdentifier> list = mapper.query(DynamoExternalIdentifier.class,

--- a/app/org/sagebionetworks/bridge/play/controllers/ExternalIdController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ExternalIdController.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 
+import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.accounts.ExternalIdentifierInfo;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
@@ -14,6 +15,7 @@ import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.services.ExternalIdService;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.collect.Lists;
 
 import play.mvc.Result;
 
@@ -50,6 +52,20 @@ public class ExternalIdController extends BaseController {
         externalIdService.addExternalIds(study, externalIdentifiers);
         
         return createdResult("External identifiers added.");
+    }
+    
+    public Result deleteExternalIds() throws Exception {
+        UserSession session = getAuthenticatedSession(DEVELOPER);
+        Study study = studyService.getStudy(session.getStudyIdentifier());
+
+        String[] externalIds = request().queryString().get("externalId");
+        if (externalIds == null || externalIds.length == 0) {
+            throw new BadRequestException("No external IDs provided in query string.");
+        }
+        List<String> identifiers = Lists.newArrayList(externalIds);
+        externalIdService.deleteExternalIds(study, identifiers);
+        
+        return okResult("External identifiers deleted.");
     }
 
 }

--- a/app/org/sagebionetworks/bridge/services/ExternalIdService.java
+++ b/app/org/sagebionetworks/bridge/services/ExternalIdService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Component;
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.config.Config;
 import org.sagebionetworks.bridge.dao.ExternalIdDao;
+import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.accounts.ExternalIdentifierInfo;
 import org.sagebionetworks.bridge.models.studies.Study;
@@ -101,6 +102,9 @@ public class ExternalIdService {
         checkNotNull(study);
         checkNotNull(externalIdentifiers);
         
+        if (study.isExternalIdValidationEnabled()) {
+            throw new BadRequestException("Cannot delete IDs while externalId validation is enabled for this study.");
+        }
         externalIdDao.deleteExternalIds(study.getStudyIdentifier(), externalIdentifiers);    
     }
 }

--- a/conf/routes
+++ b/conf/routes
@@ -14,11 +14,11 @@ POST   /v3/auth/verifyEmail             @org.sagebionetworks.bridge.play.control
 POST   /v3/auth/resendEmailVerification @org.sagebionetworks.bridge.play.controllers.AuthenticationController.resendEmailVerification
 
 # Participants Researcher APIs
-GET  /v3/participants                 @org.sagebionetworks.bridge.play.controllers.ParticipantController.getParticipants(offsetBy: String ?= null, pageSize: String ?= null, emailFilter: String ?= null)
-POST /v3/participants                 @org.sagebionetworks.bridge.play.controllers.ParticipantController.createParticipant
-GET  /v3/participants/member          @org.sagebionetworks.bridge.play.controllers.ParticipantController.getParticipant(email: String ?= null)
-POST /v3/participants/member          @org.sagebionetworks.bridge.play.controllers.ParticipantController.updateParticipant(email: String ?= null)
-POST /v3/participants/member/signOut  @org.sagebionetworks.bridge.play.controllers.ParticipantController.signOut(email: String ?= null)
+GET    /v3/participants                 @org.sagebionetworks.bridge.play.controllers.ParticipantController.getParticipants(offsetBy: String ?= null, pageSize: String ?= null, emailFilter: String ?= null)
+POST   /v3/participants                 @org.sagebionetworks.bridge.play.controllers.ParticipantController.createParticipant
+GET    /v3/participants/member          @org.sagebionetworks.bridge.play.controllers.ParticipantController.getParticipant(email: String ?= null)
+POST   /v3/participants/member          @org.sagebionetworks.bridge.play.controllers.ParticipantController.updateParticipant(email: String ?= null)
+POST   /v3/participants/member/signOut  @org.sagebionetworks.bridge.play.controllers.ParticipantController.signOut(email: String ?= null)
 
 POST /v3/participants/member/options  @org.sagebionetworks.bridge.play.controllers.ParticipantController.updateParticipantOptions(email: String ?= null)
 POST /v3/participants/member/profile  @org.sagebionetworks.bridge.play.controllers.ParticipantController.updateProfile(email: String ?= null)
@@ -131,6 +131,7 @@ DELETE /v3/studies/:identifier      @org.sagebionetworks.bridge.play.controllers
 
 GET    /v3/externalIds    @org.sagebionetworks.bridge.play.controllers.ExternalIdController.getExternalIds(offsetKey: String ?= null, pageSize: String ?= null, idFilter: String ?= null, assignmentFilter: String ?= null)
 POST   /v3/externalIds    @org.sagebionetworks.bridge.play.controllers.ExternalIdController.addExternalIds
+DELETE /v3/externalIds    @org.sagebionetworks.bridge.play.controllers.ExternalIdController.deleteExternalIds
 
 # APIs for getting entities across studies
 GET /v3/studies/:studyId/surveys/published @org.sagebionetworks.bridge.play.controllers.SurveyController.getAllSurveysMostRecentlyPublishedVersionForStudy(studyId: String)

--- a/conf/routes
+++ b/conf/routes
@@ -14,11 +14,11 @@ POST   /v3/auth/verifyEmail             @org.sagebionetworks.bridge.play.control
 POST   /v3/auth/resendEmailVerification @org.sagebionetworks.bridge.play.controllers.AuthenticationController.resendEmailVerification
 
 # Participants Researcher APIs
-GET    /v3/participants                 @org.sagebionetworks.bridge.play.controllers.ParticipantController.getParticipants(offsetBy: String ?= null, pageSize: String ?= null, emailFilter: String ?= null)
-POST   /v3/participants                 @org.sagebionetworks.bridge.play.controllers.ParticipantController.createParticipant
-GET    /v3/participants/member          @org.sagebionetworks.bridge.play.controllers.ParticipantController.getParticipant(email: String ?= null)
-POST   /v3/participants/member          @org.sagebionetworks.bridge.play.controllers.ParticipantController.updateParticipant(email: String ?= null)
-POST   /v3/participants/member/signOut  @org.sagebionetworks.bridge.play.controllers.ParticipantController.signOut(email: String ?= null)
+GET  /v3/participants                 @org.sagebionetworks.bridge.play.controllers.ParticipantController.getParticipants(offsetBy: String ?= null, pageSize: String ?= null, emailFilter: String ?= null)
+POST /v3/participants                 @org.sagebionetworks.bridge.play.controllers.ParticipantController.createParticipant
+GET  /v3/participants/member          @org.sagebionetworks.bridge.play.controllers.ParticipantController.getParticipant(email: String ?= null)
+POST /v3/participants/member          @org.sagebionetworks.bridge.play.controllers.ParticipantController.updateParticipant(email: String ?= null)
+POST /v3/participants/member/signOut  @org.sagebionetworks.bridge.play.controllers.ParticipantController.signOut(email: String ?= null)
 
 POST /v3/participants/member/options  @org.sagebionetworks.bridge.play.controllers.ParticipantController.updateParticipantOptions(email: String ?= null)
 POST /v3/participants/member/profile  @org.sagebionetworks.bridge.play.controllers.ParticipantController.updateProfile(email: String ?= null)

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoExternalIdDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoExternalIdDaoTest.java
@@ -269,11 +269,22 @@ public class DynamoExternalIdDaoTest {
         }
     }
     
-    // This did give a ValidationException...The provided starting key does not match the range key 
-    // predicate. Now the offset key is reset to null (the first page)
     @Test
-    public void pagingWithAFilterWorks() {
+    public void pagingWithFilterResetsInapplicableOffsetKey() {
         PagedResourceList<ExternalIdentifierInfo> page = dao.getExternalIds(studyId, "B", 5, "C", null);
+        assertEquals(new ExternalIdentifierInfo("CCC", false), page.getItems().get(0));
+        assertNull(page.getOffsetKey());
+    }
+    
+    @Test
+    public void pagingWithFilterLongerThanKeyWorks() {
+        PagedResourceList<ExternalIdentifierInfo> page = dao.getExternalIds(studyId, "CCCCC", 5, "CC", null);
+        assertTrue(page.getItems().isEmpty());
+    }
+    
+    @Test
+    public void pagingWithFilterShorterThanKeyWorks() {
+        PagedResourceList<ExternalIdentifierInfo> page = dao.getExternalIds(studyId, "C", 5, "CC", null);
         assertEquals(new ExternalIdentifierInfo("CCC", false), page.getItems().get(0));
         assertNull(page.getOffsetKey());
     }

--- a/test/org/sagebionetworks/bridge/play/controllers/ExternalIdControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ExternalIdControllerTest.java
@@ -169,7 +169,7 @@ public class ExternalIdControllerTest {
     }
     
     @Test(expected = BadRequestException.class)
-    public void deleteIdentifiersNoAtAll() throws Exception {
+    public void deleteIdentifiersNoneInQueryAtAll() throws Exception {
         Map<String,String[]> map = Maps.newHashMap();
         mockRequestWithQueryString(map);
         

--- a/test/org/sagebionetworks/bridge/play/controllers/ExternalIdControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ExternalIdControllerTest.java
@@ -3,16 +3,20 @@ package org.sagebionetworks.bridge.play.controllers;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -20,6 +24,7 @@ import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
+import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.accounts.ExternalIdentifierInfo;
@@ -32,7 +37,9 @@ import org.sagebionetworks.bridge.services.StudyService;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 
+import play.mvc.Http;
 import play.mvc.Result;
 import play.test.Helpers;
 
@@ -53,6 +60,9 @@ public class ExternalIdControllerTest {
     
     @Mock
     StudyService studyService;
+    
+    @Captor
+    ArgumentCaptor<List<String>> externalIdCaptor;
     
     Study study;
     
@@ -126,6 +136,55 @@ public class ExternalIdControllerTest {
         assertEquals(201, result.status());
         
         verify(externalIdService).addExternalIds(study, Lists.newArrayList());
+    }
+    
+    @Test
+    public void deleteIdentifiers() throws Exception {
+        Map<String,String[]> map = Maps.newHashMap();
+        String[] identifiers = new String[] {"AAA","BBB","CCC"};
+        map.put("externalId", identifiers);
+        mockRequestWithQueryString(map);
+        
+        Result result = controller.deleteExternalIds();
+        JsonNode node = MAPPER.readTree(Helpers.contentAsString(result));
+        String message = node.get("message").asText();
+        
+        assertEquals("External identifiers deleted.", message);
+        assertEquals(200, result.status());
+        
+        verify(externalIdService).deleteExternalIds(eq(study), externalIdCaptor.capture());
+        
+        List<String> values = externalIdCaptor.getValue();
+        assertEquals(Lists.newArrayList("AAA","BBB","CCC"), values);
+    }
+    
+    @Test(expected = BadRequestException.class)
+    public void deleteIdentifiersNoIdentifiers() throws Exception {
+        Map<String,String[]> map = Maps.newHashMap();
+        String[] identifiers = new String[] {};
+        map.put("externalId", identifiers);
+        mockRequestWithQueryString(map);
+        
+        controller.deleteExternalIds();
+    }
+    
+    @Test(expected = BadRequestException.class)
+    public void deleteIdentifiersNoAtAll() throws Exception {
+        Map<String,String[]> map = Maps.newHashMap();
+        mockRequestWithQueryString(map);
+        
+        controller.deleteExternalIds();
+    }
+    
+    private void mockRequestWithQueryString(Map<String,String[]> query) {
+        Http.Request request = mock(Http.Request.class);
+        
+        Http.Context context = mock(Http.Context.class);
+        when(context.request()).thenReturn(request);
+        
+        when(request.queryString()).thenReturn(query);
+
+        Http.Context.current.set(context);
     }
     
 }

--- a/test/org/sagebionetworks/bridge/services/ExternalIdServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ExternalIdServiceTest.java
@@ -146,9 +146,14 @@ public class ExternalIdServiceTest {
         verify(externalIdDao).deleteExternalIds(STUDY.getStudyIdentifier(), EXT_IDS);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test
     public void deleteExternalIdsWithValidationEnabled() {
         STUDY.setExternalIdValidationEnabled(true);
-        externalIdService.deleteExternalIds(STUDY, EXT_IDS);
+        try {
+            externalIdService.deleteExternalIds(STUDY, EXT_IDS);
+            fail("Should have thrown exception");
+        } catch(BadRequestException e) {
+        }
+        verifyNoMoreInteractions(externalIdDao);
     }
 }

--- a/test/org/sagebionetworks/bridge/services/ExternalIdServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ExternalIdServiceTest.java
@@ -21,6 +21,7 @@ import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.config.Config;
 import org.sagebionetworks.bridge.dao.ExternalIdDao;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
+import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.accounts.ExternalIdentifier;
 import org.sagebionetworks.bridge.models.studies.Study;
@@ -138,9 +139,16 @@ public class ExternalIdServiceTest {
     }
 
     @Test
-    public void deleteExternalIds() {
+    public void deleteExternalIdsWithValidationDisabled() {
+        STUDY.setExternalIdValidationEnabled(false);
         externalIdService.deleteExternalIds(STUDY, EXT_IDS);
         
         verify(externalIdDao).deleteExternalIds(STUDY.getStudyIdentifier(), EXT_IDS);
+    }
+    
+    @Test(expected = BadRequestException.class)
+    public void deleteExternalIdsWithValidationEnabled() {
+        STUDY.setExternalIdValidationEnabled(true);
+        externalIdService.deleteExternalIds(STUDY, EXT_IDS);
     }
 }


### PR DESCRIPTION
Used for testing, but I did make it available to researchers for consistency. Don't allow deletion unless they disable stricter external ID validation, as obviously you can mess that up if you delete IDs.
