### PR TITLE
worker account access to get schema API

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.play.controllers;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS;
 import static org.sagebionetworks.bridge.BridgeConstants.SESSION_TOKEN_HEADER;
@@ -10,6 +11,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Locale.LanguageRange;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
@@ -134,17 +136,28 @@ public abstract class BaseController extends Controller {
         }
         return session;
     }
-    
+
     UserSession getAuthenticatedSession(Roles role) {
         checkNotNull(role);
-        
+
         UserSession session = getAuthenticatedSession();
         if (session.getUser().isInRole(role)) {
             return session;
         }
         throw new UnauthorizedException();
     }
-    
+
+    UserSession getAuthenticatedSession(Set<Roles> roleSet) {
+        checkNotNull(roleSet);
+        checkArgument(!roleSet.isEmpty());
+
+        UserSession session = getAuthenticatedSession();
+        if (session.getUser().isInRole(roleSet)) {
+            return session;
+        }
+        throw new UnauthorizedException();
+    }
+
     void setSessionToken(String sessionToken) {
         response().setCookie(SESSION_TOKEN_HEADER, sessionToken, BRIDGE_SESSION_EXPIRE_IN_SECONDS, "/");
     }

--- a/app/org/sagebionetworks/bridge/play/controllers/UploadSchemaController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/UploadSchemaController.java
@@ -1,7 +1,9 @@
 package org.sagebionetworks.bridge.play.controllers;
 
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
+import static org.sagebionetworks.bridge.Roles.WORKER;
 
+import java.util.EnumSet;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -134,7 +136,7 @@ public class UploadSchemaController extends BaseController {
      * @return Play result with the fetched schema in JSON format
      */
     public Result getUploadSchemaByIdAndRev(String schemaId, int rev) {
-        UserSession session = getAuthenticatedSession(DEVELOPER);
+        UserSession session = getAuthenticatedSession(EnumSet.of(DEVELOPER, WORKER));
         StudyIdentifier studyId = session.getStudyIdentifier();
 
         UploadSchema uploadSchema = uploadSchemaService.getUploadSchemaByIdAndRev(studyId, schemaId, rev);

--- a/test/org/sagebionetworks/bridge/play/controllers/UploadSchemaControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/UploadSchemaControllerTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.play.controllers;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anySetOf;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
@@ -179,7 +180,7 @@ public class UploadSchemaControllerTest {
         // spy controller
         UploadSchemaController controller = spy(new UploadSchemaController());
         controller.setUploadSchemaService(mockSvc);
-        doReturn(mockSession).when(controller).getAuthenticatedSession(any(Roles.class));
+        doReturn(mockSession).when(controller).getAuthenticatedSession(anySetOf(Roles.class));
 
         // execute and validate
         Result result = controller.getUploadSchemaByIdAndRev(TEST_SCHEMA_ID, 1);


### PR DESCRIPTION
This is needed by BridgeEX to get schemas. This is needed to refactor BridgeEX to call Bridge instead of DDB, which in turn is needed for Upload Format v2.

Testing done:
- added unit tests
- manual tested, developer works, worker works, normal account 403

See also:
- https://github.com/Sage-Bionetworks/BridgeJavaSDK/pull/269
- https://github.com/Sage-Bionetworks/BridgeIntegrationTests/pull/24
