### PR TITLE
Introducing filters to serialize StudyParticipant

### DIFF
--- a/app/org/sagebionetworks/bridge/cache/CacheProvider.java
+++ b/app/org/sagebionetworks/bridge/cache/CacheProvider.java
@@ -61,7 +61,7 @@ public class CacheProvider {
         final String userKey = RedisKey.USER_SESSION.getRedisKey(userId);
         final String sessionKey = RedisKey.SESSION.getRedisKey(sessionToken);
         try (JedisTransaction transaction = jedisOps.getTransaction()) {
-            final String ser = bridgeObjectMapper.writeValueAsString(session);
+            final String ser = StudyParticipant.CACHE_WRITER.writeValueAsString(session);
             final List<Object> results = transaction
                     .setex(userKey, BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS, sessionToken)
                     .setex(sessionKey, BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS, ser)

--- a/app/org/sagebionetworks/bridge/models/accounts/UserSessionInfo.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/UserSessionInfo.java
@@ -23,6 +23,7 @@ public class UserSessionInfo {
     
     private static final String CONSENT_HISTORIES = "consentHistories";
     private static final String ENCRYPTED_HEALTH_CODE = "encryptedHealthCode";
+    private static final String HEALTH_CODE = "healthCode";
     private static final String CONSENT_STATUSES = "consentStatuses";
     private static final String CONSENTED = "consented";
     private static final String SIGNED_MOST_RECENT_CONSENT = "signedMostRecentConsent";
@@ -40,7 +41,7 @@ public class UserSessionInfo {
     private static final String LOCAL = "local";
     
     private static final BridgeObjectMapper MAPPER = BridgeObjectMapper.get();
-    private static final Set<String> PROHIBITED_FIELD_NAMES = Sets.newHashSet(TYPE, ENCRYPTED_HEALTH_CODE, CONSENT_HISTORIES);
+    private static final Set<String> PROHIBITED_FIELD_NAMES = Sets.newHashSet(TYPE, HEALTH_CODE, ENCRYPTED_HEALTH_CODE, CONSENT_HISTORIES);
     private static final Map<Environment,String> ENVIRONMENTS = new ImmutableMap.Builder<Environment,String>()
             .put(Environment.LOCAL, LOCAL)
             .put(Environment.DEV, DEVELOP)

--- a/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
@@ -13,6 +13,7 @@ import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 
+import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.PagedResourceList;
@@ -25,6 +26,7 @@ import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.services.ParticipantService;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.common.collect.Sets;
 
 import play.mvc.Result;
@@ -39,16 +41,15 @@ public class ParticipantController extends BaseController {
         this.participantService = participantService;
     }
     
-    public Result getSelfParticipant() {
+    public Result getSelfParticipant() throws Exception {
         UserSession session = getAuthenticatedSession();
         Study study = studyService.getStudy(session.getStudyIdentifier());
         
         StudyParticipant participant = participantService.getParticipant(study, session.getId(), false);
         
-        // Do not return healthCode. This will shortly be handled with Jackson filters.
-        StudyParticipant updated = new StudyParticipant.Builder().copyOf(participant)
-                .withHealthCode(null).withEncryptedHealthCode(null).build();
-        return okResult(updated);
+        String ser = StudyParticipant.API_NO_HEALTH_CODE_WRITER.writeValueAsString(participant);
+        
+        return ok(ser).as(BridgeConstants.JSON_MIME_TYPE);
     }
     
     public Result updateSelfParticipant() throws Exception {
@@ -97,7 +98,7 @@ public class ParticipantController extends BaseController {
         return createdResult(holder);
     }
     
-    public Result getParticipant(String userId) {
+    public Result getParticipant(String userId) throws Exception {
         UserSession session = getAuthenticatedSession(RESEARCHER);
         Study study = studyService.getStudy(session.getStudyIdentifier());
         
@@ -107,7 +108,13 @@ public class ParticipantController extends BaseController {
         // to introduce Jackson filters.
         StudyParticipant updated = new StudyParticipant.Builder().copyOf(participant)
                 .withHealthCode(null).withEncryptedHealthCode(null).build();
-        return okResult(updated);
+        
+        ObjectWriter writer = (study.isHealthCodeExportEnabled()) ?
+                StudyParticipant.API_WITH_HEALTH_CODE_WRITER :
+                StudyParticipant.API_NO_HEALTH_CODE_WRITER;
+        String ser = writer.writeValueAsString(updated);
+        
+        return ok(ser).as(BridgeConstants.JSON_MIME_TYPE);
     }
     
     public Result updateParticipant(String userId) {

--- a/test/org/sagebionetworks/bridge/TestConstants.java
+++ b/test/org/sagebionetworks/bridge/TestConstants.java
@@ -10,6 +10,10 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 
 public class TestConstants {
+    
+    public static final String ENCRYPTED_HEALTH_CODE = "TFMkaVFKPD48WissX0bgcD3esBMEshxb3MVgKxHnkXLSEPN4FQMKc01tDbBAVcXx94kMX6ckXVYUZ8wx4iICl08uE+oQr9gorE1hlgAyLAM=";
+    public static final String UNENCRYPTED_HEALTH_CODE = "5a2192ee-f55d-4d01-a385-2d19f15a0880";
+    
     public static final String DUMMY_IMAGE_DATA = "VGhpcyBpc24ndCBhIHJlYWwgaW1hZ2Uu";
 
     public static final String TEST_STUDY_IDENTIFIER = "api";

--- a/test/org/sagebionetworks/bridge/models/accounts/UserSessionTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/UserSessionTest.java
@@ -20,7 +20,6 @@ import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -52,8 +51,8 @@ public class UserSessionTest {
         session.setStudyIdentifier(new StudyIdentifierImpl("study-key"));
         session.setConsentStatuses(statuses);
         
-        String json = new ObjectMapper().writeValueAsString(session);
-        UserSession newSession = new ObjectMapper().readValue(json, UserSession.class);
+        String json = StudyParticipant.CACHE_WRITER.writeValueAsString(session);
+        UserSession newSession = BridgeObjectMapper.get().readValue(json, UserSession.class);
 
         assertEquals(session.getSessionToken(), newSession.getSessionToken());
         assertEquals(session.getInternalSessionToken(), newSession.getInternalSessionToken());
@@ -67,7 +66,7 @@ public class UserSessionTest {
     public void doesNotExposeHealthCodeInRedisSerialization() throws Exception {
         UserSession session = new UserSession(new StudyParticipant.Builder().withHealthCode("123abc").build());
         
-        String json = BridgeObjectMapper.get().writeValueAsString(session);
+        String json = StudyParticipant.CACHE_WRITER.writeValueAsString(session);
         assertFalse(json.contains("123abc"));
     }
     
@@ -77,7 +76,7 @@ public class UserSessionTest {
                 .withEmail("userEmail")
                 .withId("userId")
                 .withHealthCode("123abc").build());
-        String sessionSer = BridgeObjectMapper.get().writeValueAsString(session);
+        String sessionSer = StudyParticipant.CACHE_WRITER.writeValueAsString(session);
         assertNotNull(sessionSer);
         assertFalse("Health code should have been encrypted in the serialized string.",
                 sessionSer.toLowerCase().contains("123abc"));

--- a/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
@@ -31,7 +31,7 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 
-
+import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
@@ -63,8 +63,6 @@ import play.test.Helpers;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ParticipantControllerTest {
-
-    private static final String ENCRYPTED_HEALTH_CODE = "TFMkaVFKPD48WissX0bgcD3esBMEshxb3MVgKxHnkXLSEPN4FQMKc01tDbBAVcXx94kMX6ckXVYUZ8wx4iICl08uE+oQr9gorE1hlgAyLAM=";
     
     private static final Set<Roles> CALLER_ROLES = Sets.newHashSet(Roles.RESEARCHER);
     
@@ -169,11 +167,12 @@ public class ParticipantControllerTest {
     public void getParticipant() throws Exception {
         study.setHealthCodeExportEnabled(true);
         StudyParticipant studyParticipant = new StudyParticipant.Builder().withFirstName("Test")
-                .withEncryptedHealthCode(ENCRYPTED_HEALTH_CODE).build();
+                .withEncryptedHealthCode(TestConstants.ENCRYPTED_HEALTH_CODE).build();
         
         when(participantService.getParticipant(study, ID, true)).thenReturn(studyParticipant);
         
         Result result = controller.getParticipant(ID);
+        assertEquals(result.contentType(), "application/json");
         String json = Helpers.contentAsString(result);
         StudyParticipant retrievedParticipant = BridgeObjectMapper.get().readValue(json, StudyParticipant.class);
         
@@ -291,12 +290,13 @@ public class ParticipantControllerTest {
     @Test
     public void getSelfParticipant() throws Exception {
         StudyParticipant studyParticipant = new StudyParticipant.Builder()
-                .withEncryptedHealthCode(ENCRYPTED_HEALTH_CODE)
+                .withEncryptedHealthCode(TestConstants.ENCRYPTED_HEALTH_CODE)
                 .withFirstName("Test").build();
         
         when(participantService.getParticipant(study, ID, false)).thenReturn(studyParticipant);
 
         Result result = controller.getSelfParticipant();
+        assertEquals("application/json", result.contentType());
         
         verify(participantService).getParticipant(study, ID, false);
         

--- a/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
@@ -31,7 +31,6 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
@@ -2,7 +2,6 @@ package org.sagebionetworks.bridge.services;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;


### PR DESCRIPTION
With the correct healthCode and/or encryptedHealthCode based on where it is going -- into the cache or returned via the API.
