### PR TITLE
Allowing researchers, developers and admins to see the JSON for their own study

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/StudyController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/StudyController.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge.play.controllers;
 
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
+import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -60,7 +61,7 @@ public class StudyController extends BaseController {
     }
 
     public Result getCurrentStudy() throws Exception {
-        UserSession session = getAuthenticatedSession(DEVELOPER);
+        UserSession session = getAuthenticatedSession(DEVELOPER, RESEARCHER, ADMIN);
         Study study = studyService.getStudy(session.getStudyIdentifier());
 
         return ok(Study.STUDY_WRITER.writeValueAsString(study));

--- a/app/org/sagebionetworks/bridge/play/controllers/UploadSchemaController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/UploadSchemaController.java
@@ -3,7 +3,6 @@ package org.sagebionetworks.bridge.play.controllers;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.WORKER;
 
-import java.util.EnumSet;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -136,7 +135,7 @@ public class UploadSchemaController extends BaseController {
      * @return Play result with the fetched schema in JSON format
      */
     public Result getUploadSchemaByIdAndRev(String schemaId, int rev) {
-        UserSession session = getAuthenticatedSession(EnumSet.of(DEVELOPER, WORKER));
+        UserSession session = getAuthenticatedSession(DEVELOPER, WORKER);
         StudyIdentifier studyId = session.getStudyIdentifier();
 
         UploadSchema uploadSchema = uploadSchemaService.getUploadSchemaByIdAndRev(studyId, schemaId, rev);

--- a/test/org/sagebionetworks/bridge/play/controllers/BaseControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/BaseControllerTest.java
@@ -21,7 +21,6 @@ import static org.sagebionetworks.bridge.TestUtils.createJson;
 import static org.sagebionetworks.bridge.TestUtils.mockPlayContext;
 import static org.sagebionetworks.bridge.TestUtils.newLinkedHashSet;
 
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -197,8 +196,8 @@ public class BaseControllerTest {
                 .withRoles(Sets.newHashSet(Roles.RESEARCHER)).build();
         
         UserSession session = new UserSession(participant);
-
-        doReturn(session).when(controller).getAuthenticatedSession();
+        session.setAuthenticated(true);
+        doReturn(session).when(controller).getSessionIfItExists();
 
         // Single arg success.
         assertNotNull(controller.getAuthenticatedSession(Roles.RESEARCHER));
@@ -213,13 +212,13 @@ public class BaseControllerTest {
         }
 
         // Success with sets.
-        assertNotNull(controller.getAuthenticatedSession(EnumSet.of(Roles.RESEARCHER)));
-        assertNotNull(controller.getAuthenticatedSession(EnumSet.of(Roles.DEVELOPER, Roles.RESEARCHER)));
-        assertNotNull(controller.getAuthenticatedSession(EnumSet.of(Roles.DEVELOPER, Roles.RESEARCHER, Roles.WORKER)));
+        assertNotNull(controller.getAuthenticatedSession(Roles.RESEARCHER));
+        assertNotNull(controller.getAuthenticatedSession(Roles.DEVELOPER, Roles.RESEARCHER));
+        assertNotNull(controller.getAuthenticatedSession(Roles.DEVELOPER, Roles.RESEARCHER, Roles.WORKER));
 
         // Unauthorized with sets
         try {
-            controller.getAuthenticatedSession(EnumSet.of(Roles.ADMIN, Roles.DEVELOPER, Roles.WORKER));
+            controller.getAuthenticatedSession(Roles.ADMIN, Roles.DEVELOPER, Roles.WORKER);
             fail("expected exception");
         } catch (UnauthorizedException ex) {
             // expected exception

--- a/test/org/sagebionetworks/bridge/play/controllers/FPHSControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/FPHSControllerTest.java
@@ -94,9 +94,11 @@ public class FPHSControllerTest {
         
         UserSession session = new UserSession(participant);
         session.setStudyIdentifier(new StudyIdentifierImpl("test-study"));
+        session.setAuthenticated(true);
         
-        doReturn(session).when(controller).getAuthenticatedAndConsentedSession();
-        doReturn(session).when(controller).getAuthenticatedSession();
+        //doReturn(session).when(controller).getAuthenticatedAndConsentedSession();
+        //doReturn(session).when(controller).getAuthenticatedSession();
+        doReturn(session).when(controller).getSessionIfItExists();
         return session;
     }
     
@@ -209,7 +211,6 @@ public class FPHSControllerTest {
         setFPHSExternalIdentifiersPost(Lists.newArrayList(id1, id2));
         
         UserSession session = setUserSession();
-        
         // Now when we have an admin user, we get back results
         session.setParticipant(new StudyParticipant.Builder().copyOf(session.getParticipant())
                 .withRoles(Sets.newHashSet(Roles.ADMIN)).build());

--- a/test/org/sagebionetworks/bridge/play/controllers/FPHSControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/FPHSControllerTest.java
@@ -96,8 +96,6 @@ public class FPHSControllerTest {
         session.setStudyIdentifier(new StudyIdentifierImpl("test-study"));
         session.setAuthenticated(true);
         
-        //doReturn(session).when(controller).getAuthenticatedAndConsentedSession();
-        //doReturn(session).when(controller).getAuthenticatedSession();
         doReturn(session).when(controller).getSessionIfItExists();
         return session;
     }

--- a/test/org/sagebionetworks/bridge/play/controllers/StudyControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/StudyControllerTest.java
@@ -148,20 +148,37 @@ public class StudyControllerTest {
     }
     
     @Test
-    public void humanAdminRolesCanGetCurrentStudy() throws Exception {
-        StudyParticipant participant = new StudyParticipant.Builder()
-                .withRoles(Sets.newHashSet(Roles.RESEARCHER)).build();
+    public void developerCanAccessCurrentStudy() throws Exception {
+        testRoleAccessToCurrentStudy(Roles.DEVELOPER);
+    }
+    
+    @Test
+    public void researcherCanAccessCurrentStudy() throws Exception {
+        testRoleAccessToCurrentStudy(Roles.RESEARCHER);
+    }
+    
+    @Test
+    public void adminCanAccessCurrentStudy() throws Exception {
+        testRoleAccessToCurrentStudy(Roles.ADMIN);
+    }
+    
+    @Test(expected = UnauthorizedException.class)
+    public void userCannotAccessCurrentStudy() throws Exception {
+        testRoleAccessToCurrentStudy(null);
+    }
+    
+    private void testRoleAccessToCurrentStudy(Roles role) throws Exception {
+        StudyParticipant participant = new StudyParticipant.Builder().withRoles(Sets.newHashSet(role)).build();
         UserSession session = new UserSession(participant);
         session.setAuthenticated(true);
         session.setStudyIdentifier(studyId);
-        
         doReturn(session).when(controller).getSessionIfItExists();
         
         Result result = controller.getCurrentStudy();
         assertEquals(200, result.status());
         
         Study study = BridgeObjectMapper.get().readValue(Helpers.contentAsString(result), Study.class);
-        assertEquals(EMAIL_ADDRESS, study.getSupportEmail());
+        assertEquals(EMAIL_ADDRESS, study.getSupportEmail());        
     }
 
 }

--- a/test/org/sagebionetworks/bridge/play/controllers/SubpopulationControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SubpopulationControllerTest.java
@@ -76,12 +76,13 @@ public class SubpopulationControllerTest {
         participant = new StudyParticipant.Builder().withRoles(Sets.newHashSet(Roles.DEVELOPER)).build();
         session = new UserSession(participant);
         session.setStudyIdentifier(STUDY_IDENTIFIER);
+        session.setAuthenticated(true);
         
         controller.setSubpopulationService(subpopService);
         controller.setStudyService(studyService);
         
         when(study.getStudyIdentifier()).thenReturn(STUDY_IDENTIFIER);
-        doReturn(session).when(controller).getAuthenticatedSession();
+        doReturn(session).when(controller).getSessionIfItExists();
         when(studyService.getStudy(STUDY_IDENTIFIER)).thenReturn(study);
     }
     

--- a/test/org/sagebionetworks/bridge/play/controllers/UploadSchemaControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/UploadSchemaControllerTest.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.bridge.play.controllers;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anySetOf;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
@@ -180,7 +179,7 @@ public class UploadSchemaControllerTest {
         // spy controller
         UploadSchemaController controller = spy(new UploadSchemaController());
         controller.setUploadSchemaService(mockSvc);
-        doReturn(mockSession).when(controller).getAuthenticatedSession(anySetOf(Roles.class));
+        doReturn(mockSession).when(controller).getAuthenticatedSession(Roles.DEVELOPER, Roles.WORKER);
 
         // execute and validate
         Result result = controller.getUploadSchemaByIdAndRev(TEST_SCHEMA_ID, 1);

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
@@ -2,7 +2,6 @@ package org.sagebionetworks.bridge.services;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;


### PR DESCRIPTION
To create a UI for researchers to view and manipulate users, we need the study object, which has information like the user profiles, whether or not we're showing health codes, etc. It's reasonable to show this to any administrative role. Changed getAuthenticationSession() for the relevant controller method.

Also reducing three getAuthenticatedSession() methods (taking no role, one role, or a set of roles) down to one (with a varargs role parameter). One nice fallout of this is that it's easier to mock the controllers by returning the session of your choice from getSessionIfItExists().
