### PR TITLE
Show 400 errors back to user on password reset screen. 

### DIFF
--- a/app/org/sagebionetworks/bridge/models/accounts/PasswordReset.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/PasswordReset.java
@@ -8,10 +8,17 @@ public class PasswordReset implements BridgeEntity {
 
     private final String password;
     private final String sptoken;
+    private final String studyIdentifier;
     
-    public PasswordReset(@JsonProperty("password") String password, @JsonProperty("sptoken") String sptoken) {
+    public PasswordReset(@JsonProperty("password") String password, @JsonProperty("sptoken") String sptoken,
+            @JsonProperty("study") String studyId) {
         this.password = password;
         this.sptoken = sptoken;
+        this.studyIdentifier = studyId;
+    }
+    
+    public String getStudyIdentifier() {
+        return studyIdentifier;
     }
     
     public String getPassword() {

--- a/app/org/sagebionetworks/bridge/validators/StudyParticipantValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/StudyParticipantValidator.java
@@ -57,26 +57,8 @@ public class StudyParticipantValidator implements Validator {
         }
         if (isNew) {
             String password = participant.getPassword();
-            if (StringUtils.isBlank(password)) {
-                errors.rejectValue("password", "is required");
-            } else {
-                PasswordPolicy passwordPolicy = study.getPasswordPolicy();
-                if (passwordPolicy.getMinLength() > 0 && password.length() < passwordPolicy.getMinLength()) {
-                    errors.rejectValue("password", "must be at least "+passwordPolicy.getMinLength()+" characters");
-                }
-                if (passwordPolicy.isNumericRequired() && !password.matches(".*\\d+.*")) {
-                    errors.rejectValue("password", "must contain at least one number (0-9)");
-                }
-                if (passwordPolicy.isSymbolRequired() && !password.matches(".*\\p{Punct}+.*")) {
-                    errors.rejectValue("password", "must contain at least one symbol ( !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~ )");
-                }
-                if (passwordPolicy.isLowerCaseRequired() && !password.matches(".*[a-z]+.*")) {
-                    errors.rejectValue("password", "must contain at least one lowercase letter (a-z)");
-                }
-                if (passwordPolicy.isUpperCaseRequired() && !password.matches(".*[A-Z]+.*")) {
-                    errors.rejectValue("password", "must contain at least one uppercase letter (A-Z)");
-                }
-            }
+            PasswordPolicy passwordPolicy = study.getPasswordPolicy();
+            ValidatorUtils.validatePassword(errors, passwordPolicy, password);
         }
     }
     

--- a/app/org/sagebionetworks/bridge/validators/ValidatorUtils.java
+++ b/app/org/sagebionetworks/bridge/validators/ValidatorUtils.java
@@ -1,0 +1,31 @@
+package org.sagebionetworks.bridge.validators;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.validation.Errors;
+
+import org.sagebionetworks.bridge.models.studies.PasswordPolicy;
+
+public class ValidatorUtils {
+
+    public static void validatePassword(Errors errors, PasswordPolicy passwordPolicy, String password) {
+        if (StringUtils.isBlank(password)) {
+            errors.rejectValue("password", "is required");
+        } else {
+            if (passwordPolicy.getMinLength() > 0 && password.length() < passwordPolicy.getMinLength()) {
+                errors.rejectValue("password", "must be at least "+passwordPolicy.getMinLength()+" characters");
+            }
+            if (passwordPolicy.isNumericRequired() && !password.matches(".*\\d+.*")) {
+                errors.rejectValue("password", "must contain at least one number (0-9)");
+            }
+            if (passwordPolicy.isSymbolRequired() && !password.matches(".*\\p{Punct}+.*")) {
+                errors.rejectValue("password", "must contain at least one symbol ( !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~ )");
+            }
+            if (passwordPolicy.isLowerCaseRequired() && !password.matches(".*[a-z]+.*")) {
+                errors.rejectValue("password", "must contain at least one lowercase letter (a-z)");
+            }
+            if (passwordPolicy.isUpperCaseRequired() && !password.matches(".*[A-Z]+.*")) {
+                errors.rejectValue("password", "must contain at least one uppercase letter (A-Z)");
+            }
+        }
+    }
+}

--- a/app/views/resetPassword.scala.html
+++ b/app/views/resetPassword.scala.html
@@ -44,7 +44,6 @@ location.search.substr(1).split("&").forEach(function(item) {
 $("*[name='password']").focus();
 
 function success() {
-	console.log(arguments);
     $("#resetPasswordSection").html("<p class='success'>Your password has been successfully updated.</p>");
 }
 function error(msg) {
@@ -93,7 +92,7 @@ $("form").on("submit", function(e) {
         });
         p.done(success).fail(failure);
     } catch(e) { // happens if the query string is wrong.
-        console.log(e);
+        console.error(e);
         failure();
     }
 });

--- a/app/views/resetPassword.scala.html
+++ b/app/views/resetPassword.scala.html
@@ -44,6 +44,7 @@ location.search.substr(1).split("&").forEach(function(item) {
 $("*[name='password']").focus();
 
 function success() {
+	console.log(arguments);
     $("#resetPasswordSection").html("<p class='success'>Your password has been successfully updated.</p>");
 }
 function error(msg) {
@@ -51,8 +52,13 @@ function error(msg) {
     $("#submit").attr("value","Reset Password");
     submitted = false;
 }
-function failure() {
-    error("Your password could not be reset. Contact <a href='mailto:@studySupportEmail'>@studySupportEmail</a> to receive further assistance.");
+function failure(response) {
+	if (response.responseJSON && response.responseJSON.message) {
+		var msg = response.responseJSON.message.replace("PasswordReset", "Password reset");
+		error(msg);
+	} else {
+		error("Your password could not be reset. Contact <a href='mailto:@studySupportEmail'>@studySupportEmail</a> to receive further assistance.");
+	}
 }
 if (!params.study) {
     failure();

--- a/test/org/sagebionetworks/bridge/models/accounts/PasswordResetTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/PasswordResetTest.java
@@ -1,0 +1,22 @@
+package org.sagebionetworks.bridge.models.accounts;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.TestUtils;
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+public class PasswordResetTest {
+
+    @Test
+    public void canDeserialize() throws Exception {
+        String json = TestUtils.createJson("{'sptoken': '3x9HSBY3vZr5zrx9qkEtLa', 'password': 'pass', 'study': 'api'}");
+        
+        PasswordReset reset = BridgeObjectMapper.get().readValue(json, PasswordReset.class);
+        assertEquals("3x9HSBY3vZr5zrx9qkEtLa", reset.getSptoken());
+        assertEquals("pass", reset.getPassword());
+        assertEquals("api", reset.getStudyIdentifier());
+    }
+    
+}

--- a/test/org/sagebionetworks/bridge/validators/PasswordResetValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/PasswordResetValidatorTest.java
@@ -1,0 +1,100 @@
+package org.sagebionetworks.bridge.validators;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import org.sagebionetworks.bridge.dynamodb.DynamoMpowerVisualizationTest;
+import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
+import org.sagebionetworks.bridge.models.accounts.PasswordReset;
+import org.sagebionetworks.bridge.models.studies.PasswordPolicy;
+import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.services.StudyService;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PasswordResetValidatorTest {
+    
+    PasswordResetValidator validator;
+    
+    @Mock
+    StudyService studyService;
+    
+    @Mock
+    Study study;
+    
+    @Before
+    public void before() {
+        doReturn(PasswordPolicy.DEFAULT_PASSWORD_POLICY).when(study).getPasswordPolicy();
+        doReturn(study).when(studyService).getStudy("api");
+        
+        validator = new PasswordResetValidator();
+        validator.setStudyService(studyService);
+    }
+    
+    @Test
+    public void supportsClass() {
+        assertTrue(validator.supports(PasswordReset.class));
+    }
+
+    @Test
+    public void validatesValid() {
+        PasswordReset reset = new PasswordReset("P@ssword1`", "token", "api");
+        
+        Validate.entityThrowingException(validator, reset);
+    }
+    
+    @Test
+    public void passwordRequired() {
+        validate(new PasswordReset("", "token", "api"), (e) -> {
+            assertError(e, "password", "is required");
+        });
+    }
+    
+    @Test
+    public void spTokenRequired() {
+        validate(new PasswordReset("asdfasdf", "", "api"), (e) -> {
+            assertError(e, "sptoken", "is required");
+        });
+    }
+    
+    @Test
+    public void studyRequired() {
+        validate(new PasswordReset("asdfasdf", "token", ""), (e) -> {
+            assertError(e, "study", "is required");
+        });
+    }
+    
+    @Test
+    public void invalidPassword() {
+        validate(new PasswordReset("e", "token", "api"), (e) -> {
+            assertError(e, "password", "must be at least 8 characters",
+                    "must contain at least one number (0-9)",
+                    "must contain at least one symbol ( !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~ )",
+                    "must contain at least one uppercase letter (A-Z)");
+        });
+    }
+
+    private void validate(PasswordReset reset, Consumer<InvalidEntityException> consumer) {
+        try {
+            Validate.entityThrowingException(validator, reset);    
+        } catch(InvalidEntityException e) {
+            consumer.accept(e);
+        }
+    }
+    
+    private void assertError(InvalidEntityException e, String fieldName, String... messages) {
+        for (int i=0; i < messages.length; i++) {
+            String message = messages[i];
+            assertEquals(fieldName + " " + message, e.getErrors().get(fieldName).get(i));
+        }
+    }
+}


### PR DESCRIPTION
Add password validation to the reset password pathway. Factored out validation code (based on PasswordPolicy) to a utility method so we can also validate in ParticipantStudyValidator.

Communicate 400 errors back to the reset password UI. Otherwise users have no idea if there are password constraints they are not meeting, they just get a generic error message back.
