### PR TITLE
Allow getParticipants() to succeed if account does not have a healthCode

### DIFF
--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -103,7 +103,7 @@ public class ParticipantService {
         
         StudyParticipant.Builder participant = new StudyParticipant.Builder();
         Account account = getAccountThrowingException(study, email);
-        String healthCode = getHealthCodeThrowingException(account);
+        String healthCode = getHealthCode(account);
 
         List<Subpopulation> subpopulations = subpopService.getSubpopulations(study.getStudyIdentifier());
         for (Subpopulation subpop : subpopulations) {
@@ -267,14 +267,22 @@ public class ParticipantService {
         return account;
     }
     
-    private String getHealthCodeThrowingException(Account account) {
+    private String getHealthCode(Account account) {
         if (account.getHealthId() != null) {
             HealthId healthId = healthCodeService.getMapping(account.getHealthId());
             if (healthId != null && healthId.getCode() != null) {
                 return healthId.getCode();
             }
         }
-        throw new BridgeServiceException("Participant cannot be updated (no health code exists for user).");
+        return null;
+    }
+    
+    private String getHealthCodeThrowingException(Account account) {
+        String healthCode = getHealthCode(account);
+        if (healthCode == null) {
+            throw new BridgeServiceException("Participant cannot be updated (no health code exists for user).");    
+        }
+        return healthCode;
     }
     
 }

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.services;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -372,6 +373,39 @@ public class ParticipantServiceTest {
         
         List<UserConsentHistory> retrievedHistory2 = participant.getConsentHistories().get(subpop2.getGuidString());
         assertTrue(retrievedHistory2.isEmpty());
+    }
+    
+    @Test
+    public void getStudyParticipantWithoutHealthCode() {
+        // A lot of mocks have to be set up first, this call aggregates almost everything we know about the user
+        DateTime createdOn = DateTime.now();
+        when(account.getHealthId()).thenReturn(null);
+        when(account.getFirstName()).thenReturn("firstName");
+        when(account.getLastName()).thenReturn("lastName");
+        when(account.getEmail()).thenReturn(EMAIL);
+        when(account.getStatus()).thenReturn(AccountStatus.DISABLED);
+        when(account.getCreatedOn()).thenReturn(createdOn);
+        when(account.getAttribute("attr2")).thenReturn("anAttribute2");
+        
+        when(accountDao.getAccount(STUDY, EMAIL)).thenReturn(account);
+        when(healthId.getCode()).thenReturn(null);
+        
+        StudyParticipant participant = participantService.getParticipant(STUDY, EMAIL);
+        
+        assertEquals("firstName", participant.getFirstName());
+        assertEquals("lastName", participant.getLastName());
+        assertFalse(participant.isNotifyByEmail());
+        assertTrue(participant.getDataGroups().isEmpty());
+        assertNull(participant.getExternalId());
+        assertNull(participant.getSharingScope());
+        assertNull(participant.getHealthCode());
+        assertEquals(EMAIL, participant.getEmail());
+        assertEquals(AccountStatus.DISABLED, participant.getStatus());
+        assertEquals(createdOn, participant.getCreatedOn());
+        assertTrue(participant.getLanguages().isEmpty());
+        assertNull(participant.getAttributes().get("attr1"));
+        assertEquals("anAttribute2", participant.getAttributes().get("attr2"));
+        assertTrue(participant.getConsentHistories().isEmpty());
     }
     
     private void mockGetAccount() {


### PR DESCRIPTION
Although I've moved health code generation to the sign up code so all accounts will have a health code mapping, there are many accounts out there that do not have health codes, I think because they were created, but never used to sign in. This shouldn't really be an issue, and the getParticipant() code going back to the export roster accounts for people who do not have healthCodes. Allow that and return normally rather than throwing an exception from getParticipants(). 
