### PR TITLE
add multi choice answer list to field definitions, strict validation handler

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadFieldDefinition.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadFieldDefinition.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.dynamodb;
 
+import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -21,6 +22,7 @@ public final class DynamoUploadFieldDefinition implements UploadFieldDefinition 
     private final @Nullable Integer minAppVersion;
     private final @Nullable Integer maxAppVersion;
     private final @Nullable Integer maxLength;
+    private final @Nullable List<String> multiChoiceAnswerList;
     private final @Nonnull String name;
     private final boolean required;
     private final @Nonnull UploadFieldType type;
@@ -28,12 +30,14 @@ public final class DynamoUploadFieldDefinition implements UploadFieldDefinition 
     /** Private constructor. Construction of a DynamoUploadFieldDefinition should go through the Builder. */
     private DynamoUploadFieldDefinition(@Nullable String fileExtension, @Nullable String mimeType,
             @Nullable Integer minAppVersion, @Nullable Integer maxAppVersion, @Nullable Integer maxLength,
-            @Nonnull String name, boolean required, @Nonnull UploadFieldType type) {
+            @Nullable List<String> multiChoiceAnswerList, @Nonnull String name, boolean required,
+            @Nonnull UploadFieldType type) {
         this.fileExtension = fileExtension;
         this.mimeType = mimeType;
         this.minAppVersion = minAppVersion;
         this.maxAppVersion = maxAppVersion;
         this.maxLength = maxLength;
+        this.multiChoiceAnswerList = multiChoiceAnswerList;
         this.name = name;
         this.required = required;
         this.type = type;
@@ -71,6 +75,12 @@ public final class DynamoUploadFieldDefinition implements UploadFieldDefinition 
 
     /** {@inheritDoc} */
     @Override
+    public @Nullable List<String> getMultiChoiceAnswerList() {
+        return multiChoiceAnswerList;
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public @Nonnull String getName() {
         return name;
     }
@@ -103,6 +113,7 @@ public final class DynamoUploadFieldDefinition implements UploadFieldDefinition 
                 Objects.equals(minAppVersion, that.minAppVersion) &&
                 Objects.equals(maxAppVersion, that.maxAppVersion) &&
                 Objects.equals(maxLength, that.maxLength) &&
+                Objects.equals(multiChoiceAnswerList, that.multiChoiceAnswerList) &&
                 Objects.equals(name, that.name) &&
                 type == that.type;
     }
@@ -110,7 +121,8 @@ public final class DynamoUploadFieldDefinition implements UploadFieldDefinition 
     /** {@inheritDoc} */
     @Override
     public int hashCode() {
-        return Objects.hash(fileExtension, mimeType, minAppVersion, maxAppVersion, maxLength, name, required, type);
+        return Objects.hash(fileExtension, mimeType, minAppVersion, maxAppVersion, maxLength, multiChoiceAnswerList,
+                name, required, type);
     }
 
     /** Builder for DynamoUploadFieldDefinition */
@@ -120,6 +132,7 @@ public final class DynamoUploadFieldDefinition implements UploadFieldDefinition 
         private Integer minAppVersion;
         private Integer maxAppVersion;
         private Integer maxLength;
+        private List<String> multiChoiceAnswerList;
         private String name;
         private Boolean required;
         private UploadFieldType type;
@@ -131,6 +144,7 @@ public final class DynamoUploadFieldDefinition implements UploadFieldDefinition 
             this.minAppVersion = other.getMinAppVersion();
             this.maxAppVersion = other.getMaxAppVersion();
             this.maxLength = other.getMaxLength();
+            this.multiChoiceAnswerList = other.getMultiChoiceAnswerList();
             this.name = other.getName();
             this.required = other.isRequired();
             this.type = other.getType();
@@ -167,6 +181,12 @@ public final class DynamoUploadFieldDefinition implements UploadFieldDefinition 
             return this;
         }
 
