### PR TITLE
Use classpath instead of filepath for resources

### DIFF
--- a/app/org/sagebionetworks/bridge/cache/CacheProvider.java
+++ b/app/org/sagebionetworks/bridge/cache/CacheProvider.java
@@ -160,7 +160,7 @@ public class CacheProvider {
             String ser = jedisOps.get(redisKey);
             if (ser != null) {
                 jedisOps.expire(redisKey, BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS);
-                return BridgeObjectMapper.get().readValue(ser, Study.class);
+                return bridgeObjectMapper.readValue(ser, Study.class);
             }
         } catch (Throwable e) {
             promptToStartRedisIfLocal(e);

--- a/conf/application-context.xml
+++ b/conf/application-context.xml
@@ -4,6 +4,6 @@
         http://www.springframework.org/schema/beans     
         http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-    <import resource="file:conf/shared-config.xml" />
+    <import resource="classpath:/shared-config.xml" />
     <bean class="org.sagebionetworks.bridge.config.BridgeProductionSpringConfig" />
 </beans>

--- a/conf/test-context.xml
+++ b/conf/test-context.xml
@@ -4,7 +4,7 @@
         http://www.springframework.org/schema/beans     
         http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-    <import resource="file:conf/shared-config.xml" />
+    <import resource="classpath:/shared-config.xml" />
 
     <bean class="org.sagebionetworks.bridge.config.BridgeTestSpringConfig" />
 

--- a/test/org/sagebionetworks/bridge/crypto/CmsEncryptorCacheLoaderTest.java
+++ b/test/org/sagebionetworks/bridge/crypto/CmsEncryptorCacheLoaderTest.java
@@ -7,10 +7,10 @@ import static org.mockito.Mockito.when;
 import java.io.File;
 import java.nio.file.Files;
 
+import com.google.common.base.Charsets;
 import org.junit.Test;
 import org.sagebionetworks.bridge.s3.S3Helper;
-
-import com.google.common.base.Charsets;
+import org.springframework.core.io.ClassPathResource;
 
 public class CmsEncryptorCacheLoaderTest {
     @Test
@@ -19,10 +19,10 @@ public class CmsEncryptorCacheLoaderTest {
         // test materials instead of calling through to S3.
 
         // set up cert and priv key PEM files as strings
-        File certFile = new File("test/resources/cms/rsacert.pem");
+        File certFile =  new ClassPathResource("/cms/rsacert.pem").getFile();
         byte[] certBytes = Files.readAllBytes(certFile.toPath());
         String certString = new String(certBytes, Charsets.UTF_8);
-        File privKeyFile = new File("test/resources/cms/rsaprivkey.pem");
+        File privKeyFile =  new ClassPathResource("/cms/rsaprivkey.pem").getFile();
         byte[] privKeyBytes = Files.readAllBytes(privKeyFile.toPath());
         String privKeyString = new String(privKeyBytes, Charsets.UTF_8);
 

--- a/test/org/sagebionetworks/bridge/services/UploadArchiveServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/UploadArchiveServiceTest.java
@@ -24,6 +24,7 @@ import org.sagebionetworks.bridge.crypto.BcCmsEncryptor;
 import org.sagebionetworks.bridge.crypto.CmsEncryptor;
 import org.sagebionetworks.bridge.crypto.PemUtils;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
+import org.springframework.core.io.ClassPathResource;
 
 @SuppressWarnings("unchecked")
 public class UploadArchiveServiceTest {
@@ -32,10 +33,10 @@ public class UploadArchiveServiceTest {
     @Before
     public void before() throws Exception {
         // encryptor
-        File certFile = new File("test/resources/cms/rsacert.pem");
+        File certFile = new ClassPathResource("/cms/rsacert.pem").getFile();
         byte[] certBytes = Files.readAllBytes(certFile.toPath());
         X509Certificate cert = PemUtils.loadCertificateFromPem(new String(certBytes));
-        File privateKeyFile = new File("test/resources/cms/rsaprivkey.pem");
+        File privateKeyFile = new ClassPathResource("/cms/rsaprivkey.pem").getFile();
         byte[] privateKeyBytes = Files.readAllBytes(privateKeyFile.toPath());
         PrivateKey privateKey = PemUtils.loadPrivateKeyFromPem(new String(privateKeyBytes));
         CmsEncryptor encryptor = new BcCmsEncryptor(cert, privateKey);
@@ -99,7 +100,7 @@ public class UploadArchiveServiceTest {
     @Test
     public void decryptAndUnzipRealFile() throws Exception {
         // get archive file, which is stored in git
-        File archiveFile = new File("test/resources/cms/data/archive");
+        File archiveFile = new ClassPathResource("/cms/data/archive").getFile();
         byte[] encryptedBytes = Files.readAllBytes(archiveFile.toPath());
 
         // decrypt


### PR DESCRIPTION
- This allows intellij to load spring configuration and other resource files
