### PR TITLE
Scheduling updates

### DIFF
--- a/app/org/sagebionetworks/bridge/models/accounts/User.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/User.java
@@ -5,6 +5,8 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.joda.time.DateTime;
+
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.config.BridgeConfigFactory;
@@ -33,6 +35,7 @@ public final class User implements BridgeEntity {
     private String healthCode;
     private String studyKey;
     private SharingScope sharingScope;
+    private DateTime accountCreatedOn;
     private Set<Roles> roles;
     private Set<String> dataGroups;
     private Map<SubpopulationGuid,ConsentStatus> consentStatuses;
@@ -51,6 +54,7 @@ public final class User implements BridgeEntity {
         this.firstName = account.getFirstName();
         this.lastName = account.getLastName();
         this.id = account.getId();
+        this.accountCreatedOn = account.getCreatedOn();
         setRoles(account.getRoles());
     }
 
@@ -88,6 +92,14 @@ public final class User implements BridgeEntity {
         this.healthCode = healthCode;
     }
 
+    public DateTime getAccountCreatedOn() {
+        return accountCreatedOn;
+    }
+    
+    public void setAccountCreatedOn(DateTime accountCreatedOn) {
+        this.accountCreatedOn = accountCreatedOn;
+    }
+    
     public String getEncryptedHealthCode() {
         return ENCRYPTOR.encrypt(healthCode);
     }
@@ -179,7 +191,7 @@ public final class User implements BridgeEntity {
     @Override
     public int hashCode() {
         return Objects.hashCode(email, firstName, lastName, healthCode, id, roles, sharingScope, 
-                studyKey, dataGroups, consentStatuses, languages);
+                accountCreatedOn, studyKey, dataGroups, consentStatuses, languages);
     }
 
     @Override
@@ -194,13 +206,14 @@ public final class User implements BridgeEntity {
                 && Objects.equal(id, other.id) && Objects.equal(roles, other.roles)
                 && Objects.equal(sharingScope, other.sharingScope) && Objects.equal(studyKey, other.studyKey)
                 && Objects.equal(dataGroups, other.dataGroups)
+                && Objects.equal(accountCreatedOn, other.accountCreatedOn)
                 && Objects.equal(consentStatuses, other.consentStatuses)
                 && Objects.equal(languages, other.languages));
     }
 
     @Override
     public String toString() {
-        return String.format("User [email=%s, firstName=%s, lastName=%s, id=%s, roles=%s, sharingScope=%s, studyKey=%s, dataGroups=%s, consentStatuses=%s, languages=%s]", 
-                email, firstName, lastName, id, roles, sharingScope, studyKey, dataGroups, consentStatuses, languages);
+        return String.format("User [email=%s, firstName=%s, lastName=%s, id=%s, roles=%s, sharingScope=%s, studyKey=%s, accountCreatedOn=%s, dataGroups=%s, consentStatuses=%s, languages=%s]", 
+                email, firstName, lastName, id, roles, sharingScope, studyKey, accountCreatedOn, dataGroups, consentStatuses, languages);
     }
 }

