### PR TITLE
Switching getParticipant() to use ID

### DIFF
--- a/app/org/sagebionetworks/bridge/cache/ViewCache.java
+++ b/app/org/sagebionetworks/bridge/cache/ViewCache.java
@@ -18,6 +18,8 @@ public class ViewCache {
     
     private static final Logger logger = LoggerFactory.getLogger(ViewCache.class);
     
+    private static final Joiner COLON_JOINER = Joiner.on(":");
+    
     public final class ViewCacheKey<T> {
         private final String key;
         public ViewCacheKey(String key) {
@@ -73,7 +75,7 @@ public class ViewCache {
      * @return
      */
     public <T> ViewCacheKey<T> getCacheKey(Class<T> clazz, String... identifiers) {
-        String id = Joiner.on(":").join(identifiers);
+        String id = COLON_JOINER.join(identifiers);
         return new ViewCacheKey<T>(RedisKey.VIEW.getRedisKey(id + ":" + clazz.getName()));
     }
     

--- a/app/org/sagebionetworks/bridge/play/controllers/FPHSController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/FPHSController.java
@@ -88,6 +88,6 @@ public class FPHSController extends BaseController {
         List<FPHSExternalIdentifier> externalIds = MAPPER.convertValue(requestToJSON(request()), EXTERNAL_ID_TYPE_REF);
         fphsService.addExternalIdentifiers(externalIds);
         
-        return okResult("External identifiers added.");
+        return createdResult("External identifiers added.");
     }
 }

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -97,19 +97,19 @@ public class ParticipantService {
         this.cacheProvider = cacheProvider;
     }
     
-    public StudyParticipant getParticipant(Study study, String email) {
+    public StudyParticipant getParticipant(Study study, String id) {
         checkNotNull(study);
-        checkArgument(isNotBlank(email));
+        checkArgument(isNotBlank(id));
         
         StudyParticipant.Builder participant = new StudyParticipant.Builder();
-        Account account = getAccountThrowingException(study, email);
+        Account account = getAccountThrowingException(study, id);
         String healthCode = getHealthCode(account);
 
         List<Subpopulation> subpopulations = subpopService.getSubpopulations(study.getStudyIdentifier());
         for (Subpopulation subpop : subpopulations) {
             if (healthCode != null) {
                 // always returns a list, even if empty
-                List<UserConsentHistory> history = consentService.getUserConsentHistory(study, subpop.getGuid(), healthCode, email);
+                List<UserConsentHistory> history = consentService.getUserConsentHistory(study, subpop.getGuid(), healthCode, id);
                 participant.addConsentHistory(subpop.getGuid(), history);
             } else {
                 // Create an empty history if there's no health Code.
@@ -133,6 +133,7 @@ public class ParticipantService {
         participant.withStatus(account.getStatus());
         participant.withCreatedOn(account.getCreatedOn());
         participant.withRoles(account.getRoles());
+        participant.withId(account.getId());
         
         Map<String,String> attributes = Maps.newHashMap();
         for (String attribute : study.getUserProfileAttributes()) {

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge;
 
 import static org.apache.http.HttpHeaders.CONTENT_TYPE;
 import static org.apache.http.HttpHeaders.USER_AGENT;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
@@ -28,6 +29,7 @@ import org.sagebionetworks.bridge.dynamodb.DynamoCriteria;
 import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.models.Criteria;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
@@ -52,6 +54,8 @@ import org.sagebionetworks.bridge.runnable.FailableRunnable;
 import play.Application;
 import play.inject.guice.GuiceApplicationBuilder;
 import play.mvc.Http;
+import play.mvc.Result;
+import play.test.Helpers;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -69,6 +73,13 @@ public class TestUtils {
         Map<String,List<String>> errors = e.getErrors();
         List<String> messages = errors.get(propName);
         assertTrue(messages.get(0).contains(propName + error));
+    }
+    
+    public static void assertResult(Result result, int statusCode, String message) throws Exception {
+        JsonNode node = BridgeObjectMapper.get().readTree(Helpers.contentAsString(result));
+        String resultMessage = node.get("message").asText();
+        assertEquals(statusCode, result.status());
+        assertEquals(message, resultMessage);
     }
 
     /**

--- a/test/org/sagebionetworks/bridge/play/controllers/ConsentControllerMockedTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ConsentControllerMockedTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.dao.ParticipantOption.SHARING_SCOPE;
+import static org.sagebionetworks.bridge.TestUtils.assertResult;
 
 import org.joda.time.DateTimeUtils;
 import org.junit.After;
@@ -129,10 +130,7 @@ public class ConsentControllerMockedTest {
         ArgumentCaptor<ConsentSignature> captor = setUpContextWithJson(json);
         
         Result result = controller.giveV2();
-        
-        String response = Helpers.contentAsString(result);
-        JsonNode node = BridgeObjectMapper.get().readTree(response);
-        assertEquals("Consent to research has been recorded.", node.get("message").asText());
+        assertResult(result, 201, "Consent to research has been recorded.");
 
         validateSignature(captor.getValue());
     }
@@ -146,10 +144,7 @@ public class ConsentControllerMockedTest {
         ArgumentCaptor<ConsentSignature> captor = setUpContextWithJson(json);
         
         Result result = controller.giveV2();
-        
-        String response = Helpers.contentAsString(result);
-        JsonNode node = BridgeObjectMapper.get().readTree(response);
-        assertEquals("Consent to research has been recorded.", node.get("message").asText());
+        assertResult(result, 201, "Consent to research has been recorded.");
         
         validateSignature(captor.getValue());
     }
@@ -162,9 +157,7 @@ public class ConsentControllerMockedTest {
         TestUtils.mockPlayContextWithJson(json);
         
         Result result = controller.withdrawConsent();
-        String response = Helpers.contentAsString(result);
-        JsonNode node = BridgeObjectMapper.get().readTree(response);
-        assertEquals("User has been withdrawn from the study.", node.get("message").asText());
+        assertResult(result, 200, "User has been withdrawn from the study.");
         
         // Should call the service and withdraw
         verify(consentService).withdrawConsent(study, SubpopulationGuid.create(study.getIdentifier()), user,
@@ -182,9 +175,7 @@ public class ConsentControllerMockedTest {
         TestUtils.mockPlayContextWithJson(json);
         
         Result result = controller.withdrawConsent();
-        String response = Helpers.contentAsString(result);
-        JsonNode node = BridgeObjectMapper.get().readTree(response);
-        assertEquals("User has been withdrawn from the study.", node.get("message").asText());
+        assertResult(result, 200, "User has been withdrawn from the study.");
         
         verify(consentService).withdrawConsent(study, SubpopulationGuid.create(study.getIdentifier()), user,
                 new Withdrawal(null), 20000);
@@ -220,10 +211,7 @@ public class ConsentControllerMockedTest {
         ArgumentCaptor<ConsentSignature> captor = setUpContextWithJson(json);
         
         Result result = controller.giveV3(SUBPOP_GUID.getGuid());
-        
-        String response = Helpers.contentAsString(result);
-        JsonNode node = BridgeObjectMapper.get().readTree(response);
-        assertEquals("Consent to research has been recorded.", node.get("message").asText());
+        assertResult(result, 201, "Consent to research has been recorded.");
         
         validateSignature(captor.getValue());
     }
@@ -236,11 +224,8 @@ public class ConsentControllerMockedTest {
         ArgumentCaptor<ConsentSignature> captor = setUpContextWithJson(json);
         
         Result result = controller.giveV3(SUBPOP_GUID.getGuid());
+        assertResult(result, 201, "Consent to research has been recorded.");
         
-        String response = Helpers.contentAsString(result);
-        JsonNode node = BridgeObjectMapper.get().readTree(response);
-        assertEquals("Consent to research has been recorded.", node.get("message").asText());
-
         validateSignature(captor.getValue());
     }
     
@@ -251,9 +236,7 @@ public class ConsentControllerMockedTest {
         TestUtils.mockPlayContextWithJson(json);
         
         Result result = controller.withdrawConsentV2(SUBPOP_GUID.getGuid());
-        String response = Helpers.contentAsString(result);
-        JsonNode node = BridgeObjectMapper.get().readTree(response);
-        assertEquals("User has been withdrawn from the study.", node.get("message").asText());
+        assertResult(result, 200, "User has been withdrawn from the study.");
         
         // Should call the service and withdraw
         verify(consentService).withdrawConsent(study, SUBPOP_GUID, user, new Withdrawal("Because, reasons."), 20000);
@@ -269,9 +252,7 @@ public class ConsentControllerMockedTest {
         TestUtils.mockPlayContextWithJson(json);
         
         Result result = controller.withdrawConsentV2(SUBPOP_GUID.getGuid());
-        String response = Helpers.contentAsString(result);
-        JsonNode node = BridgeObjectMapper.get().readTree(response);
-        assertEquals("User has been withdrawn from the study.", node.get("message").asText());
+        assertResult(result, 200, "User has been withdrawn from the study.");
         
         verify(consentService).withdrawConsent(study, SUBPOP_GUID, user, new Withdrawal(null), 20000);
     }
@@ -279,9 +260,8 @@ public class ConsentControllerMockedTest {
     @Test
     public void emailCopyV2() throws Exception {
         Result result = controller.emailCopyV2(SUBPOP_GUID.getGuid());
-        String response = Helpers.contentAsString(result);
-        JsonNode node = BridgeObjectMapper.get().readTree(response);
-        assertEquals("Emailed consent.", node.get("message").asText());
+        
+        assertResult(result, 200, "Emailed consent.");
         
         verify(consentService).emailConsentAgreement(study, SUBPOP_GUID, user);
     }
@@ -294,10 +274,8 @@ public class ConsentControllerMockedTest {
         ArgumentCaptor<ConsentSignature> captor = setUpContextWithJson(json);
         
         Result result = controller.giveV3("test-subpop");
-        String response = Helpers.contentAsString(result);
-        JsonNode node = BridgeObjectMapper.get().readTree(response);
-        assertEquals("Consent to research has been recorded.", node.get("message").asText());
-
+        assertResult(result, 201, "Consent to research has been recorded.");
+        
         verify(consentService).consentToResearch(eq(study), eq(SubpopulationGuid.create("test-subpop")), eq(user),
                 captor.capture(), eq(SharingScope.NO_SHARING), eq(true));
         
@@ -311,9 +289,7 @@ public class ConsentControllerMockedTest {
         TestUtils.mockPlayContextWithJson(json);
         
         Result result = controller.withdrawConsentV2("test-subpop");
-        String response = Helpers.contentAsString(result);
-        JsonNode node = BridgeObjectMapper.get().readTree(response);
-        assertEquals("User has been withdrawn from the study.", node.get("message").asText());
+        assertResult(result, 200, "User has been withdrawn from the study.");
         
         // Should call the service and withdraw
         verify(consentService).withdrawConsent(study, SubpopulationGuid.create("test-subpop"), user,
@@ -330,9 +306,7 @@ public class ConsentControllerMockedTest {
         TestUtils.mockPlayContextWithJson(json);
         
         Result result = controller.withdrawConsentV2("test-subpop");
-        String response = Helpers.contentAsString(result);
-        JsonNode node = BridgeObjectMapper.get().readTree(response);
-        assertEquals("User has been withdrawn from the study.", node.get("message").asText());
+        assertResult(result, 200, "User has been withdrawn from the study.");
         
         verify(consentService).withdrawConsent(study, SubpopulationGuid.create("test-subpop"), user,
                 new Withdrawal(null), 20000);

--- a/test/org/sagebionetworks/bridge/play/controllers/ExternalIdControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ExternalIdControllerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.sagebionetworks.bridge.TestUtils.assertResult;
 
 import java.util.List;
 import java.util.Map;
@@ -35,7 +36,6 @@ import org.sagebionetworks.bridge.services.ExternalIdService;
 import org.sagebionetworks.bridge.services.StudyService;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
@@ -115,11 +115,7 @@ public class ExternalIdControllerTest {
         TestUtils.mockPlayContextWithJson(MAPPER.writeValueAsString(identifiers));
         
         Result result = controller.addExternalIds();
-        JsonNode node = MAPPER.readTree(Helpers.contentAsString(result));
-        String message = node.get("message").asText();
-        
-        assertEquals("External identifiers added.", message);
-        assertEquals(201, result.status());
+        assertResult(result, 201, "External identifiers added.");
         
         verify(externalIdService).addExternalIds(study, identifiers);
     }
@@ -129,11 +125,7 @@ public class ExternalIdControllerTest {
         TestUtils.mockPlayContextWithJson("[]");
         
         Result result = controller.addExternalIds();
-        JsonNode node = MAPPER.readTree(Helpers.contentAsString(result));
-        String message = node.get("message").asText();
-        
-        assertEquals("External identifiers added.", message);
-        assertEquals(201, result.status());
+        assertResult(result, 201, "External identifiers added.");
         
         verify(externalIdService).addExternalIds(study, Lists.newArrayList());
     }
@@ -146,11 +138,7 @@ public class ExternalIdControllerTest {
         mockRequestWithQueryString(map);
         
         Result result = controller.deleteExternalIds();
-        JsonNode node = MAPPER.readTree(Helpers.contentAsString(result));
-        String message = node.get("message").asText();
-        
-        assertEquals("External identifiers deleted.", message);
-        assertEquals(200, result.status());
+        assertResult(result, 200, "External identifiers deleted.");
         
         verify(externalIdService).deleteExternalIds(eq(study), externalIdCaptor.capture());
         

--- a/test/org/sagebionetworks/bridge/play/controllers/FPHSControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/FPHSControllerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
+import static org.sagebionetworks.bridge.TestUtils.assertResult;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
@@ -155,8 +156,7 @@ public class FPHSControllerTest {
         setExternalIdentifierPost(ExternalIdentifier.create(TestConstants.TEST_STUDY, "foo"));
 
         Result result = controller.registerExternalIdentifier();
-        JsonNode node = resultToJson(result);
-        assertEquals("External identifier added to user profile.", node.get("message").asText());
+        assertResult(result, 200, "External identifier added to user profile.");
 
         assertEquals(Sets.newHashSet("football_player"), user.getDataGroups());
         verify(consentService).getConsentStatuses(any(CriteriaContext.class));
@@ -221,7 +221,6 @@ public class FPHSControllerTest {
         List<FPHSExternalIdentifier> passedList = (List<FPHSExternalIdentifier>)captor.getValue();
         assertEquals(2, passedList.size());
         
-        JsonNode node = resultToJson(result);
-        assertEquals("External identifiers added.", node.get("message").asText());
+        assertResult(result, 201, "External identifiers added.");
     }
 }

--- a/test/org/sagebionetworks/bridge/play/controllers/StudyConsentControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/StudyConsentControllerTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.play.controllers;
 
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
+import static org.sagebionetworks.bridge.TestUtils.assertResult;
 import static org.sagebionetworks.bridge.TestUtils.mockPlayContext;
 import static org.sagebionetworks.bridge.TestUtils.mockPlayContextWithJson;
 
@@ -147,9 +148,9 @@ public class StudyConsentControllerTest {
         
         Result result = controller.publishConsentV2(GUID, DATETIME_STRING);
         
+        assertResult(result, 200, "Consent document set as active.");
+
         verify(studyConsentService).publishConsent(STUDY, SUBPOP_GUID, DateTime.parse(DATETIME_STRING).getMillis());
-        JsonNode node = BridgeObjectMapper.get().readTree(Helpers.contentAsString(result));
-        assertEquals("Consent document set as active.", node.get("message").asText());
     }
     
 }

--- a/test/org/sagebionetworks/bridge/play/controllers/SubpopulationControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SubpopulationControllerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.sagebionetworks.bridge.TestUtils.assertResult;
 
 import java.util.List;
 
@@ -190,11 +191,8 @@ public class SubpopulationControllerTest {
         TestUtils.mockPlayContext();
 
         Result result = controller.deleteSubpopulation(SUBPOP_GUID.getGuid(), null);
-        assertEquals(200, result.status());
-        String json = Helpers.contentAsString(result);
-        JsonNode node = BridgeObjectMapper.get().readTree(json);
-        assertEquals("Subpopulation has been deleted.", node.get("message").asText());
         
+        assertResult(result, 200, "Subpopulation has been deleted.");
         verify(subpopService).deleteSubpopulation(STUDY_IDENTIFIER, SUBPOP_GUID, false);
     }
     
@@ -208,21 +206,13 @@ public class SubpopulationControllerTest {
         user.setRoles(Sets.newHashSet(Roles.ADMIN));
         
         Result result = controller.deleteSubpopulation(SUBPOP_GUID.getGuid(), "true");
-        assertEquals(200, result.status());
-        String json = Helpers.contentAsString(result);
-        JsonNode node = BridgeObjectMapper.get().readTree(json);
         
         // Message indicates a physical (permanent) delete, true is submitted
-        assertEquals("Subpopulation has been permanently deleted.", node.get("message").asText());
+        assertResult(result, 200, "Subpopulation has been permanently deleted.");
         
         user.setRoles(Sets.newHashSet(Roles.DEVELOPER, Roles.ADMIN));
         result = controller.deleteSubpopulation(SUBPOP_GUID.getGuid(), "true");
-        assertEquals(200, result.status());
-        json = Helpers.contentAsString(result);
-        node = BridgeObjectMapper.get().readTree(json);
-        
-        // Message indicates a physical (permanent) delete, true is submitted
-        assertEquals("Subpopulation has been permanently deleted.", node.get("message").asText());
+        assertResult(result, 200, "Subpopulation has been permanently deleted.");
         
         verify(subpopService, times(2)).deleteSubpopulation(STUDY_IDENTIFIER, SUBPOP_GUID, true);
     }

--- a/test/org/sagebionetworks/bridge/play/controllers/UserProfileControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/UserProfileControllerTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
+import static org.sagebionetworks.bridge.TestUtils.assertResult;
 import static org.sagebionetworks.bridge.dao.ParticipantOption.DATA_GROUPS;
 
 import org.junit.Before;
@@ -142,8 +143,7 @@ public class UserProfileControllerTest {
         
         assertEquals(dataGroupSet, session.getUser().getDataGroups());
         
-        JsonNode node = BridgeObjectMapper.get().readTree(Helpers.contentAsString(result));
-        assertEquals("Data groups updated.", node.get("message").asText());
+        assertResult(result, 200, "Data groups updated.");
     }
     
     @SuppressWarnings({"unchecked"})
@@ -191,7 +191,6 @@ public class UserProfileControllerTest {
         Set<String> dataGroups = (Set<String>)captor.getValue();
         assertEquals(Sets.newHashSet(), dataGroups);
         
-        JsonNode node = BridgeObjectMapper.get().readTree(Helpers.contentAsString(result));
-        assertEquals("Data groups updated.", node.get("message").asText());
+        assertResult(result, 200, "Data groups updated.");
     }
 }

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -68,11 +68,13 @@ public class ParticipantServiceTest {
     private static final Set<String> STUDY_DATA_GROUPS = BridgeUtils.commaListToOrderedSet("group1,group2");
     private static final LinkedHashSet<String> USER_LANGUAGES = (LinkedHashSet<String>)BridgeUtils.commaListToOrderedSet("de,fr");
     private static final String EMAIL = "email@email.com";
+    private static final String ID = "ASDF";
     private static final Map<String,String> ATTRS = new ImmutableMap.Builder<String,String>().put("phone","123456789").build();
     private static final StudyParticipant PARTICIPANT = new StudyParticipant.Builder()
             .withFirstName("firstName")
             .withLastName("lastName")
             .withEmail(EMAIL)
+            .withId(ID)
             .withPassword("P@ssword1")
             .withSharingScope(SharingScope.ALL_QUALIFIED_RESEARCHERS)
             .withNotifyByEmail(true)
@@ -293,9 +295,9 @@ public class ParticipantServiceTest {
     
     @Test(expected = EntityNotFoundException.class)
     public void getParticipantEmailDoesNotExist() {
-        when(accountDao.getAccount(STUDY, EMAIL)).thenReturn(null);
+        when(accountDao.getAccount(STUDY, ID)).thenReturn(null);
         
-        participantService.getParticipant(STUDY, EMAIL);
+        participantService.getParticipant(STUDY, ID);
     }
     
     @Test
@@ -306,6 +308,7 @@ public class ParticipantServiceTest {
         when(account.getFirstName()).thenReturn("firstName");
         when(account.getLastName()).thenReturn("lastName");
         when(account.getEmail()).thenReturn(EMAIL);
+        when(account.getId()).thenReturn(ID);
         when(account.getStatus()).thenReturn(AccountStatus.DISABLED);
         when(account.getCreatedOn()).thenReturn(createdOn);
         when(account.getAttribute("attr2")).thenReturn("anAttribute2");
@@ -338,8 +341,8 @@ public class ParticipantServiceTest {
         
         List<UserConsentHistory> histories2 = Lists.newArrayList();
         
-        when(consentService.getUserConsentHistory(STUDY, subpop1.getGuid(), "healthCode", EMAIL)).thenReturn(histories1);
-        when(consentService.getUserConsentHistory(STUDY, subpop2.getGuid(), "healthCode", EMAIL)).thenReturn(histories2);
+        when(consentService.getUserConsentHistory(STUDY, subpop1.getGuid(), "healthCode", ID)).thenReturn(histories1);
+        when(consentService.getUserConsentHistory(STUDY, subpop2.getGuid(), "healthCode", ID)).thenReturn(histories2);
         
         when(lookup.getEnum(SHARING_SCOPE, SharingScope.class)).thenReturn(SharingScope.ALL_QUALIFIED_RESEARCHERS);
         when(lookup.getBoolean(EMAIL_NOTIFICATIONS)).thenReturn(true);
@@ -349,7 +352,7 @@ public class ParticipantServiceTest {
         when(optionsService.getOptions("healthCode")).thenReturn(lookup);
         
         // Get the participant
-        StudyParticipant participant = participantService.getParticipant(STUDY, EMAIL);
+        StudyParticipant participant = participantService.getParticipant(STUDY, ID);
         
         assertEquals("firstName", participant.getFirstName());
         assertEquals("lastName", participant.getLastName());
@@ -359,6 +362,7 @@ public class ParticipantServiceTest {
         assertEquals(SharingScope.ALL_QUALIFIED_RESEARCHERS, participant.getSharingScope());
         assertEquals("healthCode", participant.getHealthCode());
         assertEquals(EMAIL, participant.getEmail());
+        assertEquals(ID, participant.getId());
         assertEquals(AccountStatus.DISABLED, participant.getStatus());
         assertEquals(createdOn, participant.getCreatedOn());
         assertEquals(TestUtils.newLinkedHashSet("fr","de"), participant.getLanguages());
@@ -383,14 +387,15 @@ public class ParticipantServiceTest {
         when(account.getFirstName()).thenReturn("firstName");
         when(account.getLastName()).thenReturn("lastName");
         when(account.getEmail()).thenReturn(EMAIL);
+        when(account.getId()).thenReturn(ID);
         when(account.getStatus()).thenReturn(AccountStatus.DISABLED);
         when(account.getCreatedOn()).thenReturn(createdOn);
         when(account.getAttribute("attr2")).thenReturn("anAttribute2");
         
-        when(accountDao.getAccount(STUDY, EMAIL)).thenReturn(account);
+        when(accountDao.getAccount(STUDY, ID)).thenReturn(account);
         when(healthId.getCode()).thenReturn(null);
         
-        StudyParticipant participant = participantService.getParticipant(STUDY, EMAIL);
+        StudyParticipant participant = participantService.getParticipant(STUDY, ID);
         
         assertEquals("firstName", participant.getFirstName());
         assertEquals("lastName", participant.getLastName());
@@ -400,6 +405,7 @@ public class ParticipantServiceTest {
         assertNull(participant.getSharingScope());
         assertNull(participant.getHealthCode());
         assertEquals(EMAIL, participant.getEmail());
+        assertEquals(ID, participant.getId());
         assertEquals(AccountStatus.DISABLED, participant.getStatus());
         assertEquals(createdOn, participant.getCreatedOn());
         assertTrue(participant.getLanguages().isEmpty());
@@ -409,7 +415,7 @@ public class ParticipantServiceTest {
     }
     
     private void mockGetAccount() {
-        when(accountDao.getAccount(STUDY, EMAIL)).thenReturn(account);
+        when(accountDao.getAccount(STUDY, ID)).thenReturn(account);
         when(account.getHealthId()).thenReturn("healthId");
         when(healthId.getCode()).thenReturn("healthCode");
         when(healthCodeService.getMapping("healthId")).thenReturn(healthId);
@@ -417,19 +423,19 @@ public class ParticipantServiceTest {
 
     @Test(expected = EntityNotFoundException.class)
     public void signOutUserWhoDoesNotExist() {
-        when(accountDao.getAccount(STUDY, EMAIL)).thenReturn(null);
+        when(accountDao.getAccount(STUDY, ID)).thenReturn(null);
         
-        participantService.signUserOut(STUDY, EMAIL);
+        participantService.signUserOut(STUDY, ID);
     }
     
     @Test
     public void signOutUser() {
-        when(accountDao.getAccount(STUDY, EMAIL)).thenReturn(account);
+        when(accountDao.getAccount(STUDY, ID)).thenReturn(account);
         when(account.getId()).thenReturn("userId");
         
-        participantService.signUserOut(STUDY, EMAIL);
+        participantService.signUserOut(STUDY, ID);
         
-        verify(accountDao).getAccount(STUDY, EMAIL);
+        verify(accountDao).getAccount(STUDY, ID);
         verify(cacheProvider).removeSessionByUserId("userId");
     }
     
@@ -439,13 +445,13 @@ public class ParticipantServiceTest {
         doReturn("healthId").when(account).getHealthId();
         doReturn(healthId).when(healthCodeService).getMapping("healthId");
         doReturn("healthCode").when(healthId).getCode();
-        doReturn(account).when(accountDao).getAccount(STUDY, EMAIL);
+        doReturn(account).when(accountDao).getAccount(STUDY, ID);
         doReturn("id").when(account).getId();
         
         doReturn(lookup).when(optionsService).getOptions("healthCode");
         doReturn(null).when(lookup).getString(EXTERNAL_IDENTIFIER);
         
-        participantService.updateParticipant(STUDY, EMAIL, PARTICIPANT);
+        participantService.updateParticipant(STUDY, ID, PARTICIPANT);
         
         verify(optionsService).setAllOptions(eq(STUDY.getStudyIdentifier()), eq("healthCode"), optionsCaptor.capture());
         Map<ParticipantOption, String> options = optionsCaptor.getValue();
@@ -471,12 +477,12 @@ public class ParticipantServiceTest {
         doReturn("healthId").when(account).getHealthId();
         doReturn(healthId).when(healthCodeService).getMapping("healthId");
         doReturn("healthCode").when(healthId).getCode();
-        doReturn(account).when(accountDao).getAccount(STUDY, EMAIL);
+        doReturn(account).when(accountDao).getAccount(STUDY, ID);
         
         doReturn(lookup).when(optionsService).getOptions("healthCode");
         doReturn("BBB").when(lookup).getString(EXTERNAL_IDENTIFIER);
         
-        participantService.updateParticipant(STUDY, EMAIL, PARTICIPANT);
+        participantService.updateParticipant(STUDY, ID, PARTICIPANT);
     }
 
     @Test(expected = BadRequestException.class)
@@ -485,7 +491,7 @@ public class ParticipantServiceTest {
         doReturn("healthId").when(account).getHealthId();
         doReturn(healthId).when(healthCodeService).getMapping("healthId");
         doReturn("healthCode").when(healthId).getCode();
-        doReturn(account).when(accountDao).getAccount(STUDY, EMAIL);
+        doReturn(account).when(accountDao).getAccount(STUDY, ID);
         
         doReturn(lookup).when(optionsService).getOptions("healthCode");
         doReturn("BBB").when(lookup).getString(EXTERNAL_IDENTIFIER);
@@ -498,7 +504,7 @@ public class ParticipantServiceTest {
                 .withDataGroups(PARTICIPANT.getDataGroups())
                 .withAttributes(PARTICIPANT.getAttributes())
                 .withLanguages(PARTICIPANT.getLanguages()).build();
-        participantService.updateParticipant(STUDY, EMAIL, participant);
+        participantService.updateParticipant(STUDY, ID, participant);
     }
     
     @Test
@@ -507,13 +513,13 @@ public class ParticipantServiceTest {
         doReturn("healthId").when(account).getHealthId();
         doReturn(healthId).when(healthCodeService).getMapping("healthId");
         doReturn("healthCode").when(healthId).getCode();
-        doReturn(account).when(accountDao).getAccount(STUDY, EMAIL);
+        doReturn(account).when(accountDao).getAccount(STUDY, ID);
         
         doReturn(lookup).when(optionsService).getOptions("healthCode");
         doReturn("POWERS").when(lookup).getString(EXTERNAL_IDENTIFIER);
         
         // This just succeeds because the IDs are the same, and we'll verify no attempt was made to update it.
-        participantService.updateParticipant(STUDY, EMAIL, PARTICIPANT);
+        participantService.updateParticipant(STUDY, ID, PARTICIPANT);
         
         verifyNoMoreInteractions(externalIdService);
     }
@@ -524,7 +530,7 @@ public class ParticipantServiceTest {
         doReturn("healthId").when(account).getHealthId();
         doReturn(healthId).when(healthCodeService).getMapping("healthId");
         doReturn("healthCode").when(healthId).getCode();
-        doReturn(account).when(accountDao).getAccount(STUDY, EMAIL);
+        doReturn(account).when(accountDao).getAccount(STUDY, ID);
         
         doReturn(lookup).when(optionsService).getOptions("healthCode");
         doReturn(null).when(lookup).getString(EXTERNAL_IDENTIFIER);
@@ -537,12 +543,12 @@ public class ParticipantServiceTest {
                 .withDataGroups(PARTICIPANT.getDataGroups())
                 .withAttributes(PARTICIPANT.getAttributes())
                 .withLanguages(PARTICIPANT.getLanguages()).build();
-        participantService.updateParticipant(STUDY, EMAIL, participant);
+        participantService.updateParticipant(STUDY, ID, participant);
     }
     
     @Test(expected = InvalidEntityException.class)
     public void updateParticipantWithInvalidParticipant() {
-        doReturn(account).when(accountDao).getAccount(STUDY, EMAIL);
+        doReturn(account).when(accountDao).getAccount(STUDY, ID);
         doReturn("healthId").when(account).getHealthId();
         doReturn(healthId).when(healthCodeService).getMapping("healthId");
         doReturn("healthCode").when(healthId).getCode();
@@ -551,14 +557,14 @@ public class ParticipantServiceTest {
                 .withDataGroups(Sets.newHashSet("bogusGroup"))
                 .build();
         
-        participantService.updateParticipant(STUDY, EMAIL, participant);
+        participantService.updateParticipant(STUDY, ID, participant);
     }
     
     @Test
     public void updateParticipantWithNoAccount() {
-        doThrow(new EntityNotFoundException(Account.class)).when(accountDao).getAccount(STUDY, EMAIL);
+        doThrow(new EntityNotFoundException(Account.class)).when(accountDao).getAccount(STUDY, ID);
         try {
-            participantService.updateParticipant(STUDY, EMAIL, PARTICIPANT);
+            participantService.updateParticipant(STUDY, ID, PARTICIPANT);
             fail("Should have thrown exception.");
         } catch(EntityNotFoundException e) {
         }
@@ -574,9 +580,9 @@ public class ParticipantServiceTest {
         doReturn("healthId").when(account).getHealthId();
         doReturn(healthId).when(healthCodeService).getMapping("healthId");
         doReturn("healthCode").when(healthId).getCode();
-        doReturn(account).when(accountDao).getAccount(STUDY, EMAIL);
+        doReturn(account).when(accountDao).getAccount(STUDY, ID);
         
-        participantService.updateParticipant(STUDY, EMAIL, PARTICIPANT);
+        participantService.updateParticipant(STUDY, ID, PARTICIPANT);
         
         verifyNoMoreInteractions(externalIdService);
         verify(optionsService).setAllOptions(eq(STUDY.getStudyIdentifier()), eq("healthCode"), optionsCaptor.capture());
@@ -589,9 +595,9 @@ public class ParticipantServiceTest {
         STUDY.setExternalIdValidationEnabled(true);
         doReturn(null).when(healthCodeService).getMapping("healthId");
         doReturn(null).when(account).getHealthId();
-        doReturn(account).when(accountDao).getAccount(STUDY, EMAIL);
+        doReturn(account).when(accountDao).getAccount(STUDY, ID);
         
-        participantService.updateParticipant(STUDY, EMAIL, PARTICIPANT);
+        participantService.updateParticipant(STUDY, ID, PARTICIPANT);
     }
     
     @Test


### PR DESCRIPTION
- added assertResult to clean up tests of message responses;
- renamed constants to demonstrate use of IDs and not emails, and replaced email still being used in a few tests with an ID
- more tests of controllers
