### PR TITLE
v4 Schema APIs

### DIFF
--- a/app/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/app/org/sagebionetworks/bridge/BridgeUtils.java
@@ -36,9 +36,9 @@ import com.stormpath.sdk.group.GroupList;
 public class BridgeUtils {
     
     public static final Joiner COMMA_SPACE_JOINER = Joiner.on(", ");
-
     public static final Joiner COMMA_JOINER = Joiner.on(",");
-    
+    public static final Joiner SEMICOLON_SPACE_JOINER = Joiner.on("; ");
+
     /**
      * A simple means of providing template variables in template strings, in the format <code>${variableName}</code>.
      * This value will be replaced with the value of the variable name. The variable name/value pairs are passed to the

--- a/app/org/sagebionetworks/bridge/dao/UploadSchemaDao.java
+++ b/app/org/sagebionetworks/bridge/dao/UploadSchemaDao.java
@@ -11,6 +11,19 @@ import org.sagebionetworks.bridge.models.upload.UploadSchema;
 /** DAO for upload schemas. This encapsulates standard CRUD operations as well as list operations. */
 public interface UploadSchemaDao {
     /**
+     * DAO for creating schema revision using the new V4 semantics. The schema ID and revision will be taken from the
+     * UploadSchema object. If the revision isn't specified, we'll get the latest schema rev for the schema ID and use
+     * that rev + 1.
+     *
+     * @param studyId
+     *         study that will contain the schema
+     * @param uploadSchema
+     *         schema to create
+     * @return the created schema revision
+     */
+    @Nonnull UploadSchema createSchemaRevisionV4(@Nonnull StudyIdentifier studyId, @Nonnull UploadSchema uploadSchema);
+
+    /**
      * DAO method for creating and updating upload schemas. This method creates an upload schema, using the study ID
      * and schema ID of the specified schema, or updates an existing one if it already exists.
      *
@@ -107,4 +120,21 @@ public interface UploadSchemaDao {
      * @return a list of upload schemas
      */
     @Nonnull List<UploadSchema> getUploadSchemasForStudy(@Nonnull StudyIdentifier studyId);
+
+    /**
+     * DAO for updating a schema rev using V4 semantics. This also validates that the schema changes are legal. Legal
+     * changes means schema fields cannot be deleted or modified (except for adding the maxAppVersion attributes).
+     *
+     * @param studyId
+     *         study that contains the schema
+     * @param schemaId
+     *         schema ID to update
+     * @param schemaRev
+     *         schema revision to update
+     * @param uploadSchema
+     *         schema with updates to persist
+     * @return the updated schema revision
+     */
+    @Nonnull UploadSchema updateSchemaRevisionV4(@Nonnull StudyIdentifier studyId, @Nonnull String schemaId, int schemaRev,
+            @Nonnull UploadSchema uploadSchema);
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadFieldDefinition.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadFieldDefinition.java
@@ -124,6 +124,19 @@ public final class DynamoUploadFieldDefinition implements UploadFieldDefinition 
         private Boolean required;
         private UploadFieldType type;
 
+        /** Copies attributes from the given field definition. */
+        public Builder copyOf(UploadFieldDefinition other) {
+            this.fileExtension = other.getFileExtension();
+            this.mimeType = other.getMimeType();
+            this.minAppVersion = other.getMinAppVersion();
+            this.maxAppVersion = other.getMaxAppVersion();
+            this.maxLength = other.getMaxLength();
+            this.name = other.getName();
+            this.required = other.isRequired();
+            this.type = other.getType();
+            return this;
+        }
+
         /** @see org.sagebionetworks.bridge.models.upload.UploadFieldDefinition#getFileExtension */
         public Builder withFileExtension(String fileExtension) {
             this.fileExtension = fileExtension;

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDao.java
@@ -8,6 +8,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
@@ -17,9 +19,11 @@ import com.amazonaws.services.dynamodbv2.model.ExpectedAttributeValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
+import com.google.common.collect.Sets;
 import org.springframework.stereotype.Component;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.dao.UploadSchemaDao;
+import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.ConcurrentModificationException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
@@ -66,6 +70,37 @@ public class DynamoUploadSchemaDao implements UploadSchemaDao {
     @Resource(name = "uploadSchemaStudyIdIndex")
     public void setStudyIdIndex(DynamoIndexHelper studyIdIndex) {
         this.studyIdIndex = studyIdIndex;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public @Nonnull UploadSchema createSchemaRevisionV4(@Nonnull StudyIdentifier studyId,
+            @Nonnull UploadSchema uploadSchema) {
+        // Currently, all UploadSchemas are DynamoUploadSchemas, so we don't need to validate this class cast.
+        DynamoUploadSchema ddbUploadSchema = (DynamoUploadSchema) uploadSchema;
+
+        // Set revision if needed. 0 represents an unset schema rev.
+        if (uploadSchema.getRevision() == 0) {
+            int oldRev = getCurrentSchemaRevision(studyId.getIdentifier(), uploadSchema.getSchemaId());
+            ddbUploadSchema.setRevision(oldRev + 1);
+        }
+
+        // Set study.
+        ddbUploadSchema.setStudyId(studyId.getIdentifier());
+
+        // Blank of version. This allows people to copy-paste schema revs from other studies, or easily create a new
+        // schema rev from a previously existing one. It also means if they get a schema rev and then try to create
+        // that schema rev again, we'll correctly through a ConcurrentModificationException.
+        ddbUploadSchema.setVersion(null);
+
+        // Call DDB to create.
+        try {
+            mapper.save(ddbUploadSchema);
+        } catch (ConditionalCheckFailedException ex) {
+            throw new ConcurrentModificationException(ddbUploadSchema);
+        }
+
+        return ddbUploadSchema;
     }
 
     /** {@inheritDoc} */
@@ -365,5 +400,106 @@ public class DynamoUploadSchemaDao implements UploadSchemaDao {
         }
         // Do we care if it's sorted? What would it be sorted by?
         return ImmutableList.copyOf(schemaMap.values());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public @Nonnull UploadSchema updateSchemaRevisionV4(@Nonnull StudyIdentifier studyId, @Nonnull String schemaId,
+            int schemaRev, @Nonnull UploadSchema uploadSchema) {
+        List<String> errorMessageList = new ArrayList<>();
+
+        // Get existing version of the schema rev (throws if it doesn't exist).
+        UploadSchema oldSchema = getUploadSchemaByIdAndRev(studyId, schemaId, schemaRev);
+
+        // Get field names for old and new schema and compute the fields that have been deleted or retained. (Don't
+        // care about added fields.)
+        Map<String, UploadFieldDefinition> oldFieldMap = getFieldsByName(oldSchema);
+        Set<String> oldFieldNameSet = oldFieldMap.keySet();
+
+        Map<String, UploadFieldDefinition> newFieldMap = getFieldsByName(uploadSchema);
+        Set<String> newFieldNameSet = newFieldMap.keySet();
+
+        Set<String> deletedFieldNameSet = Sets.difference(oldFieldNameSet, newFieldNameSet);
+        Set<String> retainedFieldNameSet = Sets.intersection(oldFieldNameSet, newFieldNameSet);
+
+        // Check deleted fields.
+        if (!deletedFieldNameSet.isEmpty()) {
+            errorMessageList.add("Can't delete fields: " + BridgeUtils.COMMA_SPACE_JOINER.join(deletedFieldNameSet));
+        }
+
+        // Check retained fields, make sure none are modified.
+        Set<String> modifiedFieldNameSet = new TreeSet<>();
+        for (String oneRetainedFieldName : retainedFieldNameSet) {
+            UploadFieldDefinition oldFieldDef = oldFieldMap.get(oneRetainedFieldName);
+            UploadFieldDefinition newFieldDef = newFieldMap.get(oneRetainedFieldName);
+
+            if (!equalsExceptMaxAppVersion(oldFieldDef, newFieldDef)) {
+                modifiedFieldNameSet.add(oneRetainedFieldName);
+            }
+        }
+        if (!modifiedFieldNameSet.isEmpty()) {
+            errorMessageList.add("Can't modify fields: " + BridgeUtils.COMMA_SPACE_JOINER.join(modifiedFieldNameSet));
+        }
+
+        // If we have any errors, concat them together and throw a 400 bad request.
+        if (!errorMessageList.isEmpty()) {
+            throw new BadRequestException("Can't update study " + studyId.getIdentifier() + " schema " + schemaId +
+                    " revision " + schemaRev + ": " + BridgeUtils.SEMICOLON_SPACE_JOINER.join(errorMessageList));
+        }
+
+        // Currently, all UploadSchemas are DynamoUploadSchemas, so we don't need to validate this class cast.
+        DynamoUploadSchema ddbUploadSchema = (DynamoUploadSchema) uploadSchema;
+
+        // Set the study ID, since clients don't have this.
+        ddbUploadSchema.setStudyId(studyId.getIdentifier());
+
+        // Use the schema ID and rev from the params. This allows callers to copy schemas and schema revs.
+        ddbUploadSchema.setSchemaId(schemaId);
+        ddbUploadSchema.setRevision(schemaRev);
+
+        // Everything checks out. Write the upload schema. Watch out for concurrent modification.
+        try {
+            mapper.save(ddbUploadSchema);
+        } catch (ConditionalCheckFailedException ex) {
+            throw new ConcurrentModificationException(ddbUploadSchema);
+        }
+
+        return ddbUploadSchema;
+    }
+
+    // Helper method to get a map of fields by name for an Upload Schema. Returns a TreeMap so our error messaging has
+    // the fields in a consistent order.
+    private static Map<String, UploadFieldDefinition> getFieldsByName(UploadSchema uploadSchema) {
+        Map<String, UploadFieldDefinition> fieldsByName = new TreeMap<>();
+        List<UploadFieldDefinition> fieldDefList = uploadSchema.getFieldDefinitions();
+        for (UploadFieldDefinition oneFieldDef : fieldDefList) {
+            fieldsByName.put(oneFieldDef.getName(), oneFieldDef);
+        }
+        return fieldsByName;
+    }
+
+    // Helper method to test that two field defs are identical except for the maxAppVersion field (which can only be
+    // added to newFieldDef). This is because adding maxAppVersion is how we mark fields as deprecated. Package-scoped
+    // to facilitate unit tests.
+    static boolean equalsExceptMaxAppVersion(UploadFieldDefinition oldFieldDef, UploadFieldDefinition newFieldDef) {
+        // Short-cut: If they're equal with maxAppVersion, then they're equal regardless.
+        if (oldFieldDef.equals(newFieldDef)) {
+            return true;
+        }
+
+        // Make copies of both, but blank out maxAppVersion so we can use .equals().
+        UploadFieldDefinition copyOldFieldDef = new DynamoUploadFieldDefinition.Builder().copyOf(oldFieldDef)
+                .withMaxAppVersion(null).build();
+        UploadFieldDefinition copyNewFieldDef = new DynamoUploadFieldDefinition.Builder().copyOf(newFieldDef)
+                .withMaxAppVersion(null).build();
+
+        // If the .equals() fails, short-circuit.
+        if (!copyOldFieldDef.equals(copyNewFieldDef)) {
+            return false;
+        }
+
+        // Now we know they differ only in the maxAppVersion. This is valid if old has no maxAppVersion. (Because we
+        // know the differ in maxAppVersion, if old is null, we don't need to check new.)
+        return oldFieldDef.getMaxAppVersion() == null;
     }
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDao.java
@@ -19,6 +19,7 @@ import com.amazonaws.services.dynamodbv2.model.ExpectedAttributeValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.springframework.stereotype.Component;
 import org.sagebionetworks.bridge.BridgeUtils;
@@ -90,7 +91,7 @@ public class DynamoUploadSchemaDao implements UploadSchemaDao {
 
         // Blank of version. This allows people to copy-paste schema revs from other studies, or easily create a new
         // schema rev from a previously existing one. It also means if they get a schema rev and then try to create
-        // that schema rev again, we'll correctly through a ConcurrentModificationException.
+        // that schema rev again, we'll correctly throw a ConcurrentModificationException.
         ddbUploadSchema.setVersion(null);
 
         // Call DDB to create.
@@ -471,10 +472,7 @@ public class DynamoUploadSchemaDao implements UploadSchemaDao {
     // the fields in a consistent order.
     private static Map<String, UploadFieldDefinition> getFieldsByName(UploadSchema uploadSchema) {
         Map<String, UploadFieldDefinition> fieldsByName = new TreeMap<>();
-        List<UploadFieldDefinition> fieldDefList = uploadSchema.getFieldDefinitions();
-        for (UploadFieldDefinition oneFieldDef : fieldDefList) {
-            fieldsByName.put(oneFieldDef.getName(), oneFieldDef);
-        }
+        fieldsByName.putAll(Maps.uniqueIndex(uploadSchema.getFieldDefinitions(), UploadFieldDefinition::getName));
         return fieldsByName;
     }
 

--- a/app/org/sagebionetworks/bridge/play/controllers/UploadSchemaController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/UploadSchemaController.java
@@ -26,6 +26,21 @@ public class UploadSchemaController extends BaseController {
     }
 
     /**
+     * Service handler for creating a new schema revision, using V4 API semantics. See
+     * {@link org.sagebionetworks.bridge.dao.UploadSchemaDao#createSchemaRevisionV4}
+     *
+     * @return Play result, with the created schema
+     */
+    public Result createSchemaRevisionV4() throws Exception {
+        UserSession session = getAuthenticatedSession(DEVELOPER);
+        StudyIdentifier studyId = session.getStudyIdentifier();
+
+        UploadSchema uploadSchema = parseJson(request(), UploadSchema.class);
+        UploadSchema createdSchema = uploadSchemaService.createSchemaRevisionV4(studyId, uploadSchema);
+        return createdResult(createdSchema);
+    }
+
+    /**
      * Play controller for POST /researcher/v1/uploadSchema/:schemaId. This API creates an upload schema, using the
      * study for the current service endpoint and the schema of the specified schema. If the schema already exists,
      * this method updates it instead.
@@ -138,5 +153,25 @@ public class UploadSchemaController extends BaseController {
 
         List<UploadSchema> schemaList = uploadSchemaService.getUploadSchemasForStudy(studyId);
         return okResult(schemaList);
+    }
+
+    /**
+     * Service handler for updating a new schema revision, using V4 API semantics. See
+     * {@link org.sagebionetworks.bridge.dao.UploadSchemaDao#updateSchemaRevisionV4}
+     *
+     * @param schemaId
+     *         schema ID to update
+     * @param revision
+     *         schema revision to update
+     * @return Play result, with the updated schema
+     */
+    public Result updateSchemaRevisionV4(String schemaId, int revision) {
+        UserSession session = getAuthenticatedSession(DEVELOPER);
+        StudyIdentifier studyId = session.getStudyIdentifier();
+
+        UploadSchema uploadSchema = parseJson(request(), UploadSchema.class);
+        UploadSchema updatedSchema = uploadSchemaService.updateSchemaRevisionV4(studyId, schemaId, revision,
+                uploadSchema);
+        return okResult(updatedSchema);
     }
 }

--- a/app/org/sagebionetworks/bridge/services/UploadSchemaService.java
+++ b/app/org/sagebionetworks/bridge/services/UploadSchemaService.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge.services;
 
 import java.util.List;
 
+import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -37,10 +38,11 @@ public class UploadSchemaService {
      * @return the created schema revision
      */
     public UploadSchema createSchemaRevisionV4(StudyIdentifier studyId, UploadSchema uploadSchema) {
+        // Controller guarantees valid studyId and non-null uploadSchema
+        Preconditions.checkNotNull(studyId, "studyId must be non-null");
+        Preconditions.checkNotNull(uploadSchema, "uploadSchema must be non-null");
+
         // validate schema
-        if (uploadSchema == null) {
-            throw new InvalidEntityException("Upload schema can't be null");
-        }
         Validate.entityThrowingException(UploadSchemaValidator.INSTANCE, uploadSchema);
 
         // call through to DAO
@@ -225,8 +227,11 @@ public class UploadSchemaService {
      */
     public UploadSchema updateSchemaRevisionV4(StudyIdentifier studyId, String schemaId, int schemaRevision,
             UploadSchema uploadSchema) {
-        // Validate inputs. Study ID is the only one that doesn't need validation, since it comes from the controller,
-        // not user input.
+        // Controller guarantees valid studyId and non-null uploadSchema
+        Preconditions.checkNotNull(studyId, "studyId must be non-null");
+        Preconditions.checkNotNull(uploadSchema, "uploadSchema must be non-null");
+
+        // Validate user inputs.
         if (StringUtils.isBlank(schemaId)) {
             throw new BadRequestException("Schema ID must be specified");
         }
@@ -235,9 +240,6 @@ public class UploadSchemaService {
             throw new BadRequestException("Schema revision must be positive");
         }
 
-        if (uploadSchema == null) {
-            throw new InvalidEntityException("Upload schema can't be null");
-        }
         Validate.entityThrowingException(UploadSchemaValidator.INSTANCE, uploadSchema);
 
         // Call through to the DAO

--- a/app/org/sagebionetworks/bridge/services/UploadSchemaService.java
+++ b/app/org/sagebionetworks/bridge/services/UploadSchemaService.java
@@ -27,6 +27,27 @@ public class UploadSchemaService {
     }
 
     /**
+     * Service handler for creating a new schema revision, using V4 API semantics. See
+     * {@link UploadSchemaDao#createSchemaRevisionV4}
+     *
+     * @param studyId
+     *         study that will contain the schema
+     * @param uploadSchema
+     *         schema to create
+     * @return the created schema revision
+     */
+    public UploadSchema createSchemaRevisionV4(StudyIdentifier studyId, UploadSchema uploadSchema) {
+        // validate schema
+        if (uploadSchema == null) {
+            throw new InvalidEntityException("Upload schema can't be null");
+        }
+        Validate.entityThrowingException(UploadSchemaValidator.INSTANCE, uploadSchema);
+
+        // call through to DAO
+        return uploadSchemaDao.createSchemaRevisionV4(studyId, uploadSchema);
+    }
+
+    /**
      * <p>
      * Service handler for creating and updating upload schemas. This method creates an upload schema, using the study
      * ID and schema ID of the specified schema, or updates an existing one if it already exists.
@@ -186,5 +207,40 @@ public class UploadSchemaService {
      */
     public List<UploadSchema> getUploadSchemasForStudy(StudyIdentifier studyId) {
         return uploadSchemaDao.getUploadSchemasForStudy(studyId);
+    }
+
+    /**
+     * Service handler for updating schema revision, using V4 API semantics. See
+     * {@link UploadSchemaDao#updateSchemaRevisionV4}
+     *
+     * @param studyId
+     *         study that contains the schema
+     * @param schemaId
+     *         schema ID to update
+     * @param schemaRevision
+     *         schema revision to update
+     * @param uploadSchema
+     *         schema with updates to persist
+     * @return the updated schema revision
+     */
+    public UploadSchema updateSchemaRevisionV4(StudyIdentifier studyId, String schemaId, int schemaRevision,
+            UploadSchema uploadSchema) {
+        // Validate inputs. Study ID is the only one that doesn't need validation, since it comes from the controller,
+        // not user input.
+        if (StringUtils.isBlank(schemaId)) {
+            throw new BadRequestException("Schema ID must be specified");
+        }
+
+        if (schemaRevision <= 0) {
+            throw new BadRequestException("Schema revision must be positive");
+        }
+
+        if (uploadSchema == null) {
+            throw new InvalidEntityException("Upload schema can't be null");
+        }
+        Validate.entityThrowingException(UploadSchemaValidator.INSTANCE, uploadSchema);
+
+        // Call through to the DAO
+        return uploadSchemaDao.updateSchemaRevisionV4(studyId, schemaId, schemaRevision, uploadSchema);
     }
 }

--- a/conf/routes
+++ b/conf/routes
@@ -103,6 +103,8 @@ GET    /v3/uploadstatuses/:uploadId    @org.sagebionetworks.bridge.play.controll
 # Upload Schemas
 GET    /v3/uploadschemas                           @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getUploadSchemasForStudy
 POST   /v3/uploadschemas                           @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.createOrUpdateUploadSchema
+POST   /v4/uploadschemas                           @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.createSchemaRevisionV4
+POST   /v4/uploadschemas/:schemaId/revisions/:revision @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.updateSchemaRevisionV4(schemaId: String, revision: Int)
 GET    /v3/uploadschemas/:schemaId                 @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getUploadSchemaAllRevisions(schemaId: String)
 GET    /v3/uploadschemas/:schemaId/recent          @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getUploadSchema(schemaId: String)
 GET    /v3/uploadschemas/:schemaId/revisions/:rev  @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getUploadSchemaByIdAndRev(schemaId: String, rev: Int)

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDaoDdbTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDaoDdbTest.java
@@ -13,19 +13,31 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
+import org.sagebionetworks.bridge.dao.UploadSchemaDao;
+import org.sagebionetworks.bridge.exceptions.BadRequestException;
+import org.sagebionetworks.bridge.exceptions.ConcurrentModificationException;
+import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
 import org.sagebionetworks.bridge.models.upload.UploadFieldType;
+import org.sagebionetworks.bridge.models.upload.UploadSchema;
 import org.sagebionetworks.bridge.models.upload.UploadSchemaType;
 
 @ContextConfiguration("classpath:test-context.xml")
 @RunWith(SpringJUnit4ClassRunner.class)
 public class DynamoUploadSchemaDaoDdbTest {
+    private static final UploadFieldDefinition FIELD_DEF = new DynamoUploadFieldDefinition.Builder().withName("field")
+            .withType(UploadFieldType.STRING).build();
+    private static final List<UploadFieldDefinition> FIELD_DEF_LIST = ImmutableList.of(FIELD_DEF);
     private static final int SCHEMA_REV = 7;
+
+    @Autowired
+    private UploadSchemaDao dao;
 
     @Resource(name = "uploadSchemaDdbMapper")
     private DynamoDBMapper mapper;
@@ -40,14 +52,10 @@ public class DynamoUploadSchemaDaoDdbTest {
 
     @After
     public void cleanup() {
-        DynamoUploadSchema key = new DynamoUploadSchema();
-        key.setStudyId(TestConstants.TEST_STUDY_IDENTIFIER);
-        key.setSchemaId(schemaId);
-        key.setRevision(SCHEMA_REV);
-        DynamoUploadSchema testSchema = mapper.load(key);
-
-        if (testSchema != null) {
-            mapper.delete(testSchema);
+        try {
+            dao.deleteUploadSchemaById(TestConstants.TEST_STUDY, schemaId);
+        } catch (EntityNotFoundException ex) {
+            // Schema may have already been deleted.
         }
     }
 
@@ -92,35 +100,200 @@ public class DynamoUploadSchemaDaoDdbTest {
     @Test
     public void concurrentModification() {
         // just the keys: study ID, schema ID, and rev
-        mapper.save(makeSimpleSchema("Initial Name", schemaId, null));
+        mapper.save(makeSimpleSchema("Initial Name", SCHEMA_REV, TestConstants.TEST_STUDY_IDENTIFIER, null));
 
         // Try to create a new schema with the same schema ID
         try {
-            mapper.save(makeSimpleSchema("New Schema Conflict", schemaId, null));
+            mapper.save(makeSimpleSchema("New Schema Conflict", SCHEMA_REV, TestConstants.TEST_STUDY_IDENTIFIER,
+                    null));
             fail("expected exception");
         } catch (ConditionalCheckFailedException ex) {
             // expected exception
         }
 
         // Update from version 1 to version 2
-        mapper.save(makeSimpleSchema("Updated Name", schemaId, 1L));
+        mapper.save(makeSimpleSchema("Updated Name", SCHEMA_REV, TestConstants.TEST_STUDY_IDENTIFIER, 1L));
 
         // Try to update version 1 again
         try {
-            mapper.save(makeSimpleSchema("Update Schema Conflict", schemaId, 1L));
+            mapper.save(makeSimpleSchema("Update Schema Conflict", SCHEMA_REV, TestConstants.TEST_STUDY_IDENTIFIER,
+                    1L));
             fail("expected exception");
         } catch (ConditionalCheckFailedException ex) {
             // expected exception
         }
     }
 
-    private static DynamoUploadSchema makeSimpleSchema(String name, String schemaId, Long version) {
+    @Test
+    public void crudV4() {
+        // Create schema w/o specifying rev. This auto-creates rev 1.
+        testCreateOneSchema("rev1", null, 1);
+
+        // Create schema with rev 3 (skipping rev 2).
+        testCreateOneSchema("rev3", 3, 3);
+
+        // Create schema w/o specifying rev. This should be auto-incremented to rev 4 (not rev 2).
+        testCreateOneSchema("rev4", null, 4);
+
+        // Create rev 2 (which is not the highest rev)
+        testCreateOneSchema("rev2", 2, 2);
+
+        // Re-create rev 4, get a ConcurrentModificationException.
+        UploadSchema recreatingSchema4 = makeSimpleSchema("recreate schema rev 4", 4, null, 1L);
+        try {
+            dao.createSchemaRevisionV4(TestConstants.TEST_STUDY, recreatingSchema4);
+            fail("expected exception");
+        } catch (ConcurrentModificationException ex) {
+            // expected exception
+        }
+
+        // Update schema rev 4. Do a simple update, like changing the name. (Testing field validation is another test.)
+        // Again, we don't include the study because the update API is supposed to fill it in. Current version is
+        // version 1, so we need to fill that in.
+        DynamoUploadSchema updatingSchema4 = (DynamoUploadSchema) makeSimpleSchema("rev4 v2", null, null, 1L);
+
+        // Fill in garbage schema ID and rev, because the update API ignores them and uses the params.
+        updatingSchema4.setSchemaId("fake ID");
+        updatingSchema4.setRevision(13);
+
+        // Update and validate. Validate that study, schema ID, and rev were set. Version should now be version 2.
+        UploadSchema updatedSchema4 = dao.updateSchemaRevisionV4(TestConstants.TEST_STUDY, schemaId, 4,
+                updatingSchema4);
+        assertSimpleSchema(updatedSchema4, "rev4 v2", 4, TestConstants.TEST_STUDY_IDENTIFIER, 2L);
+        UploadSchema fetchedSchema4v2 = dao.getUploadSchemaByIdAndRev(TestConstants.TEST_STUDY, schemaId, 4);
+        assertSimpleSchema(fetchedSchema4v2, "rev4 v2", 4, TestConstants.TEST_STUDY_IDENTIFIER, 2L);
+
+        // Update rev4 v1 again, get a ConcurrentModificationException.
+        UploadSchema reupdatingSchema4 = makeSimpleSchema("re-update rev4", null, null, 1L);
+        try {
+            dao.updateSchemaRevisionV4(TestConstants.TEST_STUDY, schemaId, 4, reupdatingSchema4);
+            fail("expected exception");
+        } catch (ConcurrentModificationException ex) {
+            // expected exception
+        }
+
+        // Update rev 5, which doesn't exist. Get an EntityNotFoundException.
+        UploadSchema dummySchema = makeSimpleSchema("update rev5", null, null, null);
+        try {
+            dao.updateSchemaRevisionV4(TestConstants.TEST_STUDY, schemaId, 5, dummySchema);
+            fail("expected exception");
+        } catch (EntityNotFoundException ex) {
+            // expected exception
+        }
+    }
+
+    private void testCreateOneSchema(String name, Integer createdRev, int expectedRev) {
+        // Create schema. We include version to simulate creating a new schema by copying an existing one to test that
+        // we handle that correctly. We exclude study ID, since clients won't have that, to test that we handle that as
+        // well (by getting study ID from parameters).
+        UploadSchema schema = makeSimpleSchema(name, createdRev, null, 1L);
+
+        // Created schema has version 1 and has study ID set.
+        UploadSchema createdSchema = dao.createSchemaRevisionV4(TestConstants.TEST_STUDY, schema);
+        assertSimpleSchema(createdSchema, name, expectedRev, TestConstants.TEST_STUDY_IDENTIFIER, 1L);
+        UploadSchema fetchedSchema = dao.getUploadSchemaByIdAndRev(TestConstants.TEST_STUDY, schemaId, expectedRev);
+        assertSimpleSchema(fetchedSchema, name, expectedRev, TestConstants.TEST_STUDY_IDENTIFIER, 1L);
+    }
+
+    @Test
+    public void updateFields() {
+        // old field defs
+        UploadFieldDefinition retainThis1 = new DynamoUploadFieldDefinition.Builder().withName("retain-this-1")
+                .withType(UploadFieldType.STRING).build();
+        UploadFieldDefinition retainThis2 = new DynamoUploadFieldDefinition.Builder().withName("retain-this-2")
+                .withType(UploadFieldType.STRING).build();
+        UploadFieldDefinition addThis1 = new DynamoUploadFieldDefinition.Builder().withName("add-this-1")
+                .withType(UploadFieldType.STRING).build();
+        UploadFieldDefinition addThis2 = new DynamoUploadFieldDefinition.Builder().withName("add-this-2")
+                .withType(UploadFieldType.STRING).build();
+        UploadFieldDefinition deleteThis1 = new DynamoUploadFieldDefinition.Builder().withName("delete-this-1")
+                .withType(UploadFieldType.STRING).build();
+        UploadFieldDefinition deleteThis2 = new DynamoUploadFieldDefinition.Builder().withName("delete-this-2")
+                .withType(UploadFieldType.STRING).build();
+        UploadFieldDefinition modifyThis1 = new DynamoUploadFieldDefinition.Builder().withName("modify-this-1")
+                .withType(UploadFieldType.INT).build();
+        UploadFieldDefinition modifyThis2 = new DynamoUploadFieldDefinition.Builder().withName("modify-this-2")
+                .withType(UploadFieldType.STRING).withMaxAppVersion(42).build();
+        UploadFieldDefinition addMaxAppVersion = new DynamoUploadFieldDefinition.Builder()
+                .withName("add-max-app-version").withType(UploadFieldType.STRING).build();
+
+        // modified field defs
+        UploadFieldDefinition modifiedField1 = new DynamoUploadFieldDefinition.Builder().withName("modify-this-1")
+                .withType(UploadFieldType.BOOLEAN).build();
+        UploadFieldDefinition modifiedField2 = new DynamoUploadFieldDefinition.Builder().withName("modify-this-2")
+                .withType(UploadFieldType.STRING).withMaxAppVersion(37).build();
+        UploadFieldDefinition addedMaxAppVersionField = new DynamoUploadFieldDefinition.Builder()
+                .withName("add-max-app-version").withType(UploadFieldType.STRING).withMaxAppVersion(23).build();
+
+        // Create the initial schema rev. Old field def list doesn't have "add-this" (so we can add them), but has
+        // "delete-this" (so we can delete them)
+        List<UploadFieldDefinition> oldFieldDefList = ImmutableList.of(retainThis1, retainThis2, deleteThis1,
+                deleteThis2, modifyThis1, modifyThis2, addMaxAppVersion);
         DynamoUploadSchema schema = new DynamoUploadSchema();
-        schema.setName(name);
-        schema.setStudyId(TestConstants.TEST_STUDY_IDENTIFIER);
+        schema.setFieldDefinitions(oldFieldDefList);
+        schema.setName("old schema");
+        schema.setRevision(1);
         schema.setSchemaId(schemaId);
-        schema.setRevision(SCHEMA_REV);
+        schema.setSchemaType(UploadSchemaType.IOS_DATA);
+        dao.createSchemaRevisionV4(TestConstants.TEST_STUDY, schema);
+
+        // Validate field list.
+        UploadSchema createdSchema = dao.getUploadSchemaByIdAndRev(TestConstants.TEST_STUDY, schemaId, 1);
+        assertEquals(oldFieldDefList, createdSchema.getFieldDefinitions());
+
+        // Update the schema. This is an invalid update because we deleted some fields and modified others.
+        List<UploadFieldDefinition> invalidFieldDefList = ImmutableList.of(retainThis1, retainThis2, addThis1,
+                addThis2, modifiedField1, modifiedField2, addedMaxAppVersionField);
+        schema.setFieldDefinitions(invalidFieldDefList);
+        try {
+            dao.updateSchemaRevisionV4(TestConstants.TEST_STUDY, schemaId, 1, schema);
+            fail("expected exception");
+        } catch (BadRequestException ex) {
+            // check that the error message references *all* of the problematic fields
+            assertEquals("Can't update study " + TestConstants.TEST_STUDY_IDENTIFIER + " schema " + schemaId +
+                    " revision 1: Can't delete fields: delete-this-1, delete-this-2; Can't modify fields: " +
+                    "modify-this-1, modify-this-2", ex.getMessage());
+        }
+
+        // Verify field def list is the same.
+        UploadSchema notUpdatedSchema = dao.getUploadSchemaByIdAndRev(TestConstants.TEST_STUDY, schemaId, 1);
+        assertEquals(oldFieldDefList, notUpdatedSchema.getFieldDefinitions());
+
+        // Update the schema. This is valid because we only added fields and added a maxAppVersion to a field. We also
+        // re-ordered some of the fields, which is also valid.
+        List<UploadFieldDefinition> validFieldDefList = ImmutableList.of(addedMaxAppVersionField, addThis1, addThis2,
+                deleteThis1, deleteThis2, modifyThis1, modifyThis2, retainThis1, retainThis2);
+        schema.setFieldDefinitions(validFieldDefList);
+        dao.updateSchemaRevisionV4(TestConstants.TEST_STUDY, schemaId, 1, schema);
+
+        // Verify field def list is updated
+        UploadSchema updatedSchema = dao.getUploadSchemaByIdAndRev(TestConstants.TEST_STUDY, schemaId, 1);
+        assertEquals(validFieldDefList, updatedSchema.getFieldDefinitions());
+    }
+
+    private UploadSchema makeSimpleSchema(String name, Integer rev, String studyId, Long version) {
+        DynamoUploadSchema schema = new DynamoUploadSchema();
+        schema.setFieldDefinitions(FIELD_DEF_LIST);
+        schema.setName(name);
+        schema.setSchemaId(schemaId);
+        schema.setSchemaType(UploadSchemaType.IOS_DATA);
+        schema.setStudyId(studyId);
         schema.setVersion(version);
+
+        if (rev != null) {
+            schema.setRevision(rev);
+        }
+
         return schema;
+    }
+
+    private void assertSimpleSchema(UploadSchema schema, String name, int rev, String studyId, Long version) {
+        assertEquals(FIELD_DEF_LIST, schema.getFieldDefinitions());
+        assertEquals(name, schema.getName());
+        assertEquals(rev, schema.getRevision());
+        assertEquals(schemaId, schema.getSchemaId());
+        assertEquals(UploadSchemaType.IOS_DATA, schema.getSchemaType());
+        assertEquals(studyId, schema.getStudyId());
+        assertEquals(version, schema.getVersion());
     }
 }

--- a/test/org/sagebionetworks/bridge/models/upload/UploadFieldDefinitionTest.java
+++ b/test/org/sagebionetworks/bridge/models/upload/UploadFieldDefinitionTest.java
@@ -46,14 +46,19 @@ public class UploadFieldDefinitionTest {
     public void testOptionalFields() {
         UploadFieldDefinition fieldDef = new DynamoUploadFieldDefinition.Builder().withFileExtension(".test")
                 .withMimeType("text/plain").withMinAppVersion(10).withMaxAppVersion(13).withMaxLength(128)
-                .withName("optional-stuff").withType(UploadFieldType.STRING).build();
+                .withName("optional-stuff").withRequired(false).withType(UploadFieldType.STRING).build();
         assertEquals(".test", fieldDef.getFileExtension());
         assertEquals("text/plain", fieldDef.getMimeType());
         assertEquals(10, fieldDef.getMinAppVersion().intValue());
         assertEquals(13, fieldDef.getMaxAppVersion().intValue());
         assertEquals(128, fieldDef.getMaxLength().intValue());
         assertEquals("optional-stuff", fieldDef.getName());
+        assertFalse(fieldDef.isRequired());
         assertEquals(UploadFieldType.STRING, fieldDef.getType());
+
+        // Also test copy constructor.
+        UploadFieldDefinition copy = new DynamoUploadFieldDefinition.Builder().copyOf(fieldDef).build();
+        assertEquals(fieldDef, copy);
     }
 
     @Test

--- a/test/org/sagebionetworks/bridge/services/UploadSchemaServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/UploadSchemaServiceTest.java
@@ -33,11 +33,6 @@ public class UploadSchemaServiceTest {
     private static final int SCHEMA_REV = 1;
 
     @Test(expected = InvalidEntityException.class)
-    public void createV4NullSchema() {
-        new UploadSchemaService().createSchemaRevisionV4(TestConstants.TEST_STUDY, null);
-    }
-
-    @Test(expected = InvalidEntityException.class)
     public void createV4InvalidSchema() {
         // Simple invalid schema, like one with no fields.
         new UploadSchemaService().createSchemaRevisionV4(TestConstants.TEST_STUDY, new DynamoUploadSchema());
@@ -300,11 +295,6 @@ public class UploadSchemaServiceTest {
     @Test(expected = BadRequestException.class)
     public void updateV4ZeroRev() {
         new UploadSchemaService().updateSchemaRevisionV4(TestConstants.TEST_STUDY, SCHEMA_ID, 0, makeSimpleSchema());
-    }
-
-    @Test(expected = InvalidEntityException.class)
-    public void updateV4NullSchema() {
-        new UploadSchemaService().updateSchemaRevisionV4(TestConstants.TEST_STUDY, SCHEMA_ID, SCHEMA_REV, null);
     }
 
     @Test(expected = InvalidEntityException.class)


### PR DESCRIPTION
v4 Schema APIs to support mutable schemas. See https://sagebionetworks.jira.com/browse/BRIDGE-1289 and https://sagebionetworks.jira.com/wiki/display/BRIDGE/Upload+Format+v2#UploadFormatv2-Subtask1b:MutableSchemas

Testing done:
- updated/added unit tests
- manually tested new create and update APIs

Next steps:
- test that schemas created by this API are compatible with Bridge-EX (they should be)
- Java SDK and integ tests
- hook this up to Strict Validation
- hook this up Surveys
