### PR TITLE
added usesCustomExportSchedule (hourly export schedule) to study

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 @BridgeTypeName("Study")
 @JsonFilter("filter")
 public final class DynamoStudy implements Study {
-    
     private String name;
     private String sponsorName;
     private String identifier;
@@ -34,6 +33,7 @@ public final class DynamoStudy implements Study {
     private Long synapseDataAccessTeamId;
     private String synapseProjectId;
     private String technicalEmail;
+    private boolean usesCustomExportSchedule;
     private String consentNotificationEmail;
     private int minAgeOfConsent;
     private int maxNumOfParticipants;
@@ -188,6 +188,18 @@ public final class DynamoStudy implements Study {
     @Override
     public void setTechnicalEmail(String technicalEmail) {
         this.technicalEmail = technicalEmail;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean getUsesCustomExportSchedule() {
+        return usesCustomExportSchedule;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setUsesCustomExportSchedule(boolean usesCustomExportSchedule) {
+        this.usesCustomExportSchedule = usesCustomExportSchedule;
     }
 
     /** {@inheritDoc} */
@@ -349,7 +361,8 @@ public final class DynamoStudy implements Study {
                 technicalEmail, consentNotificationEmail, stormpathHref, version, profileAttributes, taskIdentifiers,
                 dataGroups, passwordPolicy, verifyEmailTemplate, resetPasswordTemplate, active,
                 strictUploadValidationEnabled, healthCodeExportEnabled, emailVerificationEnabled,
-                externalIdValidationEnabled, minSupportedAppVersions, synapseDataAccessTeamId, synapseProjectId);
+                externalIdValidationEnabled, minSupportedAppVersions, synapseDataAccessTeamId, synapseProjectId,
+                usesCustomExportSchedule);
     }
 
     @Override
@@ -376,6 +389,7 @@ public final class DynamoStudy implements Study {
                 && Objects.equals(synapseDataAccessTeamId, other.synapseDataAccessTeamId)
                 && Objects.equals(synapseProjectId, other.synapseProjectId)
                 && Objects.equals(technicalEmail, other.technicalEmail)
+                && Objects.equals(usesCustomExportSchedule, other.usesCustomExportSchedule)
                 && Objects.equals(strictUploadValidationEnabled, other.strictUploadValidationEnabled)
                 && Objects.equals(healthCodeExportEnabled, other.healthCodeExportEnabled)
                 && Objects.equals(externalIdValidationEnabled, other.externalIdValidationEnabled)
@@ -392,11 +406,11 @@ public final class DynamoStudy implements Study {
                             + "version=%s, userProfileAttributes=%s, taskIdentifiers=%s, dataGroups=%s, passwordPolicy=%s, "
                             + "verifyEmailTemplate=%s, resetPasswordTemplate=%s, strictUploadValidationEnabled=%s, "
                             + "healthCodeExportEnabled=%s, emailVerificationEnabled=%s, externalIdValidationEnabled=%s, "
-                            + "minSupportedAppVersions=%s]",
+                            + "minSupportedAppVersions=%s, usesCustomExportSchedule=%s]",
                 name, active, sponsorName, identifier, stormpathHref, minAgeOfConsent, maxNumOfParticipants,
                 supportEmail, synapseDataAccessTeamId, synapseProjectId, technicalEmail, consentNotificationEmail,
                 version, profileAttributes, taskIdentifiers, dataGroups, passwordPolicy, verifyEmailTemplate,
                 resetPasswordTemplate, strictUploadValidationEnabled, healthCodeExportEnabled, emailVerificationEnabled,
-                externalIdValidationEnabled, minSupportedAppVersions);
+                externalIdValidationEnabled, minSupportedAppVersions, usesCustomExportSchedule);
     }
 }

--- a/app/org/sagebionetworks/bridge/models/studies/Study.java
+++ b/app/org/sagebionetworks/bridge/models/studies/Study.java
@@ -28,7 +28,7 @@ public interface Study extends BridgeEntity, StudyIdentifier {
     public static final ObjectWriter STUDY_LIST_WRITER = new BridgeObjectMapper().writer(
         new SimpleFilterProvider().addFilter("filter",
         SimpleBeanPropertyFilter.filterOutAllExcept("name", "identifier")));
-    
+
     /**
      * The display name of the study (will be seen by participants in email). This name makes the 
      * most sense when it starts with "The".
@@ -67,7 +67,7 @@ public interface Study extends BridgeEntity, StudyIdentifier {
     public void setVersion(Long version);
     
     /**
-     * User must confirm that they are at least this many years old in order to 
+     * User must confirm that they are at least this many years old in order to
      * participate in the study. 
      * @return
      */
@@ -110,7 +110,17 @@ public interface Study extends BridgeEntity, StudyIdentifier {
      */
     public String getTechnicalEmail();
     public void setTechnicalEmail(String email);
-    
+
+    /**
+     * By default, all studies are exported using the default nightly schedule. Some studies may need custom schedules
+     * for hourly or on-demand exports. To prevent this study from being exported twice (once by the custom schedule,
+     * once by the default schedule), you should set this attribute to true.
+     */
+    boolean getUsesCustomExportSchedule();
+
+    /** @see #getUsesCustomExportSchedule */
+    void setUsesCustomExportSchedule(boolean usesCustomExportSchedule);
+
     /**
      * Copies of all consent agreements, as well as rosters of all participants in a study, or any 
      * other study governance issues, will be emailed to this address. This can be a comma-separated 

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -271,6 +271,7 @@ public class TestUtils {
         study.setSynapseDataAccessTeamId(1234L);
         study.setSynapseProjectId("test-synapse-project-id");
         study.setTechnicalEmail("bridge-testing+technical@sagebase.org");
+        study.setUsesCustomExportSchedule(true);
         study.setSupportEmail("bridge-testing+support@sagebase.org");
         study.setUserProfileAttributes(Sets.newHashSet("a", "b"));
         study.setTaskIdentifiers(Sets.newHashSet("task1", "task2"));

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyDaoTest.java
@@ -82,6 +82,7 @@ public class DynamoStudyDaoTest {
         assertEquals("bridge-testing+support@sagebase.org", study.getSupportEmail());
         assertEquals("bridge-testing+consent@sagebase.org", study.getConsentNotificationEmail());
         assertEquals(USER_PROFILE_ATTRIBUTES, study.getUserProfileAttributes());
+        assertTrue(study.getUsesCustomExportSchedule());
         assertEquals(TASK_IDENTIFIERS, study.getTaskIdentifiers());
         assertEquals(DATA_GROUPS, study.getDataGroups());
 

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
@@ -48,6 +48,7 @@ public class DynamoStudyTest {
         assertEqualsAndNotNull(study.getSynapseDataAccessTeamId(), node.get("synapseDataAccessTeamId").longValue());
         assertEqualsAndNotNull(study.getSynapseProjectId(), node.get("synapseProjectId").textValue());
         assertEqualsAndNotNull(study.getTechnicalEmail(), node.get("technicalEmail").asText());
+        assertTrue(node.get("usesCustomExportSchedule").asBoolean());
         assertEqualsAndNotNull(study.getSponsorName(), node.get("sponsorName").asText());
         assertEqualsAndNotNull(study.getName(), node.get("name").asText());
         assertEqualsAndNotNull(study.isActive(), node.get("active").asBoolean());


### PR DESCRIPTION
Added a usesCustomExportSchedule flag to Study. By default, all studies are exported using the default nightly schedule. Some studies may need custom schedules for hourly or on-demand exports. To prevent this study from being exported twice (once by the custom schedule, once by the default schedule), we need a flag that tells the exporter not to export this this study as part of the default schedule.

Testing done:
- added unit tests
- manually tested flipping this flag back and forth
