### PR TITLE
add min- and maxAppVersion to Strict Validation Handler

### DIFF
--- a/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2.java
+++ b/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2.java
@@ -62,8 +62,10 @@ import org.sagebionetworks.bridge.services.UploadSchemaService;
 public class IosSchemaValidationHandler2 implements UploadValidationHandler {
     private static final Logger logger = LoggerFactory.getLogger(IosSchemaValidationHandler2.class);
 
+    private static final Pattern APP_VERSION_PATTERN = Pattern.compile("version [^,]+, build (\\d+)");
     private static final String FILENAME_INFO_JSON = "info.json";
     private static final Pattern FILENAME_TIMESTAMP_PATTERN = Pattern.compile("-\\d{8,}");
+    private static final String KEY_APP_VERSION = "appVersion";
     private static final String KEY_FILENAME = "filename";
     private static final String KEY_FILES = "files";
     private static final String KEY_IDENTIFIER = "identifier";
@@ -154,6 +156,9 @@ public class IosSchemaValidationHandler2 implements UploadValidationHandler {
         // Use info.json verbatim is the metadata.
         JsonNode infoJson = getInfoJsonFile(context, uploadId, jsonDataMap);
         recordBuilder.withMetadata(infoJson);
+
+        // parse app version from info.json
+        parseAppVersionFromInfoJson(context, uploadId, infoJson);
 
         // validate and normalize filenames
         validateInfoJsonFileList(context, uploadId, jsonDataMap, unzippedDataMap, infoJson, recordBuilder);
@@ -260,6 +265,37 @@ public class IosSchemaValidationHandler2 implements UploadValidationHandler {
             jsonDataMap.put(FILENAME_INFO_JSON, infoJson);
         }
         return infoJson;
+    }
+
+    // Parse appVersion from info.json and write the value into the context. The expected format is
+    // "version 1.1.0, build 42", and the build number (42 in our example) is the appVersion number.
+    //
+    // This is package-scoped to facilitate unit tests.
+    static void parseAppVersionFromInfoJson(UploadValidationContext context, String uploadId, JsonNode infoJson) {
+        // Attempt to parse from info.json
+        Integer appVersion = null;
+        JsonNode appVersionNode = infoJson.get(KEY_APP_VERSION);
+        if (appVersionNode != null && appVersionNode.isTextual()) {
+            String appVersionStr = appVersionNode.textValue();
+
+            Matcher matcher = APP_VERSION_PATTERN.matcher(appVersionStr);
+            if (matcher.matches()) {
+                String buildNumStr = matcher.group(1);
+                try {
+                    appVersion = Integer.valueOf(buildNumStr);
+                } catch (NumberFormatException ex) {
+                    // Suppress the exception. There will be a message written into the context soon enough that will
+                    // contain more than enough information to track this down, if necessary.
+                }
+            }
+        }
+
+        // If we have it, add it to the context. If not, write a message.
+        if (appVersion != null) {
+            context.setAppVersion(appVersion);
+        } else {
+            context.addMessage("Couldn't parse app version for upload " + uploadId);
+        }
     }
 
     private static void validateInfoJsonFileList(UploadValidationContext context, String uploadId,

--- a/app/org/sagebionetworks/bridge/upload/UploadValidationContext.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadValidationContext.java
@@ -21,6 +21,7 @@ public class UploadValidationContext {
     private byte[] decryptedData;
     private Map<String, byte[]> unzippedDataMap;
     private Map<String, JsonNode> jsonDataMap;
+    private Integer appVersion;
     private HealthDataRecordBuilder healthDataRecordBuilder;
     private Map<String, byte[]> attachmentsByFieldName;
     private String recordId;
@@ -128,6 +129,20 @@ public class UploadValidationContext {
     }
 
     /**
+     * App version, parsed from info.json appVersion field, which is the form "version 1.1.0, build 32". The build
+     * number is the app version. This is filled in by IosSchemaValidationHandler and is used by
+     * StrictValidationHandler.
+     */
+    public Integer getAppVersion() {
+        return appVersion;
+    }
+
+    /** @see #getAppVersion */
+    public void setAppVersion(Integer appVersion) {
+        this.appVersion = appVersion;
+    }
+
+    /**
      * Health Data Record Builder, used to build a health data record that will be written to the health data record
      * table. This is initially created by IosSchemaValidationHandler, is further updated by the
      * TranscribeConsentHandler, and is finalized and persisted by UploadArtifactsHandler.
@@ -191,6 +206,7 @@ public class UploadValidationContext {
         copy.decryptedData = this.decryptedData;
         copy.unzippedDataMap = this.unzippedDataMap;
         copy.jsonDataMap = this.jsonDataMap;
+        copy.appVersion = this.appVersion;
         copy.healthDataRecordBuilder = this.healthDataRecordBuilder;
         copy.attachmentsByFieldName = this.attachmentsByFieldName;
         copy.recordId = this.recordId;

--- a/test/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2AppVersionTest.java
+++ b/test/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2AppVersionTest.java
@@ -1,0 +1,94 @@
+package org.sagebionetworks.bridge.upload;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+public class IosSchemaValidationHandler2AppVersionTest {
+    private static final String UPLOAD_ID = "test-upload";
+    private static final String ERROR_MESSAGE = "Couldn't parse app version for upload " + UPLOAD_ID;
+
+    @Test
+    public void noAppVersion() throws Exception {
+        // Set up context. We only ever write to this, so no init necessary.
+        UploadValidationContext ctx = new UploadValidationContext();
+
+        // Setup JSON. We don't care about any other attribute, so an empty JSON object is fine.
+        String infoJsonText = "{}";
+        JsonNode infoJsonNode = BridgeObjectMapper.get().readTree(infoJsonText);
+
+        // Execute and validate.
+        IosSchemaValidationHandler2.parseAppVersionFromInfoJson(ctx, UPLOAD_ID, infoJsonNode);
+        assertNull(ctx.getAppVersion());
+        assertEquals(1, ctx.getMessageList().size());
+        assertEquals(ERROR_MESSAGE, ctx.getMessageList().get(0));
+    }
+
+    @Test
+    public void nullAppVersion() throws Exception {
+        // Set up context. We only ever write to this, so no init necessary.
+        UploadValidationContext ctx = new UploadValidationContext();
+
+        // Setup JSON. We don't care about any other attribute, so an empty JSON object is fine.
+        String infoJsonText = "{\"appVersion\":null}";
+        JsonNode infoJsonNode = BridgeObjectMapper.get().readTree(infoJsonText);
+
+        // Execute and validate.
+        IosSchemaValidationHandler2.parseAppVersionFromInfoJson(ctx, UPLOAD_ID, infoJsonNode);
+        assertNull(ctx.getAppVersion());
+        assertEquals(1, ctx.getMessageList().size());
+        assertEquals(ERROR_MESSAGE, ctx.getMessageList().get(0));
+    }
+
+    @Test
+    public void notAString() throws Exception {
+        // Set up context. We only ever write to this, so no init necessary.
+        UploadValidationContext ctx = new UploadValidationContext();
+
+        // Setup JSON. We don't care about any other attribute, so an empty JSON object is fine.
+        String infoJsonText = "{\"appVersion\":42}";
+        JsonNode infoJsonNode = BridgeObjectMapper.get().readTree(infoJsonText);
+
+        // Execute and validate.
+        IosSchemaValidationHandler2.parseAppVersionFromInfoJson(ctx, UPLOAD_ID, infoJsonNode);
+        assertNull(ctx.getAppVersion());
+        assertEquals(1, ctx.getMessageList().size());
+        assertEquals(ERROR_MESSAGE, ctx.getMessageList().get(0));
+    }
+
+    @Test
+    public void wrongFormat() throws Exception {
+        // Set up context. We only ever write to this, so no init necessary.
+        UploadValidationContext ctx = new UploadValidationContext();
+
+        // Setup JSON. We don't care about any other attribute, so an empty JSON object is fine.
+        String infoJsonText = "{\"appVersion\":\"this is version 42\"}";
+        JsonNode infoJsonNode = BridgeObjectMapper.get().readTree(infoJsonText);
+
+        // Execute and validate.
+        IosSchemaValidationHandler2.parseAppVersionFromInfoJson(ctx, UPLOAD_ID, infoJsonNode);
+        assertNull(ctx.getAppVersion());
+        assertEquals(1, ctx.getMessageList().size());
+        assertEquals(ERROR_MESSAGE, ctx.getMessageList().get(0));
+    }
+
+    @Test
+    public void happyCase() throws Exception {
+        // Set up context. We only ever write to this, so no init necessary.
+        UploadValidationContext ctx = new UploadValidationContext();
+
+        // Setup JSON. We don't care about any other attribute, so an empty JSON object is fine.
+        String infoJsonText = "{\"appVersion\":\"version 1.1.0, build 42\"}";
+        JsonNode infoJsonNode = BridgeObjectMapper.get().readTree(infoJsonText);
+
+        // Execute and validate.
+        IosSchemaValidationHandler2.parseAppVersionFromInfoJson(ctx, UPLOAD_ID, infoJsonNode);
+        assertEquals(42, ctx.getAppVersion().intValue());
+        assertTrue(ctx.getMessageList().isEmpty());
+    }
+}

--- a/test/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2Test.java
+++ b/test/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2Test.java
@@ -36,6 +36,8 @@ import org.sagebionetworks.bridge.services.SurveyService;
 import org.sagebionetworks.bridge.services.UploadSchemaService;
 
 public class IosSchemaValidationHandler2Test {
+    private static final int TEST_APP_VERSION = 42;
+    private static final String TEST_APP_VERSION_STRING = "version 1.1.0, build " + TEST_APP_VERSION;
     private static final String TEST_HEALTHCODE = "test-healthcode";
     private static final String TEST_STUDY_ID = "test-study";
     private static final String TEST_UPLOAD_DATE_STRING = "2015-04-13";
@@ -195,6 +197,7 @@ public class IosSchemaValidationHandler2Test {
                 "       \"filename\":\"baz.json\",\n" +
                 "       \"timestamp\":\"2015-04-02T03:24:01-07:00\"\n" +
                 "   }],\n" +
+                "   \"appVersion\":\"" + TEST_APP_VERSION_STRING + "\",\n" +
                 "   \"item\":\"test-survey\"\n" +
                 "}";
         JsonNode infoJsonNode = BridgeObjectMapper.get().readTree(infoJsonText);
@@ -241,8 +244,9 @@ public class IosSchemaValidationHandler2Test {
         handler.handle(context);
 
         // validate
+        validateCommonProps(context);
+
         HealthDataRecordBuilder recordBuilder = context.getHealthDataRecordBuilder();
-        validateCommonRecordProps(recordBuilder);
         assertEquals(DateTime.parse("2015-04-02T03:27:09-07:00").getMillis(),
                 recordBuilder.getCreatedOn().longValue());
         assertEquals("test-survey", recordBuilder.getSchemaId());
@@ -291,6 +295,7 @@ public class IosSchemaValidationHandler2Test {
                 "       \"filename\":\"baz.json\",\n" +
                 "       \"timestamp\":\"2015-08-22T03:24:01-07:00\"\n" +
                 "   }],\n" +
+                "   \"appVersion\":\"" + TEST_APP_VERSION_STRING + "\",\n" +
                 "   \"surveyGuid\":\"test-guid\",\n" +
                 "   \"surveyCreatedOn\":\"2015-08-27T13:38:55-07:00\"\n" +
                 "}";
@@ -338,8 +343,9 @@ public class IosSchemaValidationHandler2Test {
         handler.handle(context);
 
         // validate
+        validateCommonProps(context);
+
         HealthDataRecordBuilder recordBuilder = context.getHealthDataRecordBuilder();
-        validateCommonRecordProps(recordBuilder);
         assertEquals(DateTime.parse("2015-08-22T03:27:09-07:00").getMillis(),
                 recordBuilder.getCreatedOn().longValue());
         assertEquals("test-survey", recordBuilder.getSchemaId());
@@ -377,6 +383,7 @@ public class IosSchemaValidationHandler2Test {
                 "       \"filename\":\"date.json\",\n" +
                 "       \"timestamp\":\"2015-04-13T18:47:41-07:00\"\n" +
                 "   }],\n" +
+                "   \"appVersion\":\"" + TEST_APP_VERSION_STRING + "\",\n" +
                 "   \"item\":\"json-data\"\n" +
                 "}";
         JsonNode infoJsonNode = BridgeObjectMapper.get().readTree(infoJsonText);
@@ -409,8 +416,9 @@ public class IosSchemaValidationHandler2Test {
         handler.handle(context);
 
         // validate
+        validateCommonProps(context);
+
         HealthDataRecordBuilder recordBuilder = context.getHealthDataRecordBuilder();
-        validateCommonRecordProps(recordBuilder);
         assertEquals(DateTime.parse("2015-04-13T18:48:02-07:00").getMillis(),
                 recordBuilder.getCreatedOn().longValue());
         assertEquals("json-data", recordBuilder.getSchemaId());
@@ -448,6 +456,7 @@ public class IosSchemaValidationHandler2Test {
                 "       \"filename\":\"nonJsonFile.txt\",\n" +
                 "       \"timestamp\":\"2015-04-13T18:58:21-07:00\"\n" +
                 "   }],\n" +
+                "   \"appVersion\":\"" + TEST_APP_VERSION_STRING + "\",\n" +
                 "   \"item\":\"non-json-data\"\n" +
                 "}";
         JsonNode infoJsonNode = BridgeObjectMapper.get().readTree(infoJsonText);
@@ -467,8 +476,9 @@ public class IosSchemaValidationHandler2Test {
         handler.handle(context);
 
         // validate
+        validateCommonProps(context);
+
         HealthDataRecordBuilder recordBuilder = context.getHealthDataRecordBuilder();
-        validateCommonRecordProps(recordBuilder);
         assertEquals(DateTime.parse("2015-04-13T18:58:21-07:00").getMillis(),
                 recordBuilder.getCreatedOn().longValue());
         assertEquals("non-json-data", recordBuilder.getSchemaId());
@@ -507,6 +517,7 @@ public class IosSchemaValidationHandler2Test {
                 "       \"filename\":\"field.json\",\n" +
                 "       \"timestamp\":\"2015-04-22T18:39:44-07:00\"\n" +
                 "   }],\n" +
+                "   \"appVersion\":\"" + TEST_APP_VERSION_STRING + "\",\n" +
                 "   \"item\":\"mixed-data\"\n" +
                 "}";
         JsonNode infoJsonNode = BridgeObjectMapper.get().readTree(infoJsonText);
@@ -539,8 +550,9 @@ public class IosSchemaValidationHandler2Test {
         handler.handle(context);
 
         // validate
+        validateCommonProps(context);
+
         HealthDataRecordBuilder recordBuilder = context.getHealthDataRecordBuilder();
-        validateCommonRecordProps(recordBuilder);
         assertEquals(DateTime.parse("2015-04-22T18:39:44-07:00").getMillis(),
                 recordBuilder.getCreatedOn().longValue());
         assertEquals("mixed-data", recordBuilder.getSchemaId());
@@ -581,6 +593,7 @@ public class IosSchemaValidationHandler2Test {
                 "       \"filename\":\"dummy.json\",\n" +
                 "       \"timestamp\":\"2015-07-21T15:24:57-07:00\"\n" +
                 "   }],\n" +
+                "   \"appVersion\":\"" + TEST_APP_VERSION_STRING + "\",\n" +
                 "   \"item\":\"schema-rev-test\"\n" +
                 "}";
         JsonNode infoJsonNode = BridgeObjectMapper.get().readTree(infoJsonText);
@@ -599,8 +612,9 @@ public class IosSchemaValidationHandler2Test {
         handler.handle(context);
 
         // validate
+        validateCommonProps(context);
+
         HealthDataRecordBuilder recordBuilder = context.getHealthDataRecordBuilder();
-        validateCommonRecordProps(recordBuilder);
         assertEquals(DateTime.parse("2015-07-21T15:24:57-07:00").getMillis(),
                 recordBuilder.getCreatedOn().longValue());
         assertEquals("schema-rev-test", recordBuilder.getSchemaId());
@@ -625,6 +639,7 @@ public class IosSchemaValidationHandler2Test {
                 "       \"filename\":\"dummy.json\",\n" +
                 "       \"timestamp\":\"2015-07-21T15:24:57-07:00\"\n" +
                 "   }],\n" +
+                "   \"appVersion\":\"" + TEST_APP_VERSION_STRING + "\",\n" +
                 "   \"item\":\"schema-rev-test\",\n" +
                 "   \"schemaRevision\":3\n" +
                 "}";
@@ -644,8 +659,9 @@ public class IosSchemaValidationHandler2Test {
         handler.handle(context);
 
         // validate
+        validateCommonProps(context);
+
         HealthDataRecordBuilder recordBuilder = context.getHealthDataRecordBuilder();
-        validateCommonRecordProps(recordBuilder);
         assertEquals(DateTime.parse("2015-07-21T15:24:57-07:00").getMillis(),
                 recordBuilder.getCreatedOn().longValue());
         assertEquals("schema-rev-test", recordBuilder.getSchemaId());
@@ -662,9 +678,12 @@ public class IosSchemaValidationHandler2Test {
         assertTrue(context.getMessageList().isEmpty());
     }
 
-    private static void validateCommonRecordProps(HealthDataRecordBuilder recordBuilder) {
+    private static void validateCommonProps(UploadValidationContext ctx) {
         LocalDate todaysDate = LocalDate.now(BridgeConstants.LOCAL_TIME_ZONE);
 
+        assertEquals(TEST_APP_VERSION, ctx.getAppVersion().intValue());
+
+        HealthDataRecordBuilder recordBuilder = ctx.getHealthDataRecordBuilder();
         assertEquals(TEST_HEALTHCODE, recordBuilder.getHealthCode());
         assertEquals(TEST_STUDY_ID, recordBuilder.getStudyId());
         assertEquals(todaysDate, recordBuilder.getUploadDate());

--- a/test/org/sagebionetworks/bridge/upload/StrictValidationHandlerComputeIsRequiredTest.java
+++ b/test/org/sagebionetworks/bridge/upload/StrictValidationHandlerComputeIsRequiredTest.java
@@ -1,0 +1,41 @@
+package org.sagebionetworks.bridge.upload;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.dynamodb.DynamoUploadFieldDefinition;
+import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
+import org.sagebionetworks.bridge.models.upload.UploadFieldType;
+
+public class StrictValidationHandlerComputeIsRequiredTest {
+    private static final Object[][] TEST_CASES = {
+            { null, false, null, null, false, "required false" },
+            { null, true, null, null, true, "null app version" },
+            { 15, true, null, null, true, "no min or max app version" },
+            { 5, true, 10, null, false, "below min app version" },
+            { 15, true, 10, null, true, "above min, no max" },
+            { 15, true, null, 20, true, "no min, below max" },
+            { 25, true, null, 20, false, "above max app version" },
+            { 5, true, 10, 20, false, "below min and max" },
+            { 15, true, 10, 20, true, "between min and max" },
+            { 25, true, 10, 20, false, "above min and max" },
+    };
+
+    private static void test(Integer appVersion, boolean fieldIsRequired, Integer minAppVersion, Integer maxAppVersion,
+            boolean expected, String message) {
+        UploadFieldDefinition fieldDef = new DynamoUploadFieldDefinition.Builder().withName("dummy")
+                .withType(UploadFieldType.STRING).withRequired(fieldIsRequired).withMinAppVersion(minAppVersion)
+                .withMaxAppVersion(maxAppVersion).build();
+        boolean result = StrictValidationHandler.computeIsRequired(appVersion, fieldDef);
+        assertEquals(message, expected, result);
+    }
+
+    @Test
+    public void test() {
+        for (Object[] oneTestCase : TEST_CASES) {
+            test((Integer) oneTestCase[0], (boolean) oneTestCase[1], (Integer) oneTestCase[2],
+                    (Integer) oneTestCase[3], (boolean) oneTestCase[4], (String) oneTestCase[5]);
+        }
+    }
+}

--- a/test/org/sagebionetworks/bridge/upload/StrictValidationHandlerTest.java
+++ b/test/org/sagebionetworks/bridge/upload/StrictValidationHandlerTest.java
@@ -451,6 +451,43 @@ public class StrictValidationHandlerTest {
     }
 
     @Test
+    public void appVersionBelowMax() throws Exception {
+        // Upload is missing a field that's required and has a maxAppVersion. Upload has a version below the
+        // maxAppVersion. This gets validated and throws.
+
+        // additional field defs
+        List<UploadFieldDefinition> additionalFieldDefList = ImmutableList.of(new DynamoUploadFieldDefinition.Builder()
+                .withName("required with max app version").withType(UploadFieldType.STRING).withMaxAppVersion(20)
+                .build());
+
+        // expected errors
+        List<String> expectedErrorList = ImmutableList.of("required with max app version");
+
+        // add app version to context
+        context.setAppVersion(10);
+
+        // execute and validate
+        test(additionalFieldDefList, null, null, expectedErrorList, true);
+    }
+
+    @Test
+    public void appVersionAboveMax() throws Exception {
+        // Upload is missing a field that's required and has a maxAppVersion. Upload has a version above the
+        // maxAppVersion. The missing field is ignored.
+
+        // additional field defs
+        List<UploadFieldDefinition> additionalFieldDefList = ImmutableList.of(new DynamoUploadFieldDefinition.Builder()
+                .withName("required with max app version").withType(UploadFieldType.STRING).withMaxAppVersion(20)
+                .build());
+
+        // add app version to context
+        context.setAppVersion(30);
+
+        // execute and validate
+        test(additionalFieldDefList, null, null, null, false);
+    }
+
+    @Test
     public void studyConfiguredToNotThrow() throws Exception {
         // additional field defs
         List<UploadFieldDefinition> additionalFieldDefList = ImmutableList.<UploadFieldDefinition>of(

--- a/test/org/sagebionetworks/bridge/upload/UploadValidationContextTest.java
+++ b/test/org/sagebionetworks/bridge/upload/UploadValidationContextTest.java
@@ -43,6 +43,7 @@ public class UploadValidationContextTest {
         original.setDecryptedData(decryptedData);
         original.setUnzippedDataMap(unzippedDataMap);
         original.setJsonDataMap(jsonDataMap);
+        original.setAppVersion(42);
         original.setHealthDataRecordBuilder(recordBuilder);
         original.setAttachmentsByFieldName(attachmentMap);
         original.setRecordId("test-record");
@@ -56,6 +57,7 @@ public class UploadValidationContextTest {
         assertSame(decryptedData, copy.getDecryptedData());
         assertSame(unzippedDataMap, copy.getUnzippedDataMap());
         assertSame(jsonDataMap, copy.getJsonDataMap());
+        assertEquals(42, copy.getAppVersion().intValue());
         assertSame(recordBuilder, copy.getHealthDataRecordBuilder());
         assertSame(attachmentMap, copy.getAttachmentsByFieldName());
         assertEquals("test-record", copy.getRecordId());


### PR DESCRIPTION
Hooked up min- and maxAppVersion from mutable schemas to the Strict Validation Handler. The IOS Schema Validation Handler parses out the app version, and the Strict Validation Handler consumes it.

Testing done:
- updated and added unit tests
- UploadTest in BridgeIntegrationTests
- manually tested a missing field before and after maxAppVersion

Next steps:
- add/fix integration tests
- hook up v4 Schemas (Mutable Schemas) to surveys
