### PR TITLE
Switching to the user of the Stormpath ID rather than an email address

### DIFF
--- a/app/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/app/org/sagebionetworks/bridge/BridgeConstants.java
@@ -56,4 +56,6 @@ public class BridgeConstants {
     
     public static final int API_MAXIMUM_PAGE_SIZE = 100;
     
+    public static final String STORMPATH_ACCOUNT_BASE_HREF = "https://enterprise.stormpath.io/v1/accounts/";
+    
 }

--- a/app/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/app/org/sagebionetworks/bridge/BridgeUtils.java
@@ -178,5 +178,15 @@ public class BridgeUtils {
         return (set == null) ? ImmutableSet.of() : ImmutableSet.copyOf(set.stream()
                 .filter(element -> element != null).collect(Collectors.toSet()));
     }
+    
+    public static String getIdFromStormpathHref(String href) {
+        if (href != null) {
+            if (!href.contains(BridgeConstants.STORMPATH_ACCOUNT_BASE_HREF)) {
+                throw new IllegalArgumentException("Invalid Stormpath URL: " + href);
+            }
+            return href.substring(BridgeConstants.STORMPATH_ACCOUNT_BASE_HREF.length());
+        }
+        return null;
+    }
 
 }

--- a/app/org/sagebionetworks/bridge/dao/AccountDao.java
+++ b/app/org/sagebionetworks/bridge/dao/AccountDao.java
@@ -70,14 +70,14 @@ public interface AccountDao {
     public Account authenticate(Study study, SignIn signIn);
     
     /**
-     * Get an account in the context of a study by the email address. Returns null if 
-     * there is no account, it is up to callers to translate this into the appropriate 
-     * exception, if any. 
+     * Get an account in the context of a study by the user's ID or by their email address (email is 
+     * deprecated and in the process of being removed). Returns null if there is no account, it is 
+     * up to callers to translate this into the appropriate exception, if any. 
      * @param study
-     * @param email
+     * @param id
      * @return
      */
-    public Account getAccount(Study study, String email);
+    public Account getAccount(Study study, String id);
     
     /**
      * Save account changes.

--- a/app/org/sagebionetworks/bridge/models/accounts/AccountSummary.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/AccountSummary.java
@@ -13,16 +13,18 @@ public final class AccountSummary {
     private final String firstName;
     private final String lastName;
     private final String email;
+    private final String id;
     private final DateTime createdOn;
     private final AccountStatus status;
     
     @JsonCreator
     public AccountSummary(@JsonProperty("firstName") String firstName, @JsonProperty("lastName") String lastName,
-            @JsonProperty("email") String email, @JsonProperty("createdOn") DateTime createdOn,
-            @JsonProperty("status") AccountStatus status) {
+            @JsonProperty("email") String email, @JsonProperty("id") String id,
+            @JsonProperty("createdOn") DateTime createdOn, @JsonProperty("status") AccountStatus status) {
         this.firstName = firstName;
         this.lastName = lastName;
         this.email = email;
+        this.id = id;
         this.createdOn = (createdOn == null) ? null : createdOn.withZone(DateTimeZone.UTC);
         this.status = status;
     }
@@ -38,6 +40,10 @@ public final class AccountSummary {
     public String getEmail() {
         return email;
     }
+    
+    public String getId() {
+        return id;
+    }
 
     public DateTime getCreatedOn() {
         return createdOn;
@@ -49,7 +55,7 @@ public final class AccountSummary {
 
     @Override
     public int hashCode() {
-        return Objects.hash(firstName, lastName, email, createdOn, status);
+        return Objects.hash(firstName, lastName, email, id, createdOn, status);
     }
 
     @Override
@@ -61,7 +67,7 @@ public final class AccountSummary {
         AccountSummary other = (AccountSummary) obj;
         return Objects.equals(firstName, other.firstName) && Objects.equals(lastName, other.lastName)
                 && Objects.equals(email, other.email) && Objects.equals(createdOn, other.createdOn)
-                && Objects.equals(status, other.status);
+                && Objects.equals(status, other.status) && Objects.equals(id, other.id);
     }
     
     // no toString() method as the information is sensitive.

--- a/app/org/sagebionetworks/bridge/models/accounts/StudyParticipant.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/StudyParticipant.java
@@ -39,11 +39,12 @@ public class StudyParticipant implements BridgeEntity {
     private final LinkedHashSet<String> languages;
     private final AccountStatus status;
     private final DateTime createdOn;
+    private final String id;
     
     private StudyParticipant(String firstName, String lastName, String email, String externalId, String password,
             SharingScope sharingScope, boolean notifyByEmail, Set<String> dataGroups, String healthCode,
             Map<String, String> attributes, Map<String, List<UserConsentHistory>> consentHistories, Set<Roles> roles,
-            LinkedHashSet<String> languages, AccountStatus status, DateTime createdOn) {
+            LinkedHashSet<String> languages, AccountStatus status, DateTime createdOn, String id) {
         this.firstName = firstName;
         this.lastName = lastName;
         this.email = email;
@@ -59,6 +60,7 @@ public class StudyParticipant implements BridgeEntity {
         this.languages = languages;
         this.status = status;
         this.createdOn = createdOn;
+        this.id = id;
     }
     
     public String getFirstName() {
@@ -106,6 +108,9 @@ public class StudyParticipant implements BridgeEntity {
     public DateTime getCreatedOn() {
         return createdOn;
     }
+    public String getId() {
+        return id;
+    }
     
     public static class Builder {
         private String firstName;
@@ -123,6 +128,7 @@ public class StudyParticipant implements BridgeEntity {
         private LinkedHashSet<String> languages = new LinkedHashSet<>();
         private AccountStatus status;
         private DateTime createdOn;
+        private String id;
         
         public Builder withFirstName(String firstName) {
             this.firstName = firstName;
@@ -200,10 +206,14 @@ public class StudyParticipant implements BridgeEntity {
             this.createdOn = createdOn;
             return this;
         }
+        public Builder withId(String id) {
+            this.id = id;
+            return this;
+        }
         
         public StudyParticipant build() {
             return new StudyParticipant(firstName, lastName, email, externalId, password, sharingScope, notifyByEmail,
-                    dataGroups, healthCode, attributes, consentHistories, roles, languages, status, createdOn);
+                    dataGroups, healthCode, attributes, consentHistories, roles, languages, status, createdOn, id);
         }
     }
 

--- a/app/org/sagebionetworks/bridge/models/accounts/UserSessionInfo.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/UserSessionInfo.java
@@ -33,6 +33,7 @@ public class UserSessionInfo {
     private final Set<Roles> roles;
     private final Set<String> dataGroups;
     private final Map<SubpopulationGuid,ConsentStatus> consentStatuses;
+    private final String id;
 
     public UserSessionInfo(UserSession session) {
         this.authenticated = session.isAuthenticated();
@@ -43,6 +44,7 @@ public class UserSessionInfo {
         this.environment = ENVIRONMENTS.get(session.getEnvironment());
         this.email = session.getUser().getEmail();
         this.consentStatuses = session.getUser().getConsentStatuses();
+        this.id = session.getUser().getId();
     }
 
     public boolean isAuthenticated() {
@@ -84,5 +86,8 @@ public class UserSessionInfo {
     }
     public Set<String> getDataGroups() {
         return dataGroups;
+    }
+    public String getId() {
+        return id;
     }
 }

--- a/app/org/sagebionetworks/bridge/play/controllers/UserManagementController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/UserManagementController.java
@@ -1,6 +1,8 @@
 package org.sagebionetworks.bridge.play.controllers;
 
 import com.fasterxml.jackson.databind.JsonNode;
+
+import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.json.JsonUtils;
 import org.sagebionetworks.bridge.models.accounts.SignUp;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
@@ -11,11 +13,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import play.mvc.Result;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 
 @Controller
 public class UserManagementController extends BaseController {
 
+    private static final String EMAIL_REQUIRED = "User email is required.";
     private static final String CONSENT_FIELD = "consent";
 
     private UserAdminService userAdminService;
@@ -39,13 +43,20 @@ public class UserManagementController extends BaseController {
         return createdResult("User created.");
     }
 
-    public Result deleteUser(String email) throws Exception {
+    public Result deleteUser(String userId) throws Exception {
         UserSession session = getAuthenticatedSession(ADMIN);
         Study study = studyService.getStudy(session.getStudyIdentifier());
         
-        userAdminService.deleteUser(study, email);
+        userAdminService.deleteUser(study, userId);
         
         return okResult("User deleted.");
+    }
+    
+    public Result deleteUser2(String email) throws Exception {
+        if (isBlank(email)) {
+            throw new BadRequestException(EMAIL_REQUIRED);
+        }
+        return deleteUser(email);
     }
 
 }

--- a/app/org/sagebionetworks/bridge/play/controllers/UserProfileController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/UserProfileController.java
@@ -65,7 +65,7 @@ public class UserProfileController extends BaseController {
         ViewCacheKey<UserProfile> cacheKey = viewCache.getCacheKey(UserProfile.class, session.getUser().getId(), study.getIdentifier());
         String json = viewCache.getView(cacheKey, new Supplier<UserProfile>() {
             @Override public UserProfile get() {
-                return userProfileService.getProfile(study, session.getUser().getEmail());
+                return userProfileService.getProfile(study, session.getUser().getId());
             }
         });
         return ok(json).as(BridgeConstants.JSON_MIME_TYPE);

--- a/app/org/sagebionetworks/bridge/services/ConsentService.java
+++ b/app/org/sagebionetworks/bridge/services/ConsentService.java
@@ -111,7 +111,7 @@ public class ConsentService {
         // This will throw an EntityNotFoundException if the subpopulation is not in the user's study
         subpopService.getSubpopulation(study, subpopGuid);
         
-        Account account = accountDao.getAccount(study, user.getEmail());
+        Account account = accountDao.getAccount(study, user.getId());
         ConsentSignature signature = account.getActiveConsentSignature(subpopGuid);
         if (signature == null) {
             throw new EntityNotFoundException(ConsentSignature.class);    
@@ -155,7 +155,7 @@ public class ConsentService {
         Validate.entityThrowingException(validator, consentSignature);
 
         StudyConsentView studyConsent = studyConsentService.getActiveConsent(subpopGuid);
-        Account account = accountDao.getAccount(study, user.getEmail());
+        Account account = accountDao.getAccount(study, user.getId());
 
         // Throws exception if we have exceeded enrollment limit.
         if (studyEnrollmentService.isStudyAtEnrollmentLimit(study)) {
@@ -234,7 +234,7 @@ public class ConsentService {
         checkNotNull(withdrawal);
         checkArgument(withdrewOn > 0);
         
-        Account account = accountDao.getAccount(study, user.getEmail());
+        Account account = accountDao.getAccount(study, user.getId());
         
         ConsentSignature active = account.getActiveConsentSignature(subpopGuid);
         if (active == null) {
@@ -283,8 +283,8 @@ public class ConsentService {
      * @param healthCode
      * @param email
      */
-    public List<UserConsentHistory> getUserConsentHistory(Study study, SubpopulationGuid subpopGuid, String healthCode, String email) {
-        Account account = accountDao.getAccount(study, email);
+    public List<UserConsentHistory> getUserConsentHistory(Study study, SubpopulationGuid subpopGuid, String healthCode, String id) {
+        Account account = accountDao.getAccount(study, id);
         
         return account.getConsentSignatureHistory(subpopGuid).stream().map(signature -> {
             UserConsent consent = userConsentDao.getUserConsent(

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -175,13 +175,13 @@ public class ParticipantService {
         saveParticipant(study, null, participant, true);
     }
     
-    public void updateParticipant(Study study, String email, StudyParticipant participant) {
-        saveParticipant(study, email, participant, false);
+    public void updateParticipant(Study study, String id, StudyParticipant participant) {
+        saveParticipant(study, id, participant, false);
     }
 
-    public void saveParticipant(Study study, String email, StudyParticipant participant, boolean isNew) {
+    public void saveParticipant(Study study, String id, StudyParticipant participant, boolean isNew) {
         checkNotNull(study);
-        checkArgument(isNew || isNotBlank(email));
+        checkArgument(isNew || isNotBlank(id));
         checkNotNull(participant);
         
         Validate.entityThrowingException(new StudyParticipantValidator(study, isNew), participant);
@@ -199,7 +199,7 @@ public class ParticipantService {
             
             healthCode = getHealthCodeThrowingException(account);
         } else {
-            account = getAccountThrowingException(study, email);
+            account = getAccountThrowingException(study, id);
             
             healthCode = getHealthCodeThrowingException(account);
             
@@ -259,8 +259,8 @@ public class ParticipantService {
         return (isBlank(id1) || isBlank(id2) || !id1.equals(id2));
     }
 
-    private Account getAccountThrowingException(Study study, String email) {
-        Account account = accountDao.getAccount(study, email);
+    private Account getAccountThrowingException(Study study, String id) {
+        Account account = accountDao.getAccount(study, id);
         if (account == null) {
             throw new EntityNotFoundException(Account.class);
         }

--- a/app/org/sagebionetworks/bridge/services/UserProfileService.java
+++ b/app/org/sagebionetworks/bridge/services/UserProfileService.java
@@ -18,13 +18,13 @@ public class UserProfileService {
         this.accountDao = accountDao;
     }
     
-    public UserProfile getProfile(Study study, String email) {
-        Account account = accountDao.getAccount(study, email);
+    public UserProfile getProfile(Study study, String id) {
+        Account account = accountDao.getAccount(study, id);
         return profileFromAccount(study, account);
     }
     
     public User updateProfile(Study study, User user, UserProfile profile) {
-        Account account = accountDao.getAccount(study, user.getEmail());
+        Account account = accountDao.getAccount(study, user.getId());
         account.setFirstName(profile.getFirstName());
         account.setLastName(profile.getLastName());
         for(String attribute : study.getUserProfileAttributes()) {

--- a/app/org/sagebionetworks/bridge/stormpath/StormpathAccount.java
+++ b/app/org/sagebionetworks/bridge/stormpath/StormpathAccount.java
@@ -172,7 +172,7 @@ public class StormpathAccount implements Account {
     }
     @Override
     public String getId() {
-        return acct.getHref().split("/accounts/")[1];
+        return BridgeUtils.getIdFromStormpathHref(acct.getHref());
     }
     @Override
     public AccountStatus getStatus() {

--- a/app/org/sagebionetworks/bridge/stormpath/StormpathDirectoryDao.java
+++ b/app/org/sagebionetworks/bridge/stormpath/StormpathDirectoryDao.java
@@ -166,7 +166,7 @@ public class StormpathDirectoryDao implements DirectoryDao {
     private static ApplicationAccountStoreMapping getApplicationMapping(String href, Application app) {
         // This is tedious but I see no way to search for or make a reference to this 
         // mapping without iterating through the application's mappings.
-        for (ApplicationAccountStoreMapping mapping : app.getApplicationAccountStoreMappings(asmCriteria)) {
+        for (ApplicationAccountStoreMapping mapping : app.getAccountStoreMappings(asmCriteria)) {
             if (mapping.getAccountStore().getHref().equals(href)) {
                 return mapping;
             }

--- a/build.sbt
+++ b/build.sbt
@@ -46,8 +46,8 @@ libraryDependencies ++= Seq(
   // Joda-Time
   "joda-time" % "joda-time" % "2.8.2",
   // Stormpath
-  "com.stormpath.sdk" % "stormpath-sdk-api" % "1.0.RC8.1",
-  "com.stormpath.sdk" % "stormpath-sdk-httpclient" % "1.0.RC8.1",
+  "com.stormpath.sdk" % "stormpath-sdk-api" % "1.0.RC9",
+  "com.stormpath.sdk" % "stormpath-sdk-httpclient" % "1.0.RC9",
   "org.apache.httpcomponents" % "httpclient" % "4.5",
   // Redis
   "redis.clients" % "jedis" % "2.7.2",

--- a/conf/routes
+++ b/conf/routes
@@ -16,9 +16,15 @@ POST   /v3/auth/resendEmailVerification @org.sagebionetworks.bridge.play.control
 # Participants Researcher APIs
 GET  /v3/participants                 @org.sagebionetworks.bridge.play.controllers.ParticipantController.getParticipants(offsetBy: String ?= null, pageSize: String ?= null, emailFilter: String ?= null)
 POST /v3/participants                 @org.sagebionetworks.bridge.play.controllers.ParticipantController.createParticipant
-GET  /v3/participants/member          @org.sagebionetworks.bridge.play.controllers.ParticipantController.getParticipant(email: String ?= null)
-POST /v3/participants/member          @org.sagebionetworks.bridge.play.controllers.ParticipantController.updateParticipant(email: String ?= null)
-POST /v3/participants/member/signOut  @org.sagebionetworks.bridge.play.controllers.ParticipantController.signOut(email: String ?= null)
+# DEPRECATED: will remove once SDK, Researcher UI are updated
+GET  /v3/participants/member          @org.sagebionetworks.bridge.play.controllers.ParticipantController.getParticipant2(email: String ?= null)
+POST /v3/participants/member          @org.sagebionetworks.bridge.play.controllers.ParticipantController.updateParticipant2(email: String ?= null)
+POST /v3/participants/member/signOut  @org.sagebionetworks.bridge.play.controllers.ParticipantController.signOut2(email: String ?= null)
+# New routes, must come second for now, as member looks like the :userId of the routes below
+GET  /v3/participants/:userId         @org.sagebionetworks.bridge.play.controllers.ParticipantController.getParticipant(userId: String)
+POST /v3/participants/:userId         @org.sagebionetworks.bridge.play.controllers.ParticipantController.updateParticipant(userId: String)
+POST /v3/participants/:userId/signOut @org.sagebionetworks.bridge.play.controllers.ParticipantController.signOut(userId: String)
+
 
 # Study Subpopulations
 GET    /v3/subpopulations        @org.sagebionetworks.bridge.play.controllers.SubpopulationController.getAllSubpopulations
@@ -53,7 +59,8 @@ POST   /v3/consents/:timestamp/publish   @org.sagebionetworks.bridge.play.contro
 
 # Users
 POST   /v3/users                        @org.sagebionetworks.bridge.play.controllers.UserManagementController.createUser
-DELETE /v3/users                        @org.sagebionetworks.bridge.play.controllers.UserManagementController.deleteUser(email: java.lang.String ?= null)
+DELETE /v3/users                        @org.sagebionetworks.bridge.play.controllers.UserManagementController.deleteUser2(email: String ?= null)
+DELETE /v3/users/:userId                @org.sagebionetworks.bridge.play.controllers.UserManagementController.deleteUser(userId: String)
 GET    /v3/users/self                   @org.sagebionetworks.bridge.play.controllers.UserProfileController.getUserProfile
 POST   /v3/users/self                   @org.sagebionetworks.bridge.play.controllers.UserProfileController.updateUserProfile
 POST   /v3/users/self/externalId        @org.sagebionetworks.bridge.play.controllers.UserProfileController.createExternalIdentifier

--- a/test/org/sagebionetworks/bridge/BridgeUtilsTest.java
+++ b/test/org/sagebionetworks/bridge/BridgeUtilsTest.java
@@ -101,6 +101,23 @@ public class BridgeUtilsTest {
         assertEquals(Sets.newHashSet("A"), BridgeUtils.nullSafeImmutableSet(Sets.newHashSet(null, "A")));
     }
     
+    @Test
+    public void getIdFromStormpathHref() {
+        String href = "https://enterprise.stormpath.io/v1/accounts/6278jk74xoPOXkruh9vJnh";
+        String id = BridgeUtils.getIdFromStormpathHref(href);
+        assertEquals("6278jk74xoPOXkruh9vJnh", id);
+    }
+    
+    @Test
+    public void getIdFromStormpathHrefNullSafe() {
+        assertNull(BridgeUtils.getIdFromStormpathHref(null));
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void unexpectedIdFormatThrowsUnambiguousException() {
+        BridgeUtils.getIdFromStormpathHref("https://enterprise.stormpath.io/v2/accounts/6278jk74xoPOXkruh9vJnh");
+    }
+    
     // assertEquals with two sets doesn't verify the order is the same... hence this test method.
     private <T> void orderedSetsEqual(Set<T> first, Set<T> second) {
         assertEquals(first.size(), second.size());

--- a/test/org/sagebionetworks/bridge/TestUserAdminHelper.java
+++ b/test/org/sagebionetworks/bridge/TestUserAdminHelper.java
@@ -79,6 +79,9 @@ public class TestUserAdminHelper {
         public Study getStudy() {
             return study;
         }
+        public String getId() {
+            return (session == null) ? null : session.getUser().getId();
+        }
         public StudyIdentifier getStudyIdentifier() {
             return study.getStudyIdentifier();
         }
@@ -111,22 +114,18 @@ public class TestUserAdminHelper {
 
     public void deleteUser(TestUser testUser) {
         checkNotNull(testUser);
-
+        
         if (testUser.getSession() != null) {
-            // Delete using session if it exists
             authService.signOut(testUser.getSession());
-            userAdminService.deleteUser(testUser.getStudy(), testUser.getUser().getEmail());
-        } else {
-            // Otherwise delete using the user's email
-            deleteUser(testUser.getStudy(), testUser.getEmail());
         }
+        deleteUser(testUser.getStudy(), testUser.getId());
     }
 
-    public void deleteUser(Study study, String email) {
+    public void deleteUser(Study study, String id) {
         checkNotNull(study);
-        checkNotNull(email);
+        checkNotNull(id);
 
-        userAdminService.deleteUser(study, email);
+        userAdminService.deleteUser(study, id);
     }
     
     public class Builder {

--- a/test/org/sagebionetworks/bridge/models/PagedResourceListTest.java
+++ b/test/org/sagebionetworks/bridge/models/PagedResourceListTest.java
@@ -22,8 +22,8 @@ public class PagedResourceListTest {
     @Test
     public void canSerialize() throws Exception {
         List<AccountSummary> accounts = Lists.newArrayListWithCapacity(2);
-        accounts.add(new AccountSummary("firstName1", "lastName1", "email1@email.com", DateTime.now(), AccountStatus.DISABLED));
-        accounts.add(new AccountSummary("firstName2", "lastName2", "email2@email.com", DateTime.now(), AccountStatus.ENABLED));
+        accounts.add(new AccountSummary("firstName1", "lastName1", "email1@email.com", "id", DateTime.now(), AccountStatus.DISABLED));
+        accounts.add(new AccountSummary("firstName2", "lastName2", "email2@email.com", "id2", DateTime.now(), AccountStatus.ENABLED));
         
         PagedResourceList<AccountSummary> page = new PagedResourceList<AccountSummary>(accounts, 2, 100, 123)
                 .withFilter("emailFilter", "filterString");
@@ -42,6 +42,7 @@ public class PagedResourceListTest {
         assertEquals("firstName1", child1.get("firstName").asText());
         assertEquals("lastName1", child1.get("lastName").asText());
         assertEquals("email1@email.com", child1.get("email").asText());
+        assertEquals("id", child1.get("id").asText());
         assertEquals("disabled", child1.get("status").asText());
         
         PagedResourceList<AccountSummary> serPage = BridgeObjectMapper.get().readValue(node.toString(), 

--- a/test/org/sagebionetworks/bridge/models/accounts/AccountSummaryTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/AccountSummaryTest.java
@@ -24,12 +24,13 @@ public class AccountSummaryTest {
         // Set the time zone so it's not UTC, it should be converted to UTC so the strings are 
         // equal below (to demonstrate the ISO 8601 string is in UTC time zone).
         DateTime dateTime = DateTime.now().withZone(DateTimeZone.forOffsetHours(-8));
-        AccountSummary summary = new AccountSummary("firstName", "lastName", "email@email.com", dateTime, AccountStatus.UNVERIFIED);
+        AccountSummary summary = new AccountSummary("firstName", "lastName", "email@email.com", "ABC", dateTime, AccountStatus.UNVERIFIED);
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(summary);
         assertEquals("firstName", node.get("firstName").asText());
         assertEquals("lastName", node.get("lastName").asText());
         assertEquals("email@email.com", node.get("email").asText());
+        assertEquals("ABC", node.get("id").asText());
         assertEquals(dateTime.withZone(DateTimeZone.UTC).toString(), node.get("createdOn").asText());
         assertEquals("unverified", node.get("status").asText());
         assertEquals("AccountSummary", node.get("type").asText());

--- a/test/org/sagebionetworks/bridge/models/accounts/StudyParticipantTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/StudyParticipantTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Sets;
 
 public class StudyParticipantTest {
 
+    private static final String STORMPATH_ID = "6278uk74xoQkXkrbh9vJnh";
     private static final DateTime CREATED_ON = DateTime.now();
     private static final DateTime CREATED_ON_UTC = CREATED_ON.withZone(DateTimeZone.UTC);
     private static final Set<Roles> ROLES = Sets.newHashSet(Roles.ADMIN, Roles.WORKER);
@@ -51,6 +52,7 @@ public class StudyParticipantTest {
                 .withRoles(ROLES)
                 .withLanguages(LANGS)
                 .withCreatedOn(CREATED_ON)
+                .withId(STORMPATH_ID)
                 .withStatus(AccountStatus.ENABLED);
         
         List<UserConsentHistory> histories = Lists.newArrayList();
@@ -78,6 +80,7 @@ public class StudyParticipantTest {
         assertEquals("healthCode", node.get("healthCode").asText());
         assertEquals("enabled", node.get("status").asText());
         assertEquals(CREATED_ON_UTC.toString(), node.get("createdOn").asText());
+        assertEquals(STORMPATH_ID, node.get("id").asText());
         assertEquals("StudyParticipant", node.get("type").asText());
 
         Set<String> roleNames = Sets.newHashSet(
@@ -97,7 +100,7 @@ public class StudyParticipantTest {
 
         assertEquals("B", node.get("attributes").get("A").asText());
         assertEquals("D", node.get("attributes").get("C").asText());
-        assertEquals(16, node.size());
+        assertEquals(17, node.size());
         
         StudyParticipant deserParticipant = BridgeObjectMapper.get().readValue(node.toString(), StudyParticipant.class);
         assertEquals("firstName", deserParticipant.getFirstName());
@@ -112,6 +115,7 @@ public class StudyParticipantTest {
         assertEquals(ATTRIBUTES, deserParticipant.getAttributes());
         assertEquals(CREATED_ON_UTC, deserParticipant.getCreatedOn());
         assertEquals(AccountStatus.ENABLED, deserParticipant.getStatus());
+        assertEquals(STORMPATH_ID, deserParticipant.getId());
         
         UserConsentHistory deserHistory = deserParticipant.getConsentHistories().get("AAA").get(0);
         assertEquals("2002-02-02", deserHistory.getBirthdate());

--- a/test/org/sagebionetworks/bridge/models/accounts/UserSessionInfoTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/UserSessionInfoTest.java
@@ -59,6 +59,7 @@ public class UserSessionInfoTest {
         assertEquals("researcher", node.get("roles").get(0).asText());
         assertEquals("foo", node.get("dataGroups").get(0).asText());
         assertEquals("staging", node.get("environment").asText());
+        assertEquals(user.getId(), node.get("id").asText());
         assertEquals("UserSessionInfo", node.get("type").asText());
         JsonNode consentMap = node.get("consentStatuses");
         
@@ -72,7 +73,7 @@ public class UserSessionInfoTest {
         assertEquals(6, consentStatus.size());
         
         // ... and no things that shouldn't be there
-        assertEquals(13, node.size());
+        assertEquals(14, node.size());
     }
     
 }

--- a/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
@@ -54,7 +54,7 @@ public class ParticipantControllerTest {
     
     private static final TypeReference<PagedResourceList<AccountSummary>> ACCOUNT_SUMMARY_PAGE = new TypeReference<PagedResourceList<AccountSummary>>(){};
 
-    private static final AccountSummary SUMMARY = new AccountSummary("firstName","lastName","email",DateTime.now(),AccountStatus.ENABLED);
+    private static final AccountSummary SUMMARY = new AccountSummary("firstName","lastName","email","id",DateTime.now(),AccountStatus.ENABLED);
     
     private static final Study STUDY = new DynamoStudy();
     
@@ -126,12 +126,12 @@ public class ParticipantControllerTest {
     }
     
     @Test
-    public void getParticipant() throws Exception {
+    public void getParticipant2() throws Exception {
         StudyParticipant studyParticipant = new StudyParticipant.Builder().withFirstName("Test").build();
         
         when(participantService.getParticipant(STUDY, "email@email.com")).thenReturn(studyParticipant);
         
-        Result result = controller.getParticipant("email@email.com");
+        Result result = controller.getParticipant2("email@email.com");
         String string = Helpers.contentAsString(result);
         StudyParticipant retrievedParticipant = BridgeObjectMapper.get().readValue(string, StudyParticipant.class);
         // Verify that there's a field, full serialization tested in StudyParticipant2Test
@@ -149,30 +149,30 @@ public class ParticipantControllerTest {
     }
     
     @Test
-    public void signUserOut() throws Exception {
-        controller.signOut("email@email.com");
+    public void signUserOut2() throws Exception {
+        controller.signOut2("email@email.com");
         
         verify(participantService).signUserOut(STUDY, "email@email.com");
     }
 
     @Test(expected = BadRequestException.class)
-    public void getParticipantNoEmail() {
-        controller.getParticipant(null);
+    public void getParticipantNoEmail2() {
+        controller.getParticipant2(null);
     }
     
     @Test(expected = BadRequestException.class)
-    public void signOutNoEmail() throws Exception {
-        controller.signOut(null);
+    public void signOutNoEmail2() throws Exception {
+        controller.signOut2(null);
     }
 
     @Test(expected = BadRequestException.class)
-    public void getParticipantBlank() {
-        controller.getParticipant("");
+    public void getParticipantBlank2() {
+        controller.getParticipant2("");
     }
     
     @Test(expected = BadRequestException.class)
-    public void signOutBlank() throws Exception {
-        controller.signOut("");
+    public void signOutBlank2() throws Exception {
+        controller.signOut2("");
     }
     
     @Test
@@ -205,14 +205,14 @@ public class ParticipantControllerTest {
     }
 
     @Test
-    public void updateParticipant() throws Exception {
+    public void updateParticipant2() throws Exception {
         STUDY.getUserProfileAttributes().add("phone");
         TestUtils.mockPlayContextWithJson(TestUtils.createJson("{'firstName':'firstName','lastName':'lastName',"+
                 "'email':'email@email.com','externalId':'externalId','password':'newUserPassword',"+
                 "'sharingScope':'sponsors_and_partners','notifyByEmail':true,'dataGroups':['group2','group1'],"+
                 "'attributes':{'phone':'123456789'},'languages':['en','fr']}"));
         
-        Result result = controller.updateParticipant("email@email.com");
+        Result result = controller.updateParticipant2("email@email.com");
         JsonNode node = BridgeObjectMapper.get().readTree(Helpers.contentAsString(result));
         
         assertEquals(200, result.status());
@@ -234,27 +234,27 @@ public class ParticipantControllerTest {
     }
     
     @Test(expected = BadRequestException.class)
-    public void updateParticipantMissing() {
-        controller.updateParticipant(null);
+    public void updateParticipantMissing2() {
+        controller.updateParticipant2(null);
     }
     
     @Test(expected = BadRequestException.class)
-    public void updateParticipantBlank() {
-        controller.updateParticipant("");
+    public void updateParticipantBlank2() {
+        controller.updateParticipant2("");
     }
     
     @Test(expected = BadRequestException.class)
-    public void updateParticipantRequiresEmailMatch() throws Exception {
-        TestUtils.mockPlayContextWithJson(TestUtils.createJson("{'email':'email@email.com'}"));
+    public void updateParticipantRequiresIdMatch() throws Exception {
+        TestUtils.mockPlayContextWithJson(TestUtils.createJson("{'id':'id2'}"));
         
-        controller.updateParticipant("email-different@email.com");
+        controller.updateParticipant("id1");
     }
 
     @Test
-    public void updateParticipantNoJsonEmailOK() throws Exception {
+    public void updateParticipantNoJsonEmailOK2() throws Exception {
         TestUtils.mockPlayContextWithJson(TestUtils.createJson("{}"));
         
-        controller.updateParticipant("email-different@email.com");
+        controller.updateParticipant2("email-different@email.com");
         verify(participantService).updateParticipant(eq(STUDY), eq("email-different@email.com"), any());
     }
     

--- a/test/org/sagebionetworks/bridge/play/interceptors/ExceptionInterceptorTest.java
+++ b/test/org/sagebionetworks/bridge/play/interceptors/ExceptionInterceptorTest.java
@@ -94,6 +94,7 @@ public class ExceptionInterceptorTest {
         assertEquals("develop", node.get("environment").asText());
         assertEquals("email@email.com", node.get("username").asText());
         assertEquals("email@email.com", node.get("email").asText());
+        assertEquals("userId", node.get("id").asText());
         assertTrue(node.get("dataSharing").asBoolean());
         assertEquals("UserSessionInfo", node.get("type").asText());
         ArrayNode array = (ArrayNode)node.get("roles");
@@ -103,6 +104,6 @@ public class ExceptionInterceptorTest {
         assertEquals("group1", array.get(0).asText());
         assertEquals(0, node.get("consentStatuses").size());
         // And no further properties
-        assertEquals(13, node.size());
+        assertEquals(14, node.size());
     }
 }    

--- a/test/org/sagebionetworks/bridge/services/ConsentServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/ConsentServiceMockTest.java
@@ -204,7 +204,7 @@ public class ConsentServiceMockTest {
         ArgumentCaptor<MimeTypeEmailProvider> emailCaptor = ArgumentCaptor.forClass(MimeTypeEmailProvider.class);
         
         verify(userConsentDao).withdrawConsent(user.getHealthCode(), SUBPOP_GUID, UNIX_TIMESTAMP);
-        verify(accountDao).getAccount(study, user.getEmail());
+        verify(accountDao).getAccount(study, user.getId());
         verify(accountDao).updateAccount(any(Study.class), captor.capture());
         // It happens twice because we do it the first time to set up the test properly
         //verify(account, times(2)).getConsentSignatures(setterCaptor.capture());
@@ -251,7 +251,7 @@ public class ConsentServiceMockTest {
         List<ConsentSignature> signatures =  acct.getConsentSignatureHistory(SUBPOP_GUID); 
         signatures.add(new ConsentSignature.Builder().withName("Jack Aubrey").withBirthdate("1969-04-05").build());
         
-        when(accountDao.getAccount(study, user.getEmail())).thenReturn(acct);
+        when(accountDao.getAccount(study, user.getId())).thenReturn(acct);
         doThrow(new BridgeServiceException("Something bad happend", 500)).when(userConsentDao)
             .withdrawConsent("BBB", SUBPOP_GUID, UNIX_TIMESTAMP);
         

--- a/test/org/sagebionetworks/bridge/services/ConsentServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ConsentServiceTest.java
@@ -127,7 +127,7 @@ public class ConsentServiceTest {
         assertNotConsented(statuses);
         
         List<UserConsentHistory> histories = consentService.getUserConsentHistory(testUser.getStudy(),
-                defaultSubpopulation.getGuid(), testUser.getUser().getHealthCode(), testUser.getUser().getEmail());
+                defaultSubpopulation.getGuid(), testUser.getUser().getHealthCode(), testUser.getId());
         assertTrue(histories.isEmpty());
         
         try {
@@ -189,7 +189,7 @@ public class ConsentServiceTest {
         // However we have a historical record of the consent, including a revocation date
         // data is exported with the sharing status set at the time it was exported
         List<UserConsentHistory> histories = consentService.getUserConsentHistory(testUser.getStudy(),
-                defaultSubpopulation.getGuid(), testUser.getUser().getHealthCode(), testUser.getUser().getEmail());
+                defaultSubpopulation.getGuid(), testUser.getUser().getHealthCode(), testUser.getId());
         assertEquals(1, histories.size());
         assertNotNull(histories.get(0).getWithdrewOn());
     }
@@ -294,7 +294,7 @@ public class ConsentServiceTest {
             assertEquals("ConsentSignature not found.", e.getMessage());
         }
         
-        Account account = accountDao.getAccount(testUser.getStudy(), testUser.getEmail());
+        Account account = accountDao.getAccount(testUser.getStudy(), testUser.getId());
         assertEquals(1, account.getConsentSignatureHistory(defaultSubpopulation.getGuid()).size());
         ConsentSignature historicalSignature = account.getConsentSignatureHistory(defaultSubpopulation.getGuid()).get(0);
         
@@ -311,7 +311,7 @@ public class ConsentServiceTest {
         
         // Finally, verify there is a history for this user.
         List<UserConsentHistory> history = consentService.getUserConsentHistory(testUser.getStudy(),
-                defaultSubpopulation.getGuid(), testUser.getUser().getHealthCode(), testUser.getUser().getEmail());
+                defaultSubpopulation.getGuid(), testUser.getUser().getHealthCode(), testUser.getId());
         assertEquals(2, history.size());
         
         UserConsentHistory withdrawnConsent = history.get(0);

--- a/test/org/sagebionetworks/bridge/services/UserAdminServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/UserAdminServiceTest.java
@@ -92,7 +92,7 @@ public class UserAdminServiceTest {
     @After
     public void after() {
         if (testUser != null) {
-            userAdminService.deleteUser(study, testUser.getEmail());
+            userAdminService.deleteUser(study, testUser.getId());
         }
     }
 
@@ -100,7 +100,7 @@ public class UserAdminServiceTest {
     public void deletedUserHasBeenDeleted() {
         testUser = userAdminService.createUser(signUp, study, null, true, true).getUser();
 
-        userAdminService.deleteUser(study, testUser.getEmail());
+        userAdminService.deleteUser(study, testUser.getId());
 
         // This should fail with a 404.
         authService.signIn(study, TEST_CONTEXT, new SignIn(signUp.getEmail(), signUp.getPassword()));
@@ -109,7 +109,7 @@ public class UserAdminServiceTest {
     @Test
     public void canCreateUserWithoutConsentingOrSigningUserIn() {
         UserSession session1 = userAdminService.createUser(signUp, study, null, false, false);
-        assertNull("No session", session1);
+        assertFalse(session1.isAuthenticated());
 
         UserSession session = authService.signIn(study, TEST_CONTEXT, new SignIn(signUp.getEmail(),
                 signUp.getPassword()));
@@ -140,17 +140,17 @@ public class UserAdminServiceTest {
         authService.signOut(session);
         assertNull(authService.getSession(session.getSessionToken()));
         // Shouldn't crash
-        userAdminService.deleteUser(study, session.getUser().getEmail());
+        userAdminService.deleteUser(study, session.getUser().getId());
         assertNull(authService.getSession(session.getSessionToken()));
     }
 
     @Test
     public void testDeleteUserThatHasBeenDeleted() {
         UserSession session = userAdminService.createUser(signUp, study, null, true, true);
-        userAdminService.deleteUser(study, session.getUser().getEmail());
+        userAdminService.deleteUser(study, session.getUser().getId());
         assertNull(authService.getSession(session.getSessionToken()));
         // Delete again shouldn't crash
-        userAdminService.deleteUser(study, session.getUser().getEmail());
+        userAdminService.deleteUser(study, session.getUser().getId());
         assertNull(authService.getSession(session.getSessionToken()));
     }
     
@@ -167,7 +167,7 @@ public class UserAdminServiceTest {
             assertEquals(session.getUser().getHealthCode(), identifier.getHealthCode());
             
             // Now delete the user, and the assignment should then be free;
-            userAdminService.deleteUser(study, session.getUser().getEmail());
+            userAdminService.deleteUser(study, session.getUser().getId());
             
             identifier = getDynamoExternalIdentifier(session);
             assertNull(identifier.getHealthCode());

--- a/test/org/sagebionetworks/bridge/services/UserProfileServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/UserProfileServiceTest.java
@@ -39,7 +39,7 @@ public class UserProfileServiceTest {
     
     @Test
     public void canUpdateUserProfile() {
-        UserProfile profile = profileService.getProfile(testUser.getStudy(), testUser.getEmail());
+        UserProfile profile = profileService.getProfile(testUser.getStudy(), testUser.getId());
         profile.setFirstName("Test");
         profile.setLastName("Powers");
         profile.setAttribute("phone", "123-456-7890");
@@ -51,7 +51,7 @@ public class UserProfileServiceTest {
         profile.setAttribute("email", "NotEmail");
 
         profileService.updateProfile(testUser.getStudy(), testUser.getUser(), profile);
-        profile = profileService.getProfile(testUser.getStudy(), testUser.getEmail());
+        profile = profileService.getProfile(testUser.getStudy(), testUser.getId());
         
         assertEquals("First name is persisted", "Test", profile.getFirstName());
         assertEquals("Last name is persisted", "Powers", profile.getLastName());
@@ -63,12 +63,12 @@ public class UserProfileServiceTest {
 
     @Test
     public void cannotBreakProfileWithBadNameValues() {
-        UserProfile profile = profileService.getProfile(testUser.getStudy(), testUser.getEmail());
+        UserProfile profile = profileService.getProfile(testUser.getStudy(), testUser.getId());
         profile.setFirstName("");
         profile.setLastName(null);
         profileService.updateProfile(testUser.getStudy(), testUser.getUser(), profile);
 
-        profile = profileService.getProfile(testUser.getStudy(), testUser.getEmail());
+        profile = profileService.getProfile(testUser.getStudy(), testUser.getId());
         assertNull(profile.getFirstName());
         assertNull(profile.getLastName());
     }

--- a/test/org/sagebionetworks/bridge/stormpath/StormpathAccountTest.java
+++ b/test/org/sagebionetworks/bridge/stormpath/StormpathAccountTest.java
@@ -21,6 +21,7 @@ import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.crypto.BridgeEncryptor;
 import org.sagebionetworks.bridge.crypto.Encryptor;
@@ -416,7 +417,7 @@ public class StormpathAccountTest {
         when(acct.getSurname()).thenReturn("lastName");
         when(acct.getGroups()).thenReturn(groupList);
         when(acct.getCreatedAt()).thenReturn(javaDate);
-        when(acct.getHref()).thenReturn("http://something/accounts/123");
+        when(acct.getHref()).thenReturn(BridgeConstants.STORMPATH_ACCOUNT_BASE_HREF+"123");
 
         // Signatures and encrypted values (including attributes) are tested in more depth in other tests
         // These are basic values from the Stormpath account


### PR DESCRIPTION
Switching to the user of the Stormpath ID rather than an email address to retrieve users other than the currently signed in user. This will keep email addresses out of Heroku's access logs. This change is really only one method in StormpathAccountDao... and changes to many places where it is ultimately being called from. Existing use of email address outside of the server will continue to work until we can migrate the Researcher UI and Java SDK to the new ID.

Testing done:
- a few new tests for new code, mostly trivial
- verified that integration tests run against BridgePF after changes
- verified that all BridgePF tests run with lookup by email disabled, so all of them are now using an ID.

TODO: tests of new controller methods (though these are trivial new methods).
