### PR TITLE
Removing table clear methods

### DIFF
--- a/test/org/sagebionetworks/bridge/services/UserAdminServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/UserAdminServiceTest.java
@@ -68,16 +68,6 @@ public class UserAdminServiceTest {
 
     private User testUser;
 
-    @BeforeClass
-    public static void initialSetUp() {
-        DynamoTestUtil.clearTable(DynamoUserConsent3.class);
-    }
-
-    @AfterClass
-    public static void finalCleanUp() {
-        DynamoTestUtil.clearTable(DynamoUserConsent3.class);
-    }
-
     @Before
     public void before() {
         study = studyService.getStudy(TEST_STUDY_IDENTIFIER);


### PR DESCRIPTION
I get accounts left over from tests that don't have user consent records in DDB, but do have information in Stormpath. These records thrown an error in the UI, although they work, but I am not sure if this is a real bug, or an artifact of these test methods which clear the table. They aren't needed for these tests, so remove them.
