### PR TITLE
Updating the unsubscribe webhook that we provide to MailChimp

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/AccountDao.java
+++ b/app/org/sagebionetworks/bridge/dao/AccountDao.java
@@ -122,4 +122,12 @@ public interface AccountDao {
      *      about the request and the total number of records.
      */
     public PagedResourceList<AccountSummary> getPagedAccountSummaries(Study study, int offsetBy, int pageSize, String emailFilter);
+    
+    /**
+     * For MailChimp, and other external systems, we need a way to get a healthCode for a given email.
+     * @param study
+     * @param email
+     * @return
+     */
+    public String getHealthCodeForEmail(Study study, String email);
 }

--- a/app/org/sagebionetworks/bridge/play/controllers/EmailController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/EmailController.java
@@ -5,10 +5,7 @@ import static org.sagebionetworks.bridge.dao.ParticipantOption.EMAIL_NOTIFICATIO
 import java.util.Map;
 
 import org.sagebionetworks.bridge.dao.AccountDao;
-import org.sagebionetworks.bridge.models.accounts.Account;
-import org.sagebionetworks.bridge.models.accounts.HealthId;
 import org.sagebionetworks.bridge.models.studies.Study;
-import org.sagebionetworks.bridge.services.HealthCodeService;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -25,40 +22,35 @@ public class EmailController extends BaseController {
     private final Logger LOG = LoggerFactory.getLogger(EmailController.class);
 
     private AccountDao accountDao;
-    private HealthCodeService healthCodeService;
 
     @Autowired
     public void setAccountDao(AccountDao accountDao) {
         this.accountDao = accountDao;
     }
 
-    @Autowired
-    public void setHealthCodeService(HealthCodeService healthCodeService) {
-        this.healthCodeService = healthCodeService;
-    }
-
     /**
      * An URL to which a POST can be sent to set the user's email notification preference to "off". Cannot turn email
      * notifications back on through this endpoint. This cannot be part of the public API, because MailChimp doesn't
      * deal with non-200 status codes. The token that is submitted is set in the configuration, and must match to allow
-     * this call to succeed. Subject to change without warning or backwards compatibility.
+     * this call to succeed. Subject to change without warning or backwards compatibility. 
      * 
      * @return
      * @throws Exception
      */
     public Result unsubscribeFromEmail() throws Exception {
         try {
+            // Token has to be provided as an URL parameter
             String token = getParameter("token");
             if (token == null || !token.equals(bridgeConfig.getEmailUnsubscribeToken())) {
                 throw new RuntimeException("Not authorized.");
             }
-            // Study has to be provided as an URL parameter:
+            // Study has to be provided as an URL parameter
             String studyId = getParameter("study");
             if (studyId == null) {
                 throw new RuntimeException("Study not found.");
             }
             Study study = studyService.getStudy(studyId);
-
+            
             // MailChimp submits email as data[email]
             String email = getParameter("data[email]");
             if (email == null) {
@@ -67,17 +59,13 @@ public class EmailController extends BaseController {
             if (email == null) {
                 throw new RuntimeException("Email not found.");
             }
-            Account account = accountDao.getAccount(study, email);
-            if (account == null) {
-                throw new RuntimeException("Account not found.");
-            }
-            HealthId healthId = healthCodeService.getMapping(account.getHealthId());
-            if (healthId == null) {
-                throw new RuntimeException("Health code not found.");
-            }
-            optionsService.setBoolean(study, healthId.getCode(), EMAIL_NOTIFICATIONS, false);
-
+            
+            // This should always return a healthCode
+            String healthCode = accountDao.getHealthCodeForEmail(study, email);
+            optionsService.setBoolean(study, healthCode, EMAIL_NOTIFICATIONS, false);
+            
             return ok("You have been unsubscribed from future email.");
+            
         } catch(Throwable throwable) {
             String errorMsg = "Unknown error";
             if (StringUtils.isNotBlank(throwable.getMessage())) {
@@ -88,27 +76,22 @@ public class EmailController extends BaseController {
         }
     }
 
-    /**
-     * No idea how you're supposed to test all this static PF stuff. Will use a spy
-     * to work around it.
-     */
     protected DynamicForm getPostData() {
         return Form.form().bindFromRequest();
     }
+    
+    protected Map<String, String[]> getParams() {
+        return request().queryString();
+    }
 
+    // Checks both query string parameters and form data for the required values.
     private String getParameter(String paramName) {
-        Map<String, String[]> parameters = request().queryString();
-        String[] values = parameters.get(paramName);
-        String param = (values != null && values.length > 0) ? values[0] : null;
-        if (param == null) {
-            // How are you supposed to test crap like this?
-            DynamicForm requestData = getPostData();
-            param = requestData.get("data[email]");
-            if (param == null) {
-                param = requestData.get("email");
-            }
+        String[] values = getParams().get(paramName);
+        if (values != null && values.length > 0) {
+            return values[0];
         }
-        return param;
+        DynamicForm postData = getPostData();
+        return postData.get(paramName);
     }
 
 }

--- a/app/org/sagebionetworks/bridge/play/controllers/EmailController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/EmailController.java
@@ -60,8 +60,11 @@ public class EmailController extends BaseController {
                 throw new RuntimeException("Email not found.");
             }
             
-            // This should always return a healthCode
+            // This should always return a healthCode unless this is not actually an email in Stormpath
             String healthCode = accountDao.getHealthCodeForEmail(study, email);
+            if (healthCode == null) {
+                throw new RuntimeException("Email not found.");
+            }
             optionsService.setBoolean(study, healthCode, EMAIL_NOTIFICATIONS, false);
             
             return ok("You have been unsubscribed from future email.");

--- a/test/org/sagebionetworks/bridge/play/controllers/EmailControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/EmailControllerTest.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.play.controllers;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -107,7 +108,9 @@ public class EmailControllerTest {
         
         EmailController controller = createController("bridge-testing@sagebase.org");
         Result result = controller.unsubscribeFromEmail();
-        assertTrue(contentAsString(result).contains("Study not found"));
+        
+        assertEquals(200, result.status());
+        assertEquals("Study not found.", contentAsString(result));
     }
     
     @Test
@@ -116,7 +119,9 @@ public class EmailControllerTest {
         
         EmailController controller = createController(null);
         Result result = controller.unsubscribeFromEmail();
-        assertTrue(contentAsString(result).contains("Email not found"));
+        
+        assertEquals(200, result.status());
+        assertEquals("Email not found.", contentAsString(result));
     }
     
     @Test
@@ -128,7 +133,8 @@ public class EmailControllerTest {
         
         Result result = controller.unsubscribeFromEmail();
 
-        assertTrue(contentAsString(result).contains("Email not found"));
+        assertEquals(200, result.status());
+        assertEquals("Email not found.", contentAsString(result));
     }
     
     @Test
@@ -137,7 +143,9 @@ public class EmailControllerTest {
         
         EmailController controller = createController("bridge-testing@sagebase.org");
         Result result = controller.unsubscribeFromEmail();
-        assertTrue(contentAsString(result).contains("Not authorized"));
+        
+        assertEquals(200, result.status());
+        assertEquals("Not authorized.", contentAsString(result));
     }
     
 }

--- a/test/org/sagebionetworks/bridge/play/controllers/EmailControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/EmailControllerTest.java
@@ -31,7 +31,14 @@ import com.google.common.collect.Maps;
 
 public class EmailControllerTest {
 
-    private static final String EMAIL = "bridge-testing@sagebase.org";
+    private static final String EMAIL = "email";
+    private static final String DATA_BRACKET_EMAIL = "data[email]";
+    private static final String HEALTH_CODE = "healthCode";
+    private static final String UNSUBSCRIBE_TOKEN = "unsubscribeToken";
+    private static final String TOKEN = "token";
+    private static final String STUDY2 = "study";
+    private static final String API = "api";
+    private static final String EMAIL_ADDRESS = "bridge-testing@sagebase.org";
 
     private ParticipantOptionsService optionsService;
 
@@ -65,17 +72,17 @@ public class EmailControllerTest {
         optionsService = mock(ParticipantOptionsService.class);
 
         study = TestUtils.getValidStudy(EmailControllerTest.class);
-        study.setIdentifier("api");
+        study.setIdentifier(API);
 
         accountDao = mock(AccountDao.class);
-        when(accountDao.getHealthCodeForEmail(study, EMAIL)).thenReturn("healthCode");
+        when(accountDao.getHealthCodeForEmail(study, EMAIL_ADDRESS)).thenReturn(HEALTH_CODE);
 
         StudyService studyService = mock(StudyService.class);
-        when(studyService.getStudy("api")).thenReturn(study);
+        when(studyService.getStudy(API)).thenReturn(study);
         when(studyService.getStudy((String) null)).thenThrow(new EntityNotFoundException(Study.class));
 
         BridgeConfig config = mock(BridgeConfig.class);
-        when(config.getEmailUnsubscribeToken()).thenReturn("unsubscribeToken");
+        when(config.getEmailUnsubscribeToken()).thenReturn(UNSUBSCRIBE_TOKEN);
 
         EmailController controller = spy(new EmailController());
         controller.setParticipantOptionsService(optionsService);
@@ -87,38 +94,48 @@ public class EmailControllerTest {
 
     @Test
     public void fromQueryParams() throws Exception {
-        mockContext(map("data[email]", EMAIL, "study", "api", "token", "unsubscribeToken"), null);
+        mockContext(map(DATA_BRACKET_EMAIL, EMAIL_ADDRESS, STUDY2, API, TOKEN, UNSUBSCRIBE_TOKEN), null);
 
         EmailController controller = createController();
         controller.unsubscribeFromEmail();
 
-        verify(optionsService).setBoolean(study, "healthCode", EMAIL_NOTIFICATIONS, false);
+        verify(optionsService).setBoolean(study, HEALTH_CODE, EMAIL_NOTIFICATIONS, false);
     }
 
     @Test
     public void fromFormPost() throws Exception {
-        mockContext(null, map("data[email]", EMAIL, "study", "api", "token", "unsubscribeToken"));
+        mockContext(null, map(DATA_BRACKET_EMAIL, EMAIL_ADDRESS, STUDY2, API, TOKEN, UNSUBSCRIBE_TOKEN));
 
         EmailController controller = createController();
         controller.unsubscribeFromEmail();
 
-        verify(optionsService).setBoolean(study, "healthCode", EMAIL_NOTIFICATIONS, false);
+        verify(optionsService).setBoolean(study, HEALTH_CODE, EMAIL_NOTIFICATIONS, false);
     }
 
     @Test
-    public void mixed() throws Exception {
-        // study and token from query params, like in a real use case. email from form post
-        mockContext(map("study", "api", "token", "unsubscribeToken"), map("data[email]", EMAIL));
+    public void fromFormPostWithEmail() throws Exception {
+        mockContext(null, map(EMAIL, EMAIL_ADDRESS, STUDY2, API, TOKEN, UNSUBSCRIBE_TOKEN));
 
         EmailController controller = createController();
         controller.unsubscribeFromEmail();
 
-        verify(optionsService).setBoolean(study, "healthCode", EMAIL_NOTIFICATIONS, false);
+        verify(optionsService).setBoolean(study, HEALTH_CODE, EMAIL_NOTIFICATIONS, false);
+    }
+    
+    @Test
+    public void mixed() throws Exception {
+        // study and token from query params, like in a real use case. email from form post
+        mockContext(map(STUDY2, API, TOKEN, UNSUBSCRIBE_TOKEN), map(DATA_BRACKET_EMAIL, EMAIL_ADDRESS));
+
+        EmailController controller = createController();
+        controller.unsubscribeFromEmail();
+
+        verify(optionsService).setBoolean(study, HEALTH_CODE, EMAIL_NOTIFICATIONS, false);
     }
 
     @Test
     public void noStudyThrowsException() throws Exception {
-        mockContext(map("data[email]", EMAIL, "token", "unsubscribeToken"), null);
+        mockContext(map(DATA_BRACKET_EMAIL, EMAIL_ADDRESS, TOKEN, UNSUBSCRIBE_TOKEN), null);
         EmailController controller = createController();
 
         try {
@@ -131,7 +148,7 @@ public class EmailControllerTest {
 
     @Test
     public void noEmailThrowsException() throws Exception {
-        mockContext(map("study", "api", "token", "unsubscribeToken"), null);
+        mockContext(map(STUDY2, API, TOKEN, UNSUBSCRIBE_TOKEN), null);
         EmailController controller = createController();
 
         try {
@@ -144,9 +161,9 @@ public class EmailControllerTest {
 
     @Test
     public void noAccountThrowsException() throws Exception {
-        mockContext(map("data[email]", EMAIL, "study", "api", "token", "unsubscribeToken"), null);
+        mockContext(map(DATA_BRACKET_EMAIL, EMAIL_ADDRESS, STUDY2, API, TOKEN, UNSUBSCRIBE_TOKEN), null);
         EmailController controller = createController();
-        doReturn(null).when(accountDao).getHealthCodeForEmail(study, EMAIL);
+        doReturn(null).when(accountDao).getHealthCodeForEmail(study, EMAIL_ADDRESS);
 
         try {
             controller.unsubscribeFromEmail();
@@ -158,7 +175,7 @@ public class EmailControllerTest {
 
     @Test
     public void missingTokenThrowsException() throws Exception {
-        mockContext(map("data[email]", EMAIL, "study", "api"), null);
+        mockContext(map(DATA_BRACKET_EMAIL, EMAIL_ADDRESS, STUDY2, API), null);
         EmailController controller = createController();
 
         try {

--- a/test/org/sagebionetworks/bridge/play/controllers/EmailControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/EmailControllerTest.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.play.controllers;
 
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -13,7 +14,6 @@ import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.config.BridgeConfig;
 import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.play.controllers.EmailController;
-import org.sagebionetworks.bridge.services.HealthCodeService;
 import org.sagebionetworks.bridge.services.ParticipantOptionsService;
 import org.sagebionetworks.bridge.services.StudyService;
 
@@ -25,7 +25,6 @@ import java.util.Map;
 
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.accounts.Account;
-import org.sagebionetworks.bridge.models.accounts.HealthId;
 import org.sagebionetworks.bridge.models.studies.Study;
 
 import com.google.common.collect.Maps;
@@ -108,7 +107,7 @@ public class EmailControllerTest {
         
         EmailController controller = createController("bridge-testing@sagebase.org");
         Result result = controller.unsubscribeFromEmail();
-        contentAsString(result).contains("Study not found");
+        assertTrue(contentAsString(result).contains("Study not found"));
     }
     
     @Test
@@ -117,7 +116,7 @@ public class EmailControllerTest {
         
         EmailController controller = createController(null);
         Result result = controller.unsubscribeFromEmail();
-        contentAsString(result).contains("Email not found");
+        assertTrue(contentAsString(result).contains("Email not found"));
     }
     
     @Test
@@ -125,10 +124,11 @@ public class EmailControllerTest {
         mockContext("data[email]", "bridge-testing@sagebase.org", "study", "api", "token", "unsubscribeToken");
         
         EmailController controller = createController("bridge-testing@sagebase.org");
-        when(accountDao.getAccount(study, "bridge-testing@sagebase.org")).thenReturn(null);
+        when(accountDao.getHealthCodeForEmail(study, "bridge-testing@sagebase.org")).thenReturn(null);
         
         Result result = controller.unsubscribeFromEmail();
-        contentAsString(result).contains("Account not found");
+
+        assertTrue(contentAsString(result).contains("Email not found"));
     }
     
     @Test
@@ -137,7 +137,7 @@ public class EmailControllerTest {
         
         EmailController controller = createController("bridge-testing@sagebase.org");
         Result result = controller.unsubscribeFromEmail();
-        contentAsString(result).contains("Not authorized");
+        assertTrue(contentAsString(result).contains("Not authorized"));
     }
     
 }

--- a/test/org/sagebionetworks/bridge/play/controllers/EmailControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/EmailControllerTest.java
@@ -69,13 +69,8 @@ public class EmailControllerTest {
         
         accountDao = mock(AccountDao.class);
         when(accountDao.getAccount(study, "bridge-testing@sagebase.org")).thenReturn(account);
-        
-        HealthId healthId = mock(HealthId.class);
-        when(healthId.getCode()).thenReturn("healthCode");
-        
-        HealthCodeService healthCodeService = mock(HealthCodeService.class);
-        when(healthCodeService.getMapping("healthId")).thenReturn(healthId);
-        
+        when(accountDao.getHealthCodeForEmail(study, "bridge-testing@sagebase.org")).thenReturn("healthCode");
+
         StudyService studyService = mock(StudyService.class);
         when(studyService.getStudy("api")).thenReturn(study);
         when(studyService.getStudy((String)null)).thenThrow(new EntityNotFoundException(Study.class));
@@ -92,7 +87,6 @@ public class EmailControllerTest {
         controller.setParticipantOptionsService(optionsService);
         controller.setStudyService(studyService);
         controller.setAccountDao(accountDao);
-        controller.setHealthCodeService(healthCodeService);
         controller.setBridgeConfig(config);
 
         return controller;

--- a/test/org/sagebionetworks/bridge/play/controllers/EmailControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/EmailControllerTest.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.bridge.play.controllers;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;

--- a/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoTest.java
+++ b/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoTest.java
@@ -212,13 +212,14 @@ public class StormpathAccountDaoTest {
             // Update Account
             accountDao.updateAccount(study, account);
             
-            // Retrieve account with email currently works
+            // Retrieve account with ID
             Account newAccount = accountDao.getAccount(study, account.getId());
             assertEqual(signedOn, account, newAccount);
 
-            // Using account ID also works
-            newAccount = accountDao.getAccount(study,  account.getId());
-            assertEqual(signedOn, account, newAccount);
+            // Verify that you can get the health code using the email. We still need this for MailChimp.
+            String healthCode = accountDao.getHealthCodeForEmail(study, email);
+            HealthId healthId = healthCodeService.getMapping(account.getHealthId());
+            assertEquals(healthCode, healthId.getCode());
             
             // Test adding and removing some groups. This gets into verifying and avoiding saving the underlying
             // Stormpath account. There are 4 cases to consider: (1) adding groups, (2) removing groups, (3) account in


### PR DESCRIPTION
Updating the unsubscribe webhook that we provide to MailChimp for mailings. The hook seems sound but had to be adjusted because we look up users by IDs now, and that we don't get from MailChimp.

I believe the errors were originally because users without health codes were submitting unsubscribes.. ? This should not happen now with the way this has been restructured. We create health codes if they don't exist just so we can record this setting.

Tested this using curl and a POST body as described by MailChimp.

To test further I will deploy to develop, and then create a test list in MailChimp pointed at development, and send myself a mass mailing, unsubscribe, etc. This is the only way I can see to test what MailChimp sends beyond their docs.
