### PR TITLE
Move update of user's session from ParticipantService to ParticipantController

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
@@ -70,7 +70,7 @@ public class ParticipantController extends BaseController {
         
         participantService.updateParticipant(study, NO_ROLES, userId, updated);
         
-        // Update the user's session, including consent statuses.
+        // Update this user's session (creates one if it doesn't exist, but this is safe)
         CriteriaContext context = getCriteriaContext(study.getStudyIdentifier());
         session = authenticationService.updateSession(study, context, userId);
         updateSessionUser(session, session.getUser());
@@ -119,7 +119,7 @@ public class ParticipantController extends BaseController {
         }
         participantService.updateParticipant(study, session.getUser().getRoles(), userId, participant);
         
-        // Update this user's session (creates one if it doesn't exist, but this is safe)
+        // Push changes to the user's session, including consent statuses.
         CriteriaContext context = new CriteriaContext.Builder()
                 .withStudyIdentifier(study.getStudyIdentifier()).build();
         session = authenticationService.updateSession(study, context, userId);

--- a/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Controller;
 
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
+import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.accounts.AccountSummary;
 import org.sagebionetworks.bridge.models.accounts.IdentifierHolder;
@@ -68,6 +69,12 @@ public class ParticipantController extends BaseController {
                 .copyFieldsOf(participant, fieldNames).build();
         
         participantService.updateParticipant(study, NO_ROLES, userId, updated);
+        
+        // Update the user's session, including consent statuses.
+        CriteriaContext context = getCriteriaContext(study.getStudyIdentifier());
+        session = authenticationService.updateSession(study, context, userId);
+        updateSessionUser(session, session.getUser());
+        
         return okResult("Participant updated.");
     }
     
@@ -112,6 +119,12 @@ public class ParticipantController extends BaseController {
         }
         participantService.updateParticipant(study, session.getUser().getRoles(), userId, participant);
         
+        // Update this user's session (creates one if it doesn't exist, but this is safe)
+        CriteriaContext context = new CriteriaContext.Builder()
+                .withStudyIdentifier(study.getStudyIdentifier()).build();
+        session = authenticationService.updateSession(study, context, userId);
+        updateSessionUser(session, session.getUser());
+
         return okResult("Participant updated.");
     }
     

--- a/app/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -254,6 +254,11 @@ public class AuthenticationService {
         accountDao.resetPassword(passwordReset);
     }
     
+    public UserSession updateSession(Study study, CriteriaContext context, String userId) {
+        Account account = accountDao.getAccount(study, userId);
+        return getSessionFromAccount(study, context, account);
+    }
+    
     /**
      * Early in the production lifetime of the application, some accounts were created that have a signature 
      * in Stormpath, but no record in DynamoDB. Some other records had a DynamoDB record in an earlier version 

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -38,9 +38,7 @@ import org.sagebionetworks.bridge.models.accounts.HealthId;
 import org.sagebionetworks.bridge.models.accounts.IdentifierHolder;
 import org.sagebionetworks.bridge.models.accounts.ParticipantOptionsLookup;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
-import org.sagebionetworks.bridge.models.accounts.User;
 import org.sagebionetworks.bridge.models.accounts.UserConsentHistory;
-import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
 import org.sagebionetworks.bridge.validators.StudyParticipantValidator;
@@ -250,25 +248,7 @@ public class ParticipantService {
         if (isNew && isNotBlank(participant.getExternalId())) {
             externalIdService.assignExternalId(study, participant.getExternalId(), healthCode);
         }
-        // Clear the user's session so that any changes are picked up by the app. New accounts don't have this issue.
-        if (!isNew) {
-            updateSession(account.getId(), participant);
-        }
         return new IdentifierHolder(account.getId());
-    }
-    
-    private void updateSession(String userId, StudyParticipant participant) {
-        UserSession session = cacheProvider.getUserSessionByUserId(userId);
-        if (session != null) {
-            User user = session.getUser();
-            user.setFirstName(participant.getFirstName());
-            user.setLastName(participant.getLastName());
-            user.setRoles(participant.getRoles());
-            user.setDataGroups(participant.getDataGroups());
-            user.setLanguages(participant.getLanguages());
-            user.setSharingScope(participant.getSharingScope());
-            cacheProvider.setUserSession(session);
-        }
     }
     
     private boolean callerIsAdmin(Set<Roles> roles) {

--- a/test/org/sagebionetworks/bridge/BridgeUtilsTest.java
+++ b/test/org/sagebionetworks/bridge/BridgeUtilsTest.java
@@ -127,6 +127,8 @@ public class BridgeUtilsTest {
         map.put("A", "B");
         map.put("C", "D");
         
+        assertEquals("B", map.get("A"));
+        assertEquals("D", map.get("C"));
         assertEquals(map, BridgeUtils.nullSafeImmutableMap(map));
         
         Map<String,String> newMap = BridgeUtils.nullSafeImmutableMap(map);

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -2,7 +2,6 @@ package org.sagebionetworks.bridge.services;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -504,26 +503,6 @@ public class ParticipantServiceTest {
         verify(account).setLastName(LAST_NAME);
         verify(account).setStatus(AccountStatus.DISABLED);
         verify(account).setAttribute(PHONE, "123456789");
-        
-        verify(cacheProvider).setUserSession(sessionCaptor.capture());
-        
-        UserSession session = sessionCaptor.getValue();
-        assertEquals(EMAIL, session.getUser().getEmail());
-        assertEquals(FIRST_NAME, session.getUser().getFirstName());
-        assertEquals(LAST_NAME, session.getUser().getLastName());
-        assertEquals(HEALTH_CODE, session.getUser().getHealthCode());
-        assertEquals(ID, session.getUser().getId());
-        assertEquals(STUDY.getStudyIdentifier(), session.getStudyIdentifier());
-        assertEquals(Sets.newHashSet(), session.getUser().getRoles());
-        assertEquals(STUDY_DATA_GROUPS, session.getUser().getDataGroups());
-        assertEquals(USER_LANGUAGES, session.getUser().getLanguages());
-        assertEquals(SharingScope.ALL_QUALIFIED_RESEARCHERS, session.getUser().getSharingScope());
-        assertNotNull(session.getUser().getConsentStatuses());
-        assertEquals("sessionToken", session.getSessionToken());
-        assertEquals("internalSessionToken", session.getInternalSessionToken());
-        assertTrue(session.isAuthenticated());
-        assertEquals(Environment.DEV, session.getEnvironment());
-        assertEquals(STUDY.getStudyIdentifier(), session.getStudyIdentifier());
     }
     
     @Test(expected = BadRequestException.class)


### PR DESCRIPTION
- moving this to the controller allows us to recalculate consent statuses, in part based on the user's request in the case of the API to update one's own participant. Also allows us to re-use the logic for constructing a session.