+        /** @see org.sagebionetworks.bridge.models.upload.UploadFieldDefinition#getMultiChoiceAnswerList */
+        public Builder withMultiChoiceAnswerList(List<String> multiChoiceAnswerList) {
+            this.multiChoiceAnswerList = multiChoiceAnswerList;
+            return this;
+        }
+
         /** @see org.sagebionetworks.bridge.models.upload.UploadFieldDefinition#getName */
         public Builder withName(String name) {
             this.name = name;
@@ -199,7 +219,7 @@ public final class DynamoUploadFieldDefinition implements UploadFieldDefinition 
                 required = true;
             }
             return new DynamoUploadFieldDefinition(fileExtension, mimeType, minAppVersion, maxAppVersion, maxLength,
-                    name, required, type);
+                    multiChoiceAnswerList, name, required, type);
         }
     }
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadFieldDefinition.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadFieldDefinition.java
@@ -5,7 +5,9 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.collect.ImmutableList;
 
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
@@ -182,8 +184,15 @@ public final class DynamoUploadFieldDefinition implements UploadFieldDefinition 
         }
 
         /** @see org.sagebionetworks.bridge.models.upload.UploadFieldDefinition#getMultiChoiceAnswerList */
+        @JsonSetter
         public Builder withMultiChoiceAnswerList(List<String> multiChoiceAnswerList) {
             this.multiChoiceAnswerList = multiChoiceAnswerList;
+            return this;
+        }
+
+        /** @see org.sagebionetworks.bridge.models.upload.UploadFieldDefinition#getMultiChoiceAnswerList */
+        public Builder withMultiChoiceAnswerList(String... multiChoiceAnswerList) {
+            this.multiChoiceAnswerList = ImmutableList.copyOf(multiChoiceAnswerList);
             return this;
         }
 
@@ -218,8 +227,15 @@ public final class DynamoUploadFieldDefinition implements UploadFieldDefinition 
             if (required == null) {
                 required = true;
             }
+
+            // If the answer list was specified, make an immutable copy.
+            List<String> multiChoiceAnswerListCopy = null;
+            if (multiChoiceAnswerList != null) {
+                 multiChoiceAnswerListCopy = ImmutableList.copyOf(multiChoiceAnswerList);
+            }
+
             return new DynamoUploadFieldDefinition(fileExtension, mimeType, minAppVersion, maxAppVersion, maxLength,
-                    multiChoiceAnswerList, name, required, type);
+                    multiChoiceAnswerListCopy, name, required, type);
         }
     }
 }

--- a/app/org/sagebionetworks/bridge/models/upload/UploadFieldDefinition.java
+++ b/app/org/sagebionetworks/bridge/models/upload/UploadFieldDefinition.java
@@ -48,9 +48,15 @@ public interface UploadFieldDefinition extends BridgeEntity {
     @Nullable Integer getMaxLength();
 
     /**
+     * <p>
      * Used for MULTI_CHOICE types. This lists all valid answers for this field. It is used by BridgeEX to create the
      * Synapse table columns for MULTI_CHOICE fields. This is a list because order matters, in terms of Synapse
      * column order. Must be specified if the field type is a MULTI_CHOICE.
+     * </p>
+     * <p>
+     * For schemas generated from surveys, this list will be the "value" in the survey question option, or the "label"
+     * if value is not specified.
+     * </p>
      */
     @Nullable List<String> getMultiChoiceAnswerList();
 

--- a/app/org/sagebionetworks/bridge/models/upload/UploadFieldDefinition.java
+++ b/app/org/sagebionetworks/bridge/models/upload/UploadFieldDefinition.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.models.upload;
 
+import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -45,6 +46,13 @@ public interface UploadFieldDefinition extends BridgeEntity {
      * column with the right width.
      */
     @Nullable Integer getMaxLength();
+
+    /**
+     * Used for MULTI_CHOICE types. This lists all valid answers for this field. It is used by BridgeEX to create the
+     * Synapse table columns for MULTI_CHOICE fields. This is a list because order matters, in terms of Synapse
+     * column order. Must be specified if the field type is a MULTI_CHOICE.
+     */
+    @Nullable List<String> getMultiChoiceAnswerList();
 
     /** The field name. */
     @Nonnull String getName();

--- a/app/org/sagebionetworks/bridge/validators/UploadSchemaValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/UploadSchemaValidator.java
@@ -9,6 +9,7 @@ import com.google.common.base.Strings;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
+import org.sagebionetworks.bridge.models.upload.UploadFieldType;
 import org.sagebionetworks.bridge.models.upload.UploadSchema;
 
 /** Validator for {@link org.sagebionetworks.bridge.models.upload.UploadSchema} */
@@ -94,14 +95,21 @@ public class UploadSchemaValidator implements Validator {
                             fieldNameSet.add(fieldName);
                         }
 
+                        UploadFieldType fieldType = fieldDef.getType();
                         //noinspection ConstantConditions
-                        if (fieldDef.getType() == null) {
+                        if (fieldType == null) {
                             errors.rejectValue("type", "is required");
+                        }
+
+                        List<String> multiChoiceAnswerList = fieldDef.getMultiChoiceAnswerList();
+                        if (fieldType == UploadFieldType.MULTI_CHOICE && (multiChoiceAnswerList == null ||
+                                multiChoiceAnswerList.isEmpty())) {
+                            errors.rejectValue("multiChoiceAnswerList", "must be specified for MULTI_CHOICE field "
+                                    + fieldName);
                         }
 
                         errors.popNestedPath();
                     }
-                    
                 }
             }
         }

