### PR TITLE
add new schema field types

### DIFF
--- a/app/org/sagebionetworks/bridge/json/DateUtils.java
+++ b/app/org/sagebionetworks/bridge/json/DateUtils.java
@@ -92,7 +92,8 @@ public final class DateUtils {
         }
 
         // We use dateTimeParser() instead of dateTimeFmt because we want to be able to handle non-UTC timezones.
-        return ISODateTimeFormat.dateTimeParser().parseDateTime(dateTimeStr);
+        // withOffsetParsed() is needed, otherwise Joda converts everything to the local timezone.
+        return ISODateTimeFormat.dateTimeParser().withOffsetParsed().parseDateTime(dateTimeStr);
     }
 
     /**

--- a/app/org/sagebionetworks/bridge/models/upload/UploadFieldType.java
+++ b/app/org/sagebionetworks/bridge/models/upload/UploadFieldType.java
@@ -16,7 +16,7 @@ public enum UploadFieldType {
 
     /**
      * Health Data Attachment as a CSV file. The value of this field is a foreign key into the Health Data Attachments
-     * table. Data stored in this format will be used to construct de-normalized tables during data export.
+     * table. We originally planned to de-normalize this data, but that feature was punted.
      */
     ATTACHMENT_CSV,
 
@@ -29,17 +29,22 @@ public enum UploadFieldType {
 
     /**
      * Health Data Attachment as a JSON blob of a specific "table" format. The value of this field is a foreign key
-     * into the Health Data Attachments table. Data stored in this format will be used to construct de-normalizeds
-     * tables during data export.
+     * into the Health Data Attachments table. We originally planned to de-normalize this data, but that feature was
+     * punted.
      */
-    // TODO: document ATTACHMENT_JSON_TABLE data format
     ATTACHMENT_JSON_TABLE,
+
+    /** Upload V2 version of attachments. Fields of this type can be associated with any file extension or MIME type */
+    ATTACHMENT_V2,
 
     /** A boolean, expected values match Boolean.parse() */
     BOOLEAN,
 
     /** A calendar date in YYYY-MM-DD format */
     CALENDAR_DATE,
+
+    /** Duration (how long something took). Used by Upload v2. */
+    DURATION_V2,
 
     /** A floating point number, generally represented as a double in Java */
     FLOAT,
@@ -53,14 +58,22 @@ public enum UploadFieldType {
     /** An integer value, generally represented as a long in Java (64-bit signed integer) */
     INT,
 
+    /** Multiple choice question with multiple answers. */
+    MULTI_CHOICE,
+
+    /** Multiple choice question with only a single answer. */
+    SINGLE_CHOICE,
+
     /** A string value */
     STRING,
+
+    /** Time without date or timezone. Used in Upload v2. */
+    TIME_V2,
 
     /** A timestamp in ISO 8601 format (YYYY-MM-DDThhhh:mm:ss+/-zz:zz) */
     TIMESTAMP;
 
     /** A set of upload field types that are considered attachment types. */
-    public static final Set<UploadFieldType> ATTACHMENT_TYPE_SET = EnumSet.of(UploadFieldType.ATTACHMENT_BLOB,
-            UploadFieldType.ATTACHMENT_CSV, UploadFieldType.ATTACHMENT_JSON_BLOB,
-            UploadFieldType.ATTACHMENT_JSON_TABLE);
+    public static final Set<UploadFieldType> ATTACHMENT_TYPE_SET = EnumSet.of(ATTACHMENT_BLOB, ATTACHMENT_CSV,
+            ATTACHMENT_JSON_BLOB, ATTACHMENT_JSON_TABLE, ATTACHMENT_V2);
 }

--- a/app/org/sagebionetworks/bridge/upload/CanonicalizationResult.java
+++ b/app/org/sagebionetworks/bridge/upload/CanonicalizationResult.java
@@ -1,0 +1,42 @@
+package org.sagebionetworks.bridge.upload;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/** Encapsulates info related to canonicalizing upload data. */
+public class CanonicalizationResult {
+    private final JsonNode canonicalizedValueNode;
+    private final String errorMessage;
+    private final boolean isValid;
+
+    /** Makes a successful canonicalization with the canonicalized JSON node. */
+    public static CanonicalizationResult makeResult(JsonNode canonicalizedValueNode) {
+        return new CanonicalizationResult(canonicalizedValueNode, null, true);
+    }
+
+    /** Makes a failed canonicalization with the error message. */
+    public static CanonicalizationResult makeError(String errorMessage) {
+        return new CanonicalizationResult(null, errorMessage, false);
+    }
+
+    /** Private constructor. Use the static factory methods {@link #makeResult} and {@link #makeError} */
+    private CanonicalizationResult(JsonNode canonicalizedValueNode, String errorMessage, boolean isValid) {
+        this.canonicalizedValueNode = canonicalizedValueNode;
+        this.errorMessage = errorMessage;
+        this.isValid = isValid;
+    }
+
+    /** The canonicalized JSON node. Null if the canonicalization failed. */
+    public JsonNode getCanonicalizedValueNode() {
+        return canonicalizedValueNode;
+    }
+
+    /** The error message. Null if the canonicalization succeeded. */
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    /** True if the canonicalization succeeded. False if it failed. */
+    public boolean isValid() {
+        return isValid;
+    }
+}

--- a/app/org/sagebionetworks/bridge/upload/UploadUtil.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadUtil.java
@@ -1,16 +1,249 @@
 package org.sagebionetworks.bridge.upload;
 
+import java.math.BigDecimal;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.BigIntegerNode;
+import com.fasterxml.jackson.databind.node.BooleanNode;
+import com.fasterxml.jackson.databind.node.DecimalNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
+import org.joda.time.LocalTime;
+import org.joda.time.Period;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.json.DateUtils;
+import org.sagebionetworks.bridge.models.upload.UploadFieldType;
 
 /** Utility class that contains static utility methods for handling uploads. */
 public class UploadUtil {
     private static final Logger logger = LoggerFactory.getLogger(UploadUtil.class);
+
+    /** Utility method for canonicalizing an upload JSON value given the schema's field type. */
+    public static CanonicalizationResult canonicalize(final JsonNode valueNode, UploadFieldType type) {
+        if (valueNode == null || valueNode.isNull()) {
+            // Short-cut: Don't do anything if the value is Java null (non-existent) or JSON null.
+            return CanonicalizationResult.makeResult(valueNode);
+        }
+
+        switch (type) {
+            case ATTACHMENT_BLOB:
+            case ATTACHMENT_CSV:
+            case ATTACHMENT_JSON_BLOB:
+            case ATTACHMENT_JSON_TABLE:
+            case ATTACHMENT_V2:
+            case INLINE_JSON_BLOB: {
+                // always valid, always canonical
+                return CanonicalizationResult.makeResult(valueNode);
+            }
+            case BOOLEAN: {
+                if (valueNode.isIntegralNumber()) {
+                    // For numbers, 0 is false and everything else is true.
+                    boolean booleanValue = valueNode.intValue() != 0;
+                    return CanonicalizationResult.makeResult(BooleanNode.valueOf(booleanValue));
+                } else if (valueNode.isTextual()) {
+                    // We accept "true" and "false" (ignoring case), but not anything else.
+                    String boolStr = valueNode.textValue();
+                    if ("false".equalsIgnoreCase(boolStr)) {
+                        return CanonicalizationResult.makeResult(BooleanNode.FALSE);
+                    } else if ("true".equalsIgnoreCase(boolStr)) {
+                        return CanonicalizationResult.makeResult(BooleanNode.TRUE);
+                    } else {
+                        return CanonicalizationResult.makeError("Invalid boolean string " + boolStr);
+                    }
+                } else if (valueNode.isBoolean()) {
+                    // This is already canonicalized.
+                    return CanonicalizationResult.makeResult(valueNode);
+                } else {
+                    return CanonicalizationResult.makeError("Invalid boolean JSON value " + valueNode.toString());
+                }
+            }
+            case CALENDAR_DATE: {
+                if (!valueNode.isTextual()) {
+                    return CanonicalizationResult.makeError("Invalid calendar date JSON value " +
+                            valueNode.toString());
+                }
+
+                // parseIosCalendarDate() will truncate full date-times to calendar dates as needed.
+                String dateStr = valueNode.textValue();
+                LocalDate parsedDate = parseIosCalendarDate(dateStr);
+
+                if (parsedDate != null) {
+                    return CanonicalizationResult.makeResult(new TextNode(DateUtils.getCalendarDateString(
+                            parsedDate)));
+                } else {
+                    return CanonicalizationResult.makeError("Invalid calendar date string " + dateStr);
+                }
+            }
+            case DURATION_V2: {
+                if (!valueNode.isTextual()) {
+                    return CanonicalizationResult.makeError("Invalid duration JSON value " + valueNode.toString());
+                }
+
+                String durationStr = valueNode.textValue();
+                try {
+                    // Joda Duration only parses seconds and milliseconds. Use Period to get an ISO 8601 duration.
+                    // Period.parse() never returns null.
+                    Period parsedPeriod = Period.parse(durationStr);
+                    return CanonicalizationResult.makeResult(new TextNode(parsedPeriod.toString()));
+                } catch (IllegalArgumentException ex) {
+                    return CanonicalizationResult.makeError("Invalid duration string " + durationStr);
+                }
+            }
+            case FLOAT: {
+                if (valueNode.isNumber()) {
+                    // Already canonicalized.
+                    return CanonicalizationResult.makeResult(valueNode);
+                } else if (valueNode.isTextual()) {
+                    // Convert to decimal.
+                    String decimalStr = valueNode.textValue();
+                    try {
+                        BigDecimal parsedDecimal = new BigDecimal(decimalStr);
+                        return CanonicalizationResult.makeResult(new DecimalNode(parsedDecimal));
+                    } catch (IllegalArgumentException ex) {
+                        return CanonicalizationResult.makeError("Invalid decimal string " + decimalStr);
+                    }
+                } else {
+                    return CanonicalizationResult.makeError("Invalid decimal JSON value " + valueNode.toString());
+                }
+            }
+            case INT: {
+                if (valueNode.isIntegralNumber()) {
+                    // Already canonicalized
+                    return CanonicalizationResult.makeResult(valueNode);
+                } else if (valueNode.isFloatingPointNumber()) {
+                    // Convert floats to ints.
+                    return CanonicalizationResult.makeResult(new BigIntegerNode(valueNode.bigIntegerValue()));
+                } else if (valueNode.isTextual()) {
+                    // Parse as a big decimal, truncate to big int.
+                    String numberStr = valueNode.textValue();
+                    try {
+                        BigDecimal parsedNumber = new BigDecimal(numberStr);
+                        return CanonicalizationResult.makeResult(new BigIntegerNode(parsedNumber.toBigInteger()));
+                    } catch (IllegalArgumentException ex) {
+                        return CanonicalizationResult.makeError("Invalid int string " + numberStr);
+                    }
+                } else {
+                    return CanonicalizationResult.makeError("Invalid int JSON value " + valueNode.toString());
+                }
+            }
+            case MULTI_CHOICE: {
+                // Expect it in the format ["foo", "bar", "baz"]
+                if (!valueNode.isArray()) {
+                    return CanonicalizationResult.makeError("Invalid multi-choice JSON value " + valueNode.toString());
+                }
+
+                // Fields inside might not be strings. Trivially convert them to strings if they are not.
+                ArrayNode convertedValueNode = BridgeObjectMapper.get().createArrayNode();
+                int numValues = valueNode.size();
+                for (int i = 0; i < numValues; i++) {
+                    convertedValueNode.add(convertToStringNode(valueNode.get(i)));
+                }
+
+                return CanonicalizationResult.makeResult(convertedValueNode);
+            }
+            case SINGLE_CHOICE: {
+                // Older versions would send a single-element array (example: ["foo"]) as a single-choice answer. For
+                // backwards compatibility, accept arrays, but use just the single element.
+                JsonNode convertedValueNode;
+                if (valueNode.isArray()) {
+                    if (valueNode.size() == 1) {
+                        convertedValueNode = valueNode.get(0);
+                    } else {
+                        return CanonicalizationResult.makeError("Single-choice array doesn't have exactly 1 element: "
+                                + valueNode.toString());
+                    }
+                } else {
+                    // Not an array. Pass this straight through to the next step.
+                    convertedValueNode = valueNode;
+                }
+
+                // If the value isn't a string, trivially convert it into a string.
+                return CanonicalizationResult.makeResult(convertToStringNode(convertedValueNode));
+            }
+            case STRING: {
+                // If the value isn't a string, trivially convert it into a string.
+                return CanonicalizationResult.makeResult(convertToStringNode(valueNode));
+            }
+            case TIME_V2: {
+                if (!valueNode.isTextual()) {
+                    return CanonicalizationResult.makeError("Invalid time JSON value " + valueNode.toString());
+                }
+
+                // This is a time without date or time-zone, akin to Joda LocalTime. First parse it as a LocalTime.
+                String timeStr = valueNode.textValue();
+                LocalTime parsedLocalTime = null;
+                try {
+                    parsedLocalTime = LocalTime.parse(timeStr);
+                } catch (IllegalArgumentException ex) {
+                    // Swallow exception. We have better logging later in the chain.
+                }
+
+                if (parsedLocalTime == null) {
+                    // If that doesn't work, fall back to parsing a full timestamp and use just the LocalTime part.
+                    DateTime parsedDateTime = parseIosTimestamp(timeStr);
+                    if (parsedDateTime != null) {
+                        parsedLocalTime = parsedDateTime.toLocalTime();
+                    }
+                }
+
+                if (parsedLocalTime != null) {
+                    return CanonicalizationResult.makeResult(new TextNode(parsedLocalTime.toString()));
+                } else {
+                    return CanonicalizationResult.makeError("Invalid time string " + timeStr);
+                }
+            }
+            case TIMESTAMP: {
+                if (valueNode.isNumber()) {
+                    // If this is a number, then it's epoch milliseconds (implicitly in UTC).
+                    return CanonicalizationResult.makeResult(new TextNode(DateUtils.convertToISODateTime(
+                            valueNode.longValue())));
+                } else if (valueNode.isTextual()) {
+                    String dateTimeStr = valueNode.textValue();
+                    DateTime parsedDateTime = parseIosTimestamp(dateTimeStr);
+                    if (parsedDateTime != null) {
+                        return CanonicalizationResult.makeResult(new TextNode(parsedDateTime.toString()));
+                    } else {
+                        return CanonicalizationResult.makeError("Invalid date-time (timestamp) string " + dateTimeStr);
+                    }
+                } else {
+                    return CanonicalizationResult.makeError("Invalid date-time (timestamp) JSON value " +
+                            valueNode.toString());
+                }
+            }
+            default: {
+                // Should never happen, but just in case.
+                return CanonicalizationResult.makeError("Unknown field type " + type.name());
+            }
+        }
+    }
+
+    /**
+     * Call this function to convert any JSON node into a string node. If the JSON node is already a string, return it
+     * as is. If it's not a string, the returned node is a string with the JSON text as its value. For type-safety and
+     * null safety, null values are returned as is.
+     *
+     * @param inputNode
+     *         node to convert
+     * @return converted node
+     */
+    public static JsonNode convertToStringNode(JsonNode inputNode) {
+        if (inputNode == null || inputNode.isNull()) {
+            // pass back nulls
+            return inputNode;
+        } else if (inputNode.isTextual()) {
+            // This is already a string node. Note that this is identical to the null case, but we use a separate
+            // else-if block for code organization. (The compiler will optimize it away anyway.)
+            return inputNode;
+        } else {
+            return new TextNode(inputNode.toString());
+        }
+    }
 
     /**
      * <p>
@@ -54,7 +287,6 @@ public class UploadUtil {
      *         raw timestamp string
      * @return parsed DateTime, or null if it couldn't be parsed
      */
-    // TODO: Remove this hack when it's no longer needed.
     public static DateTime parseIosTimestamp(String timestampStr) {
         // Timestamps must have at least 11 chars to represent the date, at minimum.
         if (StringUtils.isBlank(timestampStr) || timestampStr.length() < 11) {

--- a/test/org/sagebionetworks/bridge/json/DateUtilsTest.java
+++ b/test/org/sagebionetworks/bridge/json/DateUtilsTest.java
@@ -68,21 +68,18 @@ public class DateUtilsTest {
 
     @Test
     public void parseISODateTime() {
-        // Arbitrarily 2014-02-17T23:00Z.
-        long expectedMillis = new DateTime(2014, 2, 17, 23, 0, DateTimeZone.UTC).getMillis();
+        // { expected, input }
+        Object[][] testCaseArray = {
+                { new DateTime(2014, 2, 17, 23, 0, DateTimeZone.UTC), "2014-02-17T23:00Z" },
+                { new DateTime(2014, 2, 17, 23, 0, DateTimeZone.forOffsetHours(-8)), "2014-02-17T23:00-0800" },
+                { new DateTime(2014, 2, 17, 23, 0, DateTimeZone.forOffsetHours(+9)), "2014-02-17T23:00+0900" },
+        };
 
-        DateTime dateTime = DateUtils.parseISODateTime("2014-02-17T23:00Z");
-        assertEquals(expectedMillis, dateTime.getMillis());
-    }
-
-    @Test
-    public void parseISODateTimeNonUtc() {
-        // Arbitrarily 2014-02-17T23:00-0800. We want to use a timezone other than UTC to make sure we can handle
-        // non-UTC timezones.
-        long expectedMillis = new DateTime(2014, 2, 17, 23, 0, BridgeConstants.LOCAL_TIME_ZONE).getMillis();
-
-        DateTime dateTime = DateUtils.parseISODateTime("2014-02-17T23:00-0800");
-        assertEquals(expectedMillis, dateTime.getMillis());
+        for (Object[] oneTestCase : testCaseArray) {
+            String input = (String) oneTestCase[1];
+            DateTime actual = DateUtils.parseISODateTime(input);
+            assertEquals("Input: " + input, oneTestCase[0], actual);
+        }
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/test/org/sagebionetworks/bridge/upload/UploadHandlersEndToEndTest.java
+++ b/test/org/sagebionetworks/bridge/upload/UploadHandlersEndToEndTest.java
@@ -1,0 +1,641 @@
+package org.sagebionetworks.bridge.upload;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeUtils;
+import org.joda.time.LocalDate;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.dao.ParticipantOption;
+import org.sagebionetworks.bridge.dao.UploadDao;
+import org.sagebionetworks.bridge.dynamodb.DynamoHealthDataAttachment;
+import org.sagebionetworks.bridge.dynamodb.DynamoHealthDataDao;
+import org.sagebionetworks.bridge.dynamodb.DynamoHealthDataRecord;
+import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
+import org.sagebionetworks.bridge.dynamodb.DynamoSurvey;
+import org.sagebionetworks.bridge.dynamodb.DynamoUpload2;
+import org.sagebionetworks.bridge.dynamodb.DynamoUploadFieldDefinition;
+import org.sagebionetworks.bridge.dynamodb.DynamoUploadSchema;
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolderImpl;
+import org.sagebionetworks.bridge.models.accounts.ParticipantOptionsLookup;
+import org.sagebionetworks.bridge.models.healthdata.HealthDataAttachment;
+import org.sagebionetworks.bridge.models.healthdata.HealthDataRecord;
+import org.sagebionetworks.bridge.models.surveys.Survey;
+import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
+import org.sagebionetworks.bridge.models.upload.UploadFieldType;
+import org.sagebionetworks.bridge.models.upload.UploadSchema;
+import org.sagebionetworks.bridge.models.upload.UploadSchemaType;
+import org.sagebionetworks.bridge.models.upload.UploadStatus;
+import org.sagebionetworks.bridge.s3.S3Helper;
+import org.sagebionetworks.bridge.services.HealthDataService;
+import org.sagebionetworks.bridge.services.ParticipantOptionsService;
+import org.sagebionetworks.bridge.services.StudyService;
+import org.sagebionetworks.bridge.services.SurveyService;
+import org.sagebionetworks.bridge.services.UploadArchiveService;
+import org.sagebionetworks.bridge.services.UploadSchemaService;
+import org.sagebionetworks.bridge.util.Zipper;
+
+@SuppressWarnings({ "rawtypes", "unchecked" })
+public class UploadHandlersEndToEndTest {
+    private static final String ATTACHMENT_ID_PREFIX = "attachment-";
+    private static final Set<String> DATA_GROUP_SET = ImmutableSet.of("parkinson", "test_user");
+    private static final String EXTERNAL_ID = "external-id";
+    private static final String HEALTH_CODE = "health-code";
+    private static final String RECORD_ID = "record-id";
+    private static final String UPLOAD_ID = "upload-id";
+    private static final Zipper ZIPPER = new Zipper(1000000, 1000000);
+
+    private static final String CREATED_ON_STRING = "2015-04-02T03:26:59.456-07:00";
+    private static final long CREATED_ON_MILLIS = DateTime.parse(CREATED_ON_STRING).getMillis();
+
+    private static final DateTime MOCK_NOW = DateTime.parse("2016-06-03T11:33:55.777-0700");
+    private static final long MOCK_NOW_MILLIS = MOCK_NOW.getMillis();
+    private static final LocalDate MOCK_TODAY = MOCK_NOW.toLocalDate();
+
+    private static final Map<String, String> PARTICIPANT_OPTIONS_MAP = ImmutableMap.<String, String>builder()
+            .put(ParticipantOption.DATA_GROUPS.name(), "parkinson,test_user")
+            .put(ParticipantOption.EXTERNAL_IDENTIFIER.name(), EXTERNAL_ID)
+            .put(ParticipantOption.SHARING_SCOPE.name(), ParticipantOption.SharingScope.SPONSORS_AND_PARTNERS.name())
+            .build();
+    private static final ParticipantOptionsLookup PARTICIPANT_OPTIONS_LOOKUP = new ParticipantOptionsLookup(
+            PARTICIPANT_OPTIONS_MAP);
+
+    private static final DynamoStudy STUDY = new DynamoStudy();
+    static {
+        STUDY.setStrictUploadValidationEnabled(true);
+    }
+
+    private static final DynamoUpload2 UPLOAD = new DynamoUpload2();
+    static {
+        UPLOAD.setHealthCode(HEALTH_CODE);
+        UPLOAD.setUploadId(UPLOAD_ID);
+    }
+
+    // The following handlers have no external dependencies. We can use real handlers with real helper class objects.
+    private static final UnzipHandler UNZIP_HANDLER = new UnzipHandler();
+    static {
+        UNZIP_HANDLER.setUploadArchiveService(new UploadArchiveService());
+    }
+
+    private static final ParseJsonHandler PARSE_JSON_HANDLER = new ParseJsonHandler();
+
+    private int numAttachments;
+    private HealthDataService mockHealthDataService;
+    private UploadDao mockUploadDao;
+    private S3Helper mockS3UploadHelper;
+    private HealthDataRecord savedRecord;
+
+    @BeforeClass
+    public static void mockDateTime() {
+        DateTimeUtils.setCurrentMillisFixed(MOCK_NOW_MILLIS);
+    }
+
+    @Before
+    public void before() {
+        // Reset all member vars, because JUnit doesn't.
+        numAttachments = 0;
+        mockHealthDataService = mock(HealthDataService.class);
+        mockUploadDao = mock(UploadDao.class);
+        mockS3UploadHelper = mock(S3Helper.class);
+        savedRecord = null;
+    }
+
+    @AfterClass
+    public static void resetDateTime() {
+        DateTimeUtils.setCurrentMillisSystem();
+    }
+
+    private void test(UploadSchema schema, Survey survey, Map<String, String> fileMap) throws Exception {
+        // fileMap is in strings. Convert to bytes so we can use the Zipper.
+        Map<String, byte[]> fileBytesMap = new HashMap<>();
+        for (Map.Entry<String, String> oneFile : fileMap.entrySet()) {
+            String filename = oneFile.getKey();
+            String fileString = oneFile.getValue();
+            fileBytesMap.put(filename, fileString.getBytes(Charsets.UTF_8));
+        }
+
+        // zip file
+        byte[] zippedFile = ZIPPER.zip(fileBytesMap);
+
+        // set up S3DownloadHandler - mock S3 Helper
+        // "S3" returns file unencrypted for simplicity of testing
+        S3Helper mockS3DownloadHelper = mock(S3Helper.class);
+        when(mockS3DownloadHelper.readS3FileAsBytes(TestConstants.UPLOAD_BUCKET, UPLOAD_ID)).thenReturn(zippedFile);
+
+        S3DownloadHandler s3DownloadHandler = new S3DownloadHandler();
+        s3DownloadHandler.setS3Helper(mockS3DownloadHelper);
+
+        // set up DecryptHandler - For ease of tests, this will just return the input verbatim.
+        UploadArchiveService mockUploadArchiveService = mock(UploadArchiveService.class);
+        when(mockUploadArchiveService.decrypt(TestConstants.TEST_STUDY_IDENTIFIER, zippedFile)).thenReturn(zippedFile);
+
+        DecryptHandler decryptHandler = new DecryptHandler();
+        decryptHandler.setUploadArchiveService(mockUploadArchiveService);
+
+        // mock schema service
+        UploadSchemaService mockUploadSchemaService = mock(UploadSchemaService.class);
+        when(mockUploadSchemaService.getUploadSchemaByIdAndRev(TestConstants.TEST_STUDY, schema.getSchemaId(),
+                schema.getRevision())).thenReturn(schema);
+
+        // set up IosSchemaValidationHandler
+        IosSchemaValidationHandler2 iosSchemaValidationHandler = new IosSchemaValidationHandler2();
+        iosSchemaValidationHandler.setUploadSchemaService(mockUploadSchemaService);
+
+        if (survey != null) {
+            SurveyService mockSurveyService = mock(SurveyService.class);
+            when(mockSurveyService.getSurvey(new GuidCreatedOnVersionHolderImpl(survey.getGuid(),
+                    survey.getCreatedOn()))).thenReturn(survey);
+            iosSchemaValidationHandler.setSurveyService(mockSurveyService);
+        }
+
+        // health data dao is only used for getBuilder(), so we can just create one without any depedencies
+        iosSchemaValidationHandler.setHealthDataDao(new DynamoHealthDataDao());
+
+        // set up StrictValidationHandler
+        StrictValidationHandler strictValidationHandler = new StrictValidationHandler();
+        strictValidationHandler.setUploadSchemaService(mockUploadSchemaService);
+
+        StudyService mockStudyService = mock(StudyService.class);
+        when(mockStudyService.getStudy(TestConstants.TEST_STUDY)).thenReturn(STUDY);
+        strictValidationHandler.setStudyService(mockStudyService);
+
+        // set up TranscribeConsentHandler
+        ParticipantOptionsService mockOptionsService = mock(ParticipantOptionsService.class);
+        when(mockOptionsService.getOptions(HEALTH_CODE)).thenReturn(PARTICIPANT_OPTIONS_LOOKUP);
+
+        TranscribeConsentHandler transcribeConsentHandler = new TranscribeConsentHandler();
+        transcribeConsentHandler.setOptionsService(mockOptionsService);
+
+        // mock HealthDataService for UploadArtifactsHandler
+        when(mockHealthDataService.createOrUpdateAttachment(any(HealthDataAttachment.class))).thenAnswer(
+                invocation -> ATTACHMENT_ID_PREFIX + (++numAttachments));
+
+        when(mockHealthDataService.createOrUpdateRecord(any(HealthDataRecord.class))).thenAnswer(invocation -> {
+            // add record ID to record
+            HealthDataRecord submittedRecord = invocation.getArgumentAt(0, HealthDataRecord.class);
+            savedRecord = new DynamoHealthDataRecord.Builder().copyOf(submittedRecord).withId(RECORD_ID).build();
+            return RECORD_ID;
+        });
+
+        when(mockHealthDataService.getAttachmentBuilder()).thenAnswer(
+                invocation -> new DynamoHealthDataAttachment.Builder());
+
+        when(mockHealthDataService.getRecordBuilder()).thenAnswer(invocation -> new DynamoHealthDataRecord.Builder());
+
+        when(mockHealthDataService.getRecordById(RECORD_ID)).thenAnswer(invocation -> savedRecord);
+
+        // set up UploadArtifactsHandler
+        UploadArtifactsHandler uploadArtifactsHandler = new UploadArtifactsHandler();
+        uploadArtifactsHandler.setHealthDataService(mockHealthDataService);
+        uploadArtifactsHandler.setS3Helper(mockS3UploadHelper);
+
+        // set up task factory
+        List<UploadValidationHandler> handlerList = ImmutableList.of(s3DownloadHandler, decryptHandler, UNZIP_HANDLER,
+                PARSE_JSON_HANDLER, iosSchemaValidationHandler, strictValidationHandler, transcribeConsentHandler,
+                uploadArtifactsHandler);
+
+        UploadValidationTaskFactory taskFactory = new UploadValidationTaskFactory();
+        taskFactory.setHandlerList(handlerList);
+        taskFactory.setUploadDao(mockUploadDao);
+
+        // create task, execute
+        UploadValidationTask task = taskFactory.newTask(TestConstants.TEST_STUDY, UPLOAD);
+        task.run();
+    }
+
+    private static void validateCommonRecordProps(HealthDataRecord record) {
+        // Ignore ID - This one is created by the DAO, so it's not present in the passed in record.
+        // Ignore version - That's internal.
+        // Data, metadata, and schema fields are specific to individual tests.
+        assertEquals(CREATED_ON_MILLIS, record.getCreatedOn().longValue());
+        assertEquals(HEALTH_CODE, record.getHealthCode());
+        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, record.getStudyId());
+        assertEquals(MOCK_TODAY, record.getUploadDate());
+        assertEquals(UPLOAD_ID, record.getUploadId());
+        assertEquals(MOCK_NOW_MILLIS, record.getUploadedOn().longValue());
+        assertEquals(ParticipantOption.SharingScope.SPONSORS_AND_PARTNERS, record.getUserSharingScope());
+        assertEquals(EXTERNAL_ID, record.getUserExternalId());
+        assertEquals(DATA_GROUP_SET, record.getUserDataGroups());
+    }
+
+    @Test
+    public void survey() throws Exception {
+        final String surveyCreatedOnStr = "2016-06-03T16:01:02.003-0700";
+        final long surveyCreatedOnMillis = DateTime.parse(surveyCreatedOnStr).getMillis();
+
+        // set up schema
+        List<UploadFieldDefinition> fieldDefList = ImmutableList.of(
+                new DynamoUploadFieldDefinition.Builder().withName("AAA").withType(UploadFieldType.SINGLE_CHOICE)
+                        .build(),
+                new DynamoUploadFieldDefinition.Builder().withName("BBB").withType(UploadFieldType.MULTI_CHOICE)
+                        .build());
+
+        DynamoUploadSchema schema = new DynamoUploadSchema();
+        schema.setFieldDefinitions(fieldDefList);
+        schema.setName("Survey Schema");
+        schema.setRevision(2);
+        schema.setSchemaId("survey-schema");
+        schema.setSchemaType(UploadSchemaType.IOS_SURVEY);
+        schema.setStudyId(TestConstants.TEST_STUDY_IDENTIFIER);
+        schema.setSurveyGuid("survey-guid");
+        schema.setSurveyCreatedOn(surveyCreatedOnMillis);
+
+        // set up survey (all we need is reference to the schema)
+        DynamoSurvey survey = new DynamoSurvey();
+        survey.setCreatedOn(surveyCreatedOnMillis);
+        survey.setGuid("survey-guid");
+        survey.setIdentifier("survey-schema");
+        survey.setSchemaRevision(2);
+
+        // set up upload files
+        String infoJsonText = "{\n" +
+                "   \"files\":[{\n" +
+                "       \"filename\":\"AAA.json\",\n" +
+                "       \"timestamp\":\"" + CREATED_ON_STRING + "\"\n" +
+                "   },{\n" +
+                "       \"filename\":\"BBB.json\",\n" +
+                "       \"timestamp\":\"" + CREATED_ON_STRING + "\"\n" +
+                "   }],\n" +
+                "   \"surveyGuid\":\"survey-guid\",\n" +
+                "   \"surveyCreatedOn\":\"" + surveyCreatedOnStr + "\",\n" +
+                "   \"appVersion\":\"version 1.0.0, build 1\",\n" +
+                "   \"phoneInfo\":\"Unit Test Hardware\"\n" +
+                "}";
+
+        String aaaJsonText = "{\n" +
+                "   \"questionType\":0,\n" +
+                "   \"choiceAnswers\":[\"Yes\"],\n" +
+                "   \"startDate\":\"2015-04-02T03:26:57-07:00\",\n" +
+                "   \"questionTypeName\":\"SingleChoice\",\n" +
+                "   \"item\":\"AAA\",\n" +
+                "   \"endDate\":\"2015-04-02T03:26:59-07:00\"\n" +
+                "}";
+
+        String bbbJsonText = "{\n" +
+                "   \"questionType\":0,\n" +
+                "   \"choiceAnswers\":[\"fencing\", \"running\", 3],\n" +
+                "   \"startDate\":\"2015-04-02T03:27:05-07:00\",\n" +
+                "   \"questionTypeName\":\"MultipleChoice\",\n" +
+                "   \"item\":\"BBB\",\n" +
+                "   \"endDate\":\"2015-04-02T03:27:09-07:00\"\n" +
+                "}";
+
+        Map<String, String> fileMap = ImmutableMap.<String, String>builder().put("info.json", infoJsonText)
+                .put("AAA.json", aaaJsonText).put("BBB.json", bbbJsonText).build();
+
+        // execute
+        test(schema, survey, fileMap);
+
+        // verify created record
+        ArgumentCaptor<HealthDataRecord> recordCaptor = ArgumentCaptor.forClass(HealthDataRecord.class);
+        verify(mockHealthDataService, atLeastOnce()).createOrUpdateRecord(recordCaptor.capture());
+
+        HealthDataRecord record = recordCaptor.getValue();
+        validateCommonRecordProps(record);
+        assertEquals("survey-schema", record.getSchemaId());
+        assertEquals(2, record.getSchemaRevision());
+
+        JsonNode dataNode = record.getData();
+        assertEquals(2, dataNode.size());
+        assertEquals("Yes", dataNode.get("AAA").textValue());
+
+        JsonNode bbbChoiceAnswersNode = dataNode.get("BBB");
+        assertEquals(3, bbbChoiceAnswersNode.size());
+        assertEquals("fencing", bbbChoiceAnswersNode.get(0).textValue());
+        assertEquals("running", bbbChoiceAnswersNode.get(1).textValue());
+        assertEquals("3", bbbChoiceAnswersNode.get(2).textValue());
+
+        // validate no uploads to S3
+        verifyZeroInteractions(mockS3UploadHelper);
+
+        // verify no attachments
+        verify(mockHealthDataService, never()).createOrUpdateAttachment(any(HealthDataAttachment.class));
+
+        // verify upload dao write validation status
+        verify(mockUploadDao).writeValidationStatus(UPLOAD, UploadStatus.SUCCEEDED, ImmutableList.of(), RECORD_ID);
+    }
+
+    @Test
+    public void nonSurvey() throws Exception {
+        // set up schema
+        List<UploadFieldDefinition> fieldDefList = ImmutableList.of(
+                new DynamoUploadFieldDefinition.Builder().withName("CCC.txt").withType(UploadFieldType.ATTACHMENT_BLOB)
+                        .build(),
+                new DynamoUploadFieldDefinition.Builder().withName("DDD.csv").withType(UploadFieldType.ATTACHMENT_CSV)
+                        .build(),
+                new DynamoUploadFieldDefinition.Builder().withName("EEE.json")
+                        .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("FFF.json")
+                        .withType(UploadFieldType.ATTACHMENT_JSON_TABLE).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("GGG.txt").withType(UploadFieldType.ATTACHMENT_V2)
+                        .build(),
+                new DynamoUploadFieldDefinition.Builder().withName("record.json.HHH")
+                        .withType(UploadFieldType.ATTACHMENT_V2).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("record.json.III").withType(UploadFieldType.BOOLEAN)
+                        .build(),
+                new DynamoUploadFieldDefinition.Builder().withName("record.json.JJJ")
+                        .withType(UploadFieldType.CALENDAR_DATE).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("record.json.LLL")
+                        .withType(UploadFieldType.DURATION_V2).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("record.json.MMM").withType(UploadFieldType.FLOAT)
+                        .build(),
+                new DynamoUploadFieldDefinition.Builder().withName("record.json.NNN")
+                        .withType(UploadFieldType.INLINE_JSON_BLOB).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("record.json.OOO").withType(UploadFieldType.INT)
+                        .build(),
+                new DynamoUploadFieldDefinition.Builder().withName("record.json.PPP").withType(UploadFieldType.STRING)
+                        .build(),
+                new DynamoUploadFieldDefinition.Builder().withName("record.json.QQQ").withType(UploadFieldType.TIME_V2)
+                        .build(),
+                new DynamoUploadFieldDefinition.Builder().withName("record.json.arrr")
+                        .withType(UploadFieldType.TIMESTAMP).build());
+
+
+        DynamoUploadSchema schema = new DynamoUploadSchema();
+        schema.setFieldDefinitions(fieldDefList);
+        schema.setName("Non-Survey Schema");
+        schema.setRevision(2);
+        schema.setSchemaId("non-survey-schema");
+        schema.setSchemaType(UploadSchemaType.IOS_DATA);
+        schema.setStudyId(TestConstants.TEST_STUDY_IDENTIFIER);
+
+        // set up upload files
+        String infoJsonText = "{\n" +
+                "   \"files\":[{\n" +
+                "       \"filename\":\"CCC.txt\",\n" +
+                "       \"timestamp\":\"" + CREATED_ON_STRING + "\"\n" +
+                "   },{\n" +
+                "       \"filename\":\"DDD.csv\",\n" +
+                "       \"timestamp\":\"" + CREATED_ON_STRING + "\"\n" +
+                "   },{\n" +
+                "       \"filename\":\"EEE.json\",\n" +
+                "       \"timestamp\":\"" + CREATED_ON_STRING + "\"\n" +
+                "   },{\n" +
+                "       \"filename\":\"FFF.json\",\n" +
+                "       \"timestamp\":\"" + CREATED_ON_STRING + "\"\n" +
+                "   },{\n" +
+                "       \"filename\":\"GGG.txt\",\n" +
+                "       \"timestamp\":\"" + CREATED_ON_STRING + "\"\n" +
+                "   },{\n" +
+                "       \"filename\":\"record.json\",\n" +
+                "       \"timestamp\":\"" + CREATED_ON_STRING + "\"\n" +
+                "   }],\n" +
+                "   \"item\":\"non-survey-schema\",\n" +
+                "   \"schemaRevision\":2,\n" +
+                "   \"appVersion\":\"version 1.0.0, build 1\",\n" +
+                "   \"phoneInfo\":\"Unit Test Hardware\"\n" +
+                "}";
+
+        String cccTxtContent = "Blob file";
+
+        String dddCsvContent = "foo,bar\nbaz,qux";
+
+        String eeeJsonContent = "{\"key\":\"value\"}";
+
+        String fffJsonContent = "[{\"name\":\"Dwayne\"},{\"name\":\"Eggplant\"}]";
+
+        String gggTxtContent = "Arbitrary attachment";
+
+        String recordJsonContent = "{\n" +
+                "   \"HHH\":[\"attachment\", \"inside\", \"file\"],\n" +
+                "   \"III\":1,\n" +
+                "   \"JJJ\":\"2016-06-03T17:03-0700\",\n" +
+                "   \"LLL\":\"PT1H\",\n" +
+                "   \"MMM\":\"3.14\",\n" +
+                "   \"NNN\":[\"inline\", \"json\"],\n" +
+                "   \"OOO\":\"2.718\",\n" +
+                "   \"PPP\":1337,\n" +
+                "   \"QQQ\":\"2016-06-03T19:21:35.378-0700\",\n" +
+                "   \"arrr\":\"2016-06-03T18:12:34.567+0900\"\n" +
+                "}";
+
+        Map<String, String> fileMap = ImmutableMap.<String, String>builder().put("info.json", infoJsonText)
+                .put("CCC.txt", cccTxtContent).put("DDD.csv", dddCsvContent).put("EEE.json", eeeJsonContent)
+                .put("FFF.json", fffJsonContent).put("GGG.txt", gggTxtContent).put("record.json", recordJsonContent)
+                .build();
+
+        // execute
+        test(schema, null, fileMap);
+
+        // verify created record
+        ArgumentCaptor<HealthDataRecord> recordCaptor = ArgumentCaptor.forClass(HealthDataRecord.class);
+        verify(mockHealthDataService, atLeastOnce()).createOrUpdateRecord(recordCaptor.capture());
+
+        HealthDataRecord record = recordCaptor.getValue();
+        validateCommonRecordProps(record);
+        assertEquals("non-survey-schema", record.getSchemaId());
+        assertEquals(2, record.getSchemaRevision());
+
+        JsonNode dataNode = record.getData();
+        assertEquals(15, dataNode.size());
+        assertTrue(dataNode.get("record.json.III").booleanValue());
+        assertEquals("2016-06-03", dataNode.get("record.json.JJJ").textValue());
+        assertEquals("PT1H", dataNode.get("record.json.LLL").textValue());
+        assertEquals(3.14, dataNode.get("record.json.MMM").doubleValue(), /*delta*/ 0.001);
+        assertEquals(2, dataNode.get("record.json.OOO").intValue());
+        assertEquals("1337", dataNode.get("record.json.PPP").textValue());
+        assertEquals("19:21:35.378", dataNode.get("record.json.QQQ").textValue());
+        assertEquals(DateTime.parse("2016-06-03T18:12:34.567+0900"),
+                DateTime.parse(dataNode.get("record.json.arrr").textValue()));
+
+        JsonNode nnnNode = dataNode.get("record.json.NNN");
+        assertEquals(2, nnnNode.size());
+        assertEquals("inline", nnnNode.get(0).textValue());
+        assertEquals("json", nnnNode.get(1).textValue());
+
+        // validate attachment content in S3
+        String cccTxtAttachmentId = dataNode.get("CCC.txt").textValue();
+        validateTextAttachment(cccTxtContent, cccTxtAttachmentId);
+
+        String dddCsvAttachmentId = dataNode.get("DDD.csv").textValue();
+        validateTextAttachment(dddCsvContent, dddCsvAttachmentId);
+
+        String gggTxtAttachmentId = dataNode.get("GGG.txt").textValue();
+        validateTextAttachment(gggTxtContent, gggTxtAttachmentId);
+
+        String eeeJsonAttachmentId = dataNode.get("EEE.json").textValue();
+        JsonNode eeeJsonNode = getAttachmentAsJson(eeeJsonAttachmentId);
+        assertEquals(1, eeeJsonNode.size());
+        assertEquals("value", eeeJsonNode.get("key").textValue());
+
+        String fffJsonAttachmentId = dataNode.get("FFF.json").textValue();
+        JsonNode fffJsonNode = getAttachmentAsJson(fffJsonAttachmentId);
+        assertEquals(2, fffJsonNode.size());
+
+        assertEquals(1, fffJsonNode.get(0).size());
+        assertEquals("Dwayne", fffJsonNode.get(0).get("name").textValue());
+
+        assertEquals(1, fffJsonNode.get(1).size());
+        assertEquals("Eggplant", fffJsonNode.get(1).get("name").textValue());
+
+        String hhhAttachmentId = dataNode.get("record.json.HHH").textValue();
+        JsonNode hhhNode = getAttachmentAsJson(hhhAttachmentId);
+        assertEquals(3, hhhNode.size());
+        assertEquals("attachment", hhhNode.get(0).textValue());
+        assertEquals("inside", hhhNode.get(1).textValue());
+        assertEquals("file", hhhNode.get(2).textValue());
+
+        // verify attachments in HealthDataAttachments - Of all the attributes, the only one that actually matters is
+        // the record ID
+        ArgumentCaptor<HealthDataAttachment> attachmentCaptor = ArgumentCaptor.forClass(HealthDataAttachment.class);
+        verify(mockHealthDataService, times(6)).createOrUpdateAttachment(attachmentCaptor.capture());
+        for (HealthDataAttachment oneAttachment : attachmentCaptor.getAllValues()) {
+            assertEquals(RECORD_ID, oneAttachment.getRecordId());
+        }
+
+        // verify upload dao write validation status
+        verify(mockUploadDao).writeValidationStatus(UPLOAD, UploadStatus.SUCCEEDED, ImmutableList.of(), RECORD_ID);
+    }
+
+    private void validateTextAttachment(String expected, String attachmentId) throws Exception {
+        ArgumentCaptor<byte[]> attachmentContentCaptor = ArgumentCaptor.forClass(byte[].class);
+        verify(mockS3UploadHelper).writeBytesToS3(eq(TestConstants.ATTACHMENT_BUCKET), eq(attachmentId),
+                attachmentContentCaptor.capture());
+        assertEquals(expected, new String(attachmentContentCaptor.getValue(), Charsets.UTF_8));
+    }
+
+    private JsonNode getAttachmentAsJson(String attachmentId) throws Exception {
+        ArgumentCaptor<byte[]> attachmentContentCaptor = ArgumentCaptor.forClass(byte[].class);
+        verify(mockS3UploadHelper).writeBytesToS3(eq(TestConstants.ATTACHMENT_BUCKET), eq(attachmentId),
+                attachmentContentCaptor.capture());
+        return BridgeObjectMapper.get().readTree(attachmentContentCaptor.getValue());
+    }
+
+    @Test
+    public void missingOptionalFieldAboveMaxAppVersion() throws Exception {
+        // set up schema
+        List<UploadFieldDefinition> fieldDefList = ImmutableList.of(
+                new DynamoUploadFieldDefinition.Builder().withName("record.json.value")
+                        .withType(UploadFieldType.INLINE_JSON_BLOB).withMaxAppVersion(20).build());
+
+        DynamoUploadSchema schema = new DynamoUploadSchema();
+        schema.setFieldDefinitions(fieldDefList);
+        schema.setName("Max App Version Test");
+        schema.setRevision(2);
+        schema.setSchemaId("max-app-version-test");
+        schema.setSchemaType(UploadSchemaType.IOS_DATA);
+        schema.setStudyId(TestConstants.TEST_STUDY_IDENTIFIER);
+
+        // set up upload files
+        String infoJsonText = "{\n" +
+                "   \"files\":[{\n" +
+                "       \"filename\":\"record.json\",\n" +
+                "       \"timestamp\":\"" + CREATED_ON_STRING + "\"\n" +
+                "   }],\n" +
+                "   \"item\":\"max-app-version-test\",\n" +
+                "   \"schemaRevision\":2,\n" +
+                "   \"appVersion\":\"version 1.30, build 30\",\n" +
+                "   \"phoneInfo\":\"Unit Test Hardware\"\n" +
+                "}";
+
+        String recordJsonText = "{}";
+
+        Map<String, String> fileMap = ImmutableMap.<String, String>builder().put("info.json", infoJsonText)
+                .put("record.json", recordJsonText).build();
+
+        // execute
+        test(schema, null, fileMap);
+
+        // verify created record
+        ArgumentCaptor<HealthDataRecord> recordCaptor = ArgumentCaptor.forClass(HealthDataRecord.class);
+        verify(mockHealthDataService, atLeastOnce()).createOrUpdateRecord(recordCaptor.capture());
+
+        HealthDataRecord record = recordCaptor.getValue();
+        validateCommonRecordProps(record);
+        assertEquals("max-app-version-test", record.getSchemaId());
+        assertEquals(2, record.getSchemaRevision());
+
+        JsonNode dataNode = record.getData();
+        assertEquals(0, dataNode.size());
+
+        // validate no uploads to S3
+        verifyZeroInteractions(mockS3UploadHelper);
+
+        // verify no attachments
+        verify(mockHealthDataService, never()).createOrUpdateAttachment(any(HealthDataAttachment.class));
+
+        // verify upload dao write validation status
+        verify(mockUploadDao).writeValidationStatus(UPLOAD, UploadStatus.SUCCEEDED, ImmutableList.of(), RECORD_ID);
+    }
+
+    @Test
+    public void missingOptionalFieldBelowMaxAppVersion() throws Exception {
+        // set up schema
+        List<UploadFieldDefinition> fieldDefList = ImmutableList.of(
+                new DynamoUploadFieldDefinition.Builder().withName("record.json.value")
+                        .withType(UploadFieldType.INLINE_JSON_BLOB).withMaxAppVersion(20).build());
+
+        DynamoUploadSchema schema = new DynamoUploadSchema();
+        schema.setFieldDefinitions(fieldDefList);
+        schema.setName("Max App Version Test");
+        schema.setRevision(2);
+        schema.setSchemaId("max-app-version-test");
+        schema.setSchemaType(UploadSchemaType.IOS_DATA);
+        schema.setStudyId(TestConstants.TEST_STUDY_IDENTIFIER);
+
+        // set up upload files
+        String infoJsonText = "{\n" +
+                "   \"files\":[{\n" +
+                "       \"filename\":\"record.json\",\n" +
+                "       \"timestamp\":\"" + CREATED_ON_STRING + "\"\n" +
+                "   }],\n" +
+                "   \"item\":\"max-app-version-test\",\n" +
+                "   \"schemaRevision\":2,\n" +
+                "   \"appVersion\":\"version 1.10, build 10\",\n" +
+                "   \"phoneInfo\":\"Unit Test Hardware\"\n" +
+                "}";
+
+        String recordJsonText = "{}";
+
+        Map<String, String> fileMap = ImmutableMap.<String, String>builder().put("info.json", infoJsonText)
+                .put("record.json", recordJsonText).build();
+
+        // execute
+        test(schema, null, fileMap);
+
+        // no records or attachments are created; nothing is uploaded to S3
+        verifyZeroInteractions(mockS3UploadHelper);
+        verify(mockHealthDataService, never()).createOrUpdateRecord(any(HealthDataRecord.class));
+        verify(mockHealthDataService, never()).createOrUpdateAttachment(any(HealthDataAttachment.class));
+
+        // verify upload dao write validation status
+        // Error message list may contain other messages. For simplicity, concat them all together and just search for
+        // the specific one you're looking for.
+        // Additionally, record ID was never assigned, since upload failed out at the StrictValidationHandler, long
+        // before the UploadArtifactsHandler.
+        ArgumentCaptor<List> errorMessageListCaptor = ArgumentCaptor.forClass(List.class);
+        verify(mockUploadDao).writeValidationStatus(eq(UPLOAD), eq(UploadStatus.VALIDATION_FAILED),
+                errorMessageListCaptor.capture(), isNull(String.class));
+        String joinedErrorMessageList = BridgeUtils.COMMA_JOINER.join(errorMessageListCaptor.getValue());
+        assertTrue(joinedErrorMessageList.contains("Required field record.json.value missing"));
+    }
+}

--- a/test/org/sagebionetworks/bridge/upload/UploadUtilTest.java
+++ b/test/org/sagebionetworks/bridge/upload/UploadUtilTest.java
@@ -1,14 +1,231 @@
 package org.sagebionetworks.bridge.upload;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.BigIntegerNode;
+import com.fasterxml.jackson.databind.node.BooleanNode;
+import com.fasterxml.jackson.databind.node.DecimalNode;
+import com.fasterxml.jackson.databind.node.DoubleNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.LongNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.junit.Test;
 
-// This file exists to support a hack, but we should still test it anyway.
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.upload.UploadFieldType;
+
+@SuppressWarnings("ConstantConditions")
 public class UploadUtilTest {
+    @Test
+    public void canonicalize() throws Exception {
+        // { inputNode, fieldType, expectedNode, expectedErrorMessage, expectedIsValid }
+        Object[][] testCaseArray = {
+                // java null
+                { null, UploadFieldType.BOOLEAN, null, true },
+                // json null
+                { NullNode.instance, UploadFieldType.BOOLEAN, NullNode.instance, true },
+                // attachment blob
+                { new TextNode("dummy attachment"), UploadFieldType.ATTACHMENT_BLOB, new TextNode("dummy attachment"),
+                        true },
+                // attachment csv
+                { new TextNode("dummy attachment"), UploadFieldType.ATTACHMENT_CSV, new TextNode("dummy attachment"),
+                        true },
+                // attachment json blob
+                { new TextNode("dummy attachment"), UploadFieldType.ATTACHMENT_JSON_BLOB,
+                        new TextNode("dummy attachment"), true },
+                // attachment json table
+                { new TextNode("dummy attachment"), UploadFieldType.ATTACHMENT_JSON_TABLE,
+                        new TextNode("dummy attachment"), true },
+                // attachment v2
+                { new TextNode("dummy attachment"), UploadFieldType.ATTACHMENT_V2, new TextNode("dummy attachment"),
+                        true },
+                // inline json
+                { new TextNode("dummy inline JSON"), UploadFieldType.INLINE_JSON_BLOB,
+                        new TextNode("dummy inline JSON"), true },
+                // boolean zero false
+                { new IntNode(0), UploadFieldType.BOOLEAN, BooleanNode.FALSE, true },
+                // boolean positive true
+                { new IntNode(3), UploadFieldType.BOOLEAN, BooleanNode.TRUE, true },
+                // boolean negative true
+                { new IntNode(-3), UploadFieldType.BOOLEAN, BooleanNode.TRUE, true },
+                // boolean string false
+                { new TextNode("false"), UploadFieldType.BOOLEAN, BooleanNode.FALSE, true },
+                // boolean mixed case string false
+                { new TextNode("fALSE"), UploadFieldType.BOOLEAN, BooleanNode.FALSE, true },
+                // boolean string true
+                { new TextNode("true"), UploadFieldType.BOOLEAN, BooleanNode.TRUE, true },
+                // boolean mixed case string true
+                { new TextNode("TrUe"), UploadFieldType.BOOLEAN, BooleanNode.TRUE, true },
+                // boolean empty string
+                { new TextNode(""), UploadFieldType.BOOLEAN, null, false },
+                // boolean invalid string
+                { new TextNode("Yes"), UploadFieldType.BOOLEAN, null, false },
+                // boolean boolean false
+                { BooleanNode.FALSE, UploadFieldType.BOOLEAN, BooleanNode.FALSE, true },
+                // boolean boolean true
+                { BooleanNode.TRUE, UploadFieldType.BOOLEAN, BooleanNode.TRUE, true },
+                // boolean invalid type
+                { new DoubleNode(3.14), UploadFieldType.BOOLEAN, null, false },
+                // calendar date invalid type
+                { new IntNode(1234), UploadFieldType.CALENDAR_DATE, null, false },
+                // calendar date empty string
+                { new TextNode(""), UploadFieldType.CALENDAR_DATE, null, false },
+                // calendar date invalid string
+                { new TextNode("June 1, 2016"), UploadFieldType.CALENDAR_DATE, null, false },
+                // calendar date valid
+                { new TextNode("2016-06-01"), UploadFieldType.CALENDAR_DATE, new TextNode("2016-06-01"), true },
+                // calendar date full datetime
+                { new TextNode("2016-06-01T11:00Z"), UploadFieldType.CALENDAR_DATE, new TextNode("2016-06-01"), true },
+                // duration invalid type
+                { new TextNode("2016-06-01"), UploadFieldType.CALENDAR_DATE, new TextNode("2016-06-01"), true },
+                // duration empty string
+                { new TextNode(""), UploadFieldType.DURATION_V2, null, false },
+                // duration invalid string
+                { new TextNode("one hour"), UploadFieldType.DURATION_V2, null, false },
+                // duration valid
+                { new TextNode("PT1H"), UploadFieldType.DURATION_V2, new TextNode("PT1H"), true },
+                // float valid
+                { new DecimalNode(new BigDecimal("3.14")), UploadFieldType.FLOAT,
+                        new DecimalNode(new BigDecimal("3.14")), true },
+                // float from int
+                { new IntNode(42), UploadFieldType.FLOAT, new IntNode(42), true },
+                // float from string
+                { new TextNode("2.718"), UploadFieldType.FLOAT, new DecimalNode(new BigDecimal("2.718")), true },
+                // float from int string
+                { new TextNode("13"), UploadFieldType.FLOAT, new DecimalNode(new BigDecimal("13")), true },
+                // float empty string
+                { new TextNode(""), UploadFieldType.FLOAT, null, false },
+                // float invalid string
+                { new TextNode("three point one four"), UploadFieldType.FLOAT, null, false },
+                // float invalid type
+                { BooleanNode.FALSE, UploadFieldType.FLOAT, null, false },
+                // int valid
+                { new IntNode(57), UploadFieldType.INT, new IntNode(57), true },
+                // int from float
+                { new DoubleNode(3.14), UploadFieldType.INT, new BigIntegerNode(new BigInteger("3")), true },
+                // int from string
+                { new TextNode("1234"), UploadFieldType.INT, new BigIntegerNode(new BigInteger("1234")), true },
+                // int from float string
+                { new TextNode("12.34"), UploadFieldType.INT, new BigIntegerNode(new BigInteger("12")), true },
+                // int empty string
+                { new TextNode(""), UploadFieldType.INT, null, false },
+                // int invalid string
+                { new TextNode("twelve"), UploadFieldType.INT, null, false },
+                // int invalid type
+                { BooleanNode.TRUE, UploadFieldType.INT, null, false },
+                // multi-choice not array
+                { new TextNode("[3, 5, 7]"), UploadFieldType.MULTI_CHOICE, null, false },
+                // multi-choice valid (some elements aren't strings)
+                { BridgeObjectMapper.get().readTree("[true, false, \"Don't Know\"]"), UploadFieldType.MULTI_CHOICE,
+                        BridgeObjectMapper.get().readTree("[\"true\", \"false\", \"Don't Know\"]"), true },
+                // single-choice array
+                { BridgeObjectMapper.get().readTree("[\"football\"]"), UploadFieldType.SINGLE_CHOICE,
+                        new TextNode("football"), true },
+                // single-choice empty array
+                { BridgeObjectMapper.get().readTree("[]"), UploadFieldType.SINGLE_CHOICE, null, false },
+                // single-choice multi array
+                { BridgeObjectMapper.get().readTree("[\"foo\", \"bar\"]"), UploadFieldType.SINGLE_CHOICE, null,
+                        false },
+                // single-choice array non-string
+                { BridgeObjectMapper.get().readTree("[42]"), UploadFieldType.SINGLE_CHOICE, new TextNode("42"), true },
+                // single-choice string
+                { new TextNode("swimming"), UploadFieldType.SINGLE_CHOICE, new TextNode("swimming"), true },
+                // single-choice other type
+                { new IntNode(23), UploadFieldType.SINGLE_CHOICE, new TextNode("23"), true },
+                // string valid
+                { new TextNode("Other"), UploadFieldType.STRING, new TextNode("Other"), true },
+                // string from non-string
+                { new IntNode(1337), UploadFieldType.STRING, new TextNode("1337"), true },
+                // local time invalid type
+                { new IntNode(2300), UploadFieldType.TIME_V2, null, false },
+                // local time empty string
+                { new TextNode(""), UploadFieldType.TIME_V2, null, false },
+                // local time invalid string
+                { new TextNode("11pm"), UploadFieldType.TIME_V2, null, false },
+                // local time valid
+                { new TextNode("12:34:56.789"), UploadFieldType.TIME_V2, new TextNode("12:34:56.789"), true },
+                // local time full datetime
+                { new TextNode("2016-06-01T12:34:56.789-0700"), UploadFieldType.TIME_V2, new TextNode("12:34:56.789"),
+                        true },
+                // datetime invalid type
+                { BooleanNode.TRUE, UploadFieldType.TIMESTAMP, null, false },
+                // datetime number
+                { new LongNode(1464825450123L), UploadFieldType.TIMESTAMP, new TextNode("2016-06-01T23:57:30.123Z"),
+                        true },
+                // datetime empty string
+                { new TextNode(""), UploadFieldType.TIMESTAMP, null, false },
+                // datetime invalid string
+                { new TextNode("Jun 1 2016 11:59pm"), UploadFieldType.TIMESTAMP, null, false },
+                // datetime valid
+                { new TextNode("2016-06-01T23:59:59.999Z"), UploadFieldType.TIMESTAMP,
+                        new TextNode("2016-06-01T23:59:59.999Z"), true },
+        };
+
+        for (Object[] oneTestCase : testCaseArray) {
+            JsonNode inputNode = (JsonNode) oneTestCase[0];
+            String inputNodeStr = BridgeObjectMapper.get().writeValueAsString(inputNode);
+            UploadFieldType fieldType = (UploadFieldType) oneTestCase[1];
+
+            CanonicalizationResult result = UploadUtil.canonicalize(inputNode, fieldType);
+            assertEquals("Test case: " + inputNodeStr + " as " + fieldType.name(), oneTestCase[2],
+                    result.getCanonicalizedValueNode());
+
+            boolean expectedIsValid = (boolean) oneTestCase[3];
+            if (expectedIsValid) {
+                assertTrue("Test case: " + inputNodeStr + " as " + fieldType.name(), result.isValid());
+                assertNull("Test case: " + inputNodeStr + " as " + fieldType.name(), result.getErrorMessage());
+            } else {
+                assertFalse("Test case: " + inputNodeStr + " as " + fieldType.name(), result.isValid());
+                assertNotNull("Test case: " + inputNodeStr + " as " + fieldType.name(), result.getErrorMessage());
+            }
+        }
+    }
+
+    @Test
+    public void convertToStringNode() throws Exception {
+        // java null
+        {
+            JsonNode result = UploadUtil.convertToStringNode(null);
+            assertNull(result);
+        }
+
+        // json null
+        {
+            JsonNode result = UploadUtil.convertToStringNode(NullNode.instance);
+            assertTrue(result.isNull());
+        }
+
+        // { inputNode, outputString }
+        Object[][] testCaseArray = {
+                // not a string
+                { new IntNode(42), "42" },
+                // empty string
+                { new TextNode(""), "" },
+                // is a string
+                { new TextNode("foobarbaz"), "foobarbaz" },
+        };
+
+        for (Object[] oneTestCase : testCaseArray) {
+            JsonNode inputNode = (JsonNode) oneTestCase[0];
+            String inputNodeStr = BridgeObjectMapper.get().writeValueAsString(inputNode);
+
+            JsonNode result = UploadUtil.convertToStringNode(inputNode);
+            assertTrue("Test case: " + inputNodeStr, result.isTextual());
+            assertEquals("Test case: " + inputNodeStr, oneTestCase[1], result.textValue());
+        }
+    }
+
     @Test
     public void nullCalendarDate() {
         assertNull(UploadUtil.parseIosCalendarDate(null));


### PR DESCRIPTION
The main change is adding the Upload v2 field types (https://sagebionetworks.jira.com/browse/BRIDGE-1288), but there's a few other changes here:
- Fixed a bug with timezone parsing in DateUtils. (This somehow went on for over a year before we noticed it.)
- New utility method to convert non-ideal but parseable field values and convert them to a more "canonical" format.
- Through end-to-end unit test for Upload Validation

Testing done:
- new and improved unit tests
- ran UploadTest integ test against local server
