### PR TITLE
fix unit tests that modify Spring context (fixing ConsentServiceTest)

### DIFF
--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoExternalIdDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoExternalIdDaoTest.java
@@ -4,15 +4,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.annotation.Resource;
 
+import com.google.common.collect.ImmutableList;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -21,7 +21,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import org.sagebionetworks.bridge.TestUtils;
-import org.sagebionetworks.bridge.config.Config;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
@@ -53,8 +52,6 @@ public class DynamoExternalIdDaoTest {
     @Before
     public void before() {
         studyId = new StudyIdentifierImpl(TestUtils.randomName(DynamoExternalIdDaoTest.class));
-
-        dao.setConfig(makeConfig(10, 30000));
         dao.addExternalIds(studyId, EXT_IDS);
     }
     
@@ -62,35 +59,29 @@ public class DynamoExternalIdDaoTest {
     public void after() {
         dao.deleteExternalIds(studyId, EXT_IDS);
     }
-    
-    private Config makeConfig(int addLimit, int timeout) {
-        Config config = mock(Config.class);
-        when(config.getInt(DynamoExternalIdDao.CONFIG_KEY_ADD_LIMIT)).thenReturn(addLimit);
-        when(config.getInt(DynamoExternalIdDao.CONFIG_KEY_LOCK_DURATION)).thenReturn(timeout);
-        return config;
-    }
-    
+
     @Test(expected = BadRequestException.class)
     public void addCannotExceedLimit() {
-        dao.setConfig(makeConfig(2, 1000));
-        
-        dao.addExternalIds(studyId, EXT_IDS);
+        // Limit is set to 10. Make a list of 11 external IDs.
+        List<String> extIdList = new ArrayList<>();
+        for (int i = 0; i < 11; i++) {
+            extIdList.add(String.valueOf(i));
+        }
+        dao.addExternalIds(studyId, extIdList);
     }
-    
+
     @Test
     public void cannotAddExistingIdentifiers() {
         dao.assignExternalId(studyId, "AAA", "healthCode");
         
         dao.addExternalIds(studyId, EXT_IDS);
         
-        DynamoDBQueryExpression<DynamoExternalIdentifier> query = new DynamoDBQueryExpression<DynamoExternalIdentifier>();
+        DynamoDBQueryExpression<DynamoExternalIdentifier> query = new DynamoDBQueryExpression<>();
         query.withScanIndexForward(false);
         query.withHashKeyValues(new DynamoExternalIdentifier(studyId, null));
         
         PaginatedQueryList<? extends DynamoExternalIdentifier> page = mapper.query(DynamoExternalIdentifier.class, query);
-        Set<String> ids = page.stream().map(item -> {
-            return item.getIdentifier();
-        }).collect(Collectors.toSet());
+        Set<String> ids = page.stream().map(DynamoExternalIdentifier::getIdentifier).collect(Collectors.toSet());
         assertEquals(Sets.newHashSet("AAA","BBB","CCC"), ids);
         
         // Just as importantly, AAA is still assigned to "healthCode"
@@ -110,10 +101,10 @@ public class DynamoExternalIdDaoTest {
     
     @Test
     public void reservationSucceedsAfterLockExpires() throws Exception {
-        dao.setConfig(makeConfig(10, 1000));
-        
         dao.reserveExternalId(studyId, "AAA");
-        Thread.sleep(1000);
+
+        // Timeout is 30 seconds. Sleep for 31 seconds.
+        Thread.sleep(31000);
         dao.reserveExternalId(studyId, "AAA");
     }
     
@@ -240,11 +231,14 @@ public class DynamoExternalIdDaoTest {
     
     @Test
     public void canRetrieveCurrentAndNextPage() {
-        dao.setConfig(makeConfig(23, 2000));
-        List<String> moreIds = Lists.newArrayList("DDD", "EEE", "FFF", "GGG", "HHH", "III", "JJJ", "KKK", "LLL", "MMM",
-                "NNN", "OOO", "PPP", "QQQ", "RRR", "SSS", "TTT", "UUU", "VVV", "WWW", "XXX", "YYY", "ZZZ");
+        // Add more external IDs.
+        List<String> moreIds1 = ImmutableList.of("DDD", "EEE", "FFF", "GGG", "HHH", "III", "JJJ", "KKK", "LLL", "MMM");
+        List<String> moreIds2 = ImmutableList.of("NNN", "OOO", "PPP", "QQQ", "RRR", "SSS", "TTT", "UUU", "VVV", "WWW");
+        List<String> moreIds3 = ImmutableList.of("XXX", "YYY", "ZZZ");
         try {
-            dao.addExternalIds(studyId, moreIds);
+            dao.addExternalIds(studyId, moreIds1);
+            dao.addExternalIds(studyId, moreIds2);
+            dao.addExternalIds(studyId, moreIds3);
 
             PagedResourceList<ExternalIdentifierInfo> page = dao.getExternalIds(studyId, null, 5, null, null);
             assertEquals(5, page.getItems().size());
@@ -263,9 +257,24 @@ public class DynamoExternalIdDaoTest {
                     Sets.newHashSet(page.getItems()));
             assertEquals(26, page.getTotal());
             assertNull(page.getOffsetKey());
-            
         } finally {
-            dao.deleteExternalIds(studyId, moreIds);
+            try {
+                dao.deleteExternalIds(studyId, moreIds1);
+            } catch (Exception ex) {
+                // suppress cleanup exception
+            }
+
+            try {
+                dao.deleteExternalIds(studyId, moreIds2);
+            } catch (Exception ex) {
+                // suppress cleanup exception
+            }
+
+            try {
+                dao.deleteExternalIds(studyId, moreIds3);
+            } catch (Exception ex) {
+                // suppress cleanup exception
+            }
         }
     }
     
@@ -313,16 +322,15 @@ public class DynamoExternalIdDaoTest {
     
     @Test
     public void retrieveUnassignedExcludesReserved() throws Exception {
-        dao.setConfig(makeConfig(10, 1000));
-        
         dao.assignExternalId(studyId, "AAA", "healthCode1");
         dao.reserveExternalId(studyId, "BBB"); // only reserved
         
         PagedResourceList<ExternalIdentifierInfo> page = dao.getExternalIds(studyId, null, 5, null, Boolean.FALSE);
         assertEquals(1, page.getItems().size());
         assertEquals(new ExternalIdentifierInfo("CCC", false), page.getItems().get(0));
-        
-        Thread.sleep(2000);
+
+        // Timeout is 30 seconds. Sleep for 31 seconds.
+        Thread.sleep(31000);
         page = dao.getExternalIds(studyId, null, 5, null, Boolean.FALSE);
         assertEquals(2, page.getItems().size());
         assertTrue(page.getItems().contains(new ExternalIdentifierInfo("BBB", false)));
@@ -331,8 +339,6 @@ public class DynamoExternalIdDaoTest {
     
     @Test
     public void retrieveAssignedIncludesReserved() throws Exception {
-        dao.setConfig(makeConfig(10, 1000));
-        
         dao.assignExternalId(studyId, "AAA", "healthCode");
         dao.reserveExternalId(studyId, "BBB");
         
@@ -342,7 +348,7 @@ public class DynamoExternalIdDaoTest {
         assertTrue(page.getItems().contains(new ExternalIdentifierInfo("BBB", true)));
         
         // Wait until lock is released, item is no longer in results that are considered assigned.
-        Thread.sleep(10000);
+        Thread.sleep(31000);
         page = dao.getExternalIds(studyId, null, 5, null, Boolean.TRUE);
         assertEquals(1, page.getItems().size());
         assertTrue(page.getItems().contains(new ExternalIdentifierInfo("AAA", true)));

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoParticipantOptionsDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoParticipantOptionsDaoMockTest.java
@@ -1,0 +1,28 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.TestConstants;
+
+public class DynamoParticipantOptionsDaoMockTest {
+    @Test
+    public void updateNoOptions() {
+        // mock mapper
+        DynamoDBMapper mockMapper = mock(DynamoDBMapper.class);
+        DynamoParticipantOptionsDao optionsDao = new DynamoParticipantOptionsDao();
+        optionsDao.setDdbMapper(mockMapper);
+
+        // execute
+        optionsDao.setAllOptions(TestConstants.TEST_STUDY, "test-healthcode", ImmutableMap.of());
+
+        // No update done, it didn't change.
+        verify(mockMapper, never()).save(any());
+    }
+}

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoParticipantOptionsDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoParticipantOptionsDaoTest.java
@@ -3,10 +3,6 @@ package org.sagebionetworks.bridge.dynamodb;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 import static org.sagebionetworks.bridge.dao.ParticipantOption.*;
 
@@ -32,7 +28,6 @@ import org.sagebionetworks.bridge.services.StudyService;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
 import org.springframework.test.context.ContextConfiguration;
@@ -182,28 +177,6 @@ public class DynamoParticipantOptionsDaoTest {
         assertEquals("externalId", lookup.getString(EXTERNAL_IDENTIFIER));
         assertEquals(DATA_GROUPS_SET, lookup.getStringSet(DATA_GROUPS));
         assertEquals(LANGUAGES_ORDERED_SET, lookup.getOrderedStringSet(LANGUAGES));
-    }
-    
-    @Test
-    public void updateNoOptions() {
-        optionsDao.setAllOptions(study, healthCode, PARTICIPANT_OPTIONS);
-        
-        mapper = spy(mapper);
-        optionsDao.setDdbMapper(mapper);
-        
-        Map<ParticipantOption,String> options = Maps.newHashMap();
-        optionsDao.setAllOptions(study, healthCode, options);
-        
-        // And the values should be exactly the same, not corrupted by lack of options
-        ParticipantOptionsLookup lookup = optionsDao.getOptions(healthCode);
-        assertEquals(SharingScope.ALL_QUALIFIED_RESEARCHERS, lookup.getEnum(SHARING_SCOPE, SharingScope.class));
-        assertTrue(lookup.getBoolean(EMAIL_NOTIFICATIONS));
-        assertEquals("externalId", lookup.getString(EXTERNAL_IDENTIFIER));
-        assertEquals(DATA_GROUPS_SET, lookup.getStringSet(DATA_GROUPS));
-        assertEquals(LANGUAGES_ORDERED_SET, lookup.getOrderedStringSet(LANGUAGES));
-        
-        // No update done, it didn't change.
-        verify(mapper, never()).save(any());
     }
 
     @Test

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDaoTest.java
@@ -1,8 +1,6 @@
 package org.sagebionetworks.bridge.dynamodb;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.TestConstants.ENROLLMENT;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
@@ -23,7 +21,6 @@ import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.models.ClientInfo;
-import org.sagebionetworks.bridge.models.accounts.UserConsent;
 import org.sagebionetworks.bridge.models.schedules.Activity;
 import org.sagebionetworks.bridge.models.schedules.Schedule;
 import org.sagebionetworks.bridge.models.schedules.ScheduleContext;
@@ -81,10 +78,6 @@ public class DynamoScheduledActivityDaoTest {
         plan = schedulePlanService.createSchedulePlan(study, plan);
 
         healthCode = BridgeUtils.generateGuid();
-        
-        // Mock user consent, we don't care about that, we're just getting an enrollment date from that.
-        UserConsent consent = mock(DynamoUserConsent3.class);
-        when(consent.getSignedOn()).thenReturn(new DateTime().minusDays(2).getMillis()); 
     }
     
     @After

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
@@ -281,11 +281,6 @@ public class AuthenticationServiceTest {
         StudyParticipant participant = new StudyParticipant.Builder()
                 .withEmail(email).withPassword("P@ssword1").withDataGroups(groups).build();
 
-        authService = spy(authService);
-        optionsService = spy(optionsService);
-        authService.setOptionsService(optionsService);
-        accountDao = spy(accountDao);
-        
         IdentifierHolder holder = authService.signUp(study, participant);
         
         Account account = accountDao.getAccount(study, holder.getIdentifier());
@@ -319,12 +314,12 @@ public class AuthenticationServiceTest {
     @Test
     public void secondSignUpTriggersResetPasswordInstead() {
         // Verify that requestResetPassword is called in this case
-        authService = spy(authService);
+        AuthenticationService authServiceSpy = spy(authService);
         
         testUser = helper.getBuilder(AuthenticationServiceTest.class)
                 .withConsent(false).withSignIn(false).build();
-        authService.signUp(testUser.getStudy(), testUser.getStudyParticipant());
-        verify(authService).requestResetPassword(any(Study.class), any(Email.class));
+        authServiceSpy.signUp(testUser.getStudy(), testUser.getStudyParticipant());
+        verify(authServiceSpy).requestResetPassword(any(Study.class), any(Email.class));
     }
     
     @Test
@@ -464,17 +459,20 @@ public class AuthenticationServiceTest {
         AccountDao accountDaoSpy = mock(AccountDao.class);
         when(accountDaoSpy.verifyEmail(study, verification)).thenReturn(accountDao.getAccount(study, testUser.getId()));
         authService.setAccountDao(accountDaoSpy);
-        
-        CriteriaContext context = new CriteriaContext.Builder().withStudyIdentifier(testUser.getStudyIdentifier()).build();
-        
-        UserSession session = authService.verifyEmail(study, context, verification);
-        // Consents are okay. User hasn't consented.
-        ConsentStatus status = session.getConsentStatuses().values().iterator().next();
-        assertFalse(status.isConsented());
-        
-        // This should not have been altered in any way by the lack of consents.
-        verify(accountDaoSpy).verifyEmail(study, verification);
-        authService.setAccountDao(accountDao);
+        try {
+            CriteriaContext context = new CriteriaContext.Builder().withStudyIdentifier(testUser.getStudyIdentifier())
+                    .build();
+
+            UserSession session = authService.verifyEmail(study, context, verification);
+            // Consents are okay. User hasn't consented.
+            ConsentStatus status = session.getConsentStatuses().values().iterator().next();
+            assertFalse(status.isConsented());
+
+            // This should not have been altered in any way by the lack of consents.
+            verify(accountDaoSpy).verifyEmail(study, verification);
+        } finally {
+            authService.setAccountDao(accountDao);
+        }
     }
 
     @Test

--- a/test/org/sagebionetworks/bridge/services/HealthCodeServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/HealthCodeServiceMockTest.java
@@ -1,0 +1,45 @@
+package org.sagebionetworks.bridge.services;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.dao.HealthIdDao;
+import org.sagebionetworks.bridge.models.accounts.HealthId;
+
+public class HealthCodeServiceMockTest {
+    @Test
+    public void invalidHealthIdReturnsNull() {
+        HealthIdDao dao = mock(HealthIdDao.class);
+        HealthCodeService healthCodeService = new HealthCodeService();
+        healthCodeService.setHealthIdDao(dao);
+
+        HealthId healthId = healthCodeService.getMapping(null);
+        assertNull(healthId);
+
+        verifyZeroInteractions(dao);
+    }
+
+    @Test
+    public void invalidHealthIdReturnsNullNotInvalidHealthIdObject() {
+        HealthIdDao dao = mock(HealthIdDao.class);
+        when(dao.getCode("123")).thenReturn("abc");
+        when(dao.getCode("456")).thenReturn(null);
+
+        HealthCodeService healthCodeService = new HealthCodeService();
+        healthCodeService.setHealthIdDao(dao);
+
+        // valid
+        HealthId id1 = healthCodeService.getMapping("123");
+        assertEquals("123", id1.getId());
+        assertEquals("abc", id1.getCode());
+
+        // invalid... should return no object at all.
+        HealthId id2 = healthCodeService.getMapping("456");
+        assertNull(id2);
+    }
+}

--- a/test/org/sagebionetworks/bridge/services/HealthCodeServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/HealthCodeServiceTest.java
@@ -3,22 +3,12 @@ package org.sagebionetworks.bridge.services;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 
 import javax.annotation.Resource;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.sagebionetworks.bridge.dao.HealthIdDao;
-import org.sagebionetworks.bridge.dynamodb.DynamoHealthCode;
-import org.sagebionetworks.bridge.dynamodb.DynamoHealthId;
-import org.sagebionetworks.bridge.dynamodb.DynamoTestUtil;
 import org.sagebionetworks.bridge.models.accounts.HealthId;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.springframework.test.context.ContextConfiguration;
@@ -34,16 +24,6 @@ public class HealthCodeServiceTest {
     @Resource
     private HealthCodeService healthCodeService;
 
-    @Before
-    public void before() {
-        clearDynamo();
-    }
-
-    @After
-    public void after() {
-        clearDynamo();
-    }
-
     @Test
     public void createAndRetrieveHealthId() {
         Study study = studyService.getStudy(TEST_STUDY_IDENTIFIER);
@@ -53,42 +33,5 @@ public class HealthCodeServiceTest {
         HealthId healthId2 = healthCodeService.createMapping(study);
         assertFalse(mapping.getId().equals(healthId2.getId()));
         assertFalse(mapping.getCode().equals(healthId2.getCode()));
-    }
-    
-    @Test
-    public void invalidHealthIdReturnsNull() {
-        HealthIdDao dao = mock(HealthIdDao.class);
-        HealthCodeService healthCodeService = new HealthCodeService();
-        healthCodeService.setHealthIdDao(dao);
-
-        HealthId healthId = healthCodeService.getMapping(null);
-        assertNull(healthId);
-        
-        verifyZeroInteractions(dao);
-    }
-    
-    @Test
-    public void invalidHealthIdReturnsNullNotInvalidHealthIdObject() {
-        HealthIdDao dao = mock(HealthIdDao.class);
-        when(dao.getCode("123")).thenReturn("abc");
-        when(dao.getCode("456")).thenReturn(null);
-        
-        HealthCodeService healthCodeService = new HealthCodeService();
-        healthCodeService.setHealthIdDao(dao);
-        
-        // valid
-        HealthId id1 = healthCodeService.getMapping("123");
-        assertEquals("123", id1.getId());
-        assertEquals("abc", id1.getCode());
-        
-        // invalid... should return no object at all.
-        HealthId id2 = healthCodeService.getMapping("456");
-        assertNull(id2);
-        
-    }
-    
-    private void clearDynamo() {
-        DynamoTestUtil.clearTable(DynamoHealthCode.class);
-        DynamoTestUtil.clearTable(DynamoHealthId.class);
     }
 }

--- a/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoMultipleSubpopulationsTest.java
+++ b/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoMultipleSubpopulationsTest.java
@@ -1,0 +1,109 @@
+package org.sagebionetworks.bridge.stormpath;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import javax.annotation.Resource;
+
+import org.joda.time.DateTime;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import org.sagebionetworks.bridge.TestUtils;
+import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
+import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
+import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
+import org.sagebionetworks.bridge.services.StudyService;
+import org.sagebionetworks.bridge.services.SubpopulationService;
+
+@ContextConfiguration("classpath:test-context.xml")
+@RunWith(SpringJUnit4ClassRunner.class)
+public class StormpathAccountDaoMultipleSubpopulationsTest {
+    private static final String PASSWORD = "P4ssword!";
+
+    @Resource(name="stormpathAccountDao")
+    private StormpathAccountDao accountDao;
+
+    @Autowired
+    private StudyService studyService;
+
+    @Autowired
+    private SubpopulationService subpopService;
+
+    private Study study;
+
+    @Before
+    public void before() {
+        Study studyToCreate = TestUtils.getValidStudy(StormpathAccountDaoMultipleSubpopulationsTest.class);
+        study = studyService.createStudy(studyToCreate);
+    }
+
+    @After
+    public void after() {
+        if (study != null) {
+            studyService.deleteStudy(study.getIdentifier());
+        }
+    }
+
+    @Test
+    public void canSetAndRetrieveConsentsForMultipleSubpopulations() {
+        // Create a second subpop for the purpose of this test.
+        Subpopulation subpopToCreate = Subpopulation.create();
+        subpopToCreate.setName("subpop 2");
+        subpopService.createSubpopulation(study, subpopToCreate);
+
+        // Get the subpops back. There should be exactly 2 subpops (one default, one we just created).
+        List<Subpopulation> subpopList = subpopService.getSubpopulations(study);
+        assertEquals(2, subpopList.size());
+        Subpopulation subpop1 = subpopList.get(0);
+        Subpopulation subpop2 = subpopList.get(1);
+
+        ConsentSignature sig1 = new ConsentSignature.Builder()
+                .withName("Name 1")
+                .withBirthdate("2000-10-10")
+                .withSignedOn(DateTime.now().getMillis())
+                .build();
+
+        ConsentSignature sig2 = new ConsentSignature.Builder()
+                .withName("Name 2")
+                .withBirthdate("2000-02-02")
+                .withSignedOn(DateTime.now().getMillis())
+                .build();
+
+        String email = TestUtils.makeRandomTestEmail(StormpathAccountDaoTest.class);
+        StudyParticipant participant = new StudyParticipant.Builder().withEmail(email).withPassword(PASSWORD).build();
+        Account account = null;
+        try {
+            account = accountDao.constructAccount(study, participant.getEmail(), participant.getPassword());
+            accountDao.createAccount(study, account, false);
+
+            account.getConsentSignatureHistory(subpop1.getGuid()).add(sig1);
+            account.getConsentSignatureHistory(subpop2.getGuid()).add(sig2);
+            accountDao.updateAccount(account);
+
+            account = accountDao.getAccount(study, account.getId());
+
+            List<ConsentSignature> history1 = account.getConsentSignatureHistory(subpop1.getGuid());
+            assertEquals(1, history1.size());
+            assertEquals(sig1, history1.get(0));
+            assertEquals(sig1, account.getActiveConsentSignature(subpop1.getGuid()));
+
+            List<ConsentSignature> history2 = account.getConsentSignatureHistory(subpop2.getGuid());
+            assertEquals(1, history2.size());
+            assertEquals(sig2, history2.get(0));
+            assertEquals(sig2, account.getActiveConsentSignature(subpop2.getGuid()));
+        } finally {
+            if (account != null) {
+                accountDao.deleteAccount(study, account.getId());
+            }
+        }
+    }
+}

--- a/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoTest.java
+++ b/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoTest.java
@@ -6,8 +6,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.TEST_USERS;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
@@ -19,7 +17,6 @@ import java.util.List;
 import javax.annotation.Resource;
 
 import org.apache.commons.lang3.RandomStringUtils;
-import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -310,62 +307,7 @@ public class StormpathAccountDaoTest {
             }
         }
     }
-    
-    @Test
-    public void canSetAndRetrieveConsentsForMultipleSubpopulations() {
-        // Need to mock out the retrieval of these two subpopulations for the purpose
-        // of this test
-        Subpopulation subpop1 = Subpopulation.create();
-        subpop1.setGuidString("test1");
-        Subpopulation subpop2 = Subpopulation.create();
-        subpop2.setGuidString("test2");
-        
-        SubpopulationService mockSubpopService = mock(SubpopulationService.class);
-        when(mockSubpopService.getSubpopulations(study)).thenReturn(Lists.newArrayList(subpop1, subpop2));
-        accountDao.setSubpopulationService(mockSubpopService);
-        
-        ConsentSignature sig1 = new ConsentSignature.Builder()
-                .withName("Name 1")
-                .withBirthdate("2000-10-10")
-                .withSignedOn(DateTime.now().getMillis())
-                .build();
-        
-        ConsentSignature sig2 = new ConsentSignature.Builder()
-                .withName("Name 2")
-                .withBirthdate("2000-02-02")
-                .withSignedOn(DateTime.now().getMillis())
-                .build();
 
-        String email = TestUtils.makeRandomTestEmail(StormpathAccountDaoTest.class);
-        StudyParticipant participant = new StudyParticipant.Builder().withEmail(email).withPassword(PASSWORD).build();
-        Account account = null;
-        try {
-            account = accountDao.constructAccount(study, participant.getEmail(), participant.getPassword());
-            accountDao.createAccount(study, account, false);
-            
-            account.getConsentSignatureHistory(subpop1.getGuid()).add(sig1);
-            account.getConsentSignatureHistory(subpop2.getGuid()).add(sig2);
-            accountDao.updateAccount(account);
-            
-            account = accountDao.getAccount(study, account.getId());
-            
-            List<ConsentSignature> history1 = account.getConsentSignatureHistory(subpop1.getGuid());
-            assertEquals(1, history1.size());
-            assertEquals(sig1, history1.get(0));
-            assertEquals(sig1, account.getActiveConsentSignature(subpop1.getGuid()));
-            
-            List<ConsentSignature> history2 = account.getConsentSignatureHistory(subpop2.getGuid());
-            assertEquals(1, history2.size());
-            assertEquals(sig2, history2.get(0));
-            assertEquals(sig2, account.getActiveConsentSignature(subpop2.getGuid()));
-
-        } finally {
-            if (account != null) {
-                accountDao.deleteAccount(study, account.getId());    
-            }
-        }
-    }
-    
     private void assertEqual(long signedOn, Account account, Account newAccount) {
         assertNotNull(newAccount.getEmail());
         assertNull(newAccount.getFirstName());


### PR DESCRIPTION
See https://sagebionetworks.jira.com/browse/BRIDGE-1341

ConsentServiceTest has been failing because a previous test modified the Spring context, causing ConsentServiceTest to do unusual things. This fixes the offending test (StormpathAccountDaoTest) and other similar problems as well.

Testing done:
- ran all modified unit tests, including ConsentServiceTest (listed last)