--- a/test/org/sagebionetworks/bridge/models/upload/UploadFieldDefinitionTest.java
+++ b/test/org/sagebionetworks/bridge/models/upload/UploadFieldDefinitionTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -42,6 +43,31 @@ public class UploadFieldDefinitionTest {
         assertEquals("test-field", fieldDef.getName());
         assertFalse(fieldDef.isRequired());
         assertEquals(UploadFieldType.ATTACHMENT_BLOB, fieldDef.getType());
+    }
+
+    @Test
+    public void testMultiChoiceAnswerList() {
+        // set up original list
+        List<String> originalAnswerList = new ArrayList<>();
+        originalAnswerList.add("first");
+        originalAnswerList.add("second");
+
+        // build and validate
+        List<String> expectedAnswerList = ImmutableList.of("first", "second");
+        UploadFieldDefinition fieldDef = new DynamoUploadFieldDefinition.Builder().withName("multi-choice-field")
+                .withType(UploadFieldType.MULTI_CHOICE).withMultiChoiceAnswerList(originalAnswerList).build();
+        assertEquals(expectedAnswerList, fieldDef.getMultiChoiceAnswerList());
+
+        // modify original list, verify that field def stays the same
+        originalAnswerList.add("third");
+        assertEquals(expectedAnswerList, fieldDef.getMultiChoiceAnswerList());
+    }
+
+    @Test
+    public void testMultiChoiceAnswerVarargs() {
+        UploadFieldDefinition fieldDef = new DynamoUploadFieldDefinition.Builder().withName("multi-choice-field")
+                .withType(UploadFieldType.MULTI_CHOICE).withMultiChoiceAnswerList("aa", "bb", "cc").build();
+        assertEquals(ImmutableList.of("aa", "bb", "cc"), fieldDef.getMultiChoiceAnswerList());
     }
 
     @Test

--- a/test/org/sagebionetworks/bridge/models/upload/UploadFieldDefinitionTest.java
+++ b/test/org/sagebionetworks/bridge/models/upload/UploadFieldDefinitionTest.java
@@ -4,8 +4,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.List;
 import java.util.Map;
 
