### PR TITLE
Always create health code

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/AccountDao.java
+++ b/app/org/sagebionetworks/bridge/dao/AccountDao.java
@@ -77,17 +77,17 @@ public interface AccountDao {
     public void deleteAccount(Study study, String email);
     
     /**
-     * Get all accounts in all studies in a given environment.
+     * Get all account summaries in all studies in a given environment.
      * @return
      */
-    public Iterator<Account> getAllAccounts();
+    public Iterator<AccountSummary> getAllAccounts();
     
     /**
-     * Get all accounts in one study in a given environment.
+     * Get all account summaries in one study in a given environment.
      * @param study
      * @return
      */
-    public Iterator<Account> getStudyAccounts(Study study);
+    public Iterator<AccountSummary> getStudyAccounts(Study study);
     
     /**
      * Get a page of lightweight account summaries (most importantly, the email addresses of 

--- a/app/org/sagebionetworks/bridge/dao/AccountDao.java
+++ b/app/org/sagebionetworks/bridge/dao/AccountDao.java
@@ -22,7 +22,8 @@ public interface AccountDao {
 
     /**
      * Create an account within the context of the study. Sending email address confirmation
-     * email is optional. 
+     * email is optional. Creating an account *always* creates a healthCode and assigns the 
+     * healthId for that healthCode to the created account.
      */
     public Account signUp(Study study, StudyParticipant participant, boolean sendEmail);
     
@@ -66,7 +67,7 @@ public interface AccountDao {
     /**
      * Save account changes.
      */
-    public void updateAccount(Study study, Account account);
+    public void updateAccount(Account account);
     
     /**
      * Delete an account along with the authentication credentials.

--- a/app/org/sagebionetworks/bridge/dao/AccountDao.java
+++ b/app/org/sagebionetworks/bridge/dao/AccountDao.java
@@ -21,9 +21,9 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 public interface AccountDao {
 
     /**
-     * Create an account within the context of the study. Sending email address confirmation
-     * email is optional. Creating an account *always* creates a healthCode and assigns the 
-     * healthId for that healthCode to the created account.
+     * Create an account within the context of the study. Sending an email to verify the user's 
+     * email address is optional. Creating an account *always* creates a healthCode and assigns 
+     * the healthId for that healthCode to the created account.
      */
     public Account signUp(Study study, StudyParticipant participant, boolean sendEmail);
     

--- a/app/org/sagebionetworks/bridge/models/accounts/Account.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/Account.java
@@ -43,8 +43,9 @@ public interface Account extends BridgeEntity {
     
     public Map<SubpopulationGuid,List<ConsentSignature>> getAllConsentSignatureHistories();
     
-    public String getHealthId();
-    public void setHealthId(String healthId);
+    public String getHealthCode();
+
+    public void setHealthId(HealthId healthId);
 
     public AccountStatus getStatus();
     public void setStatus(AccountStatus status);

--- a/app/org/sagebionetworks/bridge/models/accounts/AccountSummary.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/AccountSummary.java
@@ -1,32 +1,51 @@
 package org.sagebionetworks.bridge.models.accounts;
 
+import static org.sagebionetworks.bridge.BridgeConstants.STORMPATH_NAME_PLACEHOLDER_STRING;
+
 import java.util.Objects;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+
+import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public final class AccountSummary {
 
+    public static final AccountSummary create(StudyIdentifier studyId, com.stormpath.sdk.account.Account acct) {
+        java.util.Date javaDate = acct.getCreatedAt();
+        DateTime createdOn = (javaDate != null) ? new DateTime(javaDate) : null;
+        String id = BridgeUtils.getIdFromStormpathHref(acct.getHref());
+        
+        String firstName = (STORMPATH_NAME_PLACEHOLDER_STRING.equals(acct.getGivenName())) ? null : acct.getGivenName();
+        String lastName = (STORMPATH_NAME_PLACEHOLDER_STRING.equals(acct.getSurname())) ? null : acct.getSurname();
+        return new AccountSummary(firstName, lastName, acct.getEmail(), id, createdOn,
+                AccountStatus.valueOf(acct.getStatus().name()), studyId);
+    }
+    
     private final String firstName;
     private final String lastName;
     private final String email;
     private final String id;
     private final DateTime createdOn;
     private final AccountStatus status;
+    private final StudyIdentifier studyIdentifier;
     
     @JsonCreator
     public AccountSummary(@JsonProperty("firstName") String firstName, @JsonProperty("lastName") String lastName,
             @JsonProperty("email") String email, @JsonProperty("id") String id,
-            @JsonProperty("createdOn") DateTime createdOn, @JsonProperty("status") AccountStatus status) {
+            @JsonProperty("createdOn") DateTime createdOn, @JsonProperty("status") AccountStatus status,
+            @JsonProperty("studyIdentifier") StudyIdentifier studyIdentifier) {
         this.firstName = firstName;
         this.lastName = lastName;
         this.email = email;
         this.id = id;
         this.createdOn = (createdOn == null) ? null : createdOn.withZone(DateTimeZone.UTC);
         this.status = status;
+        this.studyIdentifier = studyIdentifier;
     }
 
     public String getFirstName() {
@@ -52,10 +71,14 @@ public final class AccountSummary {
     public AccountStatus getStatus() {
         return status;
     }
+    
+    public StudyIdentifier getStudyIdentifier() {
+        return studyIdentifier;
+    }
 
     @Override
     public int hashCode() {
-        return Objects.hash(firstName, lastName, email, id, createdOn, status);
+        return Objects.hash(firstName, lastName, email, id, createdOn, status, studyIdentifier);
     }
 
     @Override
@@ -67,7 +90,8 @@ public final class AccountSummary {
         AccountSummary other = (AccountSummary) obj;
         return Objects.equals(firstName, other.firstName) && Objects.equals(lastName, other.lastName)
                 && Objects.equals(email, other.email) && Objects.equals(createdOn, other.createdOn)
-                && Objects.equals(status, other.status) && Objects.equals(id, other.id);
+                && Objects.equals(status, other.status) && Objects.equals(id, other.id)
+                && Objects.equals(studyIdentifier, other.studyIdentifier);
     }
     
     // no toString() method as the information is sensitive.

--- a/app/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -367,7 +367,7 @@ public class AuthenticationService {
         if (healthId == null) {
             healthId = healthCodeService.createMapping(study);
             account.setHealthId(healthId.getId());
-            accountDao.updateAccount(study, account);
+            accountDao.updateAccount(account);
             logger.debug("Health ID/code pair created for " + account.getId() + " in study " + study.getName());
         }
         return healthId.getCode();

--- a/app/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -62,7 +62,6 @@ public class AuthenticationService {
     private ConsentService consentService;
     private ParticipantOptionsService optionsService;
     private AccountDao accountDao;
-    private HealthCodeService healthCodeService;
     private StudyEnrollmentService studyEnrollmentService;
     private UserConsentDao userConsentDao;
     private StudyConsentDao studyConsentDao;
@@ -95,10 +94,6 @@ public class AuthenticationService {
     @Autowired
     final void setAccountDao(AccountDao accountDao) {
         this.accountDao = accountDao;
-    }
-    @Autowired
-    final void setHealthCodeService(HealthCodeService healthCodeService) {
-        this.healthCodeService = healthCodeService;
     }
     @Autowired
     final void setStudyEnrollmentService(StudyEnrollmentService studyEnrollmentService) {
@@ -187,7 +182,7 @@ public class AuthenticationService {
             }
             Account account = accountDao.signUp(study, participant, isAnonSignUp);
             if (!participant.getDataGroups().isEmpty()) {
-                final String healthCode = healthCodeService.getMapping(account.getHealthId()).getCode();
+                final String healthCode = account.getHealthCode();
                 optionsService.setStringSet(study, healthCode, DATA_GROUPS, participant.getDataGroups());
             }
             
@@ -310,7 +305,7 @@ public class AuthenticationService {
         final User user = new User(account);
         user.setStudyKey(study.getIdentifier());
 
-        final String healthCode = healthCodeService.getMapping(account.getHealthId()).getCode();
+        final String healthCode = account.getHealthCode();
         user.setHealthCode(healthCode);
         
         ParticipantOptionsLookup lookup = optionsService.getOptions(healthCode);

--- a/app/org/sagebionetworks/bridge/services/ConsentService.java
+++ b/app/org/sagebionetworks/bridge/services/ConsentService.java
@@ -163,7 +163,7 @@ public class ConsentService {
         }
         
         account.getConsentSignatureHistory(subpopGuid).add(consentSignature);
-        accountDao.updateAccount(study, account);
+        accountDao.updateAccount(account);
         
         UserConsent userConsent = null;
         try {
@@ -172,7 +172,7 @@ public class ConsentService {
         } catch (Throwable e) {
             int len = account.getConsentSignatureHistory(subpopGuid).size();
             account.getConsentSignatureHistory(subpopGuid).remove(len-1);
-            accountDao.updateAccount(study, account);
+            accountDao.updateAccount(account);
             throw e;
         }
         // Save supplemental records, fire events, etc.
@@ -246,14 +246,14 @@ public class ConsentService {
         int index = account.getConsentSignatureHistory(subpopGuid).indexOf(active); // should be length-1
         
         account.getConsentSignatureHistory(subpopGuid).set(index, withdrawn);
-        accountDao.updateAccount(study, account);
+        accountDao.updateAccount(account);
 
         try {
             userConsentDao.withdrawConsent(user.getHealthCode(), subpopGuid, withdrewOn);    
         } catch(Exception e) {
             // Could not record the consent, compensate and rethrow the exception
             account.getConsentSignatureHistory(subpopGuid).set(index, active);
-            accountDao.updateAccount(study, account);
+            accountDao.updateAccount(account);
             throw e;
         }
         

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -300,6 +300,16 @@ public class ParticipantService {
     private boolean idsDontExistOrAreNotEqual(String id1, String id2) {
         return (isBlank(id1) || isBlank(id2) || !id1.equals(id2));
     }
+    
+    private String getHealthCodeThrowingException(Account account) {
+        HealthId healthId = healthCodeService.getMapping(account.getHealthId());
+        if (healthId != null) {
+            return healthId.getCode();
+        }
+        // This should NEVER happen, but there are tests that verify if it happens, we send back the right 
+        // exception.
+        throw new BridgeServiceException("Participant cannot be updated. Health code could not be found.");
+    }
 
     private Account getAccountThrowingException(Study study, String id) {
         Account account = accountDao.getAccount(study, id);
@@ -307,24 +317,6 @@ public class ParticipantService {
             throw new EntityNotFoundException(Account.class);
         }
         return account;
-    }
-    
-    /**
-     * Get healthCode for account. This should never fail because the contract of the AccountDao is to always
-     * return an account with an assigned healthCode.
-     */
-    private String getHealthCodeThrowingException(Account account) {
-        if (account.getHealthId() == null) {
-            throw new BridgeServiceException("Participant cannot be updated (account has no healthId).");
-        }
-        HealthId healthId = healthCodeService.getMapping(account.getHealthId());
-        if (healthId == null) {
-            throw new BridgeServiceException("Participant cannot be updated (no HealthId mapping).");
-        }
-        if (healthId.getCode() == null) {
-            throw new BridgeServiceException("Participant cannot be updated (no health code in HealthId mapping).");
-        }
-        return healthId.getCode();
     }
     
 }

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -29,12 +29,10 @@ import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dao.ParticipantOption;
 import org.sagebionetworks.bridge.dao.ParticipantOption.SharingScope;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
-import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountSummary;
-import org.sagebionetworks.bridge.models.accounts.HealthId;
 import org.sagebionetworks.bridge.models.accounts.IdentifierHolder;
 import org.sagebionetworks.bridge.models.accounts.ParticipantOptionsLookup;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
@@ -44,7 +42,6 @@ import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
 import org.sagebionetworks.bridge.validators.StudyParticipantValidator;
 import org.sagebionetworks.bridge.validators.Validate;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
@@ -53,15 +50,11 @@ public class ParticipantService {
 
     private static final String PAGE_SIZE_ERROR = "pageSize must be from "+API_MINIMUM_PAGE_SIZE+"-"+API_MAXIMUM_PAGE_SIZE+" records";
     
-    private static final List<UserConsentHistory> NO_HISTORY = ImmutableList.of();
-    
     private AccountDao accountDao;
     
     private ParticipantOptionsService optionsService;
     
     private SubpopulationService subpopService;
-    
-    private HealthCodeService healthCodeService;
     
     private ConsentService consentService;
     
@@ -82,11 +75,6 @@ public class ParticipantService {
     @Autowired
     final void setSubpopulationService(SubpopulationService subpopService) {
         this.subpopService = subpopService;
-    }
-    
-    @Autowired
-    final void setHealthCodeService(HealthCodeService healthCodeService) {
-        this.healthCodeService = healthCodeService;
     }
     
     @Autowired
@@ -111,33 +99,23 @@ public class ParticipantService {
         
         StudyParticipant.Builder participant = new StudyParticipant.Builder();
         Account account = getAccountThrowingException(study, id);
-        String healthCode = getHealthCodeThrowingException(account);
 
         Map<String,List<UserConsentHistory>> consentHistories = Maps.newHashMap();
         List<Subpopulation> subpopulations = subpopService.getSubpopulations(study.getStudyIdentifier());
         for (Subpopulation subpop : subpopulations) {
-            if (healthCode != null) {
-                // always returns a list, even if empty
-                List<UserConsentHistory> history = consentService.getUserConsentHistory(study, subpop.getGuid(), healthCode, id);
-                consentHistories.put(subpop.getGuidString(), history);
-            } else {
-                // Create an empty history if there's no health Code.
-                consentHistories.put(subpop.getGuidString(), NO_HISTORY);
-            }
+            // always returns a list, even if empty
+            List<UserConsentHistory> history = consentService.getUserConsentHistory(study, subpop.getGuid(),
+                    account.getHealthCode(), id);
+            consentHistories.put(subpop.getGuidString(), history);
         }
         participant.withConsentHistories(consentHistories);
         
-        // Accounts exist that have signatures but no health codes (when created but email is 
-        // never verified, for example). Do not want roster generation to fail because of this,
-        // so we just skip things that require the healthCode.
-        if (healthCode != null) {
-            ParticipantOptionsLookup lookup = optionsService.getOptions(healthCode);
-            participant.withSharingScope(lookup.getEnum(SHARING_SCOPE, SharingScope.class));
-            participant.withNotifyByEmail(lookup.getBoolean(EMAIL_NOTIFICATIONS));
-            participant.withExternalId(lookup.getString(EXTERNAL_IDENTIFIER));
-            participant.withDataGroups(lookup.getStringSet(DATA_GROUPS));
-            participant.withLanguages(lookup.getOrderedStringSet(LANGUAGES));
-        }
+        ParticipantOptionsLookup lookup = optionsService.getOptions(account.getHealthCode());
+        participant.withSharingScope(lookup.getEnum(SHARING_SCOPE, SharingScope.class));
+        participant.withNotifyByEmail(lookup.getBoolean(EMAIL_NOTIFICATIONS));
+        participant.withExternalId(lookup.getString(EXTERNAL_IDENTIFIER));
+        participant.withDataGroups(lookup.getStringSet(DATA_GROUPS));
+        participant.withLanguages(lookup.getOrderedStringSet(LANGUAGES));
         participant.withFirstName(account.getFirstName());
         participant.withLastName(account.getLastName());
         participant.withEmail(account.getEmail());
@@ -154,7 +132,7 @@ public class ParticipantService {
         participant.withAttributes(attributes);
         
         if (study.isHealthCodeExportEnabled() && callerRoles.contains(RESEARCHER)) {
-            participant.withHealthCode(healthCode);
+            participant.withHealthCode(account.getHealthCode());
         }
         return participant.build();
     }
@@ -200,7 +178,6 @@ public class ParticipantService {
         
         Validate.entityThrowingException(new StudyParticipantValidator(study, isNew), participant);
         Account account = null;
-        String healthCode = null;
         if (isNew) {
             // Don't set it yet. Create the user first, and only assign it if that's successful.
             // Allows us to assure that credentials and ID will be related or not created at all.
@@ -208,14 +185,12 @@ public class ParticipantService {
                 externalIdService.reserveExternalId(study, participant.getExternalId());    
             }
             account = accountDao.signUp(study, participant, study.isEmailVerificationEnabled());
-            healthCode = getHealthCodeThrowingException(account);
         } else {
             account = getAccountThrowingException(study, id);
-            healthCode = getHealthCodeThrowingException(account);
             
             // Verify now that the assignment is valid, or throw an exception before any other updates
             // TODO: Since we're enforcing addition at account creation, we might just be able to skip this.
-            addValidatedExternalId(study, participant, healthCode);
+            addValidatedExternalId(study, participant, account.getHealthCode());
         }
         Map<ParticipantOption,String> options = Maps.newHashMap();
         for (ParticipantOption option : ParticipantOption.values()) {
@@ -226,7 +201,7 @@ public class ParticipantService {
         if (study.isExternalIdValidationEnabled()) {
             options.remove(EXTERNAL_IDENTIFIER);
         }
-        optionsService.setAllOptions(study.getStudyIdentifier(), healthCode, options);
+        optionsService.setAllOptions(study.getStudyIdentifier(), account.getHealthCode(), options);
         
         account.setFirstName(participant.getFirstName());
         account.setLastName(participant.getLastName());
@@ -246,7 +221,7 @@ public class ParticipantService {
         accountDao.updateAccount(account);
         
         if (isNew && isNotBlank(participant.getExternalId())) {
-            externalIdService.assignExternalId(study, participant.getExternalId(), healthCode);
+            externalIdService.assignExternalId(study, participant.getExternalId(), account.getHealthCode());
         }
         return new IdentifierHolder(account.getId());
     }
@@ -301,16 +276,6 @@ public class ParticipantService {
         return (isBlank(id1) || isBlank(id2) || !id1.equals(id2));
     }
     
-    private String getHealthCodeThrowingException(Account account) {
-        HealthId healthId = healthCodeService.getMapping(account.getHealthId());
-        if (healthId != null) {
-            return healthId.getCode();
-        }
-        // This should NEVER happen, but there are tests that verify if it happens, we send back the right 
-        // exception.
-        throw new BridgeServiceException("Participant cannot be updated. Health code could not be found.");
-    }
-
     private Account getAccountThrowingException(Study study, String id) {
         Account account = accountDao.getAccount(study, id);
         if (account == null) {

--- a/app/org/sagebionetworks/bridge/services/UserAdminService.java
+++ b/app/org/sagebionetworks/bridge/services/UserAdminService.java
@@ -180,25 +180,21 @@ public class UserAdminService {
         // up accurate information about the state of the account (as we can recover it)
         cacheProvider.removeSessionByUserId(account.getId());
         
-        // Because this account was retrieved via the iterators in AccountDao, the existence of 
-        // a health code is not enforce.
         String healthCode = account.getHealthCode();
-        if (account.getHealthCode() != null) {
-            consentService.deleteAllConsentsForUser(study, healthCode);
-            healthDataService.deleteRecordsForHealthCode(healthCode);
-            scheduledActivityService.deleteActivitiesForUser(healthCode);
-            activityEventService.deleteActivityEvents(healthCode);
-            surveyResponseService.deleteSurveyResponses(healthCode);
-            
-            // Remove the externalId from the table even if validation is not enabled. If the study
-            // turns it off/back on again, we want to track what has changed
-            ParticipantOptionsLookup lookup = optionsService.getOptions(healthCode);
-            String externalId = lookup.getString(EXTERNAL_IDENTIFIER);
-            if (externalId != null) {
-                externalIdService.unassignExternalId(study, externalId, healthCode);    
-            }
-            optionsService.deleteAllParticipantOptions(healthCode);
+        consentService.deleteAllConsentsForUser(study, healthCode);
+        healthDataService.deleteRecordsForHealthCode(healthCode);
+        scheduledActivityService.deleteActivitiesForUser(healthCode);
+        activityEventService.deleteActivityEvents(healthCode);
+        surveyResponseService.deleteSurveyResponses(healthCode);
+        
+        // Remove the externalId from the table even if validation is not enabled. If the study
+        // turns it off/back on again, we want to track what has changed
+        ParticipantOptionsLookup lookup = optionsService.getOptions(healthCode);
+        String externalId = lookup.getString(EXTERNAL_IDENTIFIER);
+        if (externalId != null) {
+            externalIdService.unassignExternalId(study, externalId, healthCode);    
         }
+        optionsService.deleteAllParticipantOptions(healthCode);
         accountDao.deleteAccount(study, account.getId());
     }
 }

--- a/app/org/sagebionetworks/bridge/services/UserAdminService.java
+++ b/app/org/sagebionetworks/bridge/services/UserAdminService.java
@@ -5,13 +5,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.sagebionetworks.bridge.dao.ParticipantOption.EXTERNAL_IDENTIFIER;
 import static org.sagebionetworks.bridge.dao.ParticipantOption.SharingScope.NO_SHARING;
 
-import java.util.Iterator;
-
 import org.apache.commons.lang3.StringUtils;
-import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.dao.AccountDao;
-import org.sagebionetworks.bridge.dao.HealthIdDao;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.models.CriteriaContext;
@@ -36,7 +32,6 @@ public class UserAdminService {
     private AccountDao accountDao;
     private ConsentService consentService;
     private HealthDataService healthDataService;
-    private HealthIdDao healthIdDao;
     private StudyService studyService;
     private SurveyResponseService surveyResponseService;
     private ScheduledActivityService scheduledActivityService;
@@ -64,10 +59,6 @@ public class UserAdminService {
     @Autowired
     public final void setStudyService(StudyService studyService) {
         this.studyService = studyService;
-    }
-    @Autowired
-    public final void setHealthIdDao(HealthIdDao healthIdDao) {
-        this.healthIdDao = healthIdDao;
     }
     @Autowired
     public final void setScheduledActivityService(ScheduledActivityService scheduledActivityService) {
@@ -181,16 +172,6 @@ public class UserAdminService {
         }
     }
 
-    public void deleteAllUsers(Roles role) {
-        Iterator<Account> iterator = accountDao.getAllAccounts();
-        while(iterator.hasNext()) {
-            Account account = iterator.next();
-            if (account.getRoles().contains(role)) {
-                deleteUser(account);
-            }
-        }
-    }
-
     private void deleteUser(Account account) {
         checkNotNull(account);
 
@@ -198,27 +179,25 @@ public class UserAdminService {
         // remove this first so if account is partially deleted, re-authenticating will pick
         // up accurate information about the state of the account (as we can recover it)
         cacheProvider.removeSessionByUserId(account.getId());
-        if (account.getHealthId() != null) {
-            // This is the fastest way to do this that I know of
-            String healthCode = healthIdDao.getCode(account.getHealthId());
-            // We expect to have health code, but when tests fail, we can get users who have signed in 
-            // and do not have a health code.
-            if (healthCode != null) {
-                consentService.deleteAllConsentsForUser(study, healthCode);
-                healthDataService.deleteRecordsForHealthCode(healthCode);
-                scheduledActivityService.deleteActivitiesForUser(healthCode);
-                activityEventService.deleteActivityEvents(healthCode);
-                surveyResponseService.deleteSurveyResponses(healthCode);
-                
-                // Remove the externalId from the table even if validation is not enabled. If the study
-                // turns it off/back on again, we want to track what has changed
-                ParticipantOptionsLookup lookup = optionsService.getOptions(healthCode);
-                String externalId = lookup.getString(EXTERNAL_IDENTIFIER);
-                if (externalId != null) {
-                    externalIdService.unassignExternalId(study, externalId, healthCode);    
-                }
-                optionsService.deleteAllParticipantOptions(healthCode);
+        
+        // Because this account was retrieved via the iterators in AccountDao, the existence of 
+        // a health code is not enforce.
+        String healthCode = account.getHealthCode();
+        if (account.getHealthCode() != null) {
+            consentService.deleteAllConsentsForUser(study, healthCode);
+            healthDataService.deleteRecordsForHealthCode(healthCode);
+            scheduledActivityService.deleteActivitiesForUser(healthCode);
+            activityEventService.deleteActivityEvents(healthCode);
+            surveyResponseService.deleteSurveyResponses(healthCode);
+            
+            // Remove the externalId from the table even if validation is not enabled. If the study
+            // turns it off/back on again, we want to track what has changed
+            ParticipantOptionsLookup lookup = optionsService.getOptions(healthCode);
+            String externalId = lookup.getString(EXTERNAL_IDENTIFIER);
+            if (externalId != null) {
+                externalIdService.unassignExternalId(study, externalId, healthCode);    
             }
+            optionsService.deleteAllParticipantOptions(healthCode);
         }
         accountDao.deleteAccount(study, account.getId());
     }

--- a/app/org/sagebionetworks/bridge/services/backfill/ConsentAuditAndRepairBackfill.java
+++ b/app/org/sagebionetworks/bridge/services/backfill/ConsentAuditAndRepairBackfill.java
@@ -13,7 +13,6 @@ import org.sagebionetworks.bridge.dao.ParticipantOption.SharingScope;
 import org.sagebionetworks.bridge.dao.StudyConsentDao;
 import org.sagebionetworks.bridge.dao.UserConsentDao;
 import org.sagebionetworks.bridge.models.accounts.Account;
-import org.sagebionetworks.bridge.models.accounts.HealthId;
 import org.sagebionetworks.bridge.models.accounts.UserConsent;
 import org.sagebionetworks.bridge.models.backfill.BackfillTask;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
@@ -21,7 +20,6 @@ import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
 import org.sagebionetworks.bridge.models.subpopulations.StudyConsent;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 import org.sagebionetworks.bridge.services.ActivityEventService;
-import org.sagebionetworks.bridge.services.HealthCodeService;
 import org.sagebionetworks.bridge.services.ParticipantOptionsService;
 
 /**
@@ -36,31 +34,26 @@ public class ConsentAuditAndRepairBackfill extends AsyncBackfillTemplate {
     private UserConsentDao userConsentDao;
     private ActivityEventService activityEventService;
     private StudyConsentDao studyConsentDao;
-    private HealthCodeService healthCodeService;
     private ParticipantOptionsService optionsService;
     
     @Autowired
-    public final void setAccountDao(AccountDao accountDao) {
+    final void setAccountDao(AccountDao accountDao) {
         this.accountDao = accountDao;
     }
     @Autowired
-    public final void setUserConsentDao(UserConsentDao userConsentDao) {
+    final void setUserConsentDao(UserConsentDao userConsentDao) {
         this.userConsentDao = userConsentDao;
     }
     @Autowired
-    public final void setActivityEventService(ActivityEventService activityEventService) {
+    final void setActivityEventService(ActivityEventService activityEventService) {
         this.activityEventService = activityEventService;
     }
     @Autowired
-    public final void setStudyConsentDao(StudyConsentDao studyConsentDao) {
+    final void setStudyConsentDao(StudyConsentDao studyConsentDao) {
         this.studyConsentDao = studyConsentDao;
     }
     @Autowired
-    public final void setHealthCodeService(HealthCodeService healthCodeService) {
-        this.healthCodeService = healthCodeService;
-    }
-    @Autowired
-    public final void setOptionsService(ParticipantOptionsService optionsService) {
+    final void setOptionsService(ParticipantOptionsService optionsService) {
         this.optionsService = optionsService;
     }
     
@@ -163,10 +156,13 @@ public class ConsentAuditAndRepairBackfill extends AsyncBackfillTemplate {
         return signedOn;
     }
     
+    /**
+     * Because these records are retrieved through the iterators, we don't guarantee there are health codes 
+     * (these methods can be removed at some point, they're only used in the backfills).
+     */
     private String getHealthCode(BackfillTask task, BackfillCallback callback, Account account) {
-        HealthId mapping = healthCodeService.getMapping(account.getHealthId());
-        if (mapping != null) {
-            return mapping.getCode();
+        if (account.getHealthCode() != null) {
+            return account.getHealthCode();
         }
         callback.newRecords(getBackfillRecordFactory().createOnly(task, "No health code found: " + account.getId()));
         return null;

--- a/app/org/sagebionetworks/bridge/services/backfill/ConsentAuditAndRepairBackfill.java
+++ b/app/org/sagebionetworks/bridge/services/backfill/ConsentAuditAndRepairBackfill.java
@@ -91,59 +91,53 @@ public class ConsentAuditAndRepairBackfill extends AsyncBackfillTemplate {
             ConsentSignature signature = account.getActiveConsentSignature(subpopGuid);
             if (signature != null) {
                 
-                String healthCode = getHealthCode(task, callback, account);
-                if (healthCode != null) {
-                    UserConsent consent = userConsentDao.getActiveUserConsent(healthCode, subpopGuid);
-                    if (consent == null) {
+                String healthCode = account.getHealthCode();
+                UserConsent consent = userConsentDao.getActiveUserConsent(healthCode, subpopGuid);
+                if (consent == null) {
+                    
+                    // User has signature but no consent record. Try to repair and report on it.
+                    
+                    StringBuilder sb = new StringBuilder("Repairing account '"+account.getId()+"'");
+                    
+                    DateTime enrollment = activityEventService.getActivityEventMap(healthCode).get("enrollment");
+                    
+                    // We have to assume the active consent, information about the consent that was signed is contained
+                    // in the DDB record that is missing.
+                    StudyConsent studyConsent = studyConsentDao.getActiveConsent(subpopGuid);
+                    
+                    if (studyConsent != null) {
+                        long signedOn = getSignedOnDate(sb, enrollment, syntheticSignedOn);
                         
-                        // User has signature but no consent record. Try to repair and report on it.
+                        // Give consent
+                        consent = userConsentDao.giveConsent(healthCode, subpopGuid, studyConsent.getCreatedOn(), signedOn);
+                        repaired++;
                         
-                        StringBuilder sb = new StringBuilder("Repairing account '"+account.getId()+"'");
-                        
-                        DateTime enrollment = activityEventService.getActivityEventMap(healthCode).get("enrollment");
-                        
-                        // We have to assume the active consent, information about the consent that was signed is contained
-                        // in the DDB record that is missing.
-                        StudyConsent studyConsent = studyConsentDao.getActiveConsent(subpopGuid);
-                        
-                        if (studyConsent != null) {
-                            long signedOn = getSignedOnDate(sb, enrollment, syntheticSignedOn);
-                            
-                            // Give consent
-                            consent = userConsentDao.giveConsent(healthCode, subpopGuid, studyConsent.getCreatedOn(), signedOn);
-                            repaired++;
-                            
-                            // Create an enrollment event
-                            if (consent != null && enrollment == null){
-                                activityEventService.publishEnrollmentEvent(healthCode, consent);
-                            }
-                            updateSharingScope(sb, studyId, healthCode);
-                            
-                            // Things we don't do: we don't increment the study enrollment (that will eventually be
-                            // recalculated from the db), we don't send out email, and we don't update the user's
-                            // session. If their sharing scope is NO_SHARING, we set it to limited, because we don't 
-                            // know their original choice.                            
-                            
-                            callback.newRecords(getBackfillRecordFactory().createOnly(task, sb.toString()));
-                        } else {
-                            sb.append(", no study consent found for " + studyId.getIdentifier());
+                        // Create an enrollment event
+                        if (consent != null && enrollment == null){
+                            activityEventService.publishEnrollmentEvent(healthCode, consent);
                         }
+                        updateSharingScope(sb, studyId, healthCode);
+                        
+                        // Things we don't do: we don't increment the study enrollment (that will eventually be
+                        // recalculated from the db), we don't send out email, and we don't update the user's
+                        // session. If their sharing scope is NO_SHARING, we set it to limited, because we don't 
+                        // know their original choice.                            
+                        
+                        callback.newRecords(getBackfillRecordFactory().createOnly(task, sb.toString()));
+                    } else {
+                        sb.append(", no study consent found for " + studyId.getIdentifier());
                     }
                 }
                 
             } else if (!account.getConsentSignatureHistory(subpopGuid).isEmpty()) {
                 // This can happen because people withdraw from a study. It's okay, but interesting... we still wonder if this person
                 // has a record.
-                String healthCode = getHealthCode(task, callback, account);
-                if (healthCode != null) {
-                    UserConsent consent = userConsentDao.getActiveUserConsent(healthCode, subpopGuid);
-                    if (consent == null) {
-                        callback.newRecords(getBackfillRecordFactory().createOnly(task, "Consent signatures exist but no active signature and no DDB consent record (error state?): " + account.getId()));
-                    } else {
-                        callback.newRecords(getBackfillRecordFactory().createOnly(task, "Consent signatures exist but no active signature (expected withdrawn state): " + account.getId()));
-                    }
+                String healthCode = account.getHealthCode();
+                UserConsent consent = userConsentDao.getActiveUserConsent(healthCode, subpopGuid);
+                if (consent == null) {
+                    callback.newRecords(getBackfillRecordFactory().createOnly(task, "Consent signatures exist but no active signature and no DDB consent record (error state?): " + account.getId()));
                 } else {
-                    callback.newRecords(getBackfillRecordFactory().createOnly(task, "Consent signatures exist but no healthCode (error state): " + account.getId()));    
+                    callback.newRecords(getBackfillRecordFactory().createOnly(task, "Consent signatures exist but no active signature (expected withdrawn state): " + account.getId()));
                 }
             }
         }
@@ -166,17 +160,5 @@ public class ConsentAuditAndRepairBackfill extends AsyncBackfillTemplate {
             sb.append(", no enrollment event for signedOn date, using " + syntheticSignedOn);
         }
         return signedOn;
-    }
-    
-    /**
-     * Because these records are retrieved through the iterators, we don't guarantee there are health codes 
-     * (these methods can be removed at some point, they're only used in the backfills).
-     */
-    private String getHealthCode(BackfillTask task, BackfillCallback callback, Account account) {
-        if (account.getHealthCode() != null) {
-            return account.getHealthCode();
-        }
-        callback.newRecords(getBackfillRecordFactory().createOnly(task, "No health code found: " + account.getId()));
-        return null;
     }
 }

--- a/app/org/sagebionetworks/bridge/services/backfill/HealthCodeBackfill.java
+++ b/app/org/sagebionetworks/bridge/services/backfill/HealthCodeBackfill.java
@@ -55,7 +55,7 @@ public class HealthCodeBackfill extends AsyncBackfillTemplate {
                 // and has not consented in other studies yet.
                 mapping = healthCodeService.createMapping(study);
                 account.setHealthId(mapping.getId());
-                accountDao.updateAccount(study, account);
+                accountDao.updateAccount(account);
                 callback.newRecords(getBackfillRecordFactory().createAndSave(
                         task, study, account, "health code created"));
             } 

--- a/app/org/sagebionetworks/bridge/services/backfill/HealthCodeBackfill.java
+++ b/app/org/sagebionetworks/bridge/services/backfill/HealthCodeBackfill.java
@@ -4,10 +4,8 @@ import java.util.Iterator;
 
 import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.models.accounts.Account;
-import org.sagebionetworks.bridge.models.accounts.HealthId;
 import org.sagebionetworks.bridge.models.backfill.BackfillTask;
 import org.sagebionetworks.bridge.models.studies.Study;
-import org.sagebionetworks.bridge.services.HealthCodeService;
 import org.sagebionetworks.bridge.services.StudyService;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,7 +18,6 @@ import org.springframework.stereotype.Component;
 public class HealthCodeBackfill extends AsyncBackfillTemplate {
     private AccountDao accountDao;
     private StudyService studyService;
-    private HealthCodeService healthCodeService;
 
     @Autowired
     public void setAccountDao(AccountDao accountDao) {
@@ -30,11 +27,6 @@ public class HealthCodeBackfill extends AsyncBackfillTemplate {
     @Autowired
     public void setStudyService(StudyService studyService) {
         this.studyService = studyService;
-    }
-    
-    @Autowired
-    public void setHealthCodeService(HealthCodeService healthCodeService) {
-        this.healthCodeService = healthCodeService;
     }
 
     @Override
@@ -48,17 +40,8 @@ public class HealthCodeBackfill extends AsyncBackfillTemplate {
             Account account = i.next();
             Study study = studyService.getStudy(account.getStudyIdentifier());
             
-            HealthId mapping = healthCodeService.getMapping(account.getHealthId());
-            if (mapping == null) {
-                // Backfill the account that have no health code mapping in the study.
-                // This happens when the user creates a new account and consents in a study
-                // and has not consented in other studies yet.
-                mapping = healthCodeService.createMapping(study);
-                account.setHealthId(mapping.getId());
-                accountDao.updateAccount(account);
-                callback.newRecords(getBackfillRecordFactory().createAndSave(
-                        task, study, account, "health code created"));
-            } 
+            // getting the individual account is sufficient to create a mapping if it does not exist.
+            accountDao.getAccount(study, account.getId());
         }
     }
 }

--- a/app/org/sagebionetworks/bridge/services/backfill/HealthCodeBackfill.java
+++ b/app/org/sagebionetworks/bridge/services/backfill/HealthCodeBackfill.java
@@ -3,7 +3,7 @@ package org.sagebionetworks.bridge.services.backfill;
 import java.util.Iterator;
 
 import org.sagebionetworks.bridge.dao.AccountDao;
-import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountSummary;
 import org.sagebionetworks.bridge.models.backfill.BackfillTask;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.services.StudyService;
@@ -36,12 +36,12 @@ public class HealthCodeBackfill extends AsyncBackfillTemplate {
 
     @Override
     void doBackfill(final BackfillTask task, BackfillCallback callback) {
-        for (Iterator<Account> i = accountDao.getAllAccounts(); i.hasNext();) {
-            Account account = i.next();
-            Study study = studyService.getStudy(account.getStudyIdentifier());
+        for (Iterator<AccountSummary> i = accountDao.getAllAccounts(); i.hasNext();) {
+            AccountSummary summary = i.next();
+            Study study = studyService.getStudy(summary.getStudyIdentifier());
             
             // getting the individual account is sufficient to create a mapping if it does not exist.
-            accountDao.getAccount(study, account.getId());
+            accountDao.getAccount(study, summary.getId());
         }
     }
 }

--- a/app/org/sagebionetworks/bridge/services/backfill/StudyIdBackfill.java
+++ b/app/org/sagebionetworks/bridge/services/backfill/StudyIdBackfill.java
@@ -7,6 +7,7 @@ import java.util.Iterator;
 import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dao.HealthCodeDao;
 import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountSummary;
 import org.sagebionetworks.bridge.models.backfill.BackfillTask;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.services.StudyService;
@@ -51,11 +52,11 @@ public class StudyIdBackfill extends AsyncBackfillTemplate  {
     @Override
     void doBackfill(final BackfillTask task, final BackfillCallback callback) {
         
-        for (Iterator<Account> i = accountDao.getAllAccounts(); i.hasNext();) {
+        for (Iterator<AccountSummary> i = accountDao.getAllAccounts(); i.hasNext();) {
             // This ensures the healthCode is created.
-            Account acct = i.next();
-            Study study = studyService.getStudy(acct.getStudyIdentifier());
-            Account account = accountDao.getAccount(study, acct.getId());
+            AccountSummary summary = i.next();
+            Study study = studyService.getStudy(summary.getStudyIdentifier());
+            Account account = accountDao.getAccount(study, summary.getId());
             try {
                 String healthCode = account.getHealthCode();
                 final String studyId = healthCodeDao.getStudyIdentifier(healthCode);

--- a/app/org/sagebionetworks/bridge/stormpath/StormpathAccount.java
+++ b/app/org/sagebionetworks/bridge/stormpath/StormpathAccount.java
@@ -21,6 +21,7 @@ import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.json.BridgeTypeName;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountStatus;
+import org.sagebionetworks.bridge.models.accounts.HealthId;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
@@ -63,6 +64,7 @@ public class StormpathAccount implements Account {
     private final String oldConsentSignatureKey;
     private final Map<SubpopulationGuid, List<ConsentSignature>> allSignatures;
     private ImmutableSet<Roles> roles;
+    private String healthCode;
     
     StormpathAccount(StudyIdentifier studyIdentifier, List<? extends SubpopulationGuid> subpopGuids, com.stormpath.sdk.account.Account acct,
             SortedMap<Integer, BridgeEncryptor> encryptors) {
@@ -144,13 +146,19 @@ public class StormpathAccount implements Account {
         acct.setEmail(email);
         acct.setUsername(email);
     }
-    @Override
     public String getHealthId(){
         return decryptFrom(healthIdKey);
     }
     @Override
-    public void setHealthId(String healthId) {
-        encryptTo(healthIdKey, healthId);
+    public String getHealthCode(){
+        return healthCode;
+    }
+    @Override
+    public void setHealthId(HealthId healthId) {
+        if (healthId != null) {
+            encryptTo(healthIdKey, healthId.getId());
+            this.healthCode = healthId.getCode();
+        }
     };
     @Override
     public List<ConsentSignature> getConsentSignatureHistory(SubpopulationGuid subpopGuid) {

--- a/app/org/sagebionetworks/bridge/stormpath/StormpathAccountDao.java
+++ b/app/org/sagebionetworks/bridge/stormpath/StormpathAccountDao.java
@@ -363,9 +363,9 @@ public class StormpathAccountDao implements AccountDao {
         acct.delete();
     }
     
-    // NOTE: There's no case where we don't want a health code for this account. We may simply want to have
-    // the account have the health code, and entirely hide the healthId as an implementation detail, like
-    // encryption.
+    /**
+     * Construct a StormpathAccount and guarantee that the healthid<->healthCode mapping exists for the account.
+     */
     private Account constructAccount(StudyIdentifier studyId, com.stormpath.sdk.account.Account acct) {
         List<SubpopulationGuid> subpopGuids = getSubpopulationGuids(studyId);
         StormpathAccount account = new StormpathAccount(studyId, subpopGuids, acct, encryptors);

--- a/app/org/sagebionetworks/bridge/stormpath/StormpathAccountDao.java
+++ b/app/org/sagebionetworks/bridge/stormpath/StormpathAccountDao.java
@@ -307,7 +307,7 @@ public class StormpathAccountDao implements AccountDao {
         }
         
         // This method should always succeed because construction of account will create a health code if it's missing.
-        return healthCodeService.getMapping(account.getHealthId()).getCode();
+        return account.getHealthCode();
     }
     
     @Override 
@@ -328,7 +328,7 @@ public class StormpathAccountDao implements AccountDao {
         }
         // Create the healthCode mapping when we create the account. Stop waiting to create it
         HealthId healthId = healthCodeService.createMapping(study);
-        account.setHealthId(healthId.getId());
+        account.setHealthId(healthId);
         
         try {
             Directory directory = client.getResource(study.getStormpathHref(), Directory.class);
@@ -382,17 +382,17 @@ public class StormpathAccountDao implements AccountDao {
     // encryption.
     private Account constructAccount(StudyIdentifier studyId, com.stormpath.sdk.account.Account acct) {
         List<SubpopulationGuid> subpopGuids = getSubpopulationGuids(studyId);
-        Account account = new StormpathAccount(studyId, subpopGuids, acct, encryptors);
+        StormpathAccount account = new StormpathAccount(studyId, subpopGuids, acct, encryptors);
         HealthId healthId = null;
-        if (account.getHealthId() != null) {
+        if (account.getHealthCode() == null) {
             healthId = healthCodeService.getMapping(account.getHealthId());
         }
         if (healthId == null) {
             healthId = healthCodeService.createMapping(studyId);
-            account.setHealthId(healthId.getId());
+            account.setHealthId(healthId);
             updateAccount(account);
         }
-        account.setHealthId(healthId.getId());
+        account.setHealthId(healthId);
         return account;
     }
     

--- a/app/org/sagebionetworks/bridge/stormpath/StormpathAccountIterator.java
+++ b/app/org/sagebionetworks/bridge/stormpath/StormpathAccountIterator.java
@@ -3,31 +3,18 @@ package org.sagebionetworks.bridge.stormpath;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Iterator;
-import java.util.List;
-import java.util.SortedMap;
+import org.sagebionetworks.bridge.models.accounts.AccountSummary;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 
-import org.sagebionetworks.bridge.crypto.BridgeEncryptor;
-import org.sagebionetworks.bridge.models.accounts.Account;
-import org.sagebionetworks.bridge.models.studies.Study;
-import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
+public final class StormpathAccountIterator implements Iterator<AccountSummary> {
 
-public final class StormpathAccountIterator implements Iterator<Account> {
-
-    private final Study study;
-    private final List<? extends SubpopulationGuid> subpopGuids;
-    private final SortedMap<Integer, BridgeEncryptor> encryptors;
+    private final StudyIdentifier studyId;
     private final Iterator<com.stormpath.sdk.account.Account> iterator;
     
-    public StormpathAccountIterator(Study study, List<? extends SubpopulationGuid> subpopGuids,
-            SortedMap<Integer, BridgeEncryptor> encryptors, Iterator<com.stormpath.sdk.account.Account> iterator) {
-        checkNotNull(study);
-        checkNotNull(subpopGuids);
-        checkNotNull(encryptors);
+    public StormpathAccountIterator(StudyIdentifier studyId, Iterator<com.stormpath.sdk.account.Account> iterator) {
         checkNotNull(iterator);
         
-        this.study = study;
-        this.subpopGuids = subpopGuids;
-        this.encryptors = encryptors;
+        this.studyId = studyId;
         this.iterator = iterator;
     }
     
@@ -37,10 +24,10 @@ public final class StormpathAccountIterator implements Iterator<Account> {
     }
 
     @Override
-    public Account next() {
+    public AccountSummary next() {
         com.stormpath.sdk.account.Account acct = iterator.next();
         if (acct != null) {
-            return new StormpathAccount(study, subpopGuids, acct, encryptors);
+            return AccountSummary.create(studyId, acct);
         }
         return null;
     }

--- a/test/org/sagebionetworks/bridge/models/PagedResourceListTest.java
+++ b/test/org/sagebionetworks/bridge/models/PagedResourceListTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 import org.joda.time.DateTime;
 import org.junit.Test;
 
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.accounts.AccountStatus;
 import org.sagebionetworks.bridge.models.accounts.AccountSummary;
@@ -22,8 +23,10 @@ public class PagedResourceListTest {
     @Test
     public void canSerialize() throws Exception {
         List<AccountSummary> accounts = Lists.newArrayListWithCapacity(2);
-        accounts.add(new AccountSummary("firstName1", "lastName1", "email1@email.com", "id", DateTime.now(), AccountStatus.DISABLED));
-        accounts.add(new AccountSummary("firstName2", "lastName2", "email2@email.com", "id2", DateTime.now(), AccountStatus.ENABLED));
+        accounts.add(new AccountSummary("firstName1", "lastName1", "email1@email.com", "id", DateTime.now(),
+                AccountStatus.DISABLED, TestConstants.TEST_STUDY));
+        accounts.add(new AccountSummary("firstName2", "lastName2", "email2@email.com", "id2", DateTime.now(),
+                AccountStatus.ENABLED, TestConstants.TEST_STUDY));
         
         PagedResourceList<AccountSummary> page = new PagedResourceList<AccountSummary>(accounts, 2, 100, 123)
                 .withFilter("emailFilter", "filterString");

--- a/test/org/sagebionetworks/bridge/models/accounts/AccountSummaryTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/AccountSummaryTest.java
@@ -1,19 +1,27 @@
 package org.sagebionetworks.bridge.models.accounts;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Test;
 
+import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class AccountSummaryTest {
+    
+    private static final String TIMESTAMP = "2016-05-04T19:36:46.675Z";
 
     @Test
     public void hashCodeEquals() {
@@ -40,6 +48,27 @@ public class AccountSummaryTest {
         
         AccountSummary newSummary = BridgeObjectMapper.get().treeToValue(node, AccountSummary.class);
         assertEquals(summary, newSummary);
+    }
+    
+    @Test
+    public void create() {
+        StudyIdentifier studyId = new StudyIdentifierImpl("test-study");
+        com.stormpath.sdk.account.Account acct = mock(com.stormpath.sdk.account.Account.class);
+        doReturn(DateTime.parse(TIMESTAMP).toDate()).when(acct).getCreatedAt();
+        doReturn(BridgeConstants.STORMPATH_ACCOUNT_BASE_HREF+"ABC").when(acct).getHref();
+        doReturn("<EMPTY>").when(acct).getGivenName();
+        doReturn("Powers").when(acct).getSurname();
+        doReturn(com.stormpath.sdk.account.AccountStatus.DISABLED).when(acct).getStatus();
+        doReturn("email@email.com").when(acct).getEmail();
+        
+        AccountSummary summary = AccountSummary.create(studyId, acct);
+        assertEquals(DateTime.parse(TIMESTAMP), summary.getCreatedOn());
+        assertEquals("ABC", summary.getId());
+        assertNull(summary.getFirstName());
+        assertEquals("email@email.com", summary.getEmail());
+        assertEquals("Powers", summary.getLastName());
+        assertEquals(studyId, summary.getStudyIdentifier());
+        assertEquals(AccountStatus.DISABLED, summary.getStatus());
     }
     
 }

--- a/test/org/sagebionetworks/bridge/models/accounts/AccountSummaryTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/AccountSummaryTest.java
@@ -6,6 +6,7 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Test;
 
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -24,7 +25,8 @@ public class AccountSummaryTest {
         // Set the time zone so it's not UTC, it should be converted to UTC so the strings are 
         // equal below (to demonstrate the ISO 8601 string is in UTC time zone).
         DateTime dateTime = DateTime.now().withZone(DateTimeZone.forOffsetHours(-8));
-        AccountSummary summary = new AccountSummary("firstName", "lastName", "email@email.com", "ABC", dateTime, AccountStatus.UNVERIFIED);
+        AccountSummary summary = new AccountSummary("firstName", "lastName", "email@email.com", "ABC", dateTime,
+                AccountStatus.UNVERIFIED, TestConstants.TEST_STUDY);
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(summary);
         assertEquals("firstName", node.get("firstName").asText());
@@ -33,6 +35,7 @@ public class AccountSummaryTest {
         assertEquals("ABC", node.get("id").asText());
         assertEquals(dateTime.withZone(DateTimeZone.UTC).toString(), node.get("createdOn").asText());
         assertEquals("unverified", node.get("status").asText());
+        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, node.get("studyIdentifier").get("identifier").asText());
         assertEquals("AccountSummary", node.get("type").asText());
         
         AccountSummary newSummary = BridgeObjectMapper.get().treeToValue(node, AccountSummary.class);

--- a/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
@@ -70,7 +70,8 @@ public class ParticipantControllerTest {
 
     private static final TypeReference<PagedResourceList<AccountSummary>> ACCOUNT_SUMMARY_PAGE = new TypeReference<PagedResourceList<AccountSummary>>(){};
 
-    private static final AccountSummary SUMMARY = new AccountSummary("firstName","lastName","email","id",DateTime.now(),AccountStatus.ENABLED);
+    private static final AccountSummary SUMMARY = new AccountSummary("firstName", "lastName", "email", "id",
+            DateTime.now(), AccountStatus.ENABLED, TestConstants.TEST_STUDY);
     
     private static final Study STUDY = new DynamoStudy();
     static {

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
@@ -366,7 +366,7 @@ public class AuthenticationServiceTest {
             data.remove(subpop.getGuidString()+"_signatures");
             data.remove(subpop.getGuidString()+"_signatures_version");                
         }
-        accountDao.updateAccount(testUser.getStudy(), account);
+        accountDao.updateAccount(account);
         
         // Signing in should still work to create a consented user.
         Study study = studyService.getStudy(testUser.getStudyIdentifier());

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
@@ -49,7 +49,6 @@ import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.accounts.Email;
 import org.sagebionetworks.bridge.models.accounts.EmailVerification;
-import org.sagebionetworks.bridge.models.accounts.HealthId;
 import org.sagebionetworks.bridge.models.accounts.PasswordReset;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
@@ -84,9 +83,6 @@ public class AuthenticationServiceTest {
     
     @Resource
     private AccountDao accountDao;
-    
-    @Resource
-    private HealthCodeService healthCodeService;
     
     @Resource
     private StudyService studyService;
@@ -266,11 +262,9 @@ public class AuthenticationServiceTest {
         UserSession session = authService.signIn(study, testUser.getCriteriaContext(), testUser.getSignIn());
         Account account = accountDao.getAccount(study, session.getUser().getId());
         
-        HealthId healthId = healthCodeService.getMapping(account.getHealthId());
-        
         verify(authService).signUp(any(Study.class), any(StudyParticipant.class), eq(true));
         // Verify that data groups were set correctly as an option
-        Set<String> persistedGroups = optionsService.getOptions(healthId.getCode()).getStringSet(DATA_GROUPS);
+        Set<String> persistedGroups = optionsService.getOptions(account.getHealthCode()).getStringSet(DATA_GROUPS);
         assertEquals(groups, persistedGroups);
     }
     

--- a/test/org/sagebionetworks/bridge/services/ConsentServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/ConsentServiceMockTest.java
@@ -205,7 +205,7 @@ public class ConsentServiceMockTest {
         
         verify(userConsentDao).withdrawConsent(user.getHealthCode(), SUBPOP_GUID, UNIX_TIMESTAMP);
         verify(accountDao).getAccount(study, user.getId());
-        verify(accountDao).updateAccount(any(Study.class), captor.capture());
+        verify(accountDao).updateAccount(captor.capture());
         // It happens twice because we do it the first time to set up the test properly
         //verify(account, times(2)).getConsentSignatures(setterCaptor.capture());
         verify(sendMailService).sendEmail(emailCaptor.capture());
@@ -263,7 +263,7 @@ public class ConsentServiceMockTest {
         } catch(BridgeServiceException e) {
         }
         verify(accountDao).getAccount(any(), any());
-        verify(accountDao, times(2)).updateAccount(any(), captor.capture());
+        verify(accountDao, times(2)).updateAccount(captor.capture());
         verifyNoMoreInteractions(sendMailService);
         
         Account account = captor.getAllValues().get(1);

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -29,7 +29,6 @@ import java.util.Set;
 
 import org.joda.time.DateTime;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -47,7 +46,6 @@ import org.sagebionetworks.bridge.dao.ParticipantOption;
 import org.sagebionetworks.bridge.dao.ParticipantOption.SharingScope;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
-import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -401,26 +401,6 @@ public class ParticipantServiceTest {
         assertNull(participant.getHealthCode());
     }
     
-    @Test(expected = BridgeServiceException.class)
-    @Ignore
-    public void getStudyParticipantWithoutHealthCode() {
-        // A lot of mocks have to be set up first, this call aggregates almost everything we know about the user
-        DateTime createdOn = DateTime.now();
-        when(account.getHealthCode()).thenReturn(null);
-        when(account.getFirstName()).thenReturn(FIRST_NAME);
-        when(account.getLastName()).thenReturn(LAST_NAME);
-        when(account.getEmail()).thenReturn(EMAIL);
-        when(account.getId()).thenReturn(ID);
-        when(account.getStatus()).thenReturn(AccountStatus.DISABLED);
-        when(account.getCreatedOn()).thenReturn(createdOn);
-        when(account.getAttribute("attr2")).thenReturn("anAttribute2");
-        
-        when(accountDao.getAccount(STUDY, ID)).thenReturn(account);
-        when(healthId.getCode()).thenReturn(null);
-        
-        participantService.getParticipant(STUDY, CALLER_ROLES, ID);
-    }
-
     @Test(expected = EntityNotFoundException.class)
     public void signOutUserWhoDoesNotExist() {
         when(accountDao.getAccount(STUDY, ID)).thenReturn(null);
@@ -562,16 +542,6 @@ public class ParticipantServiceTest {
         verify(optionsService).setAllOptions(eq(STUDY.getStudyIdentifier()), eq(HEALTH_CODE), optionsCaptor.capture());
         Map<ParticipantOption, String> options = optionsCaptor.getValue();
         assertEquals("POWERS", options.get(EXTERNAL_IDENTIFIER));
-    }
-    
-    @Test(expected = BridgeServiceException.class)
-    @Ignore
-    public void updateParticipantWithNoHealthCode() {
-        STUDY.setExternalIdValidationEnabled(true);
-        doReturn(null).when(account).getHealthCode();
-        doReturn(account).when(accountDao).getAccount(STUDY, ID);
-        
-        participantService.updateParticipant(STUDY, CALLER_ROLES, ID, PARTICIPANT);
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -29,6 +29,7 @@ import java.util.Set;
 
 import org.joda.time.DateTime;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -72,7 +73,6 @@ import com.google.common.collect.Sets;
 public class ParticipantServiceTest {
 
     private static final String EXTERNAL_ID = "externalId";
-    private static final String HEALTH_ID = "healthId";
     private static final String HEALTH_CODE = "healthCode";
     private static final String PHONE = "phone";
     private static final String LAST_NAME = "lastName";
@@ -124,9 +124,6 @@ public class ParticipantServiceTest {
     private SubpopulationService subpopService;
     
     @Mock
-    private HealthCodeService healthCodeService;
-    
-    @Mock
     private ConsentService consentService;
     
     @Mock
@@ -166,17 +163,14 @@ public class ParticipantServiceTest {
         participantService.setAccountDao(accountDao);
         participantService.setParticipantOptionsService(optionsService);
         participantService.setSubpopulationService(subpopService);
-        participantService.setHealthCodeService(healthCodeService);
         participantService.setUserConsent(consentService);
         participantService.setCacheProvider(cacheProvider);
         participantService.setExternalIdService(externalIdService);
     }
     
     private void mockHealthCodeAndAccountRetrieval() {
-        doReturn(HEALTH_ID).when(account).getHealthId();
         doReturn(ID).when(account).getId();
-        doReturn(healthId).when(healthCodeService).getMapping(HEALTH_ID);
-        doReturn(HEALTH_CODE).when(healthId).getCode();
+        doReturn(HEALTH_CODE).when(account).getHealthCode();
         doReturn(account).when(accountDao).signUp(eq(STUDY), any(), eq(false));
         doReturn(account).when(accountDao).getAccount(STUDY, ID);
     }
@@ -237,7 +231,6 @@ public class ParticipantServiceTest {
         verify(externalIdService).reserveExternalId(STUDY, "POWERS");
         verifyNoMoreInteractions(accountDao);
         verifyNoMoreInteractions(optionsService);
-        verifyNoMoreInteractions(healthCodeService);        
     }
     
     @Test
@@ -267,7 +260,6 @@ public class ParticipantServiceTest {
         verifyNoMoreInteractions(accountDao);
         verifyNoMoreInteractions(optionsService);
         verifyNoMoreInteractions(externalIdService);
-        verifyNoMoreInteractions(healthCodeService);
     }
     
     @Test
@@ -330,7 +322,7 @@ public class ParticipantServiceTest {
     public void getStudyParticipant() {
         // A lot of mocks have to be set up first, this call aggregates almost everything we know about the user
         DateTime createdOn = DateTime.now();
-        when(account.getHealthId()).thenReturn(HEALTH_ID);
+        when(account.getHealthCode()).thenReturn(HEALTH_CODE);
         when(account.getFirstName()).thenReturn(FIRST_NAME);
         when(account.getLastName()).thenReturn(LAST_NAME);
         when(account.getEmail()).thenReturn(EMAIL);
@@ -410,10 +402,11 @@ public class ParticipantServiceTest {
     }
     
     @Test(expected = BridgeServiceException.class)
+    @Ignore
     public void getStudyParticipantWithoutHealthCode() {
         // A lot of mocks have to be set up first, this call aggregates almost everything we know about the user
         DateTime createdOn = DateTime.now();
-        when(account.getHealthId()).thenReturn(null);
+        when(account.getHealthCode()).thenReturn(null);
         when(account.getFirstName()).thenReturn(FIRST_NAME);
         when(account.getLastName()).thenReturn(LAST_NAME);
         when(account.getEmail()).thenReturn(EMAIL);
@@ -554,7 +547,6 @@ public class ParticipantServiceTest {
         } catch(EntityNotFoundException e) {
         }
         verify(accountDao, never()).updateAccount(any());
-        verifyNoMoreInteractions(healthCodeService);
         verifyNoMoreInteractions(optionsService);
         verifyNoMoreInteractions(externalIdService);
     }
@@ -573,10 +565,10 @@ public class ParticipantServiceTest {
     }
     
     @Test(expected = BridgeServiceException.class)
+    @Ignore
     public void updateParticipantWithNoHealthCode() {
         STUDY.setExternalIdValidationEnabled(true);
-        doReturn(null).when(healthCodeService).getMapping(HEALTH_ID);
-        doReturn(null).when(account).getHealthId();
+        doReturn(null).when(account).getHealthCode();
         doReturn(account).when(accountDao).getAccount(STUDY, ID);
         
         participantService.updateParticipant(STUDY, CALLER_ROLES, ID, PARTICIPANT);

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.bridge.services;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -210,7 +209,7 @@ public class ParticipantServiceTest {
         assertTrue(options.get(LANGUAGES).contains("de"));
         assertTrue(options.get(LANGUAGES).contains("fr"));
         
-        verify(accountDao).updateAccount(eq(STUDY), accountCaptor.capture());
+        verify(accountDao).updateAccount(accountCaptor.capture());
         Account account = accountCaptor.getValue();
         verify(account).setFirstName(FIRST_NAME);
         verify(account).setLastName(LAST_NAME);
@@ -410,7 +409,7 @@ public class ParticipantServiceTest {
         assertNull(participant.getHealthCode());
     }
     
-    @Test
+    @Test(expected = BridgeServiceException.class)
     public void getStudyParticipantWithoutHealthCode() {
         // A lot of mocks have to be set up first, this call aggregates almost everything we know about the user
         DateTime createdOn = DateTime.now();
@@ -426,23 +425,7 @@ public class ParticipantServiceTest {
         when(accountDao.getAccount(STUDY, ID)).thenReturn(account);
         when(healthId.getCode()).thenReturn(null);
         
-        StudyParticipant participant = participantService.getParticipant(STUDY, CALLER_ROLES, ID);
-        
-        assertEquals(FIRST_NAME, participant.getFirstName());
-        assertEquals(LAST_NAME, participant.getLastName());
-        assertFalse(participant.isNotifyByEmail());
-        assertTrue(participant.getDataGroups().isEmpty());
-        assertNull(participant.getExternalId());
-        assertNull(participant.getSharingScope());
-        assertNull(participant.getHealthCode());
-        assertEquals(EMAIL, participant.getEmail());
-        assertEquals(ID, participant.getId());
-        assertEquals(AccountStatus.DISABLED, participant.getStatus());
-        assertEquals(createdOn, participant.getCreatedOn());
-        assertTrue(participant.getLanguages().isEmpty());
-        assertNull(participant.getAttributes().get("attr1"));
-        assertEquals("anAttribute2", participant.getAttributes().get("attr2"));
-        assertTrue(participant.getConsentHistories().isEmpty());
+        participantService.getParticipant(STUDY, CALLER_ROLES, ID);
     }
 
     @Test(expected = EntityNotFoundException.class)
@@ -497,7 +480,7 @@ public class ParticipantServiceTest {
         assertTrue(options.get(LANGUAGES).contains("fr"));
         assertNull(options.get(EXTERNAL_IDENTIFIER));
         
-        verify(accountDao).updateAccount(eq(STUDY), accountCaptor.capture());
+        verify(accountDao).updateAccount(accountCaptor.capture());
         Account account = accountCaptor.getValue();
         verify(account).setFirstName(FIRST_NAME);
         verify(account).setLastName(LAST_NAME);
@@ -570,7 +553,7 @@ public class ParticipantServiceTest {
             fail("Should have thrown exception.");
         } catch(EntityNotFoundException e) {
         }
-        verify(accountDao, never()).updateAccount(eq(STUDY), any());
+        verify(accountDao, never()).updateAccount(any());
         verifyNoMoreInteractions(healthCodeService);
         verifyNoMoreInteractions(optionsService);
         verifyNoMoreInteractions(externalIdService);
@@ -738,7 +721,7 @@ public class ParticipantServiceTest {
         
         participantService.createParticipant(STUDY, callerRoles, participant);
         
-        verify(accountDao).updateAccount(eq(STUDY), accountCaptor.capture());
+        verify(accountDao).updateAccount(accountCaptor.capture());
         Account account = accountCaptor.getValue();
         
         verify(account, never()).setStatus(any());
@@ -754,7 +737,7 @@ public class ParticipantServiceTest {
         
         participantService.updateParticipant(STUDY, roles, ID, participant);
 
-        verify(accountDao).updateAccount(eq(STUDY), accountCaptor.capture());
+        verify(accountDao).updateAccount(accountCaptor.capture());
         Account account = accountCaptor.getValue();
 
         if (status == null) {
@@ -772,7 +755,7 @@ public class ParticipantServiceTest {
         
         participantService.createParticipant(STUDY, callerRoles, participant);
         
-        verify(accountDao).updateAccount(eq(STUDY), accountCaptor.capture());
+        verify(accountDao).updateAccount(accountCaptor.capture());
         Account account = accountCaptor.getValue();
         
         if (rolesThatAreSet != null) {
@@ -790,7 +773,7 @@ public class ParticipantServiceTest {
                 .withRoles(rolesThatAreSet).build();
         participantService.updateParticipant(STUDY, callerRoles, ID, participant);
         
-        verify(accountDao).updateAccount(eq(STUDY), accountCaptor.capture());
+        verify(accountDao).updateAccount(accountCaptor.capture());
         Account account = accountCaptor.getValue();
         
         if (expected != null) {

--- a/test/org/sagebionetworks/bridge/services/SimpleAccount.java
+++ b/test/org/sagebionetworks/bridge/services/SimpleAccount.java
@@ -9,6 +9,7 @@ import org.joda.time.DateTime;
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountStatus;
+import org.sagebionetworks.bridge.models.accounts.HealthId;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
@@ -21,7 +22,7 @@ public class SimpleAccount implements Account {
     private String firstName;
     private String lastName;
     private String email;
-    private String healthId;
+    private String healthCode;
     private StudyIdentifier studyId;
     private Map<SubpopulationGuid,List<ConsentSignature>> signatures = Maps.newHashMap();
     private Map<String,String> attributes = Maps.newHashMap();
@@ -69,12 +70,14 @@ public class SimpleAccount implements Account {
         return signatures;
     }
     @Override
-    public String getHealthId() {
-        return healthId;
+    public void setHealthId(HealthId healthId) {
+        if (healthId != null) {
+            this.healthCode = healthId.getCode();
+        }
     }
     @Override
-    public void setHealthId(String healthId) {
-        this.healthId = healthId;
+    public String getHealthCode() {
+        return healthCode;
     }
     @Override
     public StudyIdentifier getStudyIdentifier() {

--- a/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoMockTest.java
@@ -90,6 +90,12 @@ public class StormpathAccountDaoMockTest {
     @Mock
     AuthenticationResult authResult;
     
+    @Mock
+    BridgeEncryptor encryptor;
+    
+    @Mock
+    CustomData data;
+
     StormpathAccountDao dao;
     
     Study study;
@@ -104,7 +110,6 @@ public class StormpathAccountDaoMockTest {
         subpop.setGuidString(study.getIdentifier());
         when(subpopService.getSubpopulations(study.getStudyIdentifier())).thenReturn(Lists.newArrayList(subpop));
         
-        BridgeEncryptor encryptor = mock(BridgeEncryptor.class);
         when(encryptor.decrypt("2")).thenReturn("2");
         when(encryptor.decrypt("healthId")).thenReturn("healthId");
         
@@ -126,7 +131,6 @@ public class StormpathAccountDaoMockTest {
         when(client.getCurrentTenant()).thenReturn(tenant);
         when(client.verifyAccountEmail("tokenAAA")).thenReturn(stormpathAccount);
         
-        CustomData data = mock(CustomData.class);
         when(data.get("test-study_version")).thenReturn(2);
         when(data.get("test-study_code")).thenReturn("healthId");
         when(stormpathAccount.getCustomData()).thenReturn(data);
@@ -173,7 +177,7 @@ public class StormpathAccountDaoMockTest {
     
     @Test
     public void stormpathAccountCorrectlyInitialized() {
-        when(stormpathAccount.getCustomData()).thenReturn(mock(CustomData.class));
+        when(stormpathAccount.getCustomData()).thenReturn(data);
         
         when(client.instantiate(com.stormpath.sdk.account.Account.class)).thenReturn(stormpathAccount);
         when(client.getResource(study.getStormpathHref(), Directory.class)).thenReturn(directory);
@@ -212,7 +216,6 @@ public class StormpathAccountDaoMockTest {
         // mock stormpath application
         when(application.authenticateAccount(any())).thenReturn(authResult);
         
-        CustomData data = mock(CustomData.class);
         when(data.get("test-study_version")).thenReturn(2);
         when(data.get("test-study_code")).thenReturn("healthId");
         when(stormpathAccount.getCustomData()).thenReturn(data);

--- a/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoMockTest.java
@@ -312,6 +312,7 @@ public class StormpathAccountDaoMockTest {
         
         Account account = dao.verifyEmail(study, emailVerification);
         assertEquals("ABC", account.getHealthCode());
+        verify(healthCodeService).createMapping(study);
     }
     
     @Test
@@ -326,6 +327,7 @@ public class StormpathAccountDaoMockTest {
         
         Account account = dao.authenticate(study, signIn);
         assertEquals("ABC", account.getHealthCode());
+        verify(healthCodeService).createMapping(study);
     }
     
     @Test
@@ -334,6 +336,7 @@ public class StormpathAccountDaoMockTest {
         
         Account account = dao.getAccount(study, "id");
         assertEquals("ABC", account.getHealthCode());
+        verify(healthCodeService).createMapping(study);
     }
 
     private void mockAccountWithoutHealthCode() {

--- a/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoMockTest.java
@@ -27,10 +27,14 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.http.HttpStatus;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.Roles;
+import org.sagebionetworks.bridge.crypto.BridgeEncryptor;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.models.accounts.Account;
@@ -54,34 +58,80 @@ import com.stormpath.sdk.directory.Directory;
 import com.stormpath.sdk.resource.ResourceException;
 import com.stormpath.sdk.tenant.Tenant;
 
+@RunWith(MockitoJUnitRunner.class)
 public class StormpathAccountDaoMockTest {
 
     private static final String PASSWORD = "P4ssword!";
     
-    private Study study;
+    @Mock
+    SubpopulationService subpopService;
+
+    @Mock
+    Application application;
+    
+    @Mock
+    Directory directory;
+    
+    @Mock
+    Client client;
+    
+    @Mock
+    Tenant tenant;
+    
+    @Mock
+    HealthId healthId;
+    
+    @Mock
+    com.stormpath.sdk.account.Account stormpathAccount;
+    
+    @Mock
+    HealthCodeService healthCodeService;
+
+    @Mock
+    AuthenticationResult authResult;
+    
+    StormpathAccountDao dao;
+    
+    Study study;
     
     @Before
     public void setUp() {
         study = new DynamoStudy();
         study.setIdentifier("test-study");
         study.setStormpathHref("http://some/dumb.href");
+        
+        Subpopulation subpop = Subpopulation.create();
+        subpop.setGuidString(study.getIdentifier());
+        when(subpopService.getSubpopulations(study.getStudyIdentifier())).thenReturn(Lists.newArrayList(subpop));
+        
+        BridgeEncryptor encryptor = mock(BridgeEncryptor.class);
+        when(encryptor.decrypt("2")).thenReturn("2");
+        when(encryptor.decrypt("healthId")).thenReturn("healthId");
+        
+        List<BridgeEncryptor> encryptors = Lists.newArrayList();
+        encryptors.add(encryptor);
+        
+        dao = new StormpathAccountDao();
+        dao.setStormpathClient(client);
+        dao.setSubpopulationService(subpopService);
+        dao.setStormpathApplication(application);
+        dao.setHealthCodeService(healthCodeService);
+        dao.setEncryptors(encryptors);
     }
 
     @Test
     public void verifyEmail() {
-        StormpathAccountDao dao = new StormpathAccountDao();
-        
         EmailVerification verification = new EmailVerification("tokenAAA");
         
-        Client client = mock(Client.class);
-        Tenant tenant = mock(Tenant.class);
         when(client.getCurrentTenant()).thenReturn(tenant);
+        when(client.verifyAccountEmail("tokenAAA")).thenReturn(stormpathAccount);
         
-        when(client.verifyAccountEmail("tokenAAA")).thenReturn(mock(com.stormpath.sdk.account.Account.class));
-        
-        dao.setStormpathClient(client);
-        dao.setSubpopulationService(mockSubpopService());
-        
+        CustomData data = mock(CustomData.class);
+        when(data.get("test-study_version")).thenReturn(2);
+        when(data.get("test-study_code")).thenReturn("healthId");
+        when(stormpathAccount.getCustomData()).thenReturn(data);
+        when(healthCodeService.getMapping("healthId")).thenReturn(healthId);
+
         Account account = dao.verifyEmail(study, verification);
         assertNotNull(account);
         verify(client).verifyAccountEmail("tokenAAA");
@@ -91,15 +141,7 @@ public class StormpathAccountDaoMockTest {
     public void requestResetPassword() {
         String emailString = "bridge-tester+43@sagebridge.org";
         
-        Application application = mock(Application.class);
-        Directory directory = mock(Directory.class);
-        Client client = mock(Client.class);
         when(client.getResource(study.getStormpathHref(), Directory.class)).thenReturn(directory);
-        
-        StormpathAccountDao dao = new StormpathAccountDao();
-        dao.setStormpathApplication(application);
-        dao.setStormpathClient(client);
-        dao.setSubpopulationService(mockSubpopService());
         
         dao.requestResetPassword(study, new Email(study.getStudyIdentifier(), emailString));
         
@@ -111,31 +153,18 @@ public class StormpathAccountDaoMockTest {
     public void requestPasswordRequestThrowsException() {
         String emailString = "bridge-tester+43@sagebridge.org";
         
-        Application application = mock(Application.class);
-        Directory directory = mock(Directory.class);
-        Client client = mock(Client.class);
         when(client.getResource(study.getStormpathHref(), Directory.class)).thenReturn(directory);
-        
-        StormpathAccountDao dao = new StormpathAccountDao();
-        dao.setStormpathApplication(application);
-        dao.setStormpathClient(client);
         
         com.stormpath.sdk.error.Error error = mock(com.stormpath.sdk.error.Error.class);
         ResourceException e = new ResourceException(error);
         when(application.sendPasswordResetEmail(emailString, directory)).thenThrow(e);
-        dao.setStormpathApplication(application);
         
         dao.requestResetPassword(study, new Email(study.getStudyIdentifier(), emailString));
     }
 
     @Test
     public void resetPassword() {
-        StormpathAccountDao dao = new StormpathAccountDao();
         PasswordReset passwordReset = new PasswordReset("password", "sptoken");
-        
-        Application application = mock(Application.class);
-        dao.setStormpathApplication(application);
-        dao.setSubpopulationService(mockSubpopService());
         
         dao.resetPassword(passwordReset);
         verify(application).resetPassword(passwordReset.getSptoken(), passwordReset.getPassword());
@@ -144,22 +173,11 @@ public class StormpathAccountDaoMockTest {
     
     @Test
     public void stormpathAccountCorrectlyInitialized() {
-        StormpathAccountDao dao = new StormpathAccountDao();
-        
-        HealthCodeService healthCodeService = mock(HealthCodeService.class);
-        dao.setHealthCodeService(healthCodeService);
-        
-        Directory directory = mock(Directory.class);
-        com.stormpath.sdk.account.Account stormpathAccount = mock(com.stormpath.sdk.account.Account.class);
         when(stormpathAccount.getCustomData()).thenReturn(mock(CustomData.class));
-        Client client = mock(Client.class);
         
         when(client.instantiate(com.stormpath.sdk.account.Account.class)).thenReturn(stormpathAccount);
         when(client.getResource(study.getStormpathHref(), Directory.class)).thenReturn(directory);
-        dao.setStormpathClient(client);
-        dao.setSubpopulationService(mockSubpopService());
         
-        HealthId healthId = mock(HealthId.class);
         doReturn(healthId).when(healthCodeService).createMapping(study);
         
         String random = RandomStringUtils.randomAlphabetic(5);
@@ -181,35 +199,24 @@ public class StormpathAccountDaoMockTest {
     
     @Test
     public void authenticate() {
-        // mock stormpath director
-        Directory mockDirectory = mock(Directory.class);
-        
-        // mock stormpath client
-        Client mockClient = mock(Client.class);
-        when(mockClient.getResource(study.getStormpathHref(), Directory.class)).thenReturn(mockDirectory);
+        when(client.getResource(study.getStormpathHref(), Directory.class)).thenReturn(directory);
 
-        // mock subpopulation service
-        SubpopulationService mockSubpopService = mock(SubpopulationService.class);
-        
         // mock stormpath account
-        com.stormpath.sdk.account.Account mockAcct = mock(com.stormpath.sdk.account.Account.class);
-        when(mockAcct.getGivenName()).thenReturn("Test");
-        when(mockAcct.getSurname()).thenReturn("User");
-        when(mockAcct.getEmail()).thenReturn("email@email.com");
+        when(stormpathAccount.getGivenName()).thenReturn("Test");
+        when(stormpathAccount.getSurname()).thenReturn("User");
+        when(stormpathAccount.getEmail()).thenReturn("email@email.com");
         
         // mock authentication result
-        AuthenticationResult mockResult = mock(AuthenticationResult.class);
-        when(mockResult.getAccount()).thenReturn(mockAcct);
+        when(authResult.getAccount()).thenReturn(stormpathAccount);
         
         // mock stormpath application
-        Application mockApplication = mock(Application.class);
-        when(mockApplication.authenticateAccount(any())).thenReturn(mockResult);
+        when(application.authenticateAccount(any())).thenReturn(authResult);
         
-        // wire up DAO
-        StormpathAccountDao dao = new StormpathAccountDao();
-        dao.setStormpathClient(mockClient);
-        dao.setStormpathApplication(mockApplication);
-        dao.setSubpopulationService(mockSubpopService);
+        CustomData data = mock(CustomData.class);
+        when(data.get("test-study_version")).thenReturn(2);
+        when(data.get("test-study_code")).thenReturn("healthId");
+        when(stormpathAccount.getCustomData()).thenReturn(data);
+        when(healthCodeService.getMapping("healthId")).thenReturn(healthId);
         
         // authenticate
         Account account = dao.authenticate(study, new SignIn("dummy-user", PASSWORD));
@@ -221,17 +228,15 @@ public class StormpathAccountDaoMockTest {
         
         // verify eager fetch occurring. Can't verify AuthenticationRequest configuration because 
         // you can set it but settings themselves are hidden in implementation. 
-        verify(mockResult).getAccount();
-        verify(mockAcct).getCustomData();
-        verify(mockAcct).getGroups();
+        verify(authResult).getAccount();
+        verify(stormpathAccount, times(9)).getCustomData();
+        verify(stormpathAccount).getGroups();
     }
 
     @Test
     public void accountDisabled() {
         // mock stormpath client
-        Directory mockDirectory = mock(Directory.class);
-        Client mockClient = mock(Client.class);
-        when(mockClient.getResource(study.getStormpathHref(), Directory.class)).thenReturn(mockDirectory);
+        when(client.getResource(study.getStormpathHref(), Directory.class)).thenReturn(directory);
 
         // mock stormpath application - Don't check the args to Application.authenticateAccount(). This is tested
         // elsewhere.
@@ -239,14 +244,7 @@ public class StormpathAccountDaoMockTest {
         when(mockError.getCode()).thenReturn(7101);
         ResourceException spException = new ResourceException(mockError);
 
-        Application mockApplication = mock(Application.class);
-        when(mockApplication.authenticateAccount(any())).thenThrow(spException);
-
-        // setup dao
-        StormpathAccountDao dao = new StormpathAccountDao();
-        dao.setSubpopulationService(mockSubpopService());
-        dao.setStormpathApplication(mockApplication);
-        dao.setStormpathClient(mockClient);
+        when(application.authenticateAccount(any())).thenThrow(spException);
 
         // execute and validate
         try {
@@ -255,36 +253,6 @@ public class StormpathAccountDaoMockTest {
         } catch (BridgeServiceException ex) {
             assertEquals(HttpStatus.SC_LOCKED, ex.getStatusCode());
         }
-    }
-
-    private com.stormpath.sdk.account.Account setupGroupChangeTest(Set<String> oldGroupSet, Set<Roles> newGroupSet) {
-        // mock Stormpath account
-        List<Group> mockGroupJavaList = new ArrayList<>();
-        for (String oneGroupName : oldGroupSet) {
-            Group mockGroup = mock(Group.class);
-            when(mockGroup.getName()).thenReturn(oneGroupName);
-            mockGroupJavaList.add(mockGroup);
-        }
-
-        GroupList mockGroupSpList = mock(GroupList.class);
-        when(mockGroupSpList.iterator()).thenReturn(mockGroupJavaList.iterator());
-
-        // Due to some funkiness in Stormpath's type tree, DefaultAccount is the only public class we can mock.
-        com.stormpath.sdk.account.Account mockSpAccount = mock(DefaultAccount.class);
-        when(mockSpAccount.getCustomData()).thenReturn(mock(CustomData.class));
-        when(mockSpAccount.getGroups()).thenReturn(mockGroupSpList);
-
-        // mock Bridge account
-        StormpathAccount mockAccount = mock(StormpathAccount.class);
-        when(mockAccount.getAccount()).thenReturn(mockSpAccount);
-        when(mockAccount.getRoles()).thenReturn(newGroupSet);
-
-        // execute
-        StormpathAccountDao dao = new StormpathAccountDao();
-        dao.updateAccount(study, mockAccount);
-
-        // return this, so the caller can verify back-end mock calls
-        return mockSpAccount;
     }
 
     @Test
@@ -318,28 +286,46 @@ public class StormpathAccountDaoMockTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void getStudyPagedAccountsRejectsPageSizeTooSmall() {
-        StormpathAccountDao dao = new StormpathAccountDao();
         dao.getPagedAccountSummaries(study, 0, BridgeConstants.API_MINIMUM_PAGE_SIZE-1, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void getStudyPagedAccountsRejectsPageSizeTooLarge() {
-        StormpathAccountDao dao = new StormpathAccountDao();
         dao.getPagedAccountSummaries(study, 0, BridgeConstants.API_MAXIMUM_PAGE_SIZE+1, null);
     }
     
     @Test(expected = IllegalArgumentException.class)
     public void getStudyPagedAccountsRejectsNonsenseOffsetBy() {
-        StormpathAccountDao dao = new StormpathAccountDao();
         dao.getPagedAccountSummaries(study, -10, BridgeConstants.API_DEFAULT_PAGE_SIZE, null);
     }
-    
-    private SubpopulationService mockSubpopService() {
-        Subpopulation subpop = Subpopulation.create();
-        subpop.setGuidString(study.getIdentifier());
-        SubpopulationService subpopService = mock(SubpopulationService.class);
-        when(subpopService.getSubpopulations(study.getStudyIdentifier())).thenReturn(Lists.newArrayList(subpop));
-        return subpopService;
+
+    private com.stormpath.sdk.account.Account setupGroupChangeTest(Set<String> oldGroupSet, Set<Roles> newGroupSet) {
+        // mock Stormpath account
+        List<Group> mockGroupJavaList = new ArrayList<>();
+        for (String oneGroupName : oldGroupSet) {
+            Group mockGroup = mock(Group.class);
+            when(mockGroup.getName()).thenReturn(oneGroupName);
+            mockGroupJavaList.add(mockGroup);
+        }
+
+        GroupList mockGroupSpList = mock(GroupList.class);
+        when(mockGroupSpList.iterator()).thenReturn(mockGroupJavaList.iterator());
+
+        // Due to some funkiness in Stormpath's type tree, DefaultAccount is the only public class we can mock.
+        com.stormpath.sdk.account.Account mockSpAccount = mock(DefaultAccount.class);
+        when(mockSpAccount.getCustomData()).thenReturn(mock(CustomData.class));
+        when(mockSpAccount.getGroups()).thenReturn(mockGroupSpList);
+
+        // mock Bridge account
+        StormpathAccount mockAccount = mock(StormpathAccount.class);
+        when(mockAccount.getAccount()).thenReturn(mockSpAccount);
+        when(mockAccount.getRoles()).thenReturn(newGroupSet);
+
+        // execute
+        dao.updateAccount(mockAccount);
+
+        // return this, so the caller can verify back-end mock calls
+        return mockSpAccount;
     }
 
 }

--- a/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoMockTest.java
@@ -229,7 +229,7 @@ public class StormpathAccountDaoMockTest {
         // verify eager fetch occurring. Can't verify AuthenticationRequest configuration because 
         // you can set it but settings themselves are hidden in implementation. 
         verify(authResult).getAccount();
-        verify(stormpathAccount, times(9)).getCustomData();
+        verify(stormpathAccount, times(6)).getCustomData();
         verify(stormpathAccount).getGroups();
     }
 

--- a/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoTest.java
+++ b/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoTest.java
@@ -32,7 +32,6 @@ import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountSummary;
 import org.sagebionetworks.bridge.models.accounts.Email;
-import org.sagebionetworks.bridge.models.accounts.HealthId;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.studies.Study;
@@ -218,7 +217,6 @@ public class StormpathAccountDaoTest {
             assertNull(account.getLastName());
             account.setEmail(email);
             account.setAttribute("phone", "123-456-7890");
-            account.setHealthId("abc");
             account.getConsentSignatureHistory(subpop.getGuid()).add(sig);
             account.setAttribute("attribute_one", "value of attribute one");
             
@@ -231,8 +229,7 @@ public class StormpathAccountDaoTest {
 
             // Verify that you can get the health code using the email. We still need this for MailChimp.
             String healthCode = accountDao.getHealthCodeForEmail(study, email);
-            HealthId healthId = healthCodeService.getMapping(account.getHealthId());
-            assertEquals(healthCode, healthId.getCode());
+            assertEquals(healthCode, account.getHealthCode());
             
             // Test adding and removing some groups. This gets into verifying and avoiding saving the underlying
             // Stormpath account. There are 4 cases to consider: (1) adding groups, (2) removing groups, (3) account in
@@ -285,8 +282,7 @@ public class StormpathAccountDaoTest {
             String healthCode = accountDao.getHealthCodeForEmail(study, email);
             assertNotNull(healthCode);
             
-            HealthId healthId = healthCodeService.getMapping(account.getHealthId());
-            assertEquals(healthCode, healthId.getCode());
+            assertEquals(healthCode, account.getHealthCode());
         } finally {
             accountDao.deleteAccount(study, account.getId());
         }
@@ -366,7 +362,7 @@ public class StormpathAccountDaoTest {
         assertNull(newAccount.getLastName());
         assertEquals(account.getEmail(), newAccount.getEmail());
         assertEquals(account.getAttribute("phone"), newAccount.getAttribute("phone"));
-        assertEquals(account.getHealthId(), newAccount.getHealthId());
+        assertEquals(account.getHealthCode(), newAccount.getHealthCode());
         assertEquals(account.getActiveConsentSignature(subpop.getGuid()), 
                 newAccount.getActiveConsentSignature(subpop.getGuid()));
         assertEquals(account.getActiveConsentSignature(subpop.getGuid()).getSignedOn(), 

--- a/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoTest.java
+++ b/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoTest.java
@@ -77,7 +77,7 @@ public class StormpathAccountDaoTest {
     
     @Test
     public void getStudyAccounts() {
-        Iterator<Account> i = accountDao.getStudyAccounts(study);
+        Iterator<AccountSummary> i = accountDao.getStudyAccounts(study);
         
         // There's always one... the behavior of the iterator is tested separately
         assertTrue(i.hasNext());
@@ -85,7 +85,7 @@ public class StormpathAccountDaoTest {
     
     @Test
     public void getAllAccounts() {
-        Iterator<Account> i = accountDao.getAllAccounts(); 
+        Iterator<AccountSummary> i = accountDao.getAllAccounts(); 
         
         // There's always one... the behavior of the iterator is tested separately
         assertTrue(i.hasNext());

--- a/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoTest.java
+++ b/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoTest.java
@@ -223,7 +223,7 @@ public class StormpathAccountDaoTest {
             account.setAttribute("attribute_one", "value of attribute one");
             
             // Update Account
-            accountDao.updateAccount(study, account);
+            accountDao.updateAccount(account);
             
             // Retrieve account with ID
             Account newAccount = accountDao.getAccount(study, account.getId());
@@ -242,7 +242,7 @@ public class StormpathAccountDaoTest {
             roles.addAll(EnumSet.of(Roles.DEVELOPER, Roles.RESEARCHER, Roles.WORKER));
             
             newAccount.setRoles(roles);
-            accountDao.updateAccount(study, newAccount);
+            accountDao.updateAccount(newAccount);
 
             newAccount = accountDao.getAccount(study, account.getId());
             assertEquals(4, newAccount.getRoles().size());
@@ -250,7 +250,7 @@ public class StormpathAccountDaoTest {
                     Roles.TEST_USERS, Roles.WORKER)));
 
             newAccount.setRoles(EnumSet.of(Roles.TEST_USERS));
-            accountDao.updateAccount(study, newAccount);
+            accountDao.updateAccount(newAccount);
 
             newAccount = accountDao.getAccount(study, account.getId());
             assertEquals(1, newAccount.getRoles().size());
@@ -259,7 +259,7 @@ public class StormpathAccountDaoTest {
             // finally, test the name
             newAccount.setFirstName("Test");
             newAccount.setLastName("Tester");
-            accountDao.updateAccount(study, newAccount);
+            accountDao.updateAccount(newAccount);
             
             newAccount = accountDao.getAccount(study, newAccount.getId());
             assertEquals("Test", newAccount.getFirstName()); // name is now visible
@@ -341,7 +341,7 @@ public class StormpathAccountDaoTest {
             
             account.getConsentSignatureHistory(subpop1.getGuid()).add(sig1);
             account.getConsentSignatureHistory(subpop2.getGuid()).add(sig2);
-            accountDao.updateAccount(study, account);
+            accountDao.updateAccount(account);
             
             account = accountDao.getAccount(study, account.getId());
             

--- a/test/org/sagebionetworks/bridge/stormpath/StormpathAccountIteratorTest.java
+++ b/test/org/sagebionetworks/bridge/stormpath/StormpathAccountIteratorTest.java
@@ -12,7 +12,7 @@ import org.junit.Test;
 
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.TestUtils;
-import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountSummary;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
 import org.sagebionetworks.bridge.services.StudyService;
@@ -37,7 +37,7 @@ public class StormpathAccountIteratorTest {
     public void canIterateThroughMultipleStudiesMultiplePages() {
         StormpathAccountDao accountDao = getMockAccountDao();
         
-        Iterator<Account> accounts = accountDao.getAllAccounts();
+        Iterator<AccountSummary> accounts = accountDao.getAllAccounts();
         assertEquals(370, count(accounts));
     }
     
@@ -45,7 +45,7 @@ public class StormpathAccountIteratorTest {
     public void canIterateThroughOneStudyMultiplePages() {
         StormpathAccountDao accountDao = getMockAccountDao();
         
-        Iterator<Account> accounts = accountDao.getStudyAccounts(createStudy("study1"));
+        Iterator<AccountSummary> accounts = accountDao.getStudyAccounts(createStudy("study1"));
         assertEquals(10, count(accounts));
     }
 
@@ -115,6 +115,8 @@ public class StormpathAccountIteratorTest {
         for (int i=0; i < numAccounts; i++) {
             com.stormpath.sdk.account.Account acct = mock(com.stormpath.sdk.account.Account.class);
             when(acct.getCustomData()).thenReturn(mock(CustomData.class));
+            when(acct.getEmail()).thenReturn("email" + i + "@email.com");
+            when(acct.getStatus()).thenReturn(com.stormpath.sdk.account.AccountStatus.DISABLED);
             accounts.add(acct);
         }
         AccountList list = mock(AccountList.class);
@@ -126,7 +128,7 @@ public class StormpathAccountIteratorTest {
         return dir;
     }
     
-    private int count(Iterator<Account> accounts) {
+    private int count(Iterator<AccountSummary> accounts) {
         int count = 0;
         while(accounts.hasNext()) {
             accounts.next();


### PR DESCRIPTION
This started with the desire to make accounts that are created in the Stormpath UI fully editable in the Bridge Study Manager. It should also make it possible for developers we set up to use their accounts in the apps while testing, which they sometimes do. 

But then I also wanted to eliminate the code in several places to check and create the healthId/healthCode mapping if it doesn't exist. This was all highly redundant and once you ensure an account always has a health code in AccountDao, there's no reason not to return the healthCode itself as part of the account. Then it's not necessary to use healthCodeService in most places.

The iterator methods now return AccountSummary which is much faster to retrieve than an account, and then like the paged methods, you can retrieve an individual, fully-initialized account object.

In short: if you have a reference to an account it should always have a health code.
