### PR TITLE
An index of report identifiers

### DIFF
--- a/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
+++ b/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
@@ -47,6 +47,7 @@ import org.sagebionetworks.bridge.dynamodb.DynamoIndexHelper;
 import org.sagebionetworks.bridge.dynamodb.DynamoMpowerVisualization;
 import org.sagebionetworks.bridge.dynamodb.DynamoParticipantOptions;
 import org.sagebionetworks.bridge.dynamodb.DynamoReportData;
+import org.sagebionetworks.bridge.dynamodb.DynamoReportIndex;
 import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudyConsent1;
 import org.sagebionetworks.bridge.dynamodb.DynamoSurvey;
@@ -259,6 +260,12 @@ public class BridgeSpringConfig {
     @Autowired
     public DynamoDBMapper reportDataMapper(DynamoUtils dynamoUtils) {
         return dynamoUtils.getMapper(DynamoReportData.class);
+    }
+    
+    @Bean(name = "reportIndexMapper")
+    @Autowired
+    public DynamoDBMapper reportIndexMapper(DynamoUtils dynamoUtils) {
+        return dynamoUtils.getMapper(DynamoReportIndex.class);
     }
     
     @Bean(name = "healthDataDdbMapper")

--- a/app/org/sagebionetworks/bridge/dao/ReportIndexDao.java
+++ b/app/org/sagebionetworks/bridge/dao/ReportIndexDao.java
@@ -16,7 +16,8 @@ public interface ReportIndexDao {
     
     /**
      * Remove an index item for a report identifier. This can only be done for study reports, since we have no
-     * performant way to determine if an identifier for a participant report is no longer in use by any participant.
+     * performant way to determine if an identifier for a participant report is no longer in use by any participant. 
+     * Still it is better than no cleanup.
      */
     void removeIndex(ReportDataKey key);
     

--- a/app/org/sagebionetworks/bridge/dao/ReportIndexDao.java
+++ b/app/org/sagebionetworks/bridge/dao/ReportIndexDao.java
@@ -1,0 +1,28 @@
+package org.sagebionetworks.bridge.dao;
+
+import java.util.List;
+
+import org.sagebionetworks.bridge.models.reports.ReportDataKey;
+import org.sagebionetworks.bridge.models.reports.ReportIndex;
+import org.sagebionetworks.bridge.models.reports.ReportType;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
+
+public interface ReportIndexDao {
+
+    /**
+     * Add an index item for a report, so the identifier of the report can be retrieved in a list of such identifiers.
+     */
+    void addIndex(ReportDataKey key);
+    
+    /**
+     * Remove an index item for a report identifier. This can only be done for study reports, since we have no
+     * performant way to determine if an identifier for a participant report is no longer in use by any participant.
+     */
+    void removeIndex(ReportDataKey key);
+    
+    /**
+     * Get all the identifiers for a study, for either study or participant reports.
+     */
+    List<? extends ReportIndex> getIndices(StudyIdentifier studyId, ReportType type);
+    
+}

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoReportDataDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoReportDataDao.java
@@ -28,8 +28,8 @@ public class DynamoReportDataDao implements ReportDataDao {
     private DynamoDBMapper mapper;
 
     @Resource(name = "reportDataMapper")
-    final void setReportDataMapper(DynamoDBMapper schedulePlanMapper) {
-        this.mapper = schedulePlanMapper;
+    final void setReportDataMapper(DynamoDBMapper reportDataMapper) {
+        this.mapper = reportDataMapper;
     }
     
     @Override

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoReportIndex.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoReportIndex.java
@@ -1,0 +1,39 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import org.sagebionetworks.bridge.models.reports.ReportIndex;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+@DynamoDBTable(tableName = "ReportIndex")
+public class DynamoReportIndex implements ReportIndex {
+
+    private String key;
+    private String identifier;
+    
+    @JsonIgnore
+    @DynamoDBHashKey
+    @Override
+    public String getKey() {
+        return key;
+    }
+
+    @Override
+    public void setKey(String key) {
+        this.key = key;
+    }
+    
+    @DynamoDBRangeKey
+    @Override
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    @Override
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+
+    }
+}

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoReportIndexDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoReportIndexDao.java
@@ -9,7 +9,6 @@ import javax.annotation.Resource;
 
 import org.springframework.stereotype.Component;
 
-import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.dao.ReportIndexDao;
 import org.sagebionetworks.bridge.models.reports.ReportDataKey;
 import org.sagebionetworks.bridge.models.reports.ReportIndex;
@@ -18,10 +17,6 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper.FailedBatch;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
-import com.amazonaws.services.dynamodbv2.model.Condition;
 
 @Component
 public class DynamoReportIndexDao implements ReportIndexDao {

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoReportIndexDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoReportIndexDao.java
@@ -1,0 +1,85 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.List;
+
+import javax.annotation.Resource;
+
+import org.springframework.stereotype.Component;
+
+import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.dao.ReportIndexDao;
+import org.sagebionetworks.bridge.models.reports.ReportDataKey;
+import org.sagebionetworks.bridge.models.reports.ReportIndex;
+import org.sagebionetworks.bridge.models.reports.ReportType;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper.FailedBatch;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
+import com.amazonaws.services.dynamodbv2.model.Condition;
+
+@Component
+public class DynamoReportIndexDao implements ReportIndexDao {
+    
+    private DynamoDBMapper mapper;
+
+    @Resource(name = "reportIndexMapper")
+    final void setReportIndexMapper(DynamoDBMapper reportIndexMapper) {
+        this.mapper = reportIndexMapper;
+    }
+    
+    @Override
+    public void addIndex(ReportDataKey key) {
+        checkNotNull(key);
+        
+        DynamoReportIndex index = new DynamoReportIndex();
+        index.setKey(key.getIndexKeyString());
+        index.setIdentifier(key.getIdentifier());
+        
+        mapper.save(index);
+    }
+
+    @Override
+    public void removeIndex(ReportDataKey key) {
+        checkNotNull(key);
+        checkArgument(key.getReportType() != ReportType.PARTICIPANT, "cannot remove participant report indices");
+        
+        DynamoReportIndex hashKey = new DynamoReportIndex();
+        hashKey.setKey(key.getIndexKeyString());
+        
+        Condition idCondition = new Condition().withComparisonOperator(ComparisonOperator.EQ)
+                .withAttributeValueList(new AttributeValue().withS(key.getIdentifier()));
+        
+        DynamoDBQueryExpression<DynamoReportIndex> query =
+                new DynamoDBQueryExpression<DynamoReportIndex>().withHashKeyValues(hashKey)
+                        .withRangeKeyCondition("identifier", idCondition);
+        List<DynamoReportIndex> objectsToDelete = mapper.query(DynamoReportIndex.class, query);
+        
+        if (!objectsToDelete.isEmpty()) {
+            List<FailedBatch> failures = mapper.batchDelete(objectsToDelete);
+            BridgeUtils.ifFailuresThrowException(failures);
+        }
+    }
+
+    @Override
+    public List<? extends ReportIndex> getIndices(StudyIdentifier studyId, ReportType reportType) {
+        checkNotNull(studyId);
+        checkNotNull(reportType);
+        
+        String key = String.format("%s:%s", studyId.getIdentifier(), reportType.name());
+        
+        DynamoReportIndex hashKey = new DynamoReportIndex();
+        hashKey.setKey(key);
+        
+        DynamoDBQueryExpression<DynamoReportIndex> query =
+                new DynamoDBQueryExpression<DynamoReportIndex>().withHashKeyValues(hashKey);
+
+        return mapper.query(DynamoReportIndex.class, query);
+    }
+
+}

--- a/app/org/sagebionetworks/bridge/models/reports/ReportDataKey.java
+++ b/app/org/sagebionetworks/bridge/models/reports/ReportDataKey.java
@@ -2,6 +2,9 @@ package org.sagebionetworks.bridge.models.reports;
 
 import java.util.Objects;
 
+import org.joda.time.LocalDate;
+import org.springframework.validation.Errors;
+
 import org.sagebionetworks.bridge.models.BridgeEntity;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.validators.ReportDataKeyValidator;
@@ -88,6 +91,8 @@ public final class ReportDataKey implements BridgeEntity {
         private String identifier;
         private String healthCode;
         private ReportType reportType;
+        private boolean validateDate = false;
+        private LocalDate date;
         
         public Builder withStudyIdentifier(StudyIdentifier studyId) {
             this.studyId = studyId;
@@ -105,9 +110,22 @@ public final class ReportDataKey implements BridgeEntity {
             this.reportType = reportType;
             return this;
         }
+        public Builder validateWithDate(LocalDate date) {
+            this.date = date;
+            this.validateDate = true;
+            return this;
+        }
         public ReportDataKey build() {
             ReportDataKey key = new ReportDataKey(healthCode, identifier, studyId, reportType);
-            Validate.entityThrowingException(VALIDATOR, key);
+            
+            Errors errors = Validate.getErrorsFor(key);
+            Validate.entity(VALIDATOR, errors, key);
+            if (validateDate && date == null) {
+                errors.rejectValue("date", "date is required");
+            }
+            if (errors.hasErrors()) {
+                Validate.throwException(errors, key);
+            }
             return key;
         }
     }

--- a/app/org/sagebionetworks/bridge/models/reports/ReportDataKey.java
+++ b/app/org/sagebionetworks/bridge/models/reports/ReportDataKey.java
@@ -55,7 +55,12 @@ public final class ReportDataKey implements BridgeEntity {
                 String.format("%s:%s:%s", healthCode, identifier, studyId.getIdentifier()) :
                 String.format("%s:%s", identifier, studyId.getIdentifier());
     }
-
+    
+    @JsonIgnore
+    public String getIndexKeyString() {
+        return String.format("%s:%s",studyId.getIdentifier(), reportType.name());
+    }
+    
     @Override
     public String toString() {
         return "ReportDataKey [studyId=" + studyId + ", identifier=" + identifier

--- a/app/org/sagebionetworks/bridge/models/reports/ReportDataKey.java
+++ b/app/org/sagebionetworks/bridge/models/reports/ReportDataKey.java
@@ -121,7 +121,7 @@ public final class ReportDataKey implements BridgeEntity {
             Errors errors = Validate.getErrorsFor(key);
             Validate.entity(VALIDATOR, errors, key);
             if (validateDate && date == null) {
-                errors.rejectValue("date", "date is required");
+                errors.rejectValue("date", "is required");
             }
             if (errors.hasErrors()) {
                 Validate.throwException(errors, key);

--- a/app/org/sagebionetworks/bridge/models/reports/ReportIndex.java
+++ b/app/org/sagebionetworks/bridge/models/reports/ReportIndex.java
@@ -7,9 +7,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 /**
- * <p>An index entry of an identifier used for a report in a study. You can have a "default" study report and a 
- * "default" participant report, and both would co-exist in the data table. This is maintained by ReportIndex 
- * table by using a compound key that includes the study and the report type. </p>
+ * <p>An index entry of an identifier used for a report in a study. It's possible to have the same identifier 
+ * used for a study and a participant report, so the ReportIndex tables support this by including the type 
+ * as well as the study in the record's hash key. </p>
  *
  * <p>Study index records can be deleted when study reports are deleted, but we can't do the same for 
  * participants because we don't know (without scanning) when the last participant is removed from a report 

--- a/app/org/sagebionetworks/bridge/models/reports/ReportIndex.java
+++ b/app/org/sagebionetworks/bridge/models/reports/ReportIndex.java
@@ -1,0 +1,33 @@
+package org.sagebionetworks.bridge.models.reports;
+
+import org.sagebionetworks.bridge.dynamodb.DynamoReportIndex;
+import org.sagebionetworks.bridge.json.BridgeTypeName;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+/**
+ * <p>An index entry of an identifier used for a report in a study. You can have a "default" study report and a 
+ * "default" participant report, and both would co-exist in the data table. This is maintained by ReportIndex 
+ * table by using a compound key that includes the study and the report type. </p>
+ *
+ * <p>Study index records can be deleted when study reports are deleted, but we can't do the same for 
+ * participants because we don't know (without scanning) when the last participant is removed from a report 
+ * under a specific identifier.</p>
+ */
+@BridgeTypeName("ReportIndex")
+@JsonDeserialize(as=DynamoReportIndex.class)
+public interface ReportIndex {
+
+    public static ReportIndex create() {
+        return new DynamoReportIndex();
+    }
+    
+    @JsonIgnore
+    String getKey();
+    public void setKey(String key);
+    
+    String getIdentifier();
+    void setIdentifier(String identifier);
+    
+}

--- a/app/org/sagebionetworks/bridge/play/controllers/ReportController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ReportController.java
@@ -61,7 +61,7 @@ public class ReportController extends BaseController {
     }
 
     /**
-     * Reports for specific individuals accessible only to consented study participants.
+     * Reports for specific individuals accessible to either consented study participants, or to researchers.
      */
     public Result getParticipantReport(String identifier, String startDateString, String endDateString) {
         UserSession session = getAuthenticatedSession();

--- a/app/org/sagebionetworks/bridge/play/controllers/ReportController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ReportController.java
@@ -1,10 +1,12 @@
 package org.sagebionetworks.bridge.play.controllers;
 
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
+import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.Roles.WORKER;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.util.LinkedHashSet;
+import java.util.List;
 
 import org.joda.time.LocalDate;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,12 +14,15 @@ import org.springframework.stereotype.Controller;
 
 import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
+import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.DateRangeResourceList;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.reports.ReportData;
+import org.sagebionetworks.bridge.models.reports.ReportIndex;
+import org.sagebionetworks.bridge.models.reports.ReportType;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.services.ReportService;
 
@@ -45,10 +50,24 @@ public class ReportController extends BaseController {
     }
     
     /**
+     * Get a list of the identifiers used for participant reports in this study.
+     */
+    public Result getParticipantReportIndices() throws Exception {
+        UserSession session = getAuthenticatedSession(DEVELOPER);
+        
+        List<? extends ReportIndex> indices = reportService.getReportIndices(
+                session.getStudyIdentifier(), ReportType.PARTICIPANT);
+        return okResult(indices);
+    }
+
+    /**
      * Reports for specific individuals accessible only to consented study participants.
      */
     public Result getParticipantReport(String identifier, String startDateString, String endDateString) {
-        UserSession session = getAuthenticatedAndConsentedSession();
+        UserSession session = getAuthenticatedSession();
+        if (!session.isInRole(RESEARCHER) && !session.doesConsent()) {
+            throw new UnauthorizedException();
+        }
         checkHeaders();
         
         LocalDate startDate = parseDateHelper(startDateString);
@@ -109,7 +128,18 @@ public class ReportController extends BaseController {
         
         reportService.deleteParticipantReport(session.getStudyIdentifier(), identifier, account.getHealthCode());
         
-        return ok("Report deleted.");
+        return okResult("Report deleted.");
+    }
+    
+    /**
+     * Get a list of the identifiers used for participant reports in this study.
+     */
+    public Result getStudyReportIndices() throws Exception {
+        UserSession session = getAuthenticatedSession(DEVELOPER);
+        
+        List<? extends ReportIndex> indices = reportService.getReportIndices(
+                session.getStudyIdentifier(), ReportType.STUDY);
+        return okResult(indices);
     }
     
     /**
@@ -152,7 +182,7 @@ public class ReportController extends BaseController {
         
         reportService.deleteStudyReport(session.getStudyIdentifier(), identifier);
         
-        return ok("Report deleted.");
+        return okResult("Report deleted.");
     }
 
     /**

--- a/app/org/sagebionetworks/bridge/services/ReportService.java
+++ b/app/org/sagebionetworks/bridge/services/ReportService.java
@@ -33,6 +33,7 @@ public class ReportService {
         this.reportDataDao =reportDataDao;
     }
     
+    @Autowired
     final void setReportIndexDao(ReportIndexDao reportIndexDao) {
         this.reportIndexDao = reportIndexDao;
     }

--- a/conf/routes
+++ b/conf/routes
@@ -57,6 +57,7 @@ POST   /v3/consents/:timestamp/publish   @org.sagebionetworks.bridge.play.contro
 
 # Users
 POST   /v3/users                          @org.sagebionetworks.bridge.play.controllers.UserManagementController.createUser
+GET    /v3/users/reports                  @org.sagebionetworks.bridge.play.controllers.ReportController.getParticipantReportIndices
 DELETE /v3/users/:userId                  @org.sagebionetworks.bridge.play.controllers.UserManagementController.deleteUser(userId: String)
 GET    /v3/users/self                     @org.sagebionetworks.bridge.play.controllers.UserProfileController.getUserProfile
 POST   /v3/users/self                     @org.sagebionetworks.bridge.play.controllers.UserProfileController.updateUserProfile
@@ -70,6 +71,7 @@ POST   /v3/users/self/dataGroups          @org.sagebionetworks.bridge.play.contr
 GET    /v3/users/self/reports/:identifier @org.sagebionetworks.bridge.play.controllers.ReportController.getParticipantReport(identifier: String, startDate: String ?= null, endDate: String ?= null)
 
 # Study-wide reports
+GET    /v3/reports                           @org.sagebionetworks.bridge.play.controllers.ReportController.getStudyReportIndices
 GET    /v3/reports/:identifier               @org.sagebionetworks.bridge.play.controllers.ReportController.getStudyReport(identifier: String, startDate: String ?= null, endDate: String ?= null)
 POST   /v3/reports/:identifier               @org.sagebionetworks.bridge.play.controllers.ReportController.saveStudyReport(identifier: String)
 DELETE /v3/reports/:identifier               @org.sagebionetworks.bridge.play.controllers.ReportController.deleteStudyReport(identifier: String)

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoReportIndexDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoReportIndexDaoTest.java
@@ -1,0 +1,138 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import static org.junit.Assert.assertEquals;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
+
+import java.util.List;
+
+import javax.annotation.Resource;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.TestUtils;
+import org.sagebionetworks.bridge.models.reports.ReportDataKey;
+import org.sagebionetworks.bridge.models.reports.ReportIndex;
+import org.sagebionetworks.bridge.models.reports.ReportType;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper.FailedBatch;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
+import com.amazonaws.services.dynamodbv2.model.Condition;
+
+@ContextConfiguration("classpath:test-context.xml")
+@RunWith(SpringJUnit4ClassRunner.class)
+public class DynamoReportIndexDaoTest {
+
+    @Autowired
+    DynamoReportIndexDao dao;
+    
+    private ReportDataKey studyReportKey1;
+    
+    private ReportDataKey studyReportKey2;
+    
+    private ReportDataKey participantReportKey1;
+    
+    private ReportDataKey participantReportKey2;
+
+    @Resource(name = "reportIndexMapper")
+    private DynamoDBMapper mapper;
+
+    @Before
+    public void before() {
+        String reportName1 = TestUtils.randomName(DynamoReportIndexDaoTest.class);
+        String reportName2 = TestUtils.randomName(DynamoReportIndexDaoTest.class);
+        
+        ReportDataKey.Builder builder = new ReportDataKey.Builder().withStudyIdentifier(TEST_STUDY);
+        builder.withReportType(ReportType.STUDY);
+        studyReportKey1 = builder.withIdentifier(reportName1).build();
+        studyReportKey2 = builder.withIdentifier(reportName2).build();
+        
+        builder.withReportType(ReportType.PARTICIPANT);
+        participantReportKey1 = builder.withIdentifier(reportName1)
+                .withHealthCode(BridgeUtils.generateGuid()).build();
+        participantReportKey2 = builder.withIdentifier(reportName2)
+                .withHealthCode(BridgeUtils.generateGuid()).build();
+    }
+    
+    @Test
+    public void canCRUDReportIndex() {
+        int count = dao.getIndices(TEST_STUDY, ReportType.STUDY).size();
+        // adding twice is fine
+        dao.addIndex(studyReportKey1);
+        dao.addIndex(studyReportKey1);
+        dao.addIndex(studyReportKey2);
+
+        List<? extends ReportIndex> indices = dao.getIndices(TEST_STUDY, ReportType.STUDY);
+        assertEquals(count+2, indices.size());
+        
+        // Wrong type returns zero records
+        indices = dao.getIndices(TEST_STUDY, ReportType.PARTICIPANT);
+        assertEquals(0, indices.size());
+        
+        dao.removeIndex(studyReportKey1);
+        indices = dao.getIndices(TEST_STUDY, ReportType.STUDY);
+        assertEquals(count+1, indices.size());
+        
+        dao.removeIndex(studyReportKey2);
+        indices = dao.getIndices(TEST_STUDY, ReportType.STUDY);
+        assertEquals(count, indices.size());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void cannotCreateIndexForParticipantReport() {
+        dao.removeIndex(participantReportKey1);
+    }
+    
+    @Test
+    public void canCreateAndReadParticipantIndex() {
+        int count = dao.getIndices(TEST_STUDY, ReportType.PARTICIPANT).size();
+        
+        // adding twice is fine
+        dao.addIndex(participantReportKey1);
+        dao.addIndex(participantReportKey1);
+        dao.addIndex(participantReportKey2);
+        
+        List<? extends ReportIndex> indices = dao.getIndices(TEST_STUDY, ReportType.PARTICIPANT);
+        assertEquals(count+2, indices.size());
+        assertEquals(participantReportKey1.getIdentifier(), indices.get(0).getIdentifier());
+        assertEquals(participantReportKey2.getIdentifier(), indices.get(1).getIdentifier());
+        
+        // wrong type returns no records
+        indices = dao.getIndices(TEST_STUDY, ReportType.STUDY);
+        assertEquals(0, indices.size());
+        
+        // Use mapper directly to clean up, as we don't allow deletion of participant reports.
+        deleteParticipantReport(participantReportKey1);
+        deleteParticipantReport(participantReportKey2);
+        
+        indices = dao.getIndices(TEST_STUDY, ReportType.PARTICIPANT);
+        assertEquals(count, indices.size());
+    }
+    
+    private void deleteParticipantReport(ReportDataKey key) {
+        DynamoReportIndex hashKey = new DynamoReportIndex();
+        hashKey.setKey(key.getIndexKeyString());
+        
+        Condition idCondition = new Condition().withComparisonOperator(ComparisonOperator.EQ)
+                .withAttributeValueList(new AttributeValue().withS(key.getIdentifier()));
+        
+        DynamoDBQueryExpression<DynamoReportIndex> query =
+                new DynamoDBQueryExpression<DynamoReportIndex>().withHashKeyValues(hashKey)
+                        .withRangeKeyCondition("identifier", idCondition);
+        List<DynamoReportIndex> objectsToDelete = mapper.query(DynamoReportIndex.class, query);
+        
+        if (!objectsToDelete.isEmpty()) {
+            List<FailedBatch> failures = mapper.batchDelete(objectsToDelete);
+            BridgeUtils.ifFailuresThrowException(failures);
+        }
+        
+    }
+}

--- a/test/org/sagebionetworks/bridge/models/reports/ReportDataKeyTest.java
+++ b/test/org/sagebionetworks/bridge/models/reports/ReportDataKeyTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 
+import org.joda.time.LocalDate;
 import org.junit.Test;
 
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
@@ -40,7 +41,7 @@ public class ReportDataKeyTest {
             new ReportDataKey.Builder().validateWithDate(null).build();
         } catch(InvalidEntityException e) {
             assertEquals("date is required", e.getErrors().get("date").get(0));
-            // integrated alongside validator errors
+            // integrated alongside Validator errors
             assertEquals("identifier cannot be missing or blank", e.getErrors().get("identifier").get(0));
         }
     }
@@ -48,8 +49,11 @@ public class ReportDataKeyTest {
     @Test
     public void constructStudyKey() {
         ReportDataKey key = new ReportDataKey.Builder()
-                .withReportType(ReportType.STUDY).withStudyIdentifier(TEST_STUDY).withIdentifier("report").build();
+                .withReportType(ReportType.STUDY).withStudyIdentifier(TEST_STUDY)
+                .withIdentifier("report").validateWithDate(LocalDate.parse("2012-02-02")).build();
         
+        // This was constructed, the date is valid. It's not part of the key, it's validated in the builder
+        // so validation errors are combined with key validation errors.
         assertEquals("report:api", key.getKeyString());
         assertEquals("api:STUDY", key.getIndexKeyString());
         assertNull(key.getHealthCode());

--- a/test/org/sagebionetworks/bridge/models/reports/ReportDataKeyTest.java
+++ b/test/org/sagebionetworks/bridge/models/reports/ReportDataKeyTest.java
@@ -6,6 +6,7 @@ import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 
 import org.junit.Test;
 
+import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -29,6 +30,19 @@ public class ReportDataKeyTest {
         assertEquals("healthCode", key.getHealthCode());
         assertEquals("report", key.getIdentifier());
         assertEquals(ReportType.PARTICIPANT, key.getReportType());
+    }
+    
+    @Test
+    public void canIncludeDateValidation() {
+        try {
+            // This is tested in tests for the validator, but date is actually validated in the 
+            // build method.
+            new ReportDataKey.Builder().validateWithDate(null).build();
+        } catch(InvalidEntityException e) {
+            assertEquals("date is required", e.getErrors().get("date").get(0));
+            // integrated alongside validator errors
+            assertEquals("identifier cannot be missing or blank", e.getErrors().get("identifier").get(0));
+        }
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/models/reports/ReportDataKeyTest.java
+++ b/test/org/sagebionetworks/bridge/models/reports/ReportDataKeyTest.java
@@ -62,6 +62,22 @@ public class ReportDataKeyTest {
     }
     
     @Test
+    public void canConstructKeyWithoutValidatingDate() {
+        ReportDataKey key = new ReportDataKey.Builder()
+                .withReportType(ReportType.PARTICIPANT).withStudyIdentifier(TEST_STUDY)
+                .withHealthCode("AAA")
+                .withIdentifier("report").build();
+        
+        // This was constructed, the date is valid. It's not part of the key, it's validated in the builder
+        // so validation errors are combined with key validation errors.
+        assertEquals("AAA:report:api", key.getKeyString());
+        assertEquals("api:PARTICIPANT", key.getIndexKeyString());
+        assertEquals("AAA", key.getHealthCode());
+        assertEquals("report", key.getIdentifier());
+        assertEquals(ReportType.PARTICIPANT, key.getReportType());
+    }
+    
+    @Test
     public void canSerialize() throws Exception {
         ReportDataKey key = new ReportDataKey.Builder().withHealthCode("healthCode").withStudyIdentifier(TEST_STUDY)
                 .withReportType(ReportType.PARTICIPANT).withIdentifier("report").build();

--- a/test/org/sagebionetworks/bridge/models/reports/ReportDataKeyTest.java
+++ b/test/org/sagebionetworks/bridge/models/reports/ReportDataKeyTest.java
@@ -25,6 +25,7 @@ public class ReportDataKeyTest {
                 .withReportType(ReportType.PARTICIPANT).withIdentifier("report").build();
 
         assertEquals("healthCode:report:api", key.getKeyString());
+        assertEquals("api:PARTICIPANT", key.getIndexKeyString());
         assertEquals("healthCode", key.getHealthCode());
         assertEquals("report", key.getIdentifier());
         assertEquals(ReportType.PARTICIPANT, key.getReportType());
@@ -36,6 +37,7 @@ public class ReportDataKeyTest {
                 .withReportType(ReportType.STUDY).withStudyIdentifier(TEST_STUDY).withIdentifier("report").build();
         
         assertEquals("report:api", key.getKeyString());
+        assertEquals("api:STUDY", key.getIndexKeyString());
         assertNull(key.getHealthCode());
         assertEquals("report", key.getIdentifier());
         assertEquals(ReportType.STUDY, key.getReportType());

--- a/test/org/sagebionetworks/bridge/models/reports/ReportIndexTest.java
+++ b/test/org/sagebionetworks/bridge/models/reports/ReportIndexTest.java
@@ -1,0 +1,27 @@
+package org.sagebionetworks.bridge.models.reports;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class ReportIndexTest {
+
+    @Test
+    public void canSerialize() throws Exception {
+        ReportIndex index = ReportIndex.create();
+        index.setKey("asdf:STUDY");
+        index.setIdentifier("asdf");
+        
+        JsonNode node = BridgeObjectMapper.get().valueToTree(index);
+        assertEquals("asdf", node.get("identifier").asText());
+        assertEquals("ReportIndex", node.get("type").asText());
+        assertEquals(2, node.size());
+        
+        ReportIndex deser = BridgeObjectMapper.get().readValue(node.toString(), ReportIndex.class);
+        assertEquals("asdf", deser.getIdentifier());
+    }
+}

--- a/test/org/sagebionetworks/bridge/play/controllers/ReportControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ReportControllerTest.java
@@ -226,12 +226,40 @@ public class ReportControllerTest {
         assertResult(result);
     }
     
+    @Test
+    public void getStudyReportDataWithNoUserAgentAsResearcherOK() throws Exception {
+        setupContext("", VALID_LANGUAGE_HEADER);
+        doReturn(makeResults(START_DATE, END_DATE)).when(mockReportService).getStudyReport(session.getStudyIdentifier(),
+                "foo", START_DATE, END_DATE);
+        
+        controller.getStudyReport("foo", START_DATE.toString(), END_DATE.toString());
+    }    
+    
     @Test(expected = BadRequestException.class)
-    public void getStudyReportDataWithNoUserAgent() throws Exception {
+    public void getParticipantReportDataWithNoUserAgent() throws Exception {
         setupContext("", VALID_LANGUAGE_HEADER);
         
-        controller.getStudyReport("foo", null, null);
-    }    
+        SubpopulationGuid guid = SubpopulationGuid.create("foo");
+        Map<SubpopulationGuid,ConsentStatus> consentStatuses = Maps.newHashMap();
+        consentStatuses.put(guid, new ConsentStatus.Builder().withName("FullName").withConsented(true).withRequired(true).withGuid(guid).build());
+        
+        session.setConsentStatuses(consentStatuses);
+        
+        controller.getParticipantReport("foo", START_DATE.toString(), END_DATE.toString());
+    }
+    
+    @Test(expected = BadRequestException.class)
+    public void getParticipantReportDataWithNoAcceptLanguage() throws Exception {
+        setupContext(VALID_USER_AGENT_HEADER, null);
+        
+        SubpopulationGuid guid = SubpopulationGuid.create("foo");
+        Map<SubpopulationGuid,ConsentStatus> consentStatuses = Maps.newHashMap();
+        consentStatuses.put(guid, new ConsentStatus.Builder().withName("FullName").withConsented(true).withRequired(true).withGuid(guid).build());
+        
+        session.setConsentStatuses(consentStatuses);
+        
+        controller.getParticipantReport("foo", START_DATE.toString(), END_DATE.toString());
+    }
     
     @Test
     public void saveParticipantReportData() throws Exception {

--- a/test/org/sagebionetworks/bridge/play/controllers/ReportControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ReportControllerTest.java
@@ -157,7 +157,7 @@ public class ReportControllerTest {
 
     @Test
     public void getParticipantReportDataAsResearcher() throws Exception {
-        // No consents, not consented, but is a researcher... can see these reports, too
+        // No consents so user is not consented, but is a researcher and can also see these reports
         session.setConsentStatuses(Maps.newHashMap());
         StudyParticipant participant = new StudyParticipant.Builder().withHealthCode(HEALTH_CODE)
                 .withRoles(Sets.newHashSet(Roles.RESEARCHER)).build();
@@ -193,7 +193,7 @@ public class ReportControllerTest {
     @Test(expected = BadRequestException.class)
     public void getParticipantReportNoLanguageHeader() throws Exception {
         setupContext(VALID_USER_AGENT_HEADER, null);
-        
+
         controller.getParticipantReport("foo", START_DATE.toString(), END_DATE.toString());
     }
     

--- a/test/org/sagebionetworks/bridge/services/ReportServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ReportServiceTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
@@ -222,6 +221,7 @@ public class ReportServiceTest {
         service.deleteStudyReport(TEST_STUDY, IDENTIFIER);
         
         verify(mockReportDataDao).deleteReportData(STUDY_REPORT_DATA_KEY);
+        verify(mockReportIndexDao).removeIndex(STUDY_REPORT_DATA_KEY);
     }
     
     @Test
@@ -229,6 +229,7 @@ public class ReportServiceTest {
         service.deleteParticipantReport(TEST_STUDY, IDENTIFIER, HEALTH_CODE);
         
         verify(mockReportDataDao).deleteReportData(PARTICIPANT_REPORT_DATA_KEY);
+        verifyNoMoreInteractions(mockReportIndexDao);
     }
     
     // The following are date range tests from MPowerVisualizationService, they should work with this service too


### PR DESCRIPTION
Adding a table to index the identifiers used for reports. You need to list these out so that research administrators can navigate to, and add or view, report data for an individual or the study as a whole.

(I am going to add to the researcher UI so we can test reports even before integration with an analysis in Synapse is created.)
