### PR TITLE
add new fields to schemas

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadFieldDefinition.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadFieldDefinition.java
@@ -1,9 +1,10 @@
 package org.sagebionetworks.bridge.dynamodb;
 
+import java.util.Objects;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.google.common.base.Objects;
 
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
@@ -15,15 +16,57 @@ import org.sagebionetworks.bridge.models.upload.UploadFieldType;
  */
 @JsonDeserialize(builder = DynamoUploadFieldDefinition.Builder.class)
 public final class DynamoUploadFieldDefinition implements UploadFieldDefinition {
+    private final @Nullable String fileExtension;
+    private final @Nullable String mimeType;
+    private final @Nullable Integer minAppVersion;
+    private final @Nullable Integer maxAppVersion;
+    private final @Nullable Integer maxLength;
     private final @Nonnull String name;
     private final boolean required;
     private final @Nonnull UploadFieldType type;
 
     /** Private constructor. Construction of a DynamoUploadFieldDefinition should go through the Builder. */
-    private DynamoUploadFieldDefinition(@Nonnull String name, boolean required, @Nonnull UploadFieldType type) {
+    private DynamoUploadFieldDefinition(@Nullable String fileExtension, @Nullable String mimeType,
+            @Nullable Integer minAppVersion, @Nullable Integer maxAppVersion, @Nullable Integer maxLength,
+            @Nonnull String name, boolean required, @Nonnull UploadFieldType type) {
+        this.fileExtension = fileExtension;
+        this.mimeType = mimeType;
+        this.minAppVersion = minAppVersion;
+        this.maxAppVersion = maxAppVersion;
+        this.maxLength = maxLength;
         this.name = name;
         this.required = required;
         this.type = type;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public @Nullable String getFileExtension() {
+        return fileExtension;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public @Nullable String getMimeType() {
+        return mimeType;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public @Nullable Integer getMinAppVersion() {
+        return minAppVersion;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public @Nullable Integer getMaxAppVersion() {
+        return maxAppVersion;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public @Nullable Integer getMaxLength() {
+        return maxLength;
     }
 
     /** {@inheritDoc} */
@@ -54,22 +97,62 @@ public final class DynamoUploadFieldDefinition implements UploadFieldDefinition 
             return false;
         }
         DynamoUploadFieldDefinition that = (DynamoUploadFieldDefinition) o;
-        return Objects.equal(required, that.required) &&
-                Objects.equal(name, that.name) &&
-                Objects.equal(type, that.type);
+        return required == that.required &&
+                Objects.equals(fileExtension, that.fileExtension) &&
+                Objects.equals(mimeType, that.mimeType) &&
+                Objects.equals(minAppVersion, that.minAppVersion) &&
+                Objects.equals(maxAppVersion, that.maxAppVersion) &&
+                Objects.equals(maxLength, that.maxLength) &&
+                Objects.equals(name, that.name) &&
+                type == that.type;
     }
 
     /** {@inheritDoc} */
     @Override
     public int hashCode() {
-        return Objects.hashCode(name, required, type);
+        return Objects.hash(fileExtension, mimeType, minAppVersion, maxAppVersion, maxLength, name, required, type);
     }
 
     /** Builder for DynamoUploadFieldDefinition */
     public static class Builder {
+        private String fileExtension;
+        private String mimeType;
+        private Integer minAppVersion;
+        private Integer maxAppVersion;
+        private Integer maxLength;
         private String name;
         private Boolean required;
         private UploadFieldType type;
+
+        /** @see org.sagebionetworks.bridge.models.upload.UploadFieldDefinition#getFileExtension */
+        public Builder withFileExtension(String fileExtension) {
+            this.fileExtension = fileExtension;
+            return this;
+        }
+
+        /** @see org.sagebionetworks.bridge.models.upload.UploadFieldDefinition#getMimeType */
+        public Builder withMimeType(String mimeType) {
+            this.mimeType = mimeType;
+            return this;
+        }
+
+        /** @see org.sagebionetworks.bridge.models.upload.UploadFieldDefinition#getMinAppVersion */
+        public Builder withMinAppVersion(Integer minAppVersion) {
+            this.minAppVersion = minAppVersion;
+            return this;
+        }
+
+        /** @see org.sagebionetworks.bridge.models.upload.UploadFieldDefinition#getMaxAppVersion */
+        public Builder withMaxAppVersion(Integer maxAppVersion) {
+            this.maxAppVersion = maxAppVersion;
+            return this;
+        }
+
+        /** @see org.sagebionetworks.bridge.models.upload.UploadFieldDefinition#getMaxLength */
+        public Builder withMaxLength(Integer maxLength) {
+            this.maxLength = maxLength;
+            return this;
+        }
 
         /** @see org.sagebionetworks.bridge.models.upload.UploadFieldDefinition#getName */
         public Builder withName(String name) {
@@ -102,7 +185,8 @@ public final class DynamoUploadFieldDefinition implements UploadFieldDefinition 
             if (required == null) {
                 required = true;
             }
-            return new DynamoUploadFieldDefinition(name, required, type);
+            return new DynamoUploadFieldDefinition(fileExtension, mimeType, minAppVersion, maxAppVersion, maxLength,
+                    name, required, type);
         }
     }
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDao.java
@@ -86,6 +86,9 @@ public class DynamoUploadSchemaDao implements UploadSchemaDao {
         ddbUploadSchema.setRevision(oldRev + 1);
         ddbUploadSchema.setStudyId(studyId);
 
+        // Clear version. We're creating a new row to handle the new rev, so this starts at version 0 (null).
+        ddbUploadSchema.setVersion(null);
+
         try {
             mapper.save(uploadSchema, DOES_NOT_EXIST_EXPRESSION);
         } catch (ConditionalCheckFailedException ex) {

--- a/app/org/sagebionetworks/bridge/models/upload/UploadFieldDefinition.java
+++ b/app/org/sagebionetworks/bridge/models/upload/UploadFieldDefinition.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.models.upload;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import org.sagebionetworks.bridge.dynamodb.DynamoUploadFieldDefinition;
 import org.sagebionetworks.bridge.json.BridgeTypeName;
@@ -15,6 +16,36 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 @JsonDeserialize(as = DynamoUploadFieldDefinition.class)
 @BridgeTypeName("UploadFieldDefinition")
 public interface UploadFieldDefinition extends BridgeEntity {
+    /**
+     * Used for ATTACHMENT_V2 types. Used as a hint by BridgeEX to preserve the file extension as a quality-of-life
+     * improvement. Optional, defaults to ".tmp".
+     * */
+    @Nullable String getFileExtension();
+
+    /**
+     * Used for ATTACHMENT_V2 types. Used as a hint by BridgeEX to mark a Synapse file handle with the correct MIME
+     * type as a quality-of-life improvement. Optional, defaults to "application/octet-stream".
+     */
+    @Nullable String getMimeType();
+
+    /**
+     * The oldest app version number for which this field is required. App versions before this will treat this field
+     * as optional, as it doesn't exist yet. Does nothing if required is false.
+     */
+    @Nullable Integer getMinAppVersion();
+
+    /**
+     * Similar to minAppVersion. This is used for when required fields are removed from the app, but we want to re-use
+     * the old Synapse table.
+     */
+    @Nullable Integer getMaxAppVersion();
+
+    /**
+     * Used for STRING, SINGLE_CHOICE, and INLINE_JSON_BLOB types. This is a hint for BridgeEX to create a Synapse
+     * column with the right width.
+     */
+    @Nullable Integer getMaxLength();
+
     /** The field name. */
     @Nonnull String getName();
 

--- a/app/org/sagebionetworks/bridge/models/upload/UploadSchema.java
+++ b/app/org/sagebionetworks/bridge/models/upload/UploadSchema.java
@@ -26,11 +26,8 @@ public interface UploadSchema extends BridgeEntity {
     String getName();
 
     /**
-     * Schema revision number. This is managed by the Bridge back-end. For creating new schemas, this should initially
-     * be unset (or set to the default value of zero). For updating schemas, this should be set to the revision number
-     * of the schema you are updating, to ensure that you aren't updating an older version of the schema. Upon creating
-     * or updating a schema, the Bridge back-end will automatically increment this revision number by 1 (for updating
-     * existing schemas) or from 0 to 1 (for creating new schemas).
+     * Revision number. This is a secondary ID used to partition different Synapse tables based on breaking changes in
+     * a schema.
      */
     int getRevision();
 
@@ -47,9 +44,27 @@ public interface UploadSchema extends BridgeEntity {
     /** Schema type, for example survey vs data. */
     UploadSchemaType getSchemaType();
 
+    /** The survey GUID if this is a survey schema. */
+    String getSurveyGuid();
+
+    /** For survey createdOn (versionedOn) if this is a survey schema. */
+    Long getSurveyCreatedOn();
+
     /**
      * Study ID that this schema lives in. This is not exposed to the callers of the upload schema API, but is
      * available here for internal usage.
      */
     String getStudyId();
+
+    /**
+     * <p>
+     * Version number of a particular schema revision. This is used to detect concurrent modification. Callers should
+     * not modify this value. This will be automatically incremented by Bridge.
+     * </p>
+     * <p>
+     * This is currently ignored by the Schema v3 API, which manages its own versioning via revision. However, the
+     * Schema v4 API needs this as revision and versions are now independent of each other.
+     * </p>
+     */
+    Long getVersion();
 }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDaoDdbTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDaoDdbTest.java
@@ -1,0 +1,126 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.List;
+import javax.annotation.Resource;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException;
+import com.google.common.collect.ImmutableList;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.TestUtils;
+import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
+import org.sagebionetworks.bridge.models.upload.UploadFieldType;
+import org.sagebionetworks.bridge.models.upload.UploadSchemaType;
+
+@ContextConfiguration("classpath:test-context.xml")
+@RunWith(SpringJUnit4ClassRunner.class)
+public class DynamoUploadSchemaDaoDdbTest {
+    private static final int SCHEMA_REV = 7;
+
+    @Resource(name = "uploadSchemaDdbMapper")
+    private DynamoDBMapper mapper;
+
+    private String schemaId;
+
+    @Before
+    public void setup() {
+        // This runs before each method, creates a new schema ID for each method.
+        schemaId = TestUtils.randomName(DynamoUploadSchemaDaoDdbTest.class);
+    }
+
+    @After
+    public void cleanup() {
+        DynamoUploadSchema key = new DynamoUploadSchema();
+        key.setStudyId(TestConstants.TEST_STUDY_IDENTIFIER);
+        key.setSchemaId(schemaId);
+        key.setRevision(SCHEMA_REV);
+        DynamoUploadSchema testSchema = mapper.load(key);
+
+        if (testSchema != null) {
+            mapper.delete(testSchema);
+        }
+    }
+
+    @Test
+    public void ddbRoundtrip() {
+        // create test schema
+        DynamoUploadSchema schema = new DynamoUploadSchema();
+        schema.setName("Test Schema");
+        schema.setRevision(SCHEMA_REV);
+        schema.setSchemaId(schemaId);
+        schema.setSchemaType(UploadSchemaType.IOS_SURVEY);
+        schema.setSurveyGuid("test-survey-guid");
+        schema.setSurveyCreatedOn(1337L);
+        schema.setStudyId(TestConstants.TEST_STUDY_IDENTIFIER);
+
+        UploadFieldDefinition fieldDef = new DynamoUploadFieldDefinition.Builder().withName("test-field")
+                .withType(UploadFieldType.STRING).build();
+        schema.setFieldDefinitions(ImmutableList.of(fieldDef));
+
+        // Save it to DDB, then read it back and make sure it has the same fields. (Can't use .equals(), even if we
+        // implemented it, because the mapper functions modify the object we pass in.)
+        mapper.save(schema);
+        DynamoUploadSchema savedSchema = mapper.load(schema);
+
+        // validate fields
+        assertEquals("Test Schema", savedSchema.getName());
+        assertEquals(SCHEMA_REV, savedSchema.getRevision());
+        assertEquals(schemaId, savedSchema.getSchemaId());
+        assertEquals(UploadSchemaType.IOS_SURVEY, savedSchema.getSchemaType());
+        assertEquals("test-survey-guid", savedSchema.getSurveyGuid());
+        assertEquals(1337, savedSchema.getSurveyCreatedOn().longValue());
+        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, savedSchema.getStudyId());
+
+        List<UploadFieldDefinition> returnedFieldDefList = savedSchema.getFieldDefinitions();
+        assertEquals(1, returnedFieldDefList.size());
+
+        UploadFieldDefinition returnedFieldDef = returnedFieldDefList.get(0);
+        assertEquals("test-field", returnedFieldDef.getName());
+        assertEquals(UploadFieldType.STRING, returnedFieldDef.getType());
+    }
+
+    @Test
+    public void concurrentModification() {
+        // just the keys: study ID, schema ID, and rev
+        mapper.save(makeSimpleSchema("Initial Name", schemaId, null));
+
+        // Try to create a new schema with the same schema ID
+        try {
+            mapper.save(makeSimpleSchema("New Schema Conflict", schemaId, null));
+            fail("expected exception");
+        } catch (ConditionalCheckFailedException ex) {
+            // expected exception
+        }
+
+        // Update from version 1 to version 2
+        mapper.save(makeSimpleSchema("Updated Name", schemaId, 1L));
+
+        // Try to update version 1 again
+        try {
+            mapper.save(makeSimpleSchema("Update Schema Conflict", schemaId, 1L));
+            fail("expected exception");
+        } catch (ConditionalCheckFailedException ex) {
+            // expected exception
+        }
+    }
+
+    private static DynamoUploadSchema makeSimpleSchema(String name, String schemaId, Long version) {
+        DynamoUploadSchema schema = new DynamoUploadSchema();
+        schema.setName(name);
+        schema.setStudyId(TestConstants.TEST_STUDY_IDENTIFIER);
+        schema.setSchemaId(schemaId);
+        schema.setRevision(SCHEMA_REV);
+        schema.setVersion(version);
+        return schema;
+    }
+}

--- a/test/org/sagebionetworks/bridge/models/upload/UploadFieldDefinitionTest.java
+++ b/test/org/sagebionetworks/bridge/models/upload/UploadFieldDefinitionTest.java
@@ -13,6 +13,7 @@ import org.sagebionetworks.bridge.dynamodb.DynamoUploadFieldDefinition;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.json.JsonUtils;
 
+@SuppressWarnings("ConstantConditions")
 public class UploadFieldDefinitionTest {
     @Test
     public void testBuilder() {
@@ -42,9 +43,28 @@ public class UploadFieldDefinitionTest {
     }
 
     @Test
+    public void testOptionalFields() {
+        UploadFieldDefinition fieldDef = new DynamoUploadFieldDefinition.Builder().withFileExtension(".test")
+                .withMimeType("text/plain").withMinAppVersion(10).withMaxAppVersion(13).withMaxLength(128)
+                .withName("optional-stuff").withType(UploadFieldType.STRING).build();
+        assertEquals(".test", fieldDef.getFileExtension());
+        assertEquals("text/plain", fieldDef.getMimeType());
+        assertEquals(10, fieldDef.getMinAppVersion().intValue());
+        assertEquals(13, fieldDef.getMaxAppVersion().intValue());
+        assertEquals(128, fieldDef.getMaxLength().intValue());
+        assertEquals("optional-stuff", fieldDef.getName());
+        assertEquals(UploadFieldType.STRING, fieldDef.getType());
+    }
+
+    @Test
     public void testSerialization() throws Exception {
         // start with JSON
         String jsonText = "{\n" +
+                "   \"fileExtension\":\".json\",\n" +
+                "   \"mimeType\":\"text/json\",\n" +
+                "   \"minAppVersion\":2,\n" +
+                "   \"maxAppVersion\":7,\n" +
+                "   \"maxLength\":24,\n" +
                 "   \"name\":\"test-field\",\n" +
                 "   \"required\":false,\n" +
                 "   \"type\":\"INT\"\n" +
@@ -52,6 +72,11 @@ public class UploadFieldDefinitionTest {
 
         // convert to POJO
         UploadFieldDefinition fieldDef = BridgeObjectMapper.get().readValue(jsonText, UploadFieldDefinition.class);
+        assertEquals(".json", fieldDef.getFileExtension());
+        assertEquals("text/json", fieldDef.getMimeType());
+        assertEquals(2, fieldDef.getMinAppVersion().intValue());
+        assertEquals(7, fieldDef.getMaxAppVersion().intValue());
+        assertEquals(24, fieldDef.getMaxLength().intValue());
         assertEquals("test-field", fieldDef.getName());
         assertFalse(fieldDef.isRequired());
         assertEquals(UploadFieldType.INT, fieldDef.getType());
@@ -61,7 +86,12 @@ public class UploadFieldDefinitionTest {
 
         // then convert to a map so we can validate the raw JSON
         Map<String, Object> jsonMap = BridgeObjectMapper.get().readValue(convertedJson, JsonUtils.TYPE_REF_RAW_MAP);
-        assertEquals(3, jsonMap.size());
+        assertEquals(8, jsonMap.size());
+        assertEquals(".json", jsonMap.get("fileExtension"));
+        assertEquals("text/json", jsonMap.get("mimeType"));
+        assertEquals(2, jsonMap.get("minAppVersion"));
+        assertEquals(7, jsonMap.get("maxAppVersion"));
+        assertEquals(24, jsonMap.get("maxLength"));
         assertEquals("test-field", jsonMap.get("name"));
         assertFalse((boolean) jsonMap.get("required"));
         assertEquals("int", jsonMap.get("type"));


### PR DESCRIPTION
Modifying the schema fields in DDB in preparation for mutable schemas. This also adds the version field to UploadSchema, which Schema v3 APIs ignore but Schema v4 APIs will need.

See
- https://sagebionetworks.jira.com/browse/BRIDGE-1289
- https://sagebionetworks.jira.com/wiki/display/BRIDGE/Upload+Format+v2#UploadFormatv2-UploadSchemaFields

Testing done:
- updated/added unit tests
- ran UploadSchemaTest in integration tests against my local server
- manually tested schema version conflicts (which isn't currently covered in unit tests

Next steps:
- add new fields to the JavaSDK
- add integ tests to test schema version conflicts in Schema V3 API
- create Schema V4 APIs
