### PR TITLE
add granular uploadedOn timestamp to health data record

### DIFF
--- a/app/org/sagebionetworks/bridge/models/healthdata/HealthDataRecord.java
+++ b/app/org/sagebionetworks/bridge/models/healthdata/HealthDataRecord.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 @BridgeTypeName("HealthData")
 @JsonDeserialize(as = DynamoHealthDataRecord.class)
 public interface HealthDataRecord extends BridgeEntity {
-    public static final ObjectWriter PUBLIC_RECORD_WRITER = new BridgeObjectMapper().writer(
+    ObjectWriter PUBLIC_RECORD_WRITER = new BridgeObjectMapper().writer(
             new SimpleFilterProvider().addFilter("filter",
                     SimpleBeanPropertyFilter.serializeAllExcept("healthCode")));
 
@@ -56,6 +56,11 @@ public interface HealthDataRecord extends BridgeEntity {
 
     /** ID of the upload this health data record was built from, if applicable. */
     String getUploadId();
+
+    /**
+     * When the data was uploaded to Bridge in epoch milliseconds. Used as an index for hourly and on-demand exports.
+     */
+    Long getUploadedOn();
 
     /** Whether this record should be shared with all researchers, only study researchers, or not at all. */
     ParticipantOption.SharingScope getUserSharingScope();

--- a/app/org/sagebionetworks/bridge/models/healthdata/HealthDataRecordBuilder.java
+++ b/app/org/sagebionetworks/bridge/models/healthdata/HealthDataRecordBuilder.java
@@ -28,6 +28,7 @@ public abstract class HealthDataRecordBuilder {
     private String studyId;
     private LocalDate uploadDate;
     private String uploadId;
+    private Long uploadedOn;
     private String userExternalId;
     private Set<String> userDataGroups;
     private ParticipantOption.SharingScope userSharingScope;
@@ -45,6 +46,7 @@ public abstract class HealthDataRecordBuilder {
         studyId = record.getStudyId();
         uploadDate = record.getUploadDate();
         uploadId = record.getUploadId();
+        uploadedOn = record.getUploadedOn();
         userExternalId = record.getUserExternalId();
         userDataGroups = record.getUserDataGroups();
         userSharingScope = record.getUserSharingScope();
@@ -159,6 +161,17 @@ public abstract class HealthDataRecordBuilder {
     /** @see org.sagebionetworks.bridge.models.healthdata.HealthDataRecord#getUploadId */
     public HealthDataRecordBuilder withUploadId(String uploadId) {
         this.uploadId = uploadId;
+        return this;
+    }
+
+    /** @see org.sagebionetworks.bridge.models.healthdata.HealthDataRecord#getUploadedOn */
+    public Long getUploadedOn() {
+        return uploadedOn;
+    }
+
+    /** @see org.sagebionetworks.bridge.models.healthdata.HealthDataRecord#getUploadedOn */
+    public HealthDataRecordBuilder withUploadedOn(Long uploadedOn) {
+        this.uploadedOn = uploadedOn;
         return this;
     }
 

--- a/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2.java
+++ b/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2.java
@@ -148,6 +148,7 @@ public class IosSchemaValidationHandler2 implements UploadValidationHandler {
         // TODO: If we globalize Bridge, we'll need to make this timezone configurable.
         recordBuilder.withUploadDate(LocalDate.now(BridgeConstants.LOCAL_TIME_ZONE));
         recordBuilder.withUploadId(uploadId);
+        recordBuilder.withUploadedOn(DateUtils.getCurrentMillisFromEpoch());
 
         // create an empty object node in our record builder, which we'll fill in as we go
         ObjectNode dataMap = BridgeObjectMapper.get().createObjectNode();

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataDaoDdbTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataDaoDdbTest.java
@@ -1,0 +1,92 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Set;
+import javax.annotation.Resource;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableSet;
+import org.joda.time.LocalDate;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.dao.ParticipantOption;
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+@ContextConfiguration("classpath:test-context.xml")
+@RunWith(SpringJUnit4ClassRunner.class)
+public class DynamoHealthDataDaoDdbTest {
+    private static final long CREATED_ON = 1424136378727L;
+    private static final String HEALTH_CODE = "health-code";
+    private static final String RECORD_ID = "record-id";
+    private static final String DATA_TEXT = "{\"data\":\"dummy value\"}";
+    private static final String METADATA_TEXT = "{\"metadata\":\"dummy meta value\"}";
+    private static final String SCHEMA_ID = "schema-id";
+    private static final int SCHEMA_REV = 2;
+    private static final LocalDate UPLOAD_DATE = LocalDate.parse("2016-05-06");
+    private static final String UPLOAD_ID = "upload-id";
+    private static final long UPLOADED_ON = 1462575525894L;
+    private static final String USER_EXTERNAL_ID = "external-id";
+    private static final Set<String> USER_DATA_GROUPS = ImmutableSet.of("group1", "group2");
+
+    @Resource(name = "healthDataDdbMapper")
+    private DynamoDBMapper mapper;
+
+    @Test
+    public void ddbRoundtrip() throws Exception {
+        // create test record with all fields
+        DynamoHealthDataRecord record = new DynamoHealthDataRecord();
+        record.setCreatedOn(CREATED_ON);
+        record.setData(BridgeObjectMapper.get().readTree(DATA_TEXT));
+        record.setHealthCode(HEALTH_CODE);
+        record.setId(RECORD_ID);
+        record.setMetadata(BridgeObjectMapper.get().readTree(METADATA_TEXT));
+        record.setSchemaId(SCHEMA_ID);
+        record.setSchemaRevision(SCHEMA_REV);
+        record.setStudyId(TestConstants.TEST_STUDY_IDENTIFIER);
+        record.setUploadDate(UPLOAD_DATE);
+        record.setUploadId(UPLOAD_ID);
+        record.setUploadedOn(UPLOADED_ON);
+        record.setUserSharingScope(ParticipantOption.SharingScope.SPONSORS_AND_PARTNERS);
+        record.setUserExternalId(USER_EXTERNAL_ID);
+        record.setUserDataGroups(USER_DATA_GROUPS);
+
+        // Save it to DDB, then read it back and make sure it has the same fields. (Can't use .equals(), even if we
+        // implemented it, because the mapper functions modify the object we pass in.)
+        mapper.save(record);
+        DynamoHealthDataRecord savedRecord = mapper.load(record);
+
+        try {
+            // validate fields
+            assertEquals(CREATED_ON, savedRecord.getCreatedOn().longValue());
+            assertEquals(HEALTH_CODE, savedRecord.getHealthCode());
+            assertEquals(RECORD_ID, savedRecord.getId());
+            assertEquals(SCHEMA_ID, savedRecord.getSchemaId());
+            assertEquals(SCHEMA_REV, savedRecord.getSchemaRevision());
+            assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, savedRecord.getStudyId());
+            assertEquals(UPLOAD_DATE, savedRecord.getUploadDate());
+            assertEquals(UPLOAD_ID, savedRecord.getUploadId());
+            assertEquals(UPLOADED_ON, savedRecord.getUploadedOn().longValue());
+            assertEquals(ParticipantOption.SharingScope.SPONSORS_AND_PARTNERS, savedRecord.getUserSharingScope());
+            assertEquals(USER_EXTERNAL_ID, savedRecord.getUserExternalId());
+            assertEquals(USER_DATA_GROUPS, savedRecord.getUserDataGroups());
+            assertEquals(1L, savedRecord.getVersion().longValue());
+
+            JsonNode dataNode = savedRecord.getData();
+            assertEquals(1, dataNode.size());
+            assertEquals("dummy value", dataNode.get("data").textValue());
+
+            JsonNode metadataNode = savedRecord.getMetadata();
+            assertEquals(1, metadataNode.size());
+            assertEquals("dummy meta value", metadataNode.get("metadata").textValue());
+        } finally {
+            // cleanup
+            mapper.delete(savedRecord);
+        }
+    }
+}

--- a/test/org/sagebionetworks/bridge/models/healthdata/HealthDataRecordTest.java
+++ b/test/org/sagebionetworks/bridge/models/healthdata/HealthDataRecordTest.java
@@ -70,6 +70,7 @@ public class HealthDataRecordTest {
         JsonNode data = BridgeObjectMapper.get().readTree("{\"myData\":\"myDataValue\"}");
         JsonNode metadata = BridgeObjectMapper.get().readTree("{\"myMetadata\":\"myMetaValue\"}");
         long arbitraryTimestamp = 1424136378727L;
+        long uploadedOn = 1462575525894L;
 
         // arbitrarily 2015-02-12
         LocalDate uploadDate = new LocalDate(2014, 2, 12);
@@ -78,7 +79,7 @@ public class HealthDataRecordTest {
         HealthDataRecord record = DAO.getRecordBuilder().withData(data).withHealthCode("required healthcode")
                 .withId("optional record ID").withCreatedOn(arbitraryTimestamp).withMetadata(metadata)
                 .withSchemaId("required schema").withSchemaRevision(3).withStudyId("required study")
-                .withUploadDate(uploadDate).withUploadId("optional upload ID")
+                .withUploadDate(uploadDate).withUploadId("optional upload ID").withUploadedOn(uploadedOn)
                 .withUserExternalId("optional external ID")
                 .withUserSharingScope(ParticipantOption.SharingScope.SPONSORS_AND_PARTNERS)
                 .withUserDataGroups(USER_DATA_GROUPS)
@@ -93,6 +94,7 @@ public class HealthDataRecordTest {
         assertEquals("required study", record.getStudyId());
         assertEquals("2014-02-12", record.getUploadDate().toString(ISODateTimeFormat.date()));
         assertEquals("optional upload ID", record.getUploadId());
+        assertEquals(uploadedOn, record.getUploadedOn().longValue());
         assertEquals("optional external ID", record.getUserExternalId());
         assertEquals(ParticipantOption.SharingScope.SPONSORS_AND_PARTNERS, record.getUserSharingScope());
         assertEquals(USER_DATA_GROUPS, record.getUserDataGroups());
@@ -114,6 +116,7 @@ public class HealthDataRecordTest {
         assertEquals("required study", copyRecord.getStudyId());
         assertEquals("2014-02-12", copyRecord.getUploadDate().toString(ISODateTimeFormat.date()));
         assertEquals("optional upload ID", copyRecord.getUploadId());
+        assertEquals(uploadedOn, copyRecord.getUploadedOn().longValue());
         assertEquals("optional external ID", copyRecord.getUserExternalId());
         assertEquals(ParticipantOption.SharingScope.SPONSORS_AND_PARTNERS, copyRecord.getUserSharingScope());
         assertEquals(USER_DATA_GROUPS, record.getUserDataGroups());
@@ -293,6 +296,9 @@ public class HealthDataRecordTest {
 
     @Test
     public void testSerialization() throws Exception {
+        String uploadedOnStr = "2016-05-06T16:01:22.307-0700";
+        long uploadedOn = DateTime.parse(uploadedOnStr).getMillis();
+
         // start with JSON
         String jsonText = "{\n" +
                 "   \"createdOn\":\"2014-02-12T13:45-0800\",\n" +
@@ -305,6 +311,7 @@ public class HealthDataRecordTest {
                 "   \"studyId\":\"json study\",\n" +
                 "   \"uploadDate\":\"2014-02-12\",\n" +
                 "   \"uploadId\":\"json upload\",\n" +
+                "   \"uploadedOn\":\"" + uploadedOnStr + "\",\n" +
                 "   \"userSharingScope\":\"all_qualified_researchers\",\n" +
                 "   \"userExternalId\":\"ABC-123-XYZ\",\n" +
                 "   \"version\":42\n" +
@@ -321,6 +328,7 @@ public class HealthDataRecordTest {
         assertEquals("json study", record.getStudyId());
         assertEquals("2014-02-12", record.getUploadDate().toString(ISODateTimeFormat.date()));
         assertEquals("json upload", record.getUploadId());
+        assertEquals(uploadedOn, record.getUploadedOn().longValue());
         assertEquals(ParticipantOption.SharingScope.ALL_QUALIFIED_RESEARCHERS, record.getUserSharingScope());
         assertEquals("ABC-123-XYZ", record.getUserExternalId());
         assertEquals(42, record.getVersion().longValue());
@@ -336,7 +344,7 @@ public class HealthDataRecordTest {
 
         // then convert to a map so we can validate the raw JSON
         Map<String, Object> jsonMap = BridgeObjectMapper.get().readValue(convertedJson, JsonUtils.TYPE_REF_RAW_MAP);
-        assertEquals(14, jsonMap.size());
+        assertEquals(15, jsonMap.size());
         assertEquals("json healthcode", jsonMap.get("healthCode"));
         assertEquals("json record ID", jsonMap.get("id"));
         assertEquals("json schema", jsonMap.get("schemaId"));
@@ -344,6 +352,7 @@ public class HealthDataRecordTest {
         assertEquals("json study", jsonMap.get("studyId"));
         assertEquals("2014-02-12", jsonMap.get("uploadDate"));
         assertEquals("json upload", jsonMap.get("uploadId"));
+        assertEquals(uploadedOn, DateTime.parse((String) jsonMap.get("uploadedOn")).getMillis());
         assertEquals("all_qualified_researchers", jsonMap.get("userSharingScope"));
         assertEquals("ABC-123-XYZ", jsonMap.get("userExternalId"));
         assertEquals(42, jsonMap.get("version"));
@@ -365,7 +374,7 @@ public class HealthDataRecordTest {
 
         // Convert back to map again. Only validate a few key fields are present and the filtered fields are absent.
         Map<String, Object> publicJsonMap = BridgeObjectMapper.get().readValue(publicJson, JsonUtils.TYPE_REF_RAW_MAP);
-        assertEquals(13, publicJsonMap.size());
+        assertEquals(14, publicJsonMap.size());
         assertFalse(publicJsonMap.containsKey("healthCode"));
         assertEquals("json record ID", publicJsonMap.get("id"));
     }


### PR DESCRIPTION
Add a new timestamp to health data records to support both hourly export and on-demand export.

We use a compound key with the studyId as the hash and uploadedOn as the range key. This is because (1) we need to do range queries on the uploadedOn for it to be useful and (2) this feature is configured on a per-study basis anyway.

Testing done:
- added/updated unit tests
- deleted tables, then verified table is created with the new index
- manually tested on local server, verified uploadedOn
- UploadTest in integration tests
