### PR TITLE
No longer require MPower report users to be consented in order to see their reports

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/MpowerVisualizationController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/MpowerVisualizationController.java
@@ -31,7 +31,7 @@ public class MpowerVisualizationController extends BaseController {
     /** Gets the mPower visualization for the given start and end dates, inclusive. */
     public Result getVisualization(String startDate, String endDate) {
         // get health code from session
-        UserSession session = getAuthenticatedAndConsentedSession();
+        UserSession session = getAuthenticatedSession();
         String healthCode = session.getHealthCode();
 
         // parse string dates into Joda dates

--- a/test/org/sagebionetworks/bridge/play/controllers/MpowerVisualizationControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/MpowerVisualizationControllerTest.java
@@ -91,7 +91,7 @@ public class MpowerVisualizationControllerTest {
         UserSession session = new UserSession(participant);
 
         MpowerVisualizationController controller = spy(new MpowerVisualizationController());
-        doReturn(session).when(controller).getAuthenticatedAndConsentedSession();
+        doReturn(session).when(controller).getAuthenticatedSession();
 
         // mock service - For rapid development and to avoid unnecessary coupling, just mock the visualization with a
         // dummy string. Check if that dummy string is propagated through the controller.


### PR DESCRIPTION
If you are signed in but not consented, all you would get back is "{}" anyway because you can only submit data if you consent. So this is a reasonable work around for the fact that the web view is not submitting the User-Agent header necessary to verify that users are consented.
