### PR TITLE
Can only edit self

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
@@ -62,7 +62,9 @@ public class ParticipantController extends BaseController {
         StudyParticipant existing = participantService.getParticipant(study, NO_CALLER_ROLES, session.getId());
         StudyParticipant updated = new StudyParticipant.Builder()
                 .copyOf(existing)
-                .copyFieldsOf(participant, fieldNames).build();
+                .copyFieldsOf(participant, fieldNames)
+                .withId(session.getId()) // but they can't point at someone else's account!
+                .build();
         
         participantService.updateParticipant(study, NO_CALLER_ROLES, session.getId(), updated);
         

--- a/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
@@ -66,7 +66,7 @@ public class ParticipantController extends BaseController {
                 .withId(session.getId()) // but they can't point at someone else's account!
                 .build();
         
-        participantService.updateParticipant(study, NO_CALLER_ROLES, session.getId(), updated);
+        participantService.updateParticipant(study, NO_CALLER_ROLES, updated);
         
         // Update this user's session (creates one if it doesn't exist, but this is safe)
         CriteriaContext context = getCriteriaContext(study.getStudyIdentifier());
@@ -112,11 +112,11 @@ public class ParticipantController extends BaseController {
         Study study = studyService.getStudy(session.getStudyIdentifier());
 
         StudyParticipant participant = parseJson(request(), StudyParticipant.class);
-        // Just stop right here because something is wrong
-        if (participant.getId() != null && !userId.equals(participant.getId())) {
-            throw new BadRequestException("ID in JSON does not match email in URL.");
-        }
-        participantService.updateParticipant(study, session.getParticipant().getRoles(), userId, participant);
+        
+        participant = new StudyParticipant.Builder()
+                .copyOf(participant)
+                .withId(userId).build();
+        participantService.updateParticipant(study, session.getParticipant().getRoles(), participant);
         
         // Push changes to the user's session, including consent statuses.
         CriteriaContext context = new CriteriaContext.Builder()

--- a/app/org/sagebionetworks/bridge/play/controllers/UserProfileController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/UserProfileController.java
@@ -112,8 +112,9 @@ public class UserProfileController extends BaseController {
         StudyParticipant updated = new StudyParticipant.Builder().copyOf(participant)
                 .withFirstName(JsonUtils.asText(node, "firstName"))
                 .withLastName(JsonUtils.asText(node, "lastName"))
-                .withAttributes(attributes).build();
-        participantService.updateParticipant(study, NO_CALLER_ROLES, userId, updated);
+                .withAttributes(attributes)
+                .withId(session.getId()).build();
+        participantService.updateParticipant(study, NO_CALLER_ROLES, updated);
         
         session.setParticipant(updated);
         updateSession(session);
@@ -162,7 +163,7 @@ public class UserProfileController extends BaseController {
         StudyParticipant updated = new StudyParticipant.Builder().copyOf(participant)
                 .copyFieldsOf(dataGroups, DATA_GROUPS_SET).build();
         
-        participantService.updateParticipant(study, NO_CALLER_ROLES, session.getId(), updated);
+        participantService.updateParticipant(study, NO_CALLER_ROLES, updated);
         
         session.setParticipant(updated);
         

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -185,18 +185,18 @@ public class ParticipantService {
      */
     public IdentifierHolder createParticipant(Study study, Set<Roles> callerRoles, StudyParticipant participant,
             boolean sendVerifyEmail) {
-        return saveParticipant(study, callerRoles, null, participant, true, sendVerifyEmail);
+        return saveParticipant(study, callerRoles, participant, true, sendVerifyEmail);
     }
     
-    public void updateParticipant(Study study, Set<Roles> callerRoles, String id, StudyParticipant participant) {
-        saveParticipant(study, callerRoles, id, participant, false, false);
+    public void updateParticipant(Study study, Set<Roles> callerRoles, StudyParticipant participant) {
+        saveParticipant(study, callerRoles, participant, false, false);
     }
 
-    private IdentifierHolder saveParticipant(Study study, Set<Roles> callerRoles, String id,
-            StudyParticipant participant, boolean isNew, boolean sendVerifyEmail) {
+    private IdentifierHolder saveParticipant(Study study, Set<Roles> callerRoles, StudyParticipant participant,
+            boolean isNew, boolean sendVerifyEmail) {
         checkNotNull(study);
         checkNotNull(callerRoles);
-        checkArgument(isNew || isNotBlank(id));
+        checkArgument(isNew || isNotBlank(participant.getId()));
         checkNotNull(participant);
         
         Validate.entityThrowingException(new StudyParticipantValidator(study, isNew), participant);
@@ -209,7 +209,7 @@ public class ParticipantService {
             }
             account = accountDao.constructAccount(study, participant.getEmail(), participant.getPassword());
         } else {
-            account = getAccountThrowingException(study, id);
+            account = getAccountThrowingException(study, participant.getId());
             
             addValidatedExternalId(study, participant, account.getHealthCode());
         }

--- a/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
@@ -185,12 +185,12 @@ public class ParticipantControllerTest {
         TestUtils.mockPlayContextWithJson(TestUtils.createJson("{'firstName':'firstName','lastName':'lastName',"+
                 "'email':'email@email.com','externalId':'externalId','password':'newUserPassword',"+
                 "'sharingScope':'sponsors_and_partners','notifyByEmail':true,'dataGroups':['group2','group1'],"+
-                "'attributes':{'phone':'123456789'},'languages':['en','fr']}"));
+                "'id':'junkId','attributes':{'phone':'123456789'},'languages':['en','fr']}"));
         
         Result result = controller.updateParticipant(ID);
         assertResult(result, 200, "Participant updated.");
         
-        verify(participantService).updateParticipant(eq(STUDY), eq(CALLER_ROLES), eq(ID), participantCaptor.capture());
+        verify(participantService).updateParticipant(eq(STUDY), eq(CALLER_ROLES), participantCaptor.capture());
         verify(authService).updateSession(eq(STUDY), any(), eq(ID));
         
         StudyParticipant participant = participantCaptor.getValue();
@@ -204,6 +204,8 @@ public class ParticipantControllerTest {
         assertEquals(Sets.newHashSet("group2","group1"), participant.getDataGroups());
         assertEquals("123456789", participant.getAttributes().get("phone"));
         assertEquals(Sets.newHashSet("en","fr"), participant.getLanguages());
+        // the ID in the URL, not the one in the JSON (which can be wrong or missing, we don't care)
+        assertEquals(ID, participant.getId()); 
     }
     
     @Test
@@ -246,13 +248,6 @@ public class ParticipantControllerTest {
         assertEquals(Sets.newHashSet("en","fr"), participant.getLanguages());
     }
 
-    @Test(expected = BadRequestException.class)
-    public void updateParticipantRequiresIdMatch() throws Exception {
-        TestUtils.mockPlayContextWithJson(TestUtils.createJson("{'id':'id2'}"));
-        
-        controller.updateParticipant("id1");
-    }
-    
     @Test
     public void getSelfParticipant() throws Exception {
         StudyParticipant studyParticipant = new StudyParticipant.Builder().withFirstName("Test").build();
@@ -288,7 +283,7 @@ public class ParticipantControllerTest {
         // verify the object is passed to service, one field is sufficient
         verify(cacheProvider).setUserSession(any());
         verify(authService).updateSession(eq(STUDY), any(), eq(ID));
-        verify(participantService).updateParticipant(eq(STUDY), eq(NO_CALLER_ROLES), eq(ID), participantCaptor.capture());
+        verify(participantService).updateParticipant(eq(STUDY), eq(NO_CALLER_ROLES), participantCaptor.capture());
 
         // Just test the different types and verify they are there.
         StudyParticipant captured = participantCaptor.getValue();
@@ -331,7 +326,7 @@ public class ParticipantControllerTest {
         assertEquals("UserSessionInfo", node.get("type").asText());
 
         verify(authService).updateSession(eq(STUDY), any(), eq(ID));
-        verify(participantService).updateParticipant(eq(STUDY), eq(NO_CALLER_ROLES), eq(ID), participantCaptor.capture());
+        verify(participantService).updateParticipant(eq(STUDY), eq(NO_CALLER_ROLES), participantCaptor.capture());
         StudyParticipant captured = participantCaptor.getValue();
         assertEquals("firstName", captured.getFirstName());
         assertEquals("lastName", captured.getLastName());
@@ -368,7 +363,7 @@ public class ParticipantControllerTest {
         verify(controller).updateSession(session);
         
         // verify the object is passed to service, one field is sufficient
-        verify(participantService).updateParticipant(eq(STUDY), eq(NO_CALLER_ROLES), eq(ID), participantCaptor.capture());
+        verify(participantService).updateParticipant(eq(STUDY), eq(NO_CALLER_ROLES), participantCaptor.capture());
 
         // The ID was changed back to the session's participant user ID, not the one provided.
         StudyParticipant captured = participantCaptor.getValue();

--- a/test/org/sagebionetworks/bridge/play/controllers/UserProfileControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/UserProfileControllerTest.java
@@ -168,7 +168,7 @@ public class UserProfileControllerTest {
         Result result = controller.updateUserProfile();
         TestUtils.assertResult(result, 200, "Profile updated.");
 
-        verify(participantService).updateParticipant(eq(study), eq(Sets.newHashSet()), eq(ID), participantCaptor.capture());
+        verify(participantService).updateParticipant(eq(study), eq(Sets.newHashSet()), participantCaptor.capture());
         
         StudyParticipant persisted = participantCaptor.getValue();
         assertEquals("First", persisted.getFirstName());
@@ -198,7 +198,7 @@ public class UserProfileControllerTest {
         Result result = controller.updateDataGroups();
         assertResult(result, 200, "Data groups updated.");
         
-        verify(participantService).updateParticipant(eq(study), eq(NO_ROLES), eq(ID), participantCaptor.capture());
+        verify(participantService).updateParticipant(eq(study), eq(NO_ROLES),participantCaptor.capture());
         verify(consentService).getConsentStatuses(contextCaptor.capture());
         
         StudyParticipant participant = participantCaptor.getValue();
@@ -215,7 +215,7 @@ public class UserProfileControllerTest {
     public void invalidDataGroupsRejected() throws Exception {
         StudyParticipant existing = new StudyParticipant.Builder().withFirstName("First").build();
         doReturn(existing).when(participantService).getParticipant(study, NO_ROLES, ID);
-        doThrow(new InvalidEntityException("Invalid data groups")).when(participantService).updateParticipant(eq(study), eq(NO_ROLES), eq(ID), any());
+        doThrow(new InvalidEntityException("Invalid data groups")).when(participantService).updateParticipant(eq(study), eq(NO_ROLES), any());
         
         TestUtils.mockPlayContextWithJson("{\"dataGroups\":[\"completelyInvalidGroup\"]}");
         try {
@@ -256,7 +256,7 @@ public class UserProfileControllerTest {
         Result result = controller.updateDataGroups();
         assertResult(result, 200, "Data groups updated.");
         
-        verify(participantService).updateParticipant(eq(study), eq(NO_ROLES), eq(ID), participantCaptor.capture());
+        verify(participantService).updateParticipant(eq(study), eq(NO_ROLES), participantCaptor.capture());
         
         StudyParticipant updated = participantCaptor.getValue();
         assertTrue(updated.getDataGroups().isEmpty());

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
@@ -486,7 +486,7 @@ public class AuthenticationServiceTest {
         // Update the data groups
         StudyParticipant participant = participantService.getParticipant(study, CALLER_ROLES, userId);
         StudyParticipant updated = new StudyParticipant.Builder().copyOf(participant).withDataGroups(UPDATED_DATA_GROUPS).build();
-        participantService.updateParticipant(study, CALLER_ROLES, userId, updated);
+        participantService.updateParticipant(study, CALLER_ROLES, updated);
         
         // Now update the session, these changes should be reflected
         CriteriaContext context = new CriteriaContext.Builder().withStudyIdentifier(study.getStudyIdentifier()).build();

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -445,7 +445,7 @@ public class ParticipantServiceTest {
         doReturn(lookup).when(optionsService).getOptions(HEALTH_CODE);
         doReturn(null).when(lookup).getString(EXTERNAL_IDENTIFIER);
         
-        participantService.updateParticipant(STUDY, CALLER_ROLES, ID, PARTICIPANT);
+        participantService.updateParticipant(STUDY, CALLER_ROLES, PARTICIPANT);
         
         verify(optionsService).setAllOptions(eq(STUDY.getStudyIdentifier()), eq(HEALTH_CODE), optionsCaptor.capture());
         Map<ParticipantOption, String> options = optionsCaptor.getValue();
@@ -473,7 +473,7 @@ public class ParticipantServiceTest {
         doReturn(lookup).when(optionsService).getOptions(HEALTH_CODE);
         doReturn("BBB").when(lookup).getString(EXTERNAL_IDENTIFIER);
         
-        participantService.updateParticipant(STUDY, CALLER_ROLES, ID, PARTICIPANT);
+        participantService.updateParticipant(STUDY, CALLER_ROLES, PARTICIPANT);
     }
 
     @Test(expected = BadRequestException.class)
@@ -484,7 +484,7 @@ public class ParticipantServiceTest {
         doReturn(lookup).when(optionsService).getOptions(HEALTH_CODE);
         doReturn("BBB").when(lookup).getString(EXTERNAL_IDENTIFIER);
         
-        participantService.updateParticipant(STUDY, CALLER_ROLES, ID, NO_ID_PARTICIPANT);
+        participantService.updateParticipant(STUDY, CALLER_ROLES, NO_ID_PARTICIPANT);
     }
     
     @Test
@@ -496,7 +496,7 @@ public class ParticipantServiceTest {
         doReturn(USERS_HEALTH_CODE).when(lookup).getString(EXTERNAL_IDENTIFIER);
         
         // This just succeeds because the IDs are the same, and we'll verify no attempt was made to update it.
-        participantService.updateParticipant(STUDY, CALLER_ROLES, ID, PARTICIPANT);
+        participantService.updateParticipant(STUDY, CALLER_ROLES, PARTICIPANT);
         
         verifyNoMoreInteractions(externalIdService);
     }
@@ -509,7 +509,7 @@ public class ParticipantServiceTest {
         doReturn(lookup).when(optionsService).getOptions(HEALTH_CODE);
         doReturn(null).when(lookup).getString(EXTERNAL_IDENTIFIER);
         
-        participantService.updateParticipant(STUDY, CALLER_ROLES, ID, NO_ID_PARTICIPANT);
+        participantService.updateParticipant(STUDY, CALLER_ROLES, NO_ID_PARTICIPANT);
     }
     
     @Test(expected = InvalidEntityException.class)
@@ -517,16 +517,17 @@ public class ParticipantServiceTest {
         mockHealthCodeAndAccountRetrieval();
         
         StudyParticipant participant = new StudyParticipant.Builder()
+                .withId(ID)
                 .withDataGroups(Sets.newHashSet("bogusGroup"))
                 .build();
-        participantService.updateParticipant(STUDY, CALLER_ROLES, ID, participant);
+        participantService.updateParticipant(STUDY, CALLER_ROLES, participant);
     }
     
     @Test
     public void updateParticipantWithNoAccount() {
         doThrow(new EntityNotFoundException(Account.class)).when(accountDao).getAccount(STUDY, ID);
         try {
-            participantService.updateParticipant(STUDY, CALLER_ROLES, ID, PARTICIPANT);
+            participantService.updateParticipant(STUDY, CALLER_ROLES, PARTICIPANT);
             fail("Should have thrown exception.");
         } catch(EntityNotFoundException e) {
         }
@@ -540,7 +541,7 @@ public class ParticipantServiceTest {
         STUDY.setExternalIdValidationEnabled(false);
         mockHealthCodeAndAccountRetrieval();
         
-        participantService.updateParticipant(STUDY, CALLER_ROLES, ID, PARTICIPANT);
+        participantService.updateParticipant(STUDY, CALLER_ROLES, PARTICIPANT);
         
         verifyNoMoreInteractions(externalIdService);
         verify(optionsService).setAllOptions(eq(STUDY.getStudyIdentifier()), eq(HEALTH_CODE), optionsCaptor.capture());
@@ -752,7 +753,7 @@ public class ParticipantServiceTest {
         StudyParticipant participant = new StudyParticipant.Builder().copyOf(PARTICIPANT)
                 .withStatus(status).build();
         
-        participantService.updateParticipant(STUDY, roles, ID, participant);
+        participantService.updateParticipant(STUDY, roles, participant);
 
         verify(accountDao).updateAccount(accountCaptor.capture());
         Account account = accountCaptor.getValue();
@@ -789,7 +790,7 @@ public class ParticipantServiceTest {
         
         StudyParticipant participant = new StudyParticipant.Builder().copyOf(PARTICIPANT)
                 .withRoles(rolesThatAreSet).build();
-        participantService.updateParticipant(STUDY, callerRoles, ID, participant);
+        participantService.updateParticipant(STUDY, callerRoles, participant);
         
         verify(accountDao).updateAccount(accountCaptor.capture());
         Account account = accountCaptor.getValue();


### PR DESCRIPTION
Changed controllers so the participant objects always have either 1) the user's ID (for the self call) or 2) the ID specified in the URL. Also removed it as a separate parameter from the participant object which already has the ID. Upshot: You can't fool the system by signing in as one person, then editing another person's records.
