### PR TITLE
Prevent user from updating another user's StudyParticipant

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
@@ -65,8 +65,9 @@ public class ParticipantController extends BaseController {
         StudyParticipant existing = participantService.getParticipant(study, session.getId(), false);
         StudyParticipant updated = new StudyParticipant.Builder()
                 .copyOf(existing)
-                .copyFieldsOf(participant, fieldNames).build();
-        participantService.updateParticipant(study, NO_CALLER_ROLES, session.getId(), updated);
+                .copyFieldsOf(participant, fieldNames)
+                .withId(session.getId()).build();
+        participantService.updateParticipant(study, NO_CALLER_ROLES, updated);
         
         CriteriaContext context = getCriteriaContext(session);
         session = authenticationService.updateSession(study, context, session.getId());
@@ -115,11 +116,11 @@ public class ParticipantController extends BaseController {
         Study study = studyService.getStudy(session.getStudyIdentifier());
 
         StudyParticipant participant = parseJson(request(), StudyParticipant.class);
-        // Just stop right here because something is wrong
-        if (participant.getId() != null && !userId.equals(participant.getId())) {
-            throw new BadRequestException("ID in JSON does not match email in URL.");
-        }
-        participantService.updateParticipant(study, session.getParticipant().getRoles(), userId, participant);
+        
+        participant = new StudyParticipant.Builder()
+                .copyOf(participant)
+                .withId(userId).build();
+        participantService.updateParticipant(study, session.getParticipant().getRoles(), participant);
 
         return okResult("Participant updated.");
     }

--- a/app/org/sagebionetworks/bridge/play/controllers/UserProfileController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/UserProfileController.java
@@ -112,8 +112,9 @@ public class UserProfileController extends BaseController {
         StudyParticipant updated = new StudyParticipant.Builder().copyOf(participant)
                 .withFirstName(JsonUtils.asText(node, "firstName"))
                 .withLastName(JsonUtils.asText(node, "lastName"))
-                .withAttributes(attributes).build();
-        participantService.updateParticipant(study, NO_CALLER_ROLES, userId, updated);
+                .withAttributes(attributes)
+                .withId(userId).build();
+        participantService.updateParticipant(study, NO_CALLER_ROLES, updated);
         
         session.setParticipant(updated);
         updateSession(session);
@@ -160,9 +161,10 @@ public class UserProfileController extends BaseController {
         StudyParticipant dataGroups = parseJson(request(), StudyParticipant.class);
         
         StudyParticipant updated = new StudyParticipant.Builder().copyOf(participant)
-                .copyFieldsOf(dataGroups, DATA_GROUPS_SET).build();
+                .copyFieldsOf(dataGroups, DATA_GROUPS_SET)
+                .withId(session.getId()).build();
         
-        participantService.updateParticipant(study, NO_CALLER_ROLES, session.getId(), updated);
+        participantService.updateParticipant(study, NO_CALLER_ROLES, updated);
         
         session.setParticipant(updated);
         

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -161,18 +161,17 @@ public class ParticipantService {
      */
     public IdentifierHolder createParticipant(Study study, Set<Roles> callerRoles, StudyParticipant participant,
             boolean sendVerifyEmail) {
-        return saveParticipant(study, callerRoles, null, participant, true, sendVerifyEmail);
+        return saveParticipant(study, callerRoles, participant, true, sendVerifyEmail);
     }
     
-    public void updateParticipant(Study study, Set<Roles> callerRoles, String id, StudyParticipant participant) {
-        saveParticipant(study, callerRoles, id, participant, false, false);
+    public void updateParticipant(Study study, Set<Roles> callerRoles, StudyParticipant participant) {
+        saveParticipant(study, callerRoles, participant, false, false);
     }
 
-    private IdentifierHolder saveParticipant(Study study, Set<Roles> callerRoles, String id,
-            StudyParticipant participant, boolean isNew, boolean sendVerifyEmail) {
+    private IdentifierHolder saveParticipant(Study study, Set<Roles> callerRoles, StudyParticipant participant,
+            boolean isNew, boolean sendVerifyEmail) {
         checkNotNull(study);
         checkNotNull(callerRoles);
-        checkArgument(isNew || isNotBlank(id));
         checkNotNull(participant);
         
         Validate.entityThrowingException(new StudyParticipantValidator(study, isNew), participant);
@@ -185,7 +184,7 @@ public class ParticipantService {
             }
             account = accountDao.constructAccount(study, participant.getEmail(), participant.getPassword());
         } else {
-            account = getAccountThrowingException(study, id);
+            account = getAccountThrowingException(study, participant.getId());
             
             addValidatedExternalId(study, participant, account.getHealthCode());
         }

--- a/app/org/sagebionetworks/bridge/validators/StudyParticipantValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/StudyParticipantValidator.java
@@ -38,6 +38,10 @@ public class StudyParticipantValidator implements Validator {
             } else if (!emailValidator.isValid(participant.getEmail())){
                 errors.rejectValue("email", "must be a valid email address");
             }
+        } else {
+            if (StringUtils.isBlank(participant.getId())) {
+                errors.rejectValue("id", "is required");
+            }
         }
         if (study.isExternalIdValidationEnabled() && isNew) {
             if (StringUtils.isBlank(participant.getExternalId())) {

--- a/test/org/sagebionetworks/bridge/TestConstants.java
+++ b/test/org/sagebionetworks/bridge/TestConstants.java
@@ -10,6 +10,8 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 
 public class TestConstants {
+    public static final String ENCRYPTED_HEALTH_CODE = "TFMkaVFKPD48WissX0bgcD3esBMEshxb3MVgKxHnkXLSEPN4FQMKc01tDbBAVcXx94kMX6ckXVYUZ8wx4iICl08uE+oQr9gorE1hlgAyLAM=";
+    
     public static final String DUMMY_IMAGE_DATA = "VGhpcyBpc24ndCBhIHJlYWwgaW1hZ2Uu";
 
     public static final String TEST_STUDY_IDENTIFIER = "api";

--- a/test/org/sagebionetworks/bridge/models/accounts/UserSessionInfoTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/UserSessionInfoTest.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 import org.junit.Test;
 
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.config.Environment;
 import org.sagebionetworks.bridge.dao.ParticipantOption.SharingScope;
@@ -24,7 +25,7 @@ public class UserSessionInfoTest {
                 .withEmail("test@test.com")
                 .withFirstName("first name")
                 .withLastName("last name")
-                .withHealthCode("healthCode")
+                .withEncryptedHealthCode(TestConstants.ENCRYPTED_HEALTH_CODE)
                 .withId("user-identifier")
                 .withRoles(Sets.newHashSet(RESEARCHER))
                 .withSharingScope(SharingScope.ALL_QUALIFIED_RESEARCHERS)

--- a/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
@@ -64,8 +64,6 @@ import play.test.Helpers;
 @RunWith(MockitoJUnitRunner.class)
 public class ParticipantControllerTest {
 
-    private static final String ENCRYPTED_HEALTH_CODE = "TFMkaVFKPD48WissX0bgcD3esBMEshxb3MVgKxHnkXLSEPN4FQMKc01tDbBAVcXx94kMX6ckXVYUZ8wx4iICl08uE+oQr9gorE1hlgAyLAM=";
-    
     private static final Set<Roles> CALLER_ROLES = Sets.newHashSet(Roles.RESEARCHER);
     
     private static final String ID = "ASDF";
@@ -169,7 +167,7 @@ public class ParticipantControllerTest {
     public void getParticipant() throws Exception {
         study.setHealthCodeExportEnabled(true);
         StudyParticipant studyParticipant = new StudyParticipant.Builder().withFirstName("Test")
-                .withEncryptedHealthCode(ENCRYPTED_HEALTH_CODE).build();
+                .withEncryptedHealthCode(TestConstants.ENCRYPTED_HEALTH_CODE).build();
         
         when(participantService.getParticipant(study, ID, true)).thenReturn(studyParticipant);
         
@@ -220,9 +218,10 @@ public class ParticipantControllerTest {
         Result result = controller.updateParticipant(ID);
         assertResult(result, 200, "Participant updated.");
         
-        verify(participantService).updateParticipant(eq(study), eq(CALLER_ROLES), eq(ID), participantCaptor.capture());
+        verify(participantService).updateParticipant(eq(study), eq(CALLER_ROLES), participantCaptor.capture());
         
         StudyParticipant participant = participantCaptor.getValue();
+        assertEquals(ID, participant.getId());
         assertEquals("firstName", participant.getFirstName());
         assertEquals("lastName", participant.getLastName());
         assertEquals(EMAIL, participant.getEmail());
@@ -281,17 +280,22 @@ public class ParticipantControllerTest {
         assertEquals(Sets.newHashSet("en","fr"), participant.getLanguages());
     }
 
-    @Test(expected = BadRequestException.class)
-    public void updateParticipantRequiresIdMatch() throws Exception {
+    @Test
+    public void updateParticipantWithMismatchedIdsUsesURL() throws Exception {
         mockPlayContextWithJson(createJson("{'id':'id2'}"));
         
         controller.updateParticipant("id1");
+        
+        verify(participantService).updateParticipant(eq(study), eq(CALLER_ROLES), participantCaptor.capture());
+        
+        StudyParticipant persisted = participantCaptor.getValue();
+        assertEquals("id1", persisted.getId());
     }
     
     @Test
     public void getSelfParticipant() throws Exception {
         StudyParticipant studyParticipant = new StudyParticipant.Builder()
-                .withEncryptedHealthCode(ENCRYPTED_HEALTH_CODE)
+                .withEncryptedHealthCode(TestConstants.ENCRYPTED_HEALTH_CODE)
                 .withFirstName("Test").build();
         
         when(participantService.getParticipant(study, ID, false)).thenReturn(studyParticipant);
@@ -338,10 +342,11 @@ public class ParticipantControllerTest {
         // verify the object is passed to service, one field is sufficient
         verify(cacheProvider).setUserSession(any());
         verify(authService).updateSession(eq(study), any(), eq(ID));
-        verify(participantService).updateParticipant(eq(study), eq(NO_CALLER_ROLES), eq(ID), participantCaptor.capture());
+        verify(participantService).updateParticipant(eq(study), eq(NO_CALLER_ROLES), participantCaptor.capture());
 
         // Just test the different types and verify they are there.
         StudyParticipant captured = participantCaptor.getValue();
+        assertEquals(ID, captured.getId());
         assertEquals("FirstName", captured.getFirstName());
         assertEquals(SharingScope.ALL_QUALIFIED_RESEARCHERS, captured.getSharingScope());
         assertTrue(captured.isNotifyByEmail());
@@ -386,12 +391,12 @@ public class ParticipantControllerTest {
         assertEquals("UserSessionInfo", node.get("type").asText());
 
         verify(authService).updateSession(eq(study), any(), eq(ID));
-        verify(participantService).updateParticipant(eq(study), eq(NO_CALLER_ROLES), eq(ID), participantCaptor.capture());
+        verify(participantService).updateParticipant(eq(study), eq(NO_CALLER_ROLES), participantCaptor.capture());
         StudyParticipant captured = participantCaptor.getValue();
+        assertEquals(ID, captured.getId());
         assertEquals("firstName", captured.getFirstName());
         assertEquals("lastName", captured.getLastName());
         assertEquals("email@email.com", captured.getEmail());
-        assertEquals("id", captured.getId());
         assertEquals("password", captured.getPassword());
         assertEquals(SharingScope.NO_SHARING, captured.getSharingScope());
         assertFalse(captured.isNotifyByEmail());
@@ -402,6 +407,33 @@ public class ParticipantControllerTest {
         assertEquals(Sets.newHashSet("fr"), captured.getLanguages());
         assertEquals("simpleStringChange", captured.getExternalId());
     }
+    
+    @Test
+    public void updateSelfCallCannotChangeIdToSomeoneElse() throws Exception {
+        // All values should be copied over here.
+        StudyParticipant participant = TestUtils.getStudyParticipant(ParticipantControllerTest.class);
+        participant = new StudyParticipant.Builder().copyOf(participant).withId(ID).build();
+        doReturn(participant).when(participantService).getParticipant(study, ID, false);
+        
+        // Now change to some other ID
+        participant = new StudyParticipant.Builder().copyOf(participant).withId("someOtherId").build();
+        String json = BridgeObjectMapper.get().writeValueAsString(participant);
+        TestUtils.mockPlayContextWithJson(json);
+
+        Result result = controller.updateSelfParticipant();
+        JsonNode node = BridgeObjectMapper.get().readTree(Helpers.contentAsString(result));
+        assertEquals(200, result.status());
+        assertEquals("UserSessionInfo", node.get("type").asText());
+        
+        verify(controller).updateSession(session);
+        
+        // verify the object is passed to service, one field is sufficient
+        verify(participantService).updateParticipant(eq(study), eq(NO_CALLER_ROLES), participantCaptor.capture());
+
+        // The ID was changed back to the session's participant user ID, not the one provided.
+        StudyParticipant captured = participantCaptor.getValue();
+        assertEquals(ID, captured.getId());
+    } 
     
     private PagedResourceList<AccountSummary> resultToPage(Result result) throws Exception {
         String string = Helpers.contentAsString(result);

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
@@ -2,7 +2,6 @@ package org.sagebionetworks.bridge.services;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -484,8 +483,9 @@ public class AuthenticationServiceTest {
         
         // Update the data groups
         StudyParticipant participant = participantService.getParticipant(study, userId, false);
-        StudyParticipant updated = new StudyParticipant.Builder().copyOf(participant).withDataGroups(UPDATED_DATA_GROUPS).build();
-        participantService.updateParticipant(study, CALLER_ROLES, userId, updated);
+        StudyParticipant updated = new StudyParticipant.Builder().copyOf(participant)
+                .withDataGroups(UPDATED_DATA_GROUPS).withId(userId).build();
+        participantService.updateParticipant(study, CALLER_ROLES, updated);
         
         // Now update the session, these changes should be reflected
         CriteriaContext context = new CriteriaContext.Builder().withStudyIdentifier(study.getStudyIdentifier()).build();

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -440,7 +440,7 @@ public class ParticipantServiceTest {
         doReturn(lookup).when(optionsService).getOptions(HEALTH_CODE);
         doReturn(null).when(lookup).getString(EXTERNAL_IDENTIFIER);
         
-        participantService.updateParticipant(STUDY, CALLER_ROLES, ID, PARTICIPANT);
+        participantService.updateParticipant(STUDY, CALLER_ROLES, PARTICIPANT);
         
         verify(optionsService).setAllOptions(eq(STUDY.getStudyIdentifier()), eq(HEALTH_CODE), optionsCaptor.capture());
         Map<ParticipantOption, String> options = optionsCaptor.getValue();
@@ -468,7 +468,7 @@ public class ParticipantServiceTest {
         doReturn(lookup).when(optionsService).getOptions(HEALTH_CODE);
         doReturn("BBB").when(lookup).getString(EXTERNAL_IDENTIFIER);
         
-        participantService.updateParticipant(STUDY, CALLER_ROLES, ID, PARTICIPANT);
+        participantService.updateParticipant(STUDY, CALLER_ROLES, PARTICIPANT);
     }
 
     @Test(expected = BadRequestException.class)
@@ -479,7 +479,7 @@ public class ParticipantServiceTest {
         doReturn(lookup).when(optionsService).getOptions(HEALTH_CODE);
         doReturn("BBB").when(lookup).getString(EXTERNAL_IDENTIFIER);
         
-        participantService.updateParticipant(STUDY, CALLER_ROLES, ID, NO_ID_PARTICIPANT);
+        participantService.updateParticipant(STUDY, CALLER_ROLES, NO_ID_PARTICIPANT);
     }
     
     @Test
@@ -491,7 +491,7 @@ public class ParticipantServiceTest {
         doReturn(USERS_HEALTH_CODE).when(lookup).getString(EXTERNAL_IDENTIFIER);
         
         // This just succeeds because the IDs are the same, and we'll verify no attempt was made to update it.
-        participantService.updateParticipant(STUDY, CALLER_ROLES, ID, PARTICIPANT);
+        participantService.updateParticipant(STUDY, CALLER_ROLES, PARTICIPANT);
         
         verifyNoMoreInteractions(externalIdService);
     }
@@ -504,7 +504,7 @@ public class ParticipantServiceTest {
         doReturn(lookup).when(optionsService).getOptions(HEALTH_CODE);
         doReturn(null).when(lookup).getString(EXTERNAL_IDENTIFIER);
         
-        participantService.updateParticipant(STUDY, CALLER_ROLES, ID, NO_ID_PARTICIPANT);
+        participantService.updateParticipant(STUDY, CALLER_ROLES, NO_ID_PARTICIPANT);
     }
     
     @Test(expected = InvalidEntityException.class)
@@ -514,14 +514,14 @@ public class ParticipantServiceTest {
         StudyParticipant participant = new StudyParticipant.Builder()
                 .withDataGroups(Sets.newHashSet("bogusGroup"))
                 .build();
-        participantService.updateParticipant(STUDY, CALLER_ROLES, ID, participant);
+        participantService.updateParticipant(STUDY, CALLER_ROLES, participant);
     }
     
     @Test
     public void updateParticipantWithNoAccount() {
         doThrow(new EntityNotFoundException(Account.class)).when(accountDao).getAccount(STUDY, ID);
         try {
-            participantService.updateParticipant(STUDY, CALLER_ROLES, ID, PARTICIPANT);
+            participantService.updateParticipant(STUDY, CALLER_ROLES, PARTICIPANT);
             fail("Should have thrown exception.");
         } catch(EntityNotFoundException e) {
         }
@@ -535,7 +535,7 @@ public class ParticipantServiceTest {
         STUDY.setExternalIdValidationEnabled(false);
         mockHealthCodeAndAccountRetrieval();
         
-        participantService.updateParticipant(STUDY, CALLER_ROLES, ID, PARTICIPANT);
+        participantService.updateParticipant(STUDY, CALLER_ROLES, PARTICIPANT);
         
         verifyNoMoreInteractions(externalIdService);
         verify(optionsService).setAllOptions(eq(STUDY.getStudyIdentifier()), eq(HEALTH_CODE), optionsCaptor.capture());
@@ -741,7 +741,7 @@ public class ParticipantServiceTest {
         StudyParticipant participant = new StudyParticipant.Builder().copyOf(PARTICIPANT)
                 .withStatus(status).build();
         
-        participantService.updateParticipant(STUDY, roles, ID, participant);
+        participantService.updateParticipant(STUDY, roles, participant);
 
         verify(accountDao).updateAccount(accountCaptor.capture());
         Account account = accountCaptor.getValue();
@@ -778,7 +778,7 @@ public class ParticipantServiceTest {
         
         StudyParticipant participant = new StudyParticipant.Builder().copyOf(PARTICIPANT)
                 .withRoles(rolesThatAreSet).build();
-        participantService.updateParticipant(STUDY, callerRoles, ID, participant);
+        participantService.updateParticipant(STUDY, callerRoles, participant);
         
         verify(accountDao).updateAccount(accountCaptor.capture());
         Account account = accountCaptor.getValue();

--- a/test/org/sagebionetworks/bridge/validators/StudyParticipantValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/StudyParticipantValidatorTest.java
@@ -97,6 +97,20 @@ public class StudyParticipantValidatorTest {
     }
     
     @Test
+    public void validatesIdForNew() {
+        // not new, this succeeds
+        validator = new StudyParticipantValidator(study, true); 
+        Validate.entityThrowingException(validator, withEmail("email@email.com"));
+    }
+    
+    @Test(expected = InvalidEntityException.class)
+    public void validatesIdForExisting() {
+        // not new, this should fail, as there's no ID in participant.
+        validator = new StudyParticipantValidator(study, false); 
+        Validate.entityThrowingException(validator, withEmail("email@email.com"));
+    }
+    
+    @Test
     public void validPasses() {
         validator = new StudyParticipantValidator(study, true);
         Validate.entityThrowingException(validator, withEmail("email@email.com"));


### PR DESCRIPTION
- consistently use ID in URL over ID in JSON; 
- remove unnecessary id from ParticipantService method signature.
