### PR TITLE
cross-study schema API for worker accounts

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchema.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchema.java
@@ -12,6 +12,7 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMarshalling;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBVersionAttribute;
+import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -38,6 +39,7 @@ import org.sagebionetworks.bridge.validators.Validate;
  */
 @DynamoThroughput(readCapacity=15, writeCapacity=1)
 @DynamoDBTable(tableName = "UploadSchema")
+@JsonFilter("filter")
 public class DynamoUploadSchema implements UploadSchema {
     private List<UploadFieldDefinition> fieldDefList;
     private String name;
@@ -191,14 +193,12 @@ public class DynamoUploadSchema implements UploadSchema {
      * </p>
      */
     @DynamoDBIndexHashKey(attributeName = "studyId", globalSecondaryIndexName = "studyId-index")
-    @JsonIgnore
     @Override
     public String getStudyId() {
         return studyId;
     }
 
     /** @see #getStudyId */
-    @JsonIgnore
     public void setStudyId(String studyId) {
         this.studyId = studyId;
     }

--- a/app/org/sagebionetworks/bridge/models/upload/UploadSchema.java
+++ b/app/org/sagebionetworks/bridge/models/upload/UploadSchema.java
@@ -2,9 +2,13 @@ package org.sagebionetworks.bridge.models.upload;
 
 import java.util.List;
 
+import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
+import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
 import org.sagebionetworks.bridge.dynamodb.DynamoUploadSchema;
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.json.BridgeTypeName;
 import org.sagebionetworks.bridge.models.BridgeEntity;
 import org.sagebionetworks.bridge.schema.UploadSchemaKey;
@@ -16,6 +20,9 @@ import org.sagebionetworks.bridge.schema.UploadSchemaKey;
 @BridgeTypeName("UploadSchema")
 @JsonDeserialize(as = DynamoUploadSchema.class)
 public interface UploadSchema extends BridgeEntity {
+    ObjectWriter PUBLIC_SCHEMA_WRITER = BridgeObjectMapper.get().writer(new SimpleFilterProvider().addFilter("filter",
+                    SimpleBeanPropertyFilter.serializeAllExcept("studyId")));
+
     /** A list of fields defined in the schema. This can be changed across different schema revisions. */
     List<UploadFieldDefinition> getFieldDefinitions();
 

--- a/conf/routes
+++ b/conf/routes
@@ -136,6 +136,7 @@ DELETE /v3/externalIds    @org.sagebionetworks.bridge.play.controllers.ExternalI
 
 # APIs for getting entities across studies
 GET /v3/studies/:studyId/surveys/published @org.sagebionetworks.bridge.play.controllers.SurveyController.getAllSurveysMostRecentlyPublishedVersionForStudy(studyId: String)
+GET /v3/studies/:studyId/uploadschemas/:schemaId/revisions/:revision @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getUploadSchemaByStudyAndSchemaAndRev(studyId: String, schemaId: String, revision: Int)
 
 # Backfills
 GET    /v3/backfill/:name          @org.sagebionetworks.bridge.play.controllers.BackfillController.backfill(name: String)

--- a/test/org/sagebionetworks/bridge/models/upload/UploadSchemaTest.java
+++ b/test/org/sagebionetworks/bridge/models/upload/UploadSchemaTest.java
@@ -130,6 +130,7 @@ public class UploadSchemaTest {
                 "   \"revision\":3,\n" +
                 "   \"schemaId\":\"test-schema\",\n" +
                 "   \"schemaType\":\"ios_survey\",\n" +
+                "   \"studyId\":\"test-study\",\n" +
                 "   \"surveyGuid\":\"survey-guid\",\n" +
                 "   \"surveyCreatedOn\":\"" + surveyCreatedOnStr + "\",\n" +
                 "   \"version\":6,\n" +
@@ -153,6 +154,7 @@ public class UploadSchemaTest {
         assertEquals(3, uploadSchema.getRevision());
         assertEquals("test-schema", uploadSchema.getSchemaId());
         assertEquals(UploadSchemaType.IOS_SURVEY, uploadSchema.getSchemaType());
+        assertEquals("test-study", uploadSchema.getStudyId());
         assertEquals("survey-guid", uploadSchema.getSurveyGuid());
         assertEquals(surveyCreatedOnMillis, uploadSchema.getSurveyCreatedOn().longValue());
         assertEquals(6, uploadSchema.getVersion().longValue());
@@ -175,11 +177,12 @@ public class UploadSchemaTest {
 
         // then convert to a map so we can validate the raw JSON
         Map<String, Object> jsonMap = BridgeObjectMapper.get().readValue(convertedJson, JsonUtils.TYPE_REF_RAW_MAP);
-        assertEquals(9, jsonMap.size());
+        assertEquals(10, jsonMap.size());
         assertEquals("Test Schema", jsonMap.get("name"));
         assertEquals(3, jsonMap.get("revision"));
         assertEquals("test-schema", jsonMap.get("schemaId"));
         assertEquals("ios_survey", jsonMap.get("schemaType"));
+        assertEquals("test-study", jsonMap.get("studyId"));
         assertEquals("survey-guid", jsonMap.get("surveyGuid"));
         assertEquals("UploadSchema", jsonMap.get("type"));
         assertEquals(6,  jsonMap.get("version"));
@@ -201,6 +204,15 @@ public class UploadSchemaTest {
         assertEquals("bar", barJsonMap.get("name"));
         assertFalse((boolean) barJsonMap.get("required"));
         assertEquals("string", barJsonMap.get("type"));
+
+        // Serialize it again using the public writer, which includes all fields except studyId.
+        String publicJson = UploadSchema.PUBLIC_SCHEMA_WRITER.writeValueAsString(uploadSchema);
+        Map<String, Object> publicJsonMap = BridgeObjectMapper.get().readValue(publicJson, JsonUtils.TYPE_REF_RAW_MAP);
+
+        // Public JSON is missing studyId, but is otherwise identical to the non-public (internal worker) JSON.
+        assertFalse(publicJsonMap.containsKey("studyId"));
+        publicJsonMap.put("studyId", "test-study");
+        assertEquals(jsonMap, publicJsonMap);
     }
 
     @Test


### PR DESCRIPTION
I realized a bit too late that my first attempt at a schema API for workers had 2 problems: (1) it was locked into the study of the worker account (2) the APIs didn't return the study ID.

Likewise, this pull request has 2 changes: (1) a cross-study schema API for workers (2) the cross-study API will include study ID in the results, normal APIs will not.

Testing done:
- updated and ran unit tests
- UploadSchemaTest in integration tests
- manually tested new and old get schema APIs
