### PR TITLE
 optimize add/remove Stormpath groups code

### DIFF
--- a/app/org/sagebionetworks/bridge/stormpath/StormpathAccount.java
+++ b/app/org/sagebionetworks/bridge/stormpath/StormpathAccount.java
@@ -42,7 +42,7 @@ import com.google.common.collect.Maps;
  * updating these values, the version keys will be updated.
  */
 @BridgeTypeName("Account")
-public final class StormpathAccount implements Account {
+public class StormpathAccount implements Account {
     
     static final String PLACEHOLDER_STRING = "<EMPTY>";
     


### PR DESCRIPTION
This is one of two fixes for https://sagebionetworks.jira.com/browse/BRIDGE-1254 After discussing with Stormpath support, they found 2 fixes to improve the performance of our Stormpath code. The first fix is for adding and removing groups.

Notes:
- StormpathAccount is no longer final to allow for mocking. This class is being mocked because there's a lot of behavior baked in, making it difficult to use for testing straight up.
- We no longer need to get the Directory when updating groups. However, the Study is still in the interface because removing it would require changes in 19 different places.

Testing done:
- Updated unit tests
- Manual Tests: There's no way to update groups via the API (and rightfully so). So we merely tested that the Get and Update Participant APIs still work as expected on a user with at least one group/role.