+import com.google.common.collect.ImmutableList;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
@@ -44,14 +46,18 @@ public class UploadFieldDefinitionTest {
 
     @Test
     public void testOptionalFields() {
+        List<String> multiChoiceAnswerList = ImmutableList.of("foo", "bar", "baz");
+
         UploadFieldDefinition fieldDef = new DynamoUploadFieldDefinition.Builder().withFileExtension(".test")
                 .withMimeType("text/plain").withMinAppVersion(10).withMaxAppVersion(13).withMaxLength(128)
-                .withName("optional-stuff").withRequired(false).withType(UploadFieldType.STRING).build();
+                .withMultiChoiceAnswerList(multiChoiceAnswerList).withName("optional-stuff").withRequired(false)
+                .withType(UploadFieldType.STRING).build();
         assertEquals(".test", fieldDef.getFileExtension());
         assertEquals("text/plain", fieldDef.getMimeType());
         assertEquals(10, fieldDef.getMinAppVersion().intValue());
         assertEquals(13, fieldDef.getMaxAppVersion().intValue());
         assertEquals(128, fieldDef.getMaxLength().intValue());
+        assertEquals(multiChoiceAnswerList, fieldDef.getMultiChoiceAnswerList());
         assertEquals("optional-stuff", fieldDef.getName());
         assertFalse(fieldDef.isRequired());
         assertEquals(UploadFieldType.STRING, fieldDef.getType());
@@ -70,18 +76,21 @@ public class UploadFieldDefinitionTest {
                 "   \"minAppVersion\":2,\n" +
                 "   \"maxAppVersion\":7,\n" +
                 "   \"maxLength\":24,\n" +
+                "   \"multiChoiceAnswerList\":[\"asdf\", \"jkl;\"],\n" +
                 "   \"name\":\"test-field\",\n" +
                 "   \"required\":false,\n" +
                 "   \"type\":\"INT\"\n" +
                 "}";
 
         // convert to POJO
+        List<String> expectedMultiChoiceAnswerList = ImmutableList.of("asdf", "jkl;");
         UploadFieldDefinition fieldDef = BridgeObjectMapper.get().readValue(jsonText, UploadFieldDefinition.class);
         assertEquals(".json", fieldDef.getFileExtension());
         assertEquals("text/json", fieldDef.getMimeType());
         assertEquals(2, fieldDef.getMinAppVersion().intValue());
         assertEquals(7, fieldDef.getMaxAppVersion().intValue());
         assertEquals(24, fieldDef.getMaxLength().intValue());
+        assertEquals(expectedMultiChoiceAnswerList, fieldDef.getMultiChoiceAnswerList());
         assertEquals("test-field", fieldDef.getName());
         assertFalse(fieldDef.isRequired());
         assertEquals(UploadFieldType.INT, fieldDef.getType());
@@ -91,12 +100,13 @@ public class UploadFieldDefinitionTest {
 
         // then convert to a map so we can validate the raw JSON
         Map<String, Object> jsonMap = BridgeObjectMapper.get().readValue(convertedJson, JsonUtils.TYPE_REF_RAW_MAP);
-        assertEquals(8, jsonMap.size());
+        assertEquals(9, jsonMap.size());
         assertEquals(".json", jsonMap.get("fileExtension"));
         assertEquals("text/json", jsonMap.get("mimeType"));
         assertEquals(2, jsonMap.get("minAppVersion"));
         assertEquals(7, jsonMap.get("maxAppVersion"));
         assertEquals(24, jsonMap.get("maxLength"));
+        assertEquals(expectedMultiChoiceAnswerList, jsonMap.get("multiChoiceAnswerList"));
         assertEquals("test-field", jsonMap.get("name"));
         assertFalse((boolean) jsonMap.get("required"));
         assertEquals("int", jsonMap.get("type"));

--- a/test/org/sagebionetworks/bridge/upload/StrictValidationHandlerTest.java
+++ b/test/org/sagebionetworks/bridge/upload/StrictValidationHandlerTest.java
@@ -163,8 +163,7 @@ public class StrictValidationHandlerTest {
                 new DynamoUploadFieldDefinition.Builder().withName("int with float value")
                         .withType(UploadFieldType.INT).build(),
                 new DynamoUploadFieldDefinition.Builder().withName("multi-choice")
-                        .withType(UploadFieldType.MULTI_CHOICE)
-                        .withMultiChoiceAnswerList(ImmutableList.of("foo", "bar", "baz")).build(),
+                        .withType(UploadFieldType.MULTI_CHOICE).withMultiChoiceAnswerList("foo", "bar", "baz").build(),
                 new DynamoUploadFieldDefinition.Builder().withName("string timestamp")
                         .withType(UploadFieldType.TIMESTAMP).build(),
                 new DynamoUploadFieldDefinition.Builder().withName("long timestamp")
@@ -253,8 +252,7 @@ public class StrictValidationHandlerTest {
         // additional field defs
         List<UploadFieldDefinition> additionalFieldDefList = ImmutableList.of(
                 new DynamoUploadFieldDefinition.Builder().withName("invalid multi-choice")
-                        .withType(UploadFieldType.MULTI_CHOICE)
-                        .withMultiChoiceAnswerList(ImmutableList.of("good1", "good2")).build());
+                        .withType(UploadFieldType.MULTI_CHOICE).withMultiChoiceAnswerList("good1", "good2").build());
 
         // additional JSON data
         String additionalJsonText = "{\n" +

--- a/test/org/sagebionetworks/bridge/upload/StrictValidationHandlerTest.java
+++ b/test/org/sagebionetworks/bridge/upload/StrictValidationHandlerTest.java
@@ -162,6 +162,9 @@ public class StrictValidationHandlerTest {
                         .withType(UploadFieldType.INT).build(),
                 new DynamoUploadFieldDefinition.Builder().withName("int with float value")
                         .withType(UploadFieldType.INT).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("multi-choice")
+                        .withType(UploadFieldType.MULTI_CHOICE)
+                        .withMultiChoiceAnswerList(ImmutableList.of("foo", "bar", "baz")).build(),
                 new DynamoUploadFieldDefinition.Builder().withName("string timestamp")
                         .withType(UploadFieldType.TIMESTAMP).build(),
                 new DynamoUploadFieldDefinition.Builder().withName("long timestamp")
@@ -191,6 +194,7 @@ public class StrictValidationHandlerTest {
                 "   \"inline json blob\":[\"inline\", \"json\", \"blob\"],\n" +
                 "   \"int\":42,\n" +
                 "   \"int with float value\":2.78,\n" +
+                "   \"multi-choice\":[\"foo\", \"bar\", \"baz\"],\n" +
                 "   \"string timestamp\":\"2015-07-24T18:49:54-07:00\",\n" +
                 "   \"long timestamp\":1437787098066,\n" +
                 "   \"present optional json\":\"optional, but present\"\n" +
@@ -239,6 +243,29 @@ public class StrictValidationHandlerTest {
 
         // expected errors
         List<String> expectedErrorList = ImmutableList.of("invalid int");
+
+        // execute and validate
+        test(additionalFieldDefList, null, additionalJsonNode, expectedErrorList, true);
+    }
+
+    @Test
+    public void invalidMultiChoice() throws Exception {
+        // additional field defs
+        List<UploadFieldDefinition> additionalFieldDefList = ImmutableList.of(
+                new DynamoUploadFieldDefinition.Builder().withName("invalid multi-choice")
+                        .withType(UploadFieldType.MULTI_CHOICE)
+                        .withMultiChoiceAnswerList(ImmutableList.of("good1", "good2")).build());
+
+        // additional JSON data
+        String additionalJsonText = "{\n" +
+                "   \"invalid multi-choice\":[\"bad1\", \"good2\", \"bad2\"]\n" +
+                "}";
+        JsonNode additionalJsonNode = BridgeObjectMapper.get().readTree(additionalJsonText);
+
+        // expected errors
+        List<String> expectedErrorList = ImmutableList.of(
+                "Multi-Choice field invalid multi-choice contains invalid answer bad1",
+                "Multi-Choice field invalid multi-choice contains invalid answer bad2");
 
         // execute and validate
         test(additionalFieldDefList, null, additionalJsonNode, expectedErrorList, true);

--- a/test/org/sagebionetworks/bridge/upload/UploadHandlersEndToEndTest.java
+++ b/test/org/sagebionetworks/bridge/upload/UploadHandlersEndToEndTest.java
@@ -257,6 +257,7 @@ public class UploadHandlersEndToEndTest {
                 new DynamoUploadFieldDefinition.Builder().withName("AAA").withType(UploadFieldType.SINGLE_CHOICE)
                         .build(),
                 new DynamoUploadFieldDefinition.Builder().withName("BBB").withType(UploadFieldType.MULTI_CHOICE)
+                        .withMultiChoiceAnswerList(ImmutableList.of("fencing", "football", "running", "swimming", "3"))
                         .build());
 
         DynamoUploadSchema schema = new DynamoUploadSchema();

--- a/test/org/sagebionetworks/bridge/upload/UploadHandlersEndToEndTest.java
+++ b/test/org/sagebionetworks/bridge/upload/UploadHandlersEndToEndTest.java
@@ -257,8 +257,7 @@ public class UploadHandlersEndToEndTest {
                 new DynamoUploadFieldDefinition.Builder().withName("AAA").withType(UploadFieldType.SINGLE_CHOICE)
                         .build(),
                 new DynamoUploadFieldDefinition.Builder().withName("BBB").withType(UploadFieldType.MULTI_CHOICE)
-                        .withMultiChoiceAnswerList(ImmutableList.of("fencing", "football", "running", "swimming", "3"))
-                        .build());
+                        .withMultiChoiceAnswerList("fencing", "football", "running", "swimming", "3").build());
 
         DynamoUploadSchema schema = new DynamoUploadSchema();
         schema.setFieldDefinitions(fieldDefList);

--- a/test/org/sagebionetworks/bridge/validators/UploadSchemaValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/UploadSchemaValidatorTest.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
+import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 import org.sagebionetworks.bridge.dynamodb.DynamoUploadFieldDefinition;
 import org.sagebionetworks.bridge.dynamodb.DynamoUploadSchema;
@@ -113,6 +114,9 @@ public class UploadSchemaValidatorTest {
                 .withType(UploadFieldType.INT).build());
         fieldDefList.add(new DynamoUploadFieldDefinition.Builder().withName("bar-field")
                 .withType(UploadFieldType.STRING).build());
+        fieldDefList.add(new DynamoUploadFieldDefinition.Builder().withName("baz-field")
+                .withType(UploadFieldType.MULTI_CHOICE).withMultiChoiceAnswerList(ImmutableList.of("asdf", "jkl;"))
+                .build());
         schema.setFieldDefinitions(fieldDefList);
 
         // validate
@@ -353,5 +357,34 @@ public class UploadSchemaValidatorTest {
             thrownEx = ex;
         }
         assertTrue(thrownEx.getMessage().contains("cannot use foo-field (used by another field)"));
+    }
+
+    @Test
+    public void multiChoiceWithNoAnswerList() {
+        // set up schema to validate
+        DynamoUploadSchema schema = new DynamoUploadSchema();
+        schema.setName("Multi-Choice Schema");
+        schema.setSchemaId("multi-choice-schema");
+        schema.setStudyId("test-study");
+        schema.setSchemaType(UploadSchemaType.IOS_SURVEY);
+
+        // test field def list
+        List<UploadFieldDefinition> fieldDefList = new ArrayList<>();
+        fieldDefList.add(new DynamoUploadFieldDefinition.Builder().withName("multi-choice-null")
+                .withType(UploadFieldType.MULTI_CHOICE).build());
+        fieldDefList.add(new DynamoUploadFieldDefinition.Builder().withName("multi-choice-empty")
+                .withType(UploadFieldType.MULTI_CHOICE).withMultiChoiceAnswerList(ImmutableList.of()).build());
+        schema.setFieldDefinitions(fieldDefList);
+
+        // validate
+        Exception thrownEx = null;
+        try {
+            Validate.entityThrowingException(UploadSchemaValidator.INSTANCE, schema);
+            fail("expected exception");
+        } catch (InvalidEntityException ex) {
+            thrownEx = ex;
+        }
+        assertTrue(thrownEx.getMessage().contains("must be specified for MULTI_CHOICE field multi-choice-null"));
+        assertTrue(thrownEx.getMessage().contains("must be specified for MULTI_CHOICE field multi-choice-empty"));
     }
 }

--- a/test/org/sagebionetworks/bridge/validators/UploadSchemaValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/UploadSchemaValidatorTest.java
@@ -11,7 +11,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
-import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 import org.sagebionetworks.bridge.dynamodb.DynamoUploadFieldDefinition;
 import org.sagebionetworks.bridge.dynamodb.DynamoUploadSchema;
@@ -115,8 +114,7 @@ public class UploadSchemaValidatorTest {
         fieldDefList.add(new DynamoUploadFieldDefinition.Builder().withName("bar-field")
                 .withType(UploadFieldType.STRING).build());
         fieldDefList.add(new DynamoUploadFieldDefinition.Builder().withName("baz-field")
-                .withType(UploadFieldType.MULTI_CHOICE).withMultiChoiceAnswerList(ImmutableList.of("asdf", "jkl;"))
-                .build());
+                .withType(UploadFieldType.MULTI_CHOICE).withMultiChoiceAnswerList("asdf", "jkl;").build());
         schema.setFieldDefinitions(fieldDefList);
 
         // validate
@@ -373,7 +371,7 @@ public class UploadSchemaValidatorTest {
         fieldDefList.add(new DynamoUploadFieldDefinition.Builder().withName("multi-choice-null")
                 .withType(UploadFieldType.MULTI_CHOICE).build());
         fieldDefList.add(new DynamoUploadFieldDefinition.Builder().withName("multi-choice-empty")
-                .withType(UploadFieldType.MULTI_CHOICE).withMultiChoiceAnswerList(ImmutableList.of()).build());
+                .withType(UploadFieldType.MULTI_CHOICE).withMultiChoiceAnswerList().build());
         schema.setFieldDefinitions(fieldDefList);
 
         // validate


### PR DESCRIPTION
Add multiChoiceAnswerList to field definitions. Add logic to strict validation handler to check multi-choice answers. Updated unit tests accordingly.

Note that the integ test for UploadTest will be broken until I add the multi-choice answer list to it.

See also
https://github.com/Sage-Bionetworks/BridgeJavaSDK/pull/287
https://github.com/Sage-Bionetworks/BridgeIntegrationTests/pull/43