--- a/app/org/sagebionetworks/bridge/models/schedules/Activity.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/Activity.java
@@ -29,17 +29,15 @@ public final class Activity implements BridgeEntity {
     private String guid;
     private TaskReference task;
     private SurveyReference survey;
-    private SurveyResponseReference response;
     private ActivityType activityType;
 
     private Activity(String label, String labelDetail, String guid, 
-        TaskReference task, SurveyReference survey, SurveyResponseReference response) {
+        TaskReference task, SurveyReference survey) {
         this.label = label;
         this.labelDetail = labelDetail;
         this.guid = guid;
         this.survey = survey;
         this.task = task;
-        this.response = response;
         this.activityType = (task != null) ? TASK : SURVEY;
     }
     
@@ -61,9 +59,6 @@ public final class Activity implements BridgeEntity {
     public SurveyReference getSurvey() {
         return survey;
     }
-    public SurveyResponseReference getSurveyResponse() {
-        return response;
-    }
     public boolean isPersistentlyRescheduledBy(Schedule schedule) {
         return schedule.schedulesImmediatelyAfterEvent() && getActivityFinishedEventId(schedule);
     }
@@ -83,7 +78,6 @@ public final class Activity implements BridgeEntity {
         private String guid;
         private TaskReference task;
         private SurveyReference survey;
-        private SurveyResponseReference response;
         
         public Builder withActivity(Activity activity) {
             this.label = activity.label;
@@ -91,7 +85,6 @@ public final class Activity implements BridgeEntity {
             this.guid = activity.guid;
             this.task = activity.task;
             this.survey = activity.survey;
-            this.response = activity.response;
             return this;
         }
         public Builder withLabel(String label) {
@@ -128,20 +121,11 @@ public final class Activity implements BridgeEntity {
             this.survey = new SurveyReference(identifier, guid, createdOn);
             return this;
         }
-        @JsonSetter
-        public Builder withSurveyResponse(SurveyResponseReference reference) { 
-            this.response = reference;
-            return this;
-        }
-        public Builder withSurveyResponse(String identifier) {
-            this.response = new SurveyResponseReference(identifier);
-            return this;
-        }
         public Activity build() {
             if (guid == null) {
                 guid = BridgeUtils.generateGuid();
             }
-            return new Activity(label, labelDetail, guid, task, survey, response);
+            return new Activity(label, labelDetail, guid, task, survey);
         }
     }
     
@@ -153,7 +137,6 @@ public final class Activity implements BridgeEntity {
         result = prime * result + Objects.hashCode(label);
         result = prime * result + Objects.hashCode(labelDetail);
         result = prime * result + Objects.hashCode(guid);
-        result = prime * result + Objects.hashCode(response);
         result = prime * result + Objects.hashCode(survey);
         result = prime * result + Objects.hashCode(task);
         return result;
@@ -168,13 +151,12 @@ public final class Activity implements BridgeEntity {
         Activity other = (Activity) obj;
         return (Objects.equals(activityType, other.activityType) && 
             Objects.equals(label, other.label) && Objects.equals(labelDetail, other.labelDetail) &&
-            Objects.equals(guid,  other.guid) && Objects.equals(response, other.response) && 
-            Objects.equals(survey, other.survey) && Objects.equals(task, other.task));
+            Objects.equals(guid,  other.guid) && Objects.equals(survey, other.survey) && Objects.equals(task, other.task));
     }
 
     @Override
     public String toString() {
-        return String.format("Activity [label=%s, labelDetail=%s, guid=%s, task=%s, survey=%s, response=%s, activityType=%s]",
-            label, labelDetail, guid, task, survey, response, activityType);
+        return String.format("Activity [label=%s, labelDetail=%s, guid=%s, task=%s, survey=%s, activityType=%s]",
+            label, labelDetail, guid, task, survey, activityType);
     }
 }

--- a/app/org/sagebionetworks/bridge/models/schedules/ScheduleContext.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/ScheduleContext.java
@@ -27,14 +27,16 @@ public final class ScheduleContext {
     private final DateTime endsOn;
     private final Map<String,DateTime> events;
     private final DateTime now;
+    private final DateTime accountCreatedOn;
     private final CriteriaContext criteriaContext;
     
     private ScheduleContext(DateTimeZone zone, DateTime endsOn, Map<String, DateTime> events, DateTime now,
-            CriteriaContext criteriaContext) {
+            DateTime accountCreatedOn, CriteriaContext criteriaContext) {
         this.zone = zone;
         this.endsOn = endsOn;
         this.events = events;
         this.now = now;
+        this.accountCreatedOn = accountCreatedOn;
         this.criteriaContext = criteriaContext;
     }
     
@@ -83,13 +85,17 @@ public final class ScheduleContext {
         return now;
     }
     
+    public DateTime getAccountCreatedOn() {
+        return accountCreatedOn;
+    }
+    
     public CriteriaContext getCriteriaContext() {
         return criteriaContext;
     }
     
     @Override
     public int hashCode() {
-        return Objects.hash(zone, endsOn, events, now, criteriaContext);
+        return Objects.hash(zone, endsOn, events, now, accountCreatedOn, criteriaContext);
     }
 
     @Override
@@ -100,21 +106,24 @@ public final class ScheduleContext {
             return false;
         ScheduleContext other = (ScheduleContext) obj;
         return (Objects.equals(endsOn, other.endsOn) && Objects.equals(zone, other.zone) &&
-                Objects.equals(events, other.events) && Objects.equals(now, other.now) && 
+                Objects.equals(events, other.events) && Objects.equals(now, other.now) &&
+                Objects.equals(accountCreatedOn, other.accountCreatedOn) && 
                 Objects.equals(criteriaContext, other.criteriaContext));
     }
 
     @Override
     public String toString() {
-        return "ScheduleContext [zone=" + zone + ", endsOn=" + endsOn + ", events=" + events + ", criteriaContext="
-                + criteriaContext + "]";
+        return "ScheduleContext [zone=" + zone + ", endsOn=" + endsOn + ", events=" + events + ", now=" + now
+                + ", accountCreatedOn=" + accountCreatedOn + ", criteriaContext=" + criteriaContext + "]";
     }
-    
+
+
     public static class Builder {
         private DateTimeZone zone;
         private DateTime endsOn;
         private Map<String,DateTime> events;
         private DateTime now;
+        private DateTime accountCreatedOn;
         private CriteriaContext.Builder contextBuilder = new CriteriaContext.Builder();
         
         public Builder withStudyIdentifier(String studyId) {
@@ -155,6 +164,10 @@ public final class ScheduleContext {
             this.now = now;
             return this;
         }
+        public Builder withAccountCreatedOn(DateTime accountCreatedOn) {
+            this.accountCreatedOn = accountCreatedOn;
+            return this;
+        }
         public Builder withLanguages(LinkedHashSet<String> languages) {
             contextBuilder.withLanguages(languages);
             return this;
@@ -164,6 +177,7 @@ public final class ScheduleContext {
             this.endsOn = context.endsOn;
             this.events = context.events;
             this.now = context.now;
+            this.accountCreatedOn = context.accountCreatedOn;
             contextBuilder.withContext(context.criteriaContext);
             return this;
         }
@@ -174,7 +188,7 @@ public final class ScheduleContext {
             if (now == null) {
                 now = (zone == null) ? DateTime.now() : DateTime.now(zone);
             }
-            return new ScheduleContext(zone, endsOn, events, now, contextBuilder.build());
+            return new ScheduleContext(zone, endsOn, events, now, accountCreatedOn, contextBuilder.build());
         }
     }
 }

--- a/app/org/sagebionetworks/bridge/play/controllers/ScheduledActivityController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ScheduledActivityController.java
@@ -6,13 +6,18 @@ import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+
+import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.ResourceList;
+import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.User;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.schedules.ScheduleContext;
 import org.sagebionetworks.bridge.models.schedules.ScheduledActivity;
+import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.services.ScheduledActivityService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -30,10 +35,17 @@ public class ScheduledActivityController extends BaseController {
     private static final TypeReference<ArrayList<ScheduledActivity>> scheduledActivityTypeRef = new TypeReference<ArrayList<ScheduledActivity>>() {};
 
     private ScheduledActivityService scheduledActivityService;
+    
+    private AccountDao accountDao;
 
     @Autowired
     public void setScheduledActivityService(ScheduledActivityService scheduledActivityService) {
         this.scheduledActivityService = scheduledActivityService;
+    }
+    
+    @Autowired
+    public void setAccountDao(AccountDao accountDao) {
+        this.accountDao = accountDao;
     }
     
     // This annotation adds a deprecation header to the REST API method.
@@ -94,6 +106,21 @@ public class ScheduledActivityController extends BaseController {
         }
         ClientInfo clientInfo = getClientInfoFromUserAgentHeader();
         
+        DateTime accountCreatedOn = session.getUser().getAccountCreatedOn();
+        if (accountCreatedOn == null) {
+            Study study = studyService.getStudy(session.getStudyIdentifier());
+            User user = session.getUser();
+            // Everyone should have an ID at this point... otherwise sessions are hanging out for over a week.
+            if (user.getId() == null) {
+                accountCreatedOn = DateTime.now();
+            } else {
+                Account account = accountDao.getAccount(study, user.getId());
+                accountCreatedOn = account.getCreatedOn();
+            }
+            user.setAccountCreatedOn(accountCreatedOn);
+            updateSessionUser(session, user);
+        }
+        
         ScheduleContext context = new ScheduleContext.Builder()
                 .withLanguages(getLanguages(session))
                 .withUserDataGroups(session.getUser().getDataGroups())
@@ -101,6 +128,7 @@ public class ScheduledActivityController extends BaseController {
                 .withStudyIdentifier(session.getStudyIdentifier())
                 .withClientInfo(clientInfo)
                 .withTimeZone(zone)
+                .withAccountCreatedOn(accountCreatedOn)
                 .withEndsOn(endsOn).build();
         return scheduledActivityService.getScheduledActivities(session.getUser(), context);
     }

--- a/app/org/sagebionetworks/bridge/play/controllers/ScheduledActivityController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ScheduledActivityController.java
@@ -9,7 +9,6 @@ import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.sagebionetworks.bridge.cache.ViewCache;
 import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.json.DateUtils;

--- a/app/org/sagebionetworks/bridge/play/controllers/ScheduledActivityController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ScheduledActivityController.java
@@ -6,7 +6,10 @@ import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import org.sagebionetworks.bridge.cache.ViewCache;
 import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.json.DateUtils;
@@ -32,6 +35,8 @@ import play.mvc.Result;
 @Controller
 public class ScheduledActivityController extends BaseController {
 
+    private static final Logger LOG = LoggerFactory.getLogger(ScheduledActivityController.class);  
+    
     private static final TypeReference<ArrayList<ScheduledActivity>> scheduledActivityTypeRef = new TypeReference<ArrayList<ScheduledActivity>>() {};
 
     private ScheduledActivityService scheduledActivityService;
@@ -113,9 +118,11 @@ public class ScheduledActivityController extends BaseController {
             // Everyone should have an ID at this point... otherwise sessions are hanging out for over a week.
             if (user.getId() == null) {
                 accountCreatedOn = DateTime.now();
+                LOG.debug("neither accountCreatedOn nor ID exist in session, using current time");
             } else {
                 Account account = accountDao.getAccount(study, user.getId());
                 accountCreatedOn = account.getCreatedOn();
+                LOG.debug("accountCreatedOn not in session, retrieving it and updating session");
             }
             user.setAccountCreatedOn(accountCreatedOn);
             updateSessionUser(session, user);

--- a/app/org/sagebionetworks/bridge/validators/ActivityValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/ActivityValidator.java
@@ -8,7 +8,6 @@ import java.util.Set;
 
 import org.sagebionetworks.bridge.models.schedules.Activity;
 import org.sagebionetworks.bridge.models.schedules.SurveyReference;
-import org.sagebionetworks.bridge.models.schedules.SurveyResponseReference;
 import org.sagebionetworks.bridge.models.schedules.TaskReference;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
@@ -35,21 +34,12 @@ public class ActivityValidator implements Validator {
         if (isBlank(activity.getLabel())) {
             errors.rejectValue("label", CANNOT_BE_BLANK);
         }
-        if (activity.getTask() == null && activity.getSurvey() == null && activity.getSurveyResponse() == null) {
-            errors.rejectValue("reference", "must have a task or survey reference");
-            return;
-        }
         if (activity.getTask() != null) {
             validate(errors, activity.getTask());
-        } else if (activity.getSurveyResponse() != null) {
-            if (activity.getSurvey() != null) {
-                validate(errors, activity.getSurvey());
-            } else {
-                errors.reject("has a survey response, so it must also reference the survey");
-            }
-            validate(errors, activity.getSurveyResponse());
-        } else {
+        } else if (activity.getSurvey() != null){
             validate(errors, activity.getSurvey());
+        } else {
+            errors.rejectValue("", "must have a task or survey reference");
         }
     }
     
@@ -67,14 +57,6 @@ public class ActivityValidator implements Validator {
         errors.pushNestedPath("survey");
         if (isBlank(ref.getGuid())) {
             errors.rejectValue("guid", CANNOT_BE_BLANK);
-        }
-        errors.popNestedPath();
-    }
-    
-    private void validate(Errors errors, SurveyResponseReference ref) {
-        errors.pushNestedPath("surveyResponse");
-        if (isBlank(ref.getIdentifier())) {
-            errors.rejectValue("identifier", CANNOT_BE_BLANK);
         }
         errors.popNestedPath();
     }

--- a/app/org/sagebionetworks/bridge/validators/ScheduleContextValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/ScheduleContextValidator.java
@@ -30,6 +30,9 @@ public class ScheduleContextValidator implements Validator {
         if (context.getCriteriaContext().getHealthCode() == null) {
             errors.rejectValue("healthCode", "is required");
         }
+        if (context.getAccountCreatedOn() == null) {
+            errors.rejectValue("accountCreatedOn", "is required");
+        }
         // Very the ending timestamp is not invalid.
         DateTime now = context.getNow();
         if (context.getEndsOn() == null) {

--- a/test/org/sagebionetworks/bridge/models/accounts/UserTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/UserTest.java
@@ -5,10 +5,14 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Set;
 
+import org.joda.time.DateTime;
 import org.junit.Test;
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.TestUtils;
@@ -22,9 +26,31 @@ import nl.jqno.equalsverifier.Warning;
 
 public class UserTest {
 
+    private static final DateTime CREATED_ON = DateTime.now();
+    private static final Set<Roles> ROLES = Sets.newHashSet(Roles.ADMIN, Roles.DEVELOPER);
+    
     @Test
     public void hashCodeEquals() {
         EqualsVerifier.forClass(User.class).suppress(Warning.NONFINAL_FIELDS).allFieldsShouldBeUsed().verify();
+    }
+    
+    @Test
+    public void initializedFromAccount() {
+        Account account = mock(Account.class);
+        doReturn("email.email.com").when(account).getEmail();
+        doReturn("first").when(account).getFirstName();
+        doReturn("last").when(account).getLastName();
+        doReturn("id").when(account).getId();
+        doReturn(CREATED_ON).when(account).getCreatedOn();
+        doReturn(ROLES).when(account).getRoles();
+        
+        User user = new User(account);
+        assertEquals("email.email.com", user.getEmail());
+        assertEquals("first", user.getFirstName());
+        assertEquals("last", user.getLastName());
+        assertEquals("id", user.getId());
+        assertEquals(CREATED_ON, user.getAccountCreatedOn());
+        assertEquals(ROLES, user.getRoles());
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/models/activities/ActivityTest.java
+++ b/test/org/sagebionetworks/bridge/models/activities/ActivityTest.java
@@ -16,7 +16,6 @@ import org.sagebionetworks.bridge.models.schedules.Activity;
 import org.sagebionetworks.bridge.models.schedules.ActivityType;
 import org.sagebionetworks.bridge.models.schedules.Schedule;
 import org.sagebionetworks.bridge.models.schedules.SurveyReference;
-import org.sagebionetworks.bridge.models.schedules.SurveyResponseReference;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -133,53 +132,6 @@ public class ActivityTest {
     }
     
     @Test
-    public void canSerializeSurveyResponseActivity() throws Exception {
-        Activity activity = new Activity.Builder().withLabel("Label")
-            .withLabelDetail("Label Detail").withPublishedSurvey("identifier", "guid")
-            .withSurveyResponse("BBB").build();
-        
-        BridgeObjectMapper mapper = BridgeObjectMapper.get();
-        String json = mapper.writeValueAsString(activity);
-
-        JsonNode node = mapper.readTree(json);
-        assertEquals("Label", node.get("label").asText());
-        assertEquals("Label Detail", node.get("labelDetail").asText());
-        assertEquals("survey", node.get("activityType").asText());
-        String hrefString = node.get("survey").get("href").asText();
-        assertTrue(hrefString.matches("http[s]?://.*/v3/surveys/guid/revisions/published"));
-        assertNotNull("guid", node.get("guid"));
-        assertEquals("Activity", node.get("type").asText());
-        
-        JsonNode ref = node.get("survey");
-        assertEquals("identifier", ref.get("identifier").asText());
-        assertEquals("guid", ref.get("guid").asText());
-        String href = ref.get("href").asText();
-        assertTrue(href.matches("http[s]?://.*/v3/surveys/guid/revisions/published"));
-        assertEquals("SurveyReference", ref.get("type").asText());
-        
-        ref = node.get("surveyResponse");
-        assertEquals("BBB", ref.get("identifier").asText());
-        href = ref.get("href").asText();
-        assertTrue(href.matches("http[s]?://.*/v3/surveyresponses/BBB"));
-        assertEquals("SurveyResponseReference", ref.get("type").asText());
-        
-        activity = mapper.readValue(json, Activity.class);
-        assertEquals("Label", activity.getLabel());
-        assertEquals("Label Detail", activity.getLabelDetail());
-        assertEquals(ActivityType.SURVEY, activity.getActivityType());
-        
-        SurveyReference ref1 = activity.getSurvey();
-        assertEquals("identifier", ref1.getIdentifier());
-        assertNull("createdOn", ref1.getCreatedOn());
-        assertEquals("guid", ref1.getGuid());
-        assertTrue(ref1.getHref().matches("http[s]?://.*/v3/surveys/guid/revisions/published"));
-        
-        SurveyResponseReference ref2 = activity.getSurveyResponse();
-        assertEquals("BBB", ref2.getIdentifier());
-        assertTrue(ref2.getHref().matches("http[s]?://.*/v3/surveyresponses/BBB"));
-    }
-    
-    @Test
     public void olderPublishedActivitiesCanBeDeserialized() throws Exception {
         String oldJson = "{\"label\":\"Personal Health Survey\",\"ref\":\"https://webservices-staging.sagebridge.org/api/v2/surveys/ac1e57fd-5e8e-473f-b82f-bac7547b6783/revisions/published\",\"activityType\":\"survey\",\"survey\":{\"guid\":\"ac1e57fd-5e8e-473f-b82f-bac7547b6783\",\"identifier\":\"identifier\",\"type\":\"GuidCreatedOnVersionHolder\"},\"type\":\"Activity\"}";
         
@@ -259,7 +211,6 @@ public class ActivityTest {
         Activity activity1 = new Activity.Builder().withGuid("AAA").withLabel("Label").withLabelDetail("LabelDetail")
                 .withTask("TaskId")
                 .withPublishedSurvey("identifier", "BBB")
-                .withSurveyResponse("CCC")
                 .build();
         
         Activity activity2 = new Activity.Builder().withActivity(activity1).build();
@@ -269,7 +220,6 @@ public class ActivityTest {
         assertEquals("TaskId", activity2.getTask().getIdentifier());
         assertEquals("BBB", activity2.getSurvey().getGuid());
         assertEquals("identifier", activity2.getSurvey().getIdentifier());
-        assertEquals("CCC", activity2.getSurveyResponse().getIdentifier());
     }
 
 }

--- a/test/org/sagebionetworks/bridge/play/controllers/SchedulePlanControllerMockTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SchedulePlanControllerMockTest.java
@@ -74,12 +74,13 @@ public class SchedulePlanControllerMockTest {
         try {
             controller.updateSchedulePlan("test-study");
         } catch(InvalidEntityException e) {
+            System.out.println(e.getMessage());
             assertMessage(e, "label", "cannot be missing, null, or blank");
             assertMessage(e, "strategy.scheduleGroups", "groups must add up to 100%");
             assertMessage(e, "strategy.scheduleGroups[0].schedule.activities", "are required");
             assertMessage(e, "strategy.scheduleGroups[0].schedule.scheduleType", "is required");
             assertMessage(e, "strategy.scheduleGroups[1].schedule.scheduleType", "is required");
-            assertMessage(e, "strategy.scheduleGroups[1].schedule.activities[0].reference", "must have a task or survey reference");
+            assertMessage(e, "strategy.scheduleGroups[1].schedule.activities[0]", "must have a task or survey reference");
         }
     }
 }

--- a/test/org/sagebionetworks/bridge/play/controllers/ScheduledActivityControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ScheduledActivityControllerTest.java
@@ -230,6 +230,14 @@ public class ScheduledActivityControllerTest {
     }
     
     @Test
+    public void fullyInitializedSessionProvidesAccountCreatedOnInScheduleContext() throws Exception {
+        controller.getScheduledActivities(null, "-07:00", "3");
+        verify(scheduledActivityService).getScheduledActivities(any(), contextCaptor.capture());
+        ScheduleContext context = contextCaptor.getValue();
+        assertEquals(ACCOUNT_CREATED_ON, context.getAccountCreatedOn());
+    }
+    
+    @Test
     public void oldSessionsWithIdAndNoAccountCreatedOn() throws Exception {
         session.getUser().setAccountCreatedOn(null); // this is not currently in the session
         

--- a/test/org/sagebionetworks/bridge/play/controllers/ScheduledActivityControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ScheduledActivityControllerTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -19,21 +20,31 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
+import org.sagebionetworks.bridge.cache.CacheProvider;
+import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dynamodb.DynamoScheduledActivity;
 import org.sagebionetworks.bridge.exceptions.NotAuthenticatedException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.CriteriaContext;
+import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.User;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.schedules.ScheduleContext;
 import org.sagebionetworks.bridge.models.schedules.ScheduledActivity;
+import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.play.controllers.ScheduledActivityController;
 import org.sagebionetworks.bridge.services.ScheduledActivityService;
+import org.sagebionetworks.bridge.services.StudyService;
 
 import play.mvc.Result;
 import play.test.Helpers;
@@ -43,15 +54,39 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
+@RunWith(MockitoJUnitRunner.class)
 public class ScheduledActivityControllerTest {
 
-    private ScheduledActivityService scheduledActivityService;
+    private static final DateTime ACCOUNT_CREATED_ON = DateTime.now();
+    
+    private static final String ID = "id";
     
     private ScheduledActivityController controller;
     
     private ClientInfo clientInfo;
 
-    ArgumentCaptor<ScheduleContext> argument = ArgumentCaptor.forClass(ScheduleContext.class);
+    @Mock
+    ScheduledActivityService scheduledActivityService;
+    
+    @Mock
+    AccountDao accountDao;
+    
+    @Mock
+    StudyService studyService;
+    
+    @Mock
+    CacheProvider cacheProvider;
+    
+    @Mock
+    Study study;
+    
+    @Mock
+    Account account;
+    
+    @Captor
+    ArgumentCaptor<ScheduleContext> contextCaptor;
+    
+    UserSession session;
     
     @Before
     public void before() throws Exception {
@@ -65,20 +100,28 @@ public class ScheduledActivityControllerTest {
         String json = BridgeObjectMapper.get().writeValueAsString(list);
         TestUtils.mockPlayContextWithJson(json);
         
-        UserSession session = new UserSession();
+        session = new UserSession();
         User user = new User();
         user.setHealthCode("BBB");
         user.setStudyKey(TestConstants.TEST_STUDY_IDENTIFIER);
         user.setDataGroups(Sets.newHashSet("group1"));
         user.setLanguages(TestUtils.newLinkedHashSet("en","fr"));
+        user.setAccountCreatedOn(ACCOUNT_CREATED_ON);
+        user.setId(ID);
         session.setUser(user);
         session.setStudyIdentifier(TestConstants.TEST_STUDY);
         
-        scheduledActivityService = mock(ScheduledActivityService.class);
         when(scheduledActivityService.getScheduledActivities(any(User.class), any(ScheduleContext.class))).thenReturn(list);
-        
+
+        doReturn(ACCOUNT_CREATED_ON).when(account).getCreatedOn();
+        doReturn(account).when(accountDao).getAccount(any(), eq(ID));
+        doReturn(study).when(studyService).getStudy(TestConstants.TEST_STUDY_IDENTIFIER);
+
         controller = spy(new ScheduledActivityController());
         controller.setScheduledActivityService(scheduledActivityService);
+        controller.setStudyService(studyService);
+        controller.setCacheProvider(cacheProvider);
+        controller.setAccountDao(accountDao);
         doReturn(session).when(controller).getAuthenticatedAndConsentedSession();
         
         clientInfo = ClientInfo.fromUserAgentCache("App Name/4 SDK/2");
@@ -150,10 +193,10 @@ public class ScheduledActivityControllerTest {
         DateTime now = DateTime.parse("2011-05-13T12:37:31.985+03:00");
         
         controller.getScheduledActivities(now.toString(), null, null);
-        verify(scheduledActivityService).getScheduledActivities(any(User.class), argument.capture());
+        verify(scheduledActivityService).getScheduledActivities(any(User.class), contextCaptor.capture());
         verifyNoMoreInteractions(scheduledActivityService);
-        assertEquals(now, argument.getValue().getEndsOn());
-        assertEquals(now.getZone(), argument.getValue().getZone());
+        assertEquals(now, contextCaptor.getValue().getEndsOn());
+        assertEquals(now.getZone(), contextCaptor.getValue().getZone());
     }
     
     @Test
@@ -165,11 +208,11 @@ public class ScheduledActivityControllerTest {
             .withHourOfDay(23).withMinuteOfHour(59).withSecondOfMinute(59).withMillisOfSecond(0);
         
         controller.getScheduledActivities(null, "+03:00", "3");
-        verify(scheduledActivityService).getScheduledActivities(any(User.class), argument.capture());
+        verify(scheduledActivityService).getScheduledActivities(any(User.class), contextCaptor.capture());
         verifyNoMoreInteractions(scheduledActivityService);
-        assertEquals(expectedEndsOn, argument.getValue().getEndsOn().withMillisOfSecond(0));
-        assertEquals(expectedEndsOn.getZone(), argument.getValue().getZone());
-        assertEquals(clientInfo, argument.getValue().getCriteriaContext().getClientInfo());
+        assertEquals(expectedEndsOn, contextCaptor.getValue().getEndsOn().withMillisOfSecond(0));
+        assertEquals(expectedEndsOn.getZone(), contextCaptor.getValue().getZone());
+        assertEquals(clientInfo, contextCaptor.getValue().getCriteriaContext().getClientInfo());
     }
     
     @SuppressWarnings("unchecked")
@@ -186,4 +229,24 @@ public class ScheduledActivityControllerTest {
         controller.getScheduledActivities(DateTime.now().toString(), null, null);
     }
     
+    @Test
+    public void oldSessionsWithIdAndNoAccountCreatedOn() throws Exception {
+        session.getUser().setAccountCreatedOn(null); // this is not currently in the session
+        
+        controller.getScheduledActivities(null, "-07:00", "3");
+        verify(scheduledActivityService).getScheduledActivities(any(), contextCaptor.capture());
+        ScheduleContext context = contextCaptor.getValue();
+        assertEquals(ACCOUNT_CREATED_ON, context.getAccountCreatedOn());
+    }
+    
+    @Test
+    public void oldSessionsWithNoIdAndNoAccountCreatedOn() throws Exception {
+        session.getUser().setAccountCreatedOn(null); // these are not currently in the session
+        session.getUser().setId(null);
+        
+        controller.getScheduledActivities(null, "-07:00", "3");
+        verify(scheduledActivityService).getScheduledActivities(any(), contextCaptor.capture());
+        ScheduleContext context = contextCaptor.getValue();
+        assertNotNull(context.getAccountCreatedOn()); // this is a timestamp, so
+    }
 }

--- a/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceTest.java
@@ -209,6 +209,7 @@ public class ScheduledActivityServiceTest {
             .withStudyIdentifier(TEST_STUDY)
             .withClientInfo(ClientInfo.UNKNOWN_CLIENT)
             .withTimeZone(zone)
+            .withAccountCreatedOn(DateTime.now())
             // Setting the endsOn value to the end of the day, as we do in the controller.
             .withEndsOn(endsOn.withHourOfDay(23).withMinuteOfHour(59).withSecondOfMinute(59))
             .withHealthCode(testUser.getUser().getHealthCode()).build();

--- a/test/org/sagebionetworks/bridge/validators/ActivityValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/ActivityValidatorTest.java
@@ -9,7 +9,6 @@ import java.util.Set;
 import org.junit.Test;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.models.schedules.Activity;
-import org.sagebionetworks.bridge.models.schedules.SurveyResponseReference;
 
 import com.google.common.collect.Sets;
 
@@ -84,18 +83,7 @@ public class ActivityValidatorTest {
     }
     
     @Test
-    public void rejectsSurveyResponseWithoutSurvey() {
-        try {
-            Activity activity = new Activity.Builder().withLabel("Label").withSurveyResponse((String)null).build();
-            Validate.entityThrowingException(new ActivityValidator(EMPTY_TASKS), activity);
-            fail("Should have thrown exception");
-        } catch(InvalidEntityException e) {
-            assertEquals("Activity has a survey response, so it must also reference the survey", e.getErrors().get("Activity").get(0));
-        }
-    }
-    
-    @Test
     public void surveyResponseWithoutIdentifierIsOK() {
-        new Activity.Builder().withLabel("Label").withSurveyResponse((SurveyResponseReference)null).withPublishedSurvey("identifier", "guid").build();
+        new Activity.Builder().withLabel("Label").withPublishedSurvey("identifier", "guid").build();
     }
 }

--- a/test/org/sagebionetworks/bridge/validators/ScheduleContextValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/ScheduleContextValidatorTest.java
@@ -30,7 +30,7 @@ public class ScheduleContextValidatorTest {
     }
     
     @Test
-    public void studyIdentifierTimeZoneHealthCodeAndEndsOnAlwaysRequired() {
+    public void requiredFields() {
         ScheduleContext context = new ScheduleContext.Builder().withStudyIdentifier("test").build();
         try {
             Validate.nonEntityThrowingException(validator, context);
@@ -39,13 +39,15 @@ public class ScheduleContextValidatorTest {
             assertTrue(e.getMessage().contains("offset must set a time zone offset"));
             assertTrue(e.getMessage().contains("healthCode is required"));
             assertTrue(e.getMessage().contains("endsOn is required"));
+            assertTrue(e.getMessage().contains("accountCreatedOn is required"));
         }
     }
 
     @Test
     public void endsOnAfterNow() {
         ScheduleContext context = new ScheduleContext.Builder()
-            .withStudyIdentifier("study-id").withTimeZone(DateTimeZone.UTC)
+            .withStudyIdentifier("study-id")
+            .withTimeZone(DateTimeZone.UTC)
             .withEndsOn(DateTime.now().minusHours(1)).withHealthCode("healthCode").build();
         try {
             Validate.nonEntityThrowingException(validator, context);
@@ -69,7 +71,5 @@ public class ScheduleContextValidatorTest {
             assertTrue(e.getMessage().contains("endsOn must be 5 days or less"));
         }
     }
-    
-    
     
 }

--- a/test/org/sagebionetworks/bridge/validators/ScheduleContextValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/ScheduleContextValidatorTest.java
@@ -22,6 +22,7 @@ public class ScheduleContextValidatorTest {
             .withClientInfo(ClientInfo.UNKNOWN_CLIENT)
             .withEndsOn(DateTime.now().plusDays(2))
             .withTimeZone(DateTimeZone.forOffsetHours(-3))
+            .withAccountCreatedOn(DateTime.now())
             .withHealthCode("AAA")
             .build();
         


### PR DESCRIPTION
- Fixing scheduling for studies where users do not have to consent to use the server. When no enrollment event exists, we use the timestamp of the creation of the user's stormpath account (which should always exist).
- Removing references to survey responses in the scheduling system to simplify the code.

We are no longer looking for consent records if a really old account doesn't have an enrollment event. The createdOn timestamp of the user's account is close enough for the purposes of scheduling and far simpler to retrieve.
