### PR TITLE
Return session after updates

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
@@ -21,6 +21,7 @@ import org.sagebionetworks.bridge.models.accounts.AccountSummary;
 import org.sagebionetworks.bridge.models.accounts.IdentifierHolder;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
+import org.sagebionetworks.bridge.models.accounts.UserSessionInfo;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.services.ParticipantService;
 
@@ -75,7 +76,7 @@ public class ParticipantController extends BaseController {
         session = authenticationService.updateSession(study, context, userId);
         updateSessionUser(session, session.getUser());
         
-        return okResult("Participant updated.");
+        return okResult(new UserSessionInfo(session));
     }
     
     public Result getParticipants(String offsetByString, String pageSizeString, String emailFilter) {

--- a/app/org/sagebionetworks/bridge/play/controllers/UserManagementController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/UserManagementController.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.sagebionetworks.bridge.json.JsonUtils;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
+import org.sagebionetworks.bridge.models.accounts.UserSessionInfo;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.services.UserAdminService;
 
@@ -35,9 +36,9 @@ public class UserManagementController extends BaseController {
 
         boolean consent = JsonUtils.asBoolean(node, CONSENT_FIELD);
         
-        userAdminService.createUser(participant, study, null, false, consent);
+        UserSession userSession = userAdminService.createUser(participant, study, null, false, consent);
 
-        return createdResult("User created.");
+        return createdResult(new UserSessionInfo(userSession));
     }
 
     public Result deleteUser(String userId) throws Exception {


### PR DESCRIPTION
Now that we're recalculating sessions after user updates, return this session to the user. For the admin create method, the ID is useful to delete the user later; for the participant update method, it is useful so the client can see whether or not the account is still consented. We don't return a session for the general participant update API so if you edit yourself through that API, it may be out of sync. However we only expect researchers to use that API through the web app.
