### PR TITLE
Report API updates

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/ReportDataDao.java
+++ b/app/org/sagebionetworks/bridge/dao/ReportDataDao.java
@@ -36,4 +36,14 @@ public interface ReportDataDao {
      *      report to delete
      */
     void deleteReportData(ReportDataKey key);
+    
+    /**
+     * Delete a single record in a report. 
+     * 
+     * @param key
+     *         the key for this report
+     * @param date
+     *         the date of the report
+     */
+    void deleteReportDataRecord(ReportDataKey key, LocalDate date);
 }

--- a/app/org/sagebionetworks/bridge/dao/ReportIndexDao.java
+++ b/app/org/sagebionetworks/bridge/dao/ReportIndexDao.java
@@ -15,9 +15,9 @@ public interface ReportIndexDao {
     void addIndex(ReportDataKey key);
     
     /**
-     * Remove an index item for a report identifier. This can only be done for study reports, since we have no
-     * performant way to determine if an identifier for a participant report is no longer in use by any participant. 
-     * Still it is better than no cleanup.
+     * Remove an index item for a report identifier. This is only done automatically for study reports, because we 
+     * can't calculate if an identifier is still in use for a participant test in a performant way. But an endpoint 
+     * is exposed so that admins can delete these index records as a part of test clean-up.
      */
     void removeIndex(ReportDataKey key);
     

--- a/app/org/sagebionetworks/bridge/dao/ReportIndexDao.java
+++ b/app/org/sagebionetworks/bridge/dao/ReportIndexDao.java
@@ -1,7 +1,7 @@
 package org.sagebionetworks.bridge.dao;
 
-import java.util.List;
 
+import org.sagebionetworks.bridge.models.ReportTypeResourceList;
 import org.sagebionetworks.bridge.models.reports.ReportDataKey;
 import org.sagebionetworks.bridge.models.reports.ReportIndex;
 import org.sagebionetworks.bridge.models.reports.ReportType;
@@ -24,6 +24,6 @@ public interface ReportIndexDao {
     /**
      * Get all the identifiers for a study, for either study or participant reports.
      */
-    List<? extends ReportIndex> getIndices(StudyIdentifier studyId, ReportType type);
+    ReportTypeResourceList<? extends ReportIndex> getIndices(StudyIdentifier studyId, ReportType type);
     
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoReportDataDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoReportDataDao.java
@@ -77,4 +77,19 @@ public class DynamoReportDataDao implements ReportDataDao {
             BridgeUtils.ifFailuresThrowException(failures);
         }
     }
+    
+    @Override
+    public void deleteReportDataRecord(ReportDataKey key, LocalDate date) {
+        checkNotNull(key);
+        checkNotNull(date);
+
+        DynamoReportData hashKey = new DynamoReportData();
+        hashKey.setKey(key.getKeyString());
+        hashKey.setDate(date);
+        
+        DynamoReportData reportDataRecord = mapper.load(hashKey);
+        if (reportDataRecord != null) {
+            mapper.delete(reportDataRecord);
+        }
+    }
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoReportIndexDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoReportIndexDao.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import javax.annotation.Resource;
@@ -41,7 +40,6 @@ public class DynamoReportIndexDao implements ReportIndexDao {
     @Override
     public void removeIndex(ReportDataKey key) {
         checkNotNull(key);
-        checkArgument(key.getReportType() != ReportType.PARTICIPANT, "cannot remove participant report indices");
         
         DynamoReportIndex hashKey = new DynamoReportIndex();
         hashKey.setKey(key.getIndexKeyString());

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoReportIndexDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoReportIndexDao.java
@@ -3,13 +3,12 @@ package org.sagebionetworks.bridge.dynamodb;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.List;
-
 import javax.annotation.Resource;
 
 import org.springframework.stereotype.Component;
 
 import org.sagebionetworks.bridge.dao.ReportIndexDao;
+import org.sagebionetworks.bridge.models.ReportTypeResourceList;
 import org.sagebionetworks.bridge.models.reports.ReportDataKey;
 import org.sagebionetworks.bridge.models.reports.ReportIndex;
 import org.sagebionetworks.bridge.models.reports.ReportType;
@@ -55,7 +54,7 @@ public class DynamoReportIndexDao implements ReportIndexDao {
     }
 
     @Override
-    public List<? extends ReportIndex> getIndices(StudyIdentifier studyId, ReportType reportType) {
+    public ReportTypeResourceList<? extends ReportIndex> getIndices(StudyIdentifier studyId, ReportType reportType) {
         checkNotNull(studyId);
         checkNotNull(reportType);
         
@@ -68,7 +67,7 @@ public class DynamoReportIndexDao implements ReportIndexDao {
         DynamoDBQueryExpression<DynamoReportIndex> query =
                 new DynamoDBQueryExpression<DynamoReportIndex>().withHashKeyValues(hashKey);
 
-        return mapper.query(DynamoReportIndex.class, query);
+        return new ReportTypeResourceList<>(mapper.query(DynamoReportIndex.class, query), reportType);
     }
 
 }

--- a/app/org/sagebionetworks/bridge/models/ReportTypeResourceList.java
+++ b/app/org/sagebionetworks/bridge/models/ReportTypeResourceList.java
@@ -1,0 +1,29 @@
+package org.sagebionetworks.bridge.models;
+
+import java.util.List;
+
+import org.sagebionetworks.bridge.models.reports.ReportType;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ReportTypeResourceList<T> {
+    private final List<T> items;
+    private final ReportType reportType;
+
+    @JsonCreator
+    public ReportTypeResourceList(@JsonProperty("items") List<T> items,
+            @JsonProperty("reportType") ReportType reportType) {
+        this.items = items;
+        this.reportType = reportType;
+    }
+    public List<T> getItems() {
+        return items;
+    }
+    public int getTotal() {
+        return items.size();
+    }
+    public ReportType getReportType() {
+        return reportType;
+    }
+}

--- a/app/org/sagebionetworks/bridge/play/controllers/ReportController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ReportController.java
@@ -6,7 +6,6 @@ import static org.sagebionetworks.bridge.Roles.WORKER;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.util.LinkedHashSet;
-import java.util.List;
 
 import org.joda.time.LocalDate;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,6 +16,7 @@ import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.DateRangeResourceList;
+import org.sagebionetworks.bridge.models.ReportTypeResourceList;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.reports.ReportData;
@@ -72,7 +72,7 @@ public class ReportController extends BaseController {
         UserSession session = getAuthenticatedSession();
         ReportType reportType = ("participant".equals(type)) ? ReportType.PARTICIPANT : ReportType.STUDY;
         
-        List<? extends ReportIndex> indices = reportService.getReportIndices(session.getStudyIdentifier(), reportType);
+        ReportTypeResourceList<? extends ReportIndex> indices = reportService.getReportIndices(session.getStudyIdentifier(), reportType);
         return okResult(indices);
     }
     

--- a/app/org/sagebionetworks/bridge/play/controllers/ReportController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ReportController.java
@@ -65,7 +65,8 @@ public class ReportController extends BaseController {
     }
     
     /**
-     * Get a list of the identifiers used for participant reports in this study.
+     * Get a list of the identifiers used for reports in this study. If the value is missing or invalid, 
+     * defaults to list of study identifiers.
      */
     public Result getReportIndices(String type) throws Exception {
         UserSession session = getAuthenticatedSession();
@@ -93,9 +94,8 @@ public class ReportController extends BaseController {
         return ok((JsonNode)MAPPER.valueToTree(results));
     }
     
-    public Result getParticipantReportForResearcher(String identifier, String userId, String startDateString,
+    public Result getParticipantReportForResearcher(String userId, String identifier, String startDateString,
             String endDateString) {
-        
         UserSession session = getAuthenticatedSession(RESEARCHER);
         Study study = studyService.getStudy(session.getStudyIdentifier());
         
@@ -114,7 +114,7 @@ public class ReportController extends BaseController {
      * Report participant data can be saved by developers or by worker processes. The JSON for these must 
      * include a healthCode field. This is validated when constructing the DataReportKey.
      */
-    public Result saveParticipantReport(String identifier, String userId) throws Exception {
+    public Result saveParticipantReport(String userId, String identifier) throws Exception {
         UserSession session = getAuthenticatedSession(DEVELOPER);
         Study study = studyService.getStudy(session.getStudyIdentifier());
         
@@ -156,7 +156,7 @@ public class ReportController extends BaseController {
      * to know the user ID for records). This deletes all reports for all users. This is not 
      * performant for large data sets and should only be done during testing. 
      */
-    public Result deleteParticipantReport(String identifier, String userId) {
+    public Result deleteParticipantReport(String userId, String identifier) {
         UserSession session = getAuthenticatedSession(DEVELOPER, WORKER);
         Study study = studyService.getStudy(session.getStudyIdentifier());
         
@@ -170,7 +170,7 @@ public class ReportController extends BaseController {
     /**
      * Delete an individual participant report record
      */
-    public Result deleteParticipantReportRecord(String identifier, String userId, String dateString) {
+    public Result deleteParticipantReportRecord(String userId, String identifier, String dateString) {
         UserSession session = getAuthenticatedSession(DEVELOPER, WORKER);
         Study study = studyService.getStudy(session.getStudyIdentifier());
         LocalDate date = parseDateHelper(dateString);
@@ -224,6 +224,9 @@ public class ReportController extends BaseController {
         return okResult("Report deleted.");
     }
     
+    /**
+     * Delete an individual study report record. 
+     */
     public Result deleteStudyReportRecord(String identifier, String dateString) {
         UserSession session = getAuthenticatedSession(DEVELOPER, WORKER);
         LocalDate date = parseDateHelper(dateString);

--- a/app/org/sagebionetworks/bridge/play/controllers/ReportController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ReportController.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.play.controllers;
 
+import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.Roles.WORKER;
@@ -180,6 +181,14 @@ public class ReportController extends BaseController {
         reportService.deleteParticipantReportRecord(session.getStudyIdentifier(), identifier, date, account.getHealthCode());
         
         return okResult("Report record deleted.");
+    }
+    
+    public Result deleteParticipantReportIndex(String identifier) {
+        UserSession session = getAuthenticatedSession(ADMIN);
+        
+        reportService.deleteParticipantReportIndex(session.getStudyIdentifier(), identifier);
+        
+        return okResult("Report index deleted.");
     }
     
     /**

--- a/app/org/sagebionetworks/bridge/play/controllers/ReportController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ReportController.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Controller;
 
 import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
-import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.DateRangeResourceList;
@@ -30,6 +29,22 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 import play.mvc.Result;
 
+/**
+ * <p>Permissions for reports are more complicated than other controllers:</p>
+ * <p><b>Study Reports</b></p>
+ * <ul>
+ *   <li>any authenticated user can get the study identifiers (indices)</li>
+ *   <li>any authenticated user can see a study report</li>  
+ *   <li>developers/workers can add/delete</li>
+ * </ul>
+ * 
+ * <p><b>Participant Reports</b></p>
+ * <ul>
+ *   <li>any authenticated user can get the participant identifiers (indices)</li>
+ *   <li>user or researcher can see reports (for user, only self report)</li>
+ *   <li>developers/workers can add/delete</li>
+ * </ul>
+ */
 @Controller
 public class ReportController extends BaseController {
 
@@ -52,25 +67,45 @@ public class ReportController extends BaseController {
     /**
      * Get a list of the identifiers used for participant reports in this study.
      */
-    public Result getParticipantReportIndices() throws Exception {
+    public Result getReportIndices(String type) throws Exception {
         UserSession session = getAuthenticatedSession();
+        ReportType reportType = ("participant".equals(type)) ? ReportType.PARTICIPANT : ReportType.STUDY;
         
-        List<? extends ReportIndex> indices = reportService.getReportIndices(
-                session.getStudyIdentifier(), ReportType.PARTICIPANT);
+        List<? extends ReportIndex> indices = reportService.getReportIndices(session.getStudyIdentifier(), reportType);
         return okResult(indices);
     }
     
     /**
-     * Reports for specific individuals accessible to either consented study participants, or to researchers.
+     * Individuals can get their own participant reports. For this request, because we are checking consent, 
+     * we also verify the consent-related headers are being sent (this report has been retrieved by embedded web 
+     * components that haven't sent the correct headers in the past).
      */
     public Result getParticipantReport(String identifier, String startDateString, String endDateString) {
-        UserSession session = getAuthenticatedAndConsentedOrResearcherSession();
+        UserSession session = getAuthenticatedAndConsentedSession();
+        checkHeaders();
         
         LocalDate startDate = parseDateHelper(startDateString);
         LocalDate endDate = parseDateHelper(endDateString);
         
         DateRangeResourceList<? extends ReportData> results = reportService.getParticipantReport(
                 session.getStudyIdentifier(), identifier, session.getHealthCode(), startDate, endDate);
+        
+        return ok((JsonNode)MAPPER.valueToTree(results));
+    }
+    
+    public Result getParticipantReportForResearcher(String identifier, String userId, String startDateString,
+            String endDateString) {
+        
+        UserSession session = getAuthenticatedSession(RESEARCHER);
+        Study study = studyService.getStudy(session.getStudyIdentifier());
+        
+        LocalDate startDate = parseDateHelper(startDateString);
+        LocalDate endDate = parseDateHelper(endDateString);
+        
+        Account account = accountDao.getAccount(study, userId);
+        
+        DateRangeResourceList<? extends ReportData> results = reportService.getParticipantReport(
+                session.getStudyIdentifier(), identifier, account.getHealthCode(), startDate, endDate);
         
         return ok((JsonNode)MAPPER.valueToTree(results));
     }
@@ -94,6 +129,10 @@ public class ReportController extends BaseController {
         return createdResult("Report data saved.");
     }
     
+    /**
+     * When saving, worker accounts do not know the userId of the account, only the healthCode, so a 
+     * special method is needed.
+     */
     public Result saveParticipantReportForWorker(String identifier) throws Exception {
         UserSession session = getAuthenticatedSession(WORKER);
         
@@ -113,11 +152,12 @@ public class ReportController extends BaseController {
     }
     
     /**
-     * Developers and workers can delete participant report data. This deletes all reports for all users. 
-     * This is not performant for large data sets and should only be done during testing. 
+     * Developers and workers can delete participant report data (though worker accounts are unlikely 
+     * to know the user ID for records). This deletes all reports for all users. This is not 
+     * performant for large data sets and should only be done during testing. 
      */
     public Result deleteParticipantReport(String identifier, String userId) {
-        UserSession session = getAuthenticatedSession(DEVELOPER);
+        UserSession session = getAuthenticatedSession(DEVELOPER, WORKER);
         Study study = studyService.getStudy(session.getStudyIdentifier());
         
         Account account = accountDao.getAccount(study, userId);
@@ -128,14 +168,18 @@ public class ReportController extends BaseController {
     }
     
     /**
-     * Get a list of the identifiers used for participant reports in this study.
+     * Delete an individual participant report record
      */
-    public Result getStudyReportIndices() throws Exception {
-        UserSession session = getAuthenticatedSession();
+    public Result deleteParticipantReportRecord(String identifier, String userId, String dateString) {
+        UserSession session = getAuthenticatedSession(DEVELOPER, WORKER);
+        Study study = studyService.getStudy(session.getStudyIdentifier());
+        LocalDate date = parseDateHelper(dateString);
         
-        List<? extends ReportIndex> indices = reportService.getReportIndices(
-                session.getStudyIdentifier(), ReportType.STUDY);
-        return okResult(indices);
+        Account account = accountDao.getAccount(study, userId);
+        
+        reportService.deleteParticipantReportRecord(session.getStudyIdentifier(), identifier, date, account.getHealthCode());
+        
+        return okResult("Report record deleted.");
     }
     
     /**
@@ -173,23 +217,20 @@ public class ReportController extends BaseController {
      * should only be done during testing.
      */
     public Result deleteStudyReport(String identifier) {
-        UserSession session = getAuthenticatedSession(DEVELOPER);
+        UserSession session = getAuthenticatedSession(DEVELOPER, WORKER);
         
         reportService.deleteStudyReport(session.getStudyIdentifier(), identifier);
         
         return okResult("Report deleted.");
     }
-
-    private UserSession getAuthenticatedAndConsentedOrResearcherSession() {
-        UserSession session = getAuthenticatedSession();
-        if (session.isInRole(RESEARCHER)) {
-            return session;
-        }
-        if (session.doesConsent()) {
-            checkHeaders();
-            return session;
-        }
-        throw new UnauthorizedException();
+    
+    public Result deleteStudyReportRecord(String identifier, String dateString) {
+        UserSession session = getAuthenticatedSession(DEVELOPER, WORKER);
+        LocalDate date = parseDateHelper(dateString);
+        
+        reportService.deleteStudyReportRecord(session.getStudyIdentifier(), identifier, date);
+        
+        return okResult("Report record deleted.");
     }
     
     /**

--- a/app/org/sagebionetworks/bridge/services/ReportService.java
+++ b/app/org/sagebionetworks/bridge/services/ReportService.java
@@ -174,6 +174,16 @@ public class ReportService {
         
         reportDataDao.deleteReportDataRecord(key, date);
     }
+    
+    public void deleteParticipantReportIndex(StudyIdentifier studyId, String identifier) {
+        ReportDataKey key = new ReportDataKey.Builder()
+                .withHealthCode("dummy-value")
+                .withReportType(ReportType.PARTICIPANT)
+                .withIdentifier(identifier)
+                .withStudyIdentifier(studyId).build();
+        
+        reportIndexDao.removeIndex(key);
+    }
 
     private void addToIndex(ReportDataKey key) {
         try {

--- a/app/org/sagebionetworks/bridge/services/ReportService.java
+++ b/app/org/sagebionetworks/bridge/services/ReportService.java
@@ -2,7 +2,6 @@ package org.sagebionetworks.bridge.services;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -18,6 +17,7 @@ import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.models.DateRangeResourceList;
+import org.sagebionetworks.bridge.models.ReportTypeResourceList;
 import org.sagebionetworks.bridge.models.reports.ReportData;
 import org.sagebionetworks.bridge.models.reports.ReportDataKey;
 import org.sagebionetworks.bridge.models.reports.ReportIndex;
@@ -145,7 +145,7 @@ public class ReportService {
         }
     }
     
-    public List<? extends ReportIndex> getReportIndices(StudyIdentifier studyId, ReportType reportType) {
+    public ReportTypeResourceList<? extends ReportIndex> getReportIndices(StudyIdentifier studyId, ReportType reportType) {
         checkNotNull(studyId);
         checkNotNull(reportType);
         

--- a/conf/routes
+++ b/conf/routes
@@ -70,16 +70,17 @@ POST   /v3/users/self/dataGroups          @org.sagebionetworks.bridge.play.contr
 GET    /v3/users/self/reports/:identifier @org.sagebionetworks.bridge.play.controllers.ReportController.getParticipantReport(identifier: String, startDate: String ?= null, endDate: String ?= null)
 
 # Reports
-GET    /v3/reports                                 @org.sagebionetworks.bridge.play.controllers.ReportController.getReportIndices(type: String)
-GET    /v3/reports/:identifier/users/:userId       @org.sagebionetworks.bridge.play.controllers.ReportController.getParticipantReportForResearcher(identifier: String, userId: String, startDate: String ?= null, endDate: String ?= null)
-POST   /v3/reports/:identifier/users/:userId       @org.sagebionetworks.bridge.play.controllers.ReportController.saveParticipantReport(identifier: String, userId: String)
-DELETE /v3/reports/:identifier/users/:userId       @org.sagebionetworks.bridge.play.controllers.ReportController.deleteParticipantReport(identifier: String, userId: String)
-POST   /v3/reports/:identifier/users               @org.sagebionetworks.bridge.play.controllers.ReportController.saveParticipantReportForWorker(identifier: String)
-DELETE /v3/reports/:identifier/users/:userId/:date @org.sagebionetworks.bridge.play.controllers.ReportController.deleteParticipantReportRecord(identifier: String, userId: String, date: String)
-GET    /v3/reports/:identifier                     @org.sagebionetworks.bridge.play.controllers.ReportController.getStudyReport(identifier: String, startDate: String ?= null, endDate: String ?= null)
-POST   /v3/reports/:identifier                     @org.sagebionetworks.bridge.play.controllers.ReportController.saveStudyReport(identifier: String)
-DELETE /v3/reports/:identifier                     @org.sagebionetworks.bridge.play.controllers.ReportController.deleteStudyReport(identifier: String)
-DELETE /v3/reports/:identifier/:date               @org.sagebionetworks.bridge.play.controllers.ReportController.deleteStudyReportRecord(identifier: String, date: String)
+GET    /v3/reports                                        @org.sagebionetworks.bridge.play.controllers.ReportController.getReportIndices(type: String)
+GET    /v3/reports/:identifier                            @org.sagebionetworks.bridge.play.controllers.ReportController.getStudyReport(identifier: String, startDate: String ?= null, endDate: String ?= null)
+POST   /v3/reports/:identifier                            @org.sagebionetworks.bridge.play.controllers.ReportController.saveStudyReport(identifier: String)
+DELETE /v3/reports/:identifier                            @org.sagebionetworks.bridge.play.controllers.ReportController.deleteStudyReport(identifier: String)
+DELETE /v3/reports/:identifier/:date                      @org.sagebionetworks.bridge.play.controllers.ReportController.deleteStudyReportRecord(identifier: String, date: String)
+GET    /v3/participants/:userId/reports/:identifier       @org.sagebionetworks.bridge.play.controllers.ReportController.getParticipantReportForResearcher(userId: String, identifier: String, startDate: String ?= null, endDate: String ?= null)
+POST   /v3/participants/:userId/reports/:identifier       @org.sagebionetworks.bridge.play.controllers.ReportController.saveParticipantReport(userId: String, identifier: String)
+DELETE /v3/participants/:userId/reports/:identifier       @org.sagebionetworks.bridge.play.controllers.ReportController.deleteParticipantReport(userId: String, identifier: String)
+DELETE /v3/participants/:userId/reports/:identifier/:date @org.sagebionetworks.bridge.play.controllers.ReportController.deleteParticipantReportRecord(userId: String, identifier: String, date: String)
+POST   /v3/participants/reports/:identifier               @org.sagebionetworks.bridge.play.controllers.ReportController.saveParticipantReportForWorker(identifier: String)
+
 
 # Surveys
 GET    /v3/surveys                                           @org.sagebionetworks.bridge.play.controllers.SurveyController.getAllSurveysMostRecentVersion

--- a/conf/routes
+++ b/conf/routes
@@ -57,7 +57,6 @@ POST   /v3/consents/:timestamp/publish   @org.sagebionetworks.bridge.play.contro
 
 # Users
 POST   /v3/users                          @org.sagebionetworks.bridge.play.controllers.UserManagementController.createUser
-GET    /v3/users/reports                  @org.sagebionetworks.bridge.play.controllers.ReportController.getParticipantReportIndices
 DELETE /v3/users/:userId                  @org.sagebionetworks.bridge.play.controllers.UserManagementController.deleteUser(userId: String)
 GET    /v3/users/self                     @org.sagebionetworks.bridge.play.controllers.UserProfileController.getUserProfile
 POST   /v3/users/self                     @org.sagebionetworks.bridge.play.controllers.UserProfileController.updateUserProfile
@@ -70,14 +69,17 @@ GET    /v3/users/self/dataGroups          @org.sagebionetworks.bridge.play.contr
 POST   /v3/users/self/dataGroups          @org.sagebionetworks.bridge.play.controllers.UserProfileController.updateDataGroups
 GET    /v3/users/self/reports/:identifier @org.sagebionetworks.bridge.play.controllers.ReportController.getParticipantReport(identifier: String, startDate: String ?= null, endDate: String ?= null)
 
-# Study-wide reports
-GET    /v3/reports                           @org.sagebionetworks.bridge.play.controllers.ReportController.getStudyReportIndices
-GET    /v3/reports/:identifier               @org.sagebionetworks.bridge.play.controllers.ReportController.getStudyReport(identifier: String, startDate: String ?= null, endDate: String ?= null)
-POST   /v3/reports/:identifier               @org.sagebionetworks.bridge.play.controllers.ReportController.saveStudyReport(identifier: String)
-DELETE /v3/reports/:identifier               @org.sagebionetworks.bridge.play.controllers.ReportController.deleteStudyReport(identifier: String)
-POST   /v3/reports/:identifier/users/:userId @org.sagebionetworks.bridge.play.controllers.ReportController.saveParticipantReport(identifier: String, userId: String)
-DELETE /v3/reports/:identifier/users/:userId @org.sagebionetworks.bridge.play.controllers.ReportController.deleteParticipantReport(identifier: String, userId: String)
-POST   /v3/reports/:identifier/users         @org.sagebionetworks.bridge.play.controllers.ReportController.saveParticipantReportForWorker(identifier: String)
+# Reports
+GET    /v3/reports                                 @org.sagebionetworks.bridge.play.controllers.ReportController.getReportIndices(type: String)
+GET    /v3/reports/:identifier/users/:userId       @org.sagebionetworks.bridge.play.controllers.ReportController.getParticipantReportForResearcher(identifier: String, userId: String, startDate: String ?= null, endDate: String ?= null)
+POST   /v3/reports/:identifier/users/:userId       @org.sagebionetworks.bridge.play.controllers.ReportController.saveParticipantReport(identifier: String, userId: String)
+DELETE /v3/reports/:identifier/users/:userId       @org.sagebionetworks.bridge.play.controllers.ReportController.deleteParticipantReport(identifier: String, userId: String)
+POST   /v3/reports/:identifier/users               @org.sagebionetworks.bridge.play.controllers.ReportController.saveParticipantReportForWorker(identifier: String)
+DELETE /v3/reports/:identifier/users/:userId/:date @org.sagebionetworks.bridge.play.controllers.ReportController.deleteParticipantReportRecord(identifier: String, userId: String, date: String)
+GET    /v3/reports/:identifier                     @org.sagebionetworks.bridge.play.controllers.ReportController.getStudyReport(identifier: String, startDate: String ?= null, endDate: String ?= null)
+POST   /v3/reports/:identifier                     @org.sagebionetworks.bridge.play.controllers.ReportController.saveStudyReport(identifier: String)
+DELETE /v3/reports/:identifier                     @org.sagebionetworks.bridge.play.controllers.ReportController.deleteStudyReport(identifier: String)
+DELETE /v3/reports/:identifier/:date               @org.sagebionetworks.bridge.play.controllers.ReportController.deleteStudyReportRecord(identifier: String, date: String)
 
 # Surveys
 GET    /v3/surveys                                           @org.sagebionetworks.bridge.play.controllers.SurveyController.getAllSurveysMostRecentVersion

--- a/conf/routes
+++ b/conf/routes
@@ -80,7 +80,7 @@ POST   /v3/participants/:userId/reports/:identifier       @org.sagebionetworks.b
 DELETE /v3/participants/:userId/reports/:identifier       @org.sagebionetworks.bridge.play.controllers.ReportController.deleteParticipantReport(userId: String, identifier: String)
 DELETE /v3/participants/:userId/reports/:identifier/:date @org.sagebionetworks.bridge.play.controllers.ReportController.deleteParticipantReportRecord(userId: String, identifier: String, date: String)
 POST   /v3/participants/reports/:identifier               @org.sagebionetworks.bridge.play.controllers.ReportController.saveParticipantReportForWorker(identifier: String)
-
+DELETE /v3/participants/reports/:identifier               @org.sagebionetworks.bridge.play.controllers.ReportController.deleteParticipantReportIndex(identifier: String)
 
 # Surveys
 GET    /v3/surveys                                           @org.sagebionetworks.bridge.play.controllers.SurveyController.getAllSurveysMostRecentVersion

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoReportDataDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoReportDataDaoTest.java
@@ -89,6 +89,22 @@ public class DynamoReportDataDaoTest {
         assertResourceList(results, 0);
     }
 
+    @Test
+    public void canDeleteSingleStudyRecords() {
+        ReportData report1 = createReport(LocalDate.parse("2016-03-30"), "a", "b");
+        ReportData report2 = createReport(LocalDate.parse("2016-03-31"), "c", "d");
+        
+        dao.saveReportData(report1);
+        dao.saveReportData(report2);
+        assertEquals(2, dao.getReportData(reportDataKey, START_DATE, END_DATE).getTotal());
+        
+        dao.deleteReportDataRecord(reportDataKey, LocalDate.parse("2016-03-30"));
+        assertEquals(1, dao.getReportData(reportDataKey, START_DATE, END_DATE).getTotal());
+        
+        dao.deleteReportDataRecord(reportDataKey, LocalDate.parse("2016-03-31"));
+        assertEquals(0, dao.getReportData(reportDataKey, START_DATE, END_DATE).getTotal());
+    }
+    
     private ReportData createReport(LocalDate date, String fieldValue1, String fieldValue2) {
         ObjectNode node = JsonNodeFactory.instance.objectNode();
         node.put("field1", fieldValue1);

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoReportIndexDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoReportIndexDaoTest.java
@@ -82,11 +82,6 @@ public class DynamoReportIndexDaoTest {
         indices = dao.getIndices(TEST_STUDY, ReportType.STUDY);
         assertEquals(count, indices.getItems().size());
     }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void cannotCreateIndexForParticipantReport() {
-        dao.removeIndex(participantReportKey1);
-    }
     
     @Test
     public void canCreateAndReadParticipantIndex() {

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoReportIndexDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoReportIndexDaoTest.java
@@ -3,7 +3,6 @@ package org.sagebionetworks.bridge.dynamodb;
 import static org.junit.Assert.assertEquals;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 
-import java.util.List;
 import java.util.Set;
 
 import javax.annotation.Resource;
@@ -17,6 +16,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.TestUtils;
+import org.sagebionetworks.bridge.models.ReportTypeResourceList;
 import org.sagebionetworks.bridge.models.reports.ReportDataKey;
 import org.sagebionetworks.bridge.models.reports.ReportIndex;
 import org.sagebionetworks.bridge.models.reports.ReportType;
@@ -61,26 +61,26 @@ public class DynamoReportIndexDaoTest {
     
     @Test
     public void canCRUDReportIndex() {
-        int count = dao.getIndices(TEST_STUDY, ReportType.STUDY).size();
+        int count = dao.getIndices(TEST_STUDY, ReportType.STUDY).getItems().size();
         // adding twice is fine
         dao.addIndex(studyReportKey1);
         dao.addIndex(studyReportKey1);
         dao.addIndex(studyReportKey2);
 
-        List<? extends ReportIndex> indices = dao.getIndices(TEST_STUDY, ReportType.STUDY);
-        assertEquals(count+2, indices.size());
+        ReportTypeResourceList<? extends ReportIndex> indices = dao.getIndices(TEST_STUDY, ReportType.STUDY);
+        assertEquals(count+2, indices.getItems().size());
         
         // Wrong type returns zero records
         indices = dao.getIndices(TEST_STUDY, ReportType.PARTICIPANT);
-        assertEquals(0, indices.size());
+        assertEquals(0, indices.getItems().size());
         
         dao.removeIndex(studyReportKey1);
         indices = dao.getIndices(TEST_STUDY, ReportType.STUDY);
-        assertEquals(count+1, indices.size());
+        assertEquals(count+1, indices.getItems().size());
         
         dao.removeIndex(studyReportKey2);
         indices = dao.getIndices(TEST_STUDY, ReportType.STUDY);
-        assertEquals(count, indices.size());
+        assertEquals(count, indices.getItems().size());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -90,31 +90,32 @@ public class DynamoReportIndexDaoTest {
     
     @Test
     public void canCreateAndReadParticipantIndex() {
-        int count = dao.getIndices(TEST_STUDY, ReportType.PARTICIPANT).size();
+        int count = dao.getIndices(TEST_STUDY, ReportType.PARTICIPANT).getItems().size();
         
         // adding twice is fine
         dao.addIndex(participantReportKey1);
         dao.addIndex(participantReportKey1);
         dao.addIndex(participantReportKey2);
         
-        List<? extends ReportIndex> indices = dao.getIndices(TEST_STUDY, ReportType.PARTICIPANT);
-        assertEquals(count+2, indices.size());
+        ReportTypeResourceList<? extends ReportIndex> indices = dao.getIndices(TEST_STUDY, ReportType.PARTICIPANT);
+        assertEquals(count+2, indices.getItems().size());
         
-        Set<String> identifiers = Sets.newHashSet(indices.get(0).getIdentifier(), indices.get(1).getIdentifier());
+        Set<String> identifiers = Sets.newHashSet(indices.getItems().get(0).getIdentifier(),
+                indices.getItems().get(1).getIdentifier());
         Set<String> originalIdentifiers = Sets.newHashSet(participantReportKey1.getIdentifier(),
                 participantReportKey2.getIdentifier());
         assertEquals(originalIdentifiers, identifiers);
         
         // wrong type returns no records
         indices = dao.getIndices(TEST_STUDY, ReportType.STUDY);
-        assertEquals(0, indices.size());
+        assertEquals(0, indices.getItems().size());
         
         // Use mapper directly to clean up, as we don't allow deletion of participant reports.
         deleteParticipantReport(participantReportKey1);
         deleteParticipantReport(participantReportKey2);
         
         indices = dao.getIndices(TEST_STUDY, ReportType.PARTICIPANT);
-        assertEquals(count, indices.size());
+        assertEquals(count, indices.getItems().size());
     }
     
     private void deleteParticipantReport(ReportDataKey key) {

--- a/test/org/sagebionetworks/bridge/models/ReportTypeResourceListTest.java
+++ b/test/org/sagebionetworks/bridge/models/ReportTypeResourceListTest.java
@@ -1,0 +1,39 @@
+package org.sagebionetworks.bridge.models;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.reports.ReportIndex;
+import org.sagebionetworks.bridge.models.reports.ReportType;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.Lists;
+
+public class ReportTypeResourceListTest {
+
+    @Test
+    public void canSerialize() throws Exception {
+        ReportIndex index1 = ReportIndex.create();
+        index1.setKey("doesn't matter what this is");
+        index1.setIdentifier("foo");
+        
+        ReportIndex index2 = ReportIndex.create();
+        index2.setKey("doesn't matter what this is");
+        index2.setIdentifier("bar");
+        
+        ReportTypeResourceList<ReportIndex> list = new ReportTypeResourceList<>(
+                Lists.newArrayList(index1, index2), ReportType.PARTICIPANT);
+        
+        JsonNode node = BridgeObjectMapper.get().valueToTree(list);
+        assertEquals("participant", node.get("reportType").asText());
+        assertEquals(2, node.get("total").asInt());
+        assertEquals("ReportTypeResourceList", node.get("type").asText());
+        assertEquals("foo", node.get("items").get(0).get("identifier").asText());
+        assertEquals("bar", node.get("items").get(1).get("identifier").asText());
+        assertEquals(4, node.size());
+        
+        // We never deserialize this on the server side (only in the SDK).
+    }
+}

--- a/test/org/sagebionetworks/bridge/models/reports/ReportDataKeyTest.java
+++ b/test/org/sagebionetworks/bridge/models/reports/ReportDataKeyTest.java
@@ -60,16 +60,12 @@ public class ReportDataKeyTest {
         assertEquals("report", key.getIdentifier());
         assertEquals(ReportType.STUDY, key.getReportType());
     }
-    
+
     @Test
     public void canConstructKeyWithoutValidatingDate() {
-        ReportDataKey key = new ReportDataKey.Builder()
-                .withReportType(ReportType.PARTICIPANT).withStudyIdentifier(TEST_STUDY)
-                .withHealthCode("AAA")
-                .withIdentifier("report").build();
+        ReportDataKey key = new ReportDataKey.Builder().withReportType(ReportType.PARTICIPANT)
+                .withStudyIdentifier(TEST_STUDY).withHealthCode("AAA").withIdentifier("report").build();
         
-        // This was constructed, the date is valid. It's not part of the key, it's validated in the builder
-        // so validation errors are combined with key validation errors.
         assertEquals("AAA:report:api", key.getKeyString());
         assertEquals("api:PARTICIPANT", key.getIndexKeyString());
         assertEquals("AAA", key.getHealthCode());

--- a/test/org/sagebionetworks/bridge/play/controllers/ReportControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ReportControllerTest.java
@@ -56,6 +56,8 @@ import play.test.Helpers;
 @RunWith(MockitoJUnitRunner.class)
 public class ReportControllerTest {
 
+    private static final String REPORT_ID = "foo";
+
     private static final String VALID_LANGUAGE_HEADER = "en-US";
 
     private static final String VALID_USER_AGENT_HEADER = "Unknown Client/14 BridgeJavaSDK/10";
@@ -153,9 +155,9 @@ public class ReportControllerTest {
         setupContext();
         
         doReturn(makeResults(START_DATE, END_DATE)).when(mockReportService).getParticipantReport(session.getStudyIdentifier(),
-                "foo", HEALTH_CODE, START_DATE, END_DATE);
+                REPORT_ID, HEALTH_CODE, START_DATE, END_DATE);
         
-        Result result = controller.getParticipantReport("foo", START_DATE.toString(), END_DATE.toString());
+        Result result = controller.getParticipantReport(REPORT_ID, START_DATE.toString(), END_DATE.toString());
         assertEquals(200, result.status());
         assertResult(result);
     }
@@ -169,9 +171,9 @@ public class ReportControllerTest {
         session.setParticipant(participant);
         
         doReturn(makeResults(START_DATE, END_DATE)).when(mockReportService).getParticipantReport(session.getStudyIdentifier(),
-                "foo", HEALTH_CODE, START_DATE, END_DATE);
+                REPORT_ID, HEALTH_CODE, START_DATE, END_DATE);
         
-        Result result = controller.getParticipantReport("foo", START_DATE.toString(), END_DATE.toString());
+        Result result = controller.getParticipantReport(REPORT_ID, START_DATE.toString(), END_DATE.toString());
         assertEquals(200, result.status());
         assertResult(result);
     }
@@ -181,9 +183,9 @@ public class ReportControllerTest {
         setupContext();
         
         doReturn(makeResults(START_DATE, END_DATE)).when(mockReportService).getParticipantReport(session.getStudyIdentifier(),
-                "foo", HEALTH_CODE, null, null);
+                REPORT_ID, HEALTH_CODE, null, null);
         
-        Result result = controller.getParticipantReport("foo", null, null);
+        Result result = controller.getParticipantReport(REPORT_ID, null, null);
         assertEquals(200, result.status());
         assertResult(result);
     }
@@ -192,30 +194,30 @@ public class ReportControllerTest {
     public void getParticipantReportNoUserAgent() throws Exception {
         setupContext("Bad Request", VALID_LANGUAGE_HEADER);
 
-        controller.getParticipantReport("foo", START_DATE.toString(), END_DATE.toString());
+        controller.getParticipantReport(REPORT_ID, START_DATE.toString(), END_DATE.toString());
     }
     
     @Test(expected = BadRequestException.class)
     public void getParticipantReportNoLanguageHeader() throws Exception {
         setupContext(VALID_USER_AGENT_HEADER, null);
 
-        controller.getParticipantReport("foo", START_DATE.toString(), END_DATE.toString());
+        controller.getParticipantReport(REPORT_ID, START_DATE.toString(), END_DATE.toString());
     }
     
     @Test(expected = BadRequestException.class)
     public void getParticipantReportBadLanguageHeader() throws Exception {
         setupContext(VALID_USER_AGENT_HEADER, "bad language header");
 
-        controller.getParticipantReport("foo", START_DATE.toString(), END_DATE.toString());
+        controller.getParticipantReport(REPORT_ID, START_DATE.toString(), END_DATE.toString());
     }
     
     @Test
     public void getStudyReportData() throws Exception {
         setupContext();
         doReturn(makeResults(START_DATE, END_DATE)).when(mockReportService).getStudyReport(session.getStudyIdentifier(),
-                "foo", START_DATE, END_DATE);
+                REPORT_ID, START_DATE, END_DATE);
         
-        Result result = controller.getStudyReport("foo", START_DATE.toString(), END_DATE.toString());
+        Result result = controller.getStudyReport(REPORT_ID, START_DATE.toString(), END_DATE.toString());
         assertEquals(200, result.status());
         assertResult(result);
     }
@@ -224,9 +226,9 @@ public class ReportControllerTest {
     public void getStudyReportDataWithNoDates() throws Exception {
         setupContext();
         doReturn(makeResults(START_DATE, END_DATE)).when(mockReportService).getStudyReport(session.getStudyIdentifier(),
-                "foo", null, null);
+                REPORT_ID, null, null);
         
-        Result result = controller.getStudyReport("foo", null, null);
+        Result result = controller.getStudyReport(REPORT_ID, null, null);
         assertEquals(200, result.status());
         assertResult(result);
     }
@@ -235,35 +237,35 @@ public class ReportControllerTest {
     public void getStudyReportDataWithNoUserAgentAsResearcherOK() throws Exception {
         setupContext("", VALID_LANGUAGE_HEADER);
         doReturn(makeResults(START_DATE, END_DATE)).when(mockReportService).getStudyReport(session.getStudyIdentifier(),
-                "foo", START_DATE, END_DATE);
+                REPORT_ID, START_DATE, END_DATE);
         
-        controller.getStudyReport("foo", START_DATE.toString(), END_DATE.toString());
+        controller.getStudyReport(REPORT_ID, START_DATE.toString(), END_DATE.toString());
     }    
     
     @Test(expected = BadRequestException.class)
     public void getParticipantReportDataWithNoUserAgent() throws Exception {
         setupContext("", VALID_LANGUAGE_HEADER);
         
-        SubpopulationGuid guid = SubpopulationGuid.create("foo");
+        SubpopulationGuid guid = SubpopulationGuid.create(REPORT_ID);
         Map<SubpopulationGuid,ConsentStatus> consentStatuses = Maps.newHashMap();
         consentStatuses.put(guid, new ConsentStatus.Builder().withName("FullName").withConsented(true).withRequired(true).withGuid(guid).build());
         
         session.setConsentStatuses(consentStatuses);
         
-        controller.getParticipantReport("foo", START_DATE.toString(), END_DATE.toString());
+        controller.getParticipantReport(REPORT_ID, START_DATE.toString(), END_DATE.toString());
     }
     
     @Test(expected = BadRequestException.class)
     public void getParticipantReportDataWithNoAcceptLanguage() throws Exception {
         setupContext(VALID_USER_AGENT_HEADER, null);
         
-        SubpopulationGuid guid = SubpopulationGuid.create("foo");
+        SubpopulationGuid guid = SubpopulationGuid.create(REPORT_ID);
         Map<SubpopulationGuid,ConsentStatus> consentStatuses = Maps.newHashMap();
         consentStatuses.put(guid, new ConsentStatus.Builder().withName("FullName").withConsented(true).withRequired(true).withGuid(guid).build());
         
         session.setConsentStatuses(consentStatuses);
         
-        controller.getParticipantReport("foo", START_DATE.toString(), END_DATE.toString());
+        controller.getParticipantReport(REPORT_ID, START_DATE.toString(), END_DATE.toString());
     }
     
     @Test
@@ -272,10 +274,10 @@ public class ReportControllerTest {
         
         TestUtils.mockPlayContextWithJson(json);
 
-        Result result = controller.saveParticipantReport(OTHER_PARTICIPANT_ID, "foo");
+        Result result = controller.saveParticipantReport(OTHER_PARTICIPANT_ID, REPORT_ID);
         TestUtils.assertResult(result, 201, "Report data saved.");
 
-        verify(mockReportService).saveParticipantReport(eq(TEST_STUDY), eq("foo"), eq(OTHER_PARTICIPANT_HEALTH_CODE), reportDataCaptor.capture());
+        verify(mockReportService).saveParticipantReport(eq(TEST_STUDY), eq(REPORT_ID), eq(OTHER_PARTICIPANT_HEALTH_CODE), reportDataCaptor.capture());
         ReportData reportData = reportDataCaptor.getValue();
         assertEquals(LocalDate.parse("2015-02-12").toString(), reportData.getDate().toString());
         assertNull(reportData.getKey());
@@ -290,7 +292,7 @@ public class ReportControllerTest {
         
         TestUtils.mockPlayContextWithJson(json);
 
-        Result result = controller.saveParticipantReport(OTHER_PARTICIPANT_ID, "foo");
+        Result result = controller.saveParticipantReport(OTHER_PARTICIPANT_ID, REPORT_ID);
         TestUtils.assertResult(result, 201, "Report data saved.");
     }
     
@@ -300,10 +302,10 @@ public class ReportControllerTest {
         
         TestUtils.mockPlayContextWithJson(json);
 
-        Result result = controller.saveParticipantReportForWorker("foo");
+        Result result = controller.saveParticipantReportForWorker(REPORT_ID);
         TestUtils.assertResult(result, 201, "Report data saved.");
         
-        verify(mockReportService).saveParticipantReport(eq(TEST_STUDY), eq("foo"), eq(OTHER_PARTICIPANT_HEALTH_CODE), reportDataCaptor.capture());
+        verify(mockReportService).saveParticipantReport(eq(TEST_STUDY), eq(REPORT_ID), eq(OTHER_PARTICIPANT_HEALTH_CODE), reportDataCaptor.capture());
         ReportData reportData = reportDataCaptor.getValue();
         assertEquals(LocalDate.parse("2015-02-12").toString(), reportData.getDate().toString());
         assertNull(reportData.getKey());
@@ -318,7 +320,7 @@ public class ReportControllerTest {
         
         TestUtils.mockPlayContextWithJson(json);
         try {
-            controller.saveParticipantReportForWorker("foo");    
+            controller.saveParticipantReportForWorker(REPORT_ID);    
         } catch(BadRequestException e) {
             assertEquals("A health code is required to save report data.", e.getMessage());
             verifyNoMoreInteractions(mockReportService);
@@ -330,10 +332,10 @@ public class ReportControllerTest {
         String json = TestUtils.createJson("{'date':'2015-02-12','data':{'field1':'Last','field2':'Name'}}");
         TestUtils.mockPlayContextWithJson(json);
                 
-        Result result = controller.saveStudyReport("foo");
+        Result result = controller.saveStudyReport(REPORT_ID);
         TestUtils.assertResult(result, 201, "Report data saved.");
         
-        verify(mockReportService).saveStudyReport(eq(TEST_STUDY), eq("foo"), reportDataCaptor.capture());
+        verify(mockReportService).saveStudyReport(eq(TEST_STUDY), eq(REPORT_ID), reportDataCaptor.capture());
         ReportData reportData = reportDataCaptor.getValue();
         assertEquals(LocalDate.parse("2015-02-12").toString(), reportData.getDate().toString());
         assertNull(reportData.getKey());
@@ -375,35 +377,35 @@ public class ReportControllerTest {
     
     @Test
     public void deleteParticipantReportData() throws Exception {
-        Result result = controller.deleteParticipantReport(OTHER_PARTICIPANT_ID, "foo");
+        Result result = controller.deleteParticipantReport(OTHER_PARTICIPANT_ID, REPORT_ID);
         TestUtils.assertResult(result, 200, "Report deleted.");
         
-        verify(mockReportService).deleteParticipantReport(session.getStudyIdentifier(), "foo", OTHER_PARTICIPANT_HEALTH_CODE);
+        verify(mockReportService).deleteParticipantReport(session.getStudyIdentifier(), REPORT_ID, OTHER_PARTICIPANT_HEALTH_CODE);
     }
     
     @Test
     public void deleteStudyReportData() throws Exception {
-        Result result = controller.deleteStudyReport("foo");
+        Result result = controller.deleteStudyReport(REPORT_ID);
         TestUtils.assertResult(result, 200, "Report deleted.");
         
-        verify(mockReportService).deleteStudyReport(session.getStudyIdentifier(), "foo");
+        verify(mockReportService).deleteStudyReport(session.getStudyIdentifier(), REPORT_ID);
     }
     
     @Test
     public void deleteParticipantReportDataRecord() throws Exception {
-        Result result = controller.deleteParticipantReportRecord(OTHER_PARTICIPANT_ID, "foo", "2014-05-10");
+        Result result = controller.deleteParticipantReportRecord(OTHER_PARTICIPANT_ID, REPORT_ID, "2014-05-10");
         TestUtils.assertResult(result, 200, "Report record deleted.");
         
-        verify(mockReportService).deleteParticipantReportRecord(session.getStudyIdentifier(), "foo",
+        verify(mockReportService).deleteParticipantReportRecord(session.getStudyIdentifier(), REPORT_ID,
                 LocalDate.parse("2014-05-10"), OTHER_PARTICIPANT_HEALTH_CODE);
     }
     
     @Test
     public void deleteStudyReportDataRecord() throws Exception {
-        Result result = controller.deleteStudyReportRecord("foo", "2014-05-10");
+        Result result = controller.deleteStudyReportRecord(REPORT_ID, "2014-05-10");
         TestUtils.assertResult(result, 200, "Report record deleted.");
         
-        verify(mockReportService).deleteStudyReportRecord(session.getStudyIdentifier(), "foo",
+        verify(mockReportService).deleteStudyReportRecord(session.getStudyIdentifier(), REPORT_ID,
                 LocalDate.parse("2014-05-10"));
     }
     
@@ -413,7 +415,7 @@ public class ReportControllerTest {
             .withRoles(Sets.newHashSet()).build();
         session.setParticipant(regularUser);
         
-        controller.deleteStudyReportRecord("foo", "2014-05-10");
+        controller.deleteStudyReportRecord(REPORT_ID, "2014-05-10");
     }
     
     @Test(expected = UnauthorizedException.class)
@@ -422,7 +424,21 @@ public class ReportControllerTest {
             .withRoles(Sets.newHashSet(Roles.ADMIN)).build();
         session.setParticipant(regularUser);
         
-        controller.deleteParticipantReportRecord("foo", "bar", "2014-05-10");
+        controller.deleteParticipantReportRecord(REPORT_ID, "bar", "2014-05-10");
+    }
+    
+    public void adminCanDeleteParticipantIndex() {
+        StudyParticipant regularUser = new StudyParticipant.Builder().copyOf(session.getParticipant())
+                .withRoles(Sets.newHashSet(Roles.ADMIN)).build();
+            session.setParticipant(regularUser);
+        
+        controller.deleteParticipantReportIndex(REPORT_ID);
+        verify(mockReportService).deleteParticipantReportIndex(TEST_STUDY, REPORT_ID);
+    }
+    
+    @Test(expected = UnauthorizedException.class)
+    public void nonAdminCannotDeleteParticipantIndex() {
+        controller.deleteParticipantReportIndex(REPORT_ID);
     }
     
     private void assertResult(Result result) throws Exception {

--- a/test/org/sagebionetworks/bridge/play/controllers/ReportControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ReportControllerTest.java
@@ -268,7 +268,7 @@ public class ReportControllerTest {
         
         TestUtils.mockPlayContextWithJson(json);
 
-        Result result = controller.saveParticipantReport("foo", OTHER_PARTICIPANT_ID);
+        Result result = controller.saveParticipantReport(OTHER_PARTICIPANT_ID, "foo");
         TestUtils.assertResult(result, 201, "Report data saved.");
 
         verify(mockReportService).saveParticipantReport(eq(TEST_STUDY), eq("foo"), eq(OTHER_PARTICIPANT_HEALTH_CODE), reportDataCaptor.capture());
@@ -286,7 +286,7 @@ public class ReportControllerTest {
         
         TestUtils.mockPlayContextWithJson(json);
 
-        Result result = controller.saveParticipantReport("foo", OTHER_PARTICIPANT_ID);
+        Result result = controller.saveParticipantReport(OTHER_PARTICIPANT_ID, "foo");
         TestUtils.assertResult(result, 201, "Report data saved.");
     }
     
@@ -369,7 +369,7 @@ public class ReportControllerTest {
     
     @Test
     public void deleteParticipantReportData() throws Exception {
-        Result result = controller.deleteParticipantReport("foo", OTHER_PARTICIPANT_ID);
+        Result result = controller.deleteParticipantReport(OTHER_PARTICIPANT_ID, "foo");
         TestUtils.assertResult(result, 200, "Report deleted.");
         
         verify(mockReportService).deleteParticipantReport(session.getStudyIdentifier(), "foo", OTHER_PARTICIPANT_HEALTH_CODE);
@@ -385,7 +385,7 @@ public class ReportControllerTest {
     
     @Test
     public void deleteParticipantReportDataRecord() throws Exception {
-        Result result = controller.deleteParticipantReportRecord("foo", OTHER_PARTICIPANT_ID, "2014-05-10");
+        Result result = controller.deleteParticipantReportRecord(OTHER_PARTICIPANT_ID, "foo", "2014-05-10");
         TestUtils.assertResult(result, 200, "Report record deleted.");
         
         verify(mockReportService).deleteParticipantReportRecord(session.getStudyIdentifier(), "foo",

--- a/test/org/sagebionetworks/bridge/play/controllers/ReportControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ReportControllerTest.java
@@ -2,7 +2,6 @@ package org.sagebionetworks.bridge.play.controllers;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.spy;
@@ -31,7 +30,7 @@ import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.DateRangeResourceList;
-import org.sagebionetworks.bridge.models.ResourceList;
+import org.sagebionetworks.bridge.models.ReportTypeResourceList;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
@@ -127,9 +126,14 @@ public class ReportControllerTest {
         
         ReportIndex index = new DynamoReportIndex();
         index.setIdentifier("fofo");
-        List<? extends ReportIndex> list = Lists.newArrayList(index);
+        ReportTypeResourceList<? extends ReportIndex> list = new ReportTypeResourceList<>(
+                Lists.newArrayList(index), ReportType.STUDY);
+        doReturn(list).when(mockReportService).getReportIndices(eq(TEST_STUDY), eq(ReportType.STUDY));
         
-        doReturn(list).when(mockReportService).getReportIndices(eq(TEST_STUDY), any());
+        index = new DynamoReportIndex();
+        index.setIdentifier("fofo");
+        list = new ReportTypeResourceList<>(Lists.newArrayList(index), ReportType.PARTICIPANT);
+        doReturn(list).when(mockReportService).getReportIndices(eq(TEST_STUDY), eq(ReportType.PARTICIPANT));
     }
     
     private void setupContext() throws Exception {
@@ -342,11 +346,12 @@ public class ReportControllerTest {
         Result result = controller.getReportIndices("study");
         assertEquals(200, result.status());
         
-        ResourceList<ReportIndex> results = BridgeObjectMapper.get().readValue(
+        ReportTypeResourceList<ReportIndex> results = BridgeObjectMapper.get().readValue(
                 Helpers.contentAsString(result),
-                new TypeReference<ResourceList<ReportIndex>>() {});
+                new TypeReference<ReportTypeResourceList<ReportIndex>>() {});
         assertEquals(1, results.getTotal());
         assertEquals(1, results.getItems().size());
+        assertEquals(ReportType.STUDY, results.getReportType());
         assertEquals("fofo", results.getItems().get(0).getIdentifier());
         
         verify(mockReportService).getReportIndices(TEST_STUDY, ReportType.STUDY);
@@ -357,11 +362,12 @@ public class ReportControllerTest {
         Result result = controller.getReportIndices("participant");
         assertEquals(200, result.status());
         
-        ResourceList<ReportIndex> results = BridgeObjectMapper.get().readValue(
+        ReportTypeResourceList<ReportIndex> results = BridgeObjectMapper.get().readValue(
                 Helpers.contentAsString(result),
-                new TypeReference<ResourceList<ReportIndex>>() {});
+                new TypeReference<ReportTypeResourceList<ReportIndex>>() {});
         assertEquals(1, results.getTotal());
         assertEquals(1, results.getItems().size());
+        assertEquals(ReportType.PARTICIPANT, results.getReportType());
         assertEquals("fofo", results.getItems().get(0).getIdentifier());
         
         verify(mockReportService).getReportIndices(TEST_STUDY, ReportType.PARTICIPANT);

--- a/test/org/sagebionetworks/bridge/services/ReportServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ReportServiceTest.java
@@ -28,6 +28,7 @@ import org.sagebionetworks.bridge.dynamodb.DynamoReportIndex;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.models.DateRangeResourceList;
+import org.sagebionetworks.bridge.models.ReportTypeResourceList;
 import org.sagebionetworks.bridge.models.reports.ReportData;
 import org.sagebionetworks.bridge.models.reports.ReportDataKey;
 import org.sagebionetworks.bridge.models.reports.ReportIndex;
@@ -75,7 +76,7 @@ public class ReportServiceTest {
     
     DateRangeResourceList<? extends ReportData> results;
     
-    List<? extends ReportIndex> indices;
+    ReportTypeResourceList<? extends ReportIndex> indices;
     
     @Before
     public void before() throws Exception {
@@ -90,7 +91,7 @@ public class ReportServiceTest {
         
         DynamoReportIndex index = new DynamoReportIndex();
         index.setIdentifier(IDENTIFIER);
-        indices = Lists.newArrayList(index);
+        indices = new ReportTypeResourceList<>(Lists.newArrayList(index), ReportType.STUDY);
     }
     
     private static ReportData createReport(LocalDate date, String fieldValue1, String fieldValue2) {
@@ -434,19 +435,26 @@ public class ReportServiceTest {
     public void getStudyIndices() {
         doReturn(indices).when(mockReportIndexDao).getIndices(TEST_STUDY, ReportType.STUDY);
 
-        List<? extends ReportIndex> indices = service.getReportIndices(TEST_STUDY, ReportType.STUDY);
+        ReportTypeResourceList<? extends ReportIndex> indices = service.getReportIndices(TEST_STUDY, ReportType.STUDY);
         
-        assertEquals(IDENTIFIER, indices.get(0).getIdentifier());
+        assertEquals(IDENTIFIER, indices.getItems().get(0).getIdentifier());
+        assertEquals(ReportType.STUDY, indices.getReportType());
         verify(mockReportIndexDao).getIndices(TEST_STUDY, ReportType.STUDY);
     }
     
     @Test
     public void getParticipantIndices() {
+        // Need to create an index list with ReportType.PARTICIPANT for this test
+        DynamoReportIndex index = new DynamoReportIndex();
+        index.setIdentifier(IDENTIFIER);
+        indices = new ReportTypeResourceList<>(Lists.newArrayList(index), ReportType.PARTICIPANT);
+        
         doReturn(indices).when(mockReportIndexDao).getIndices(TEST_STUDY, ReportType.PARTICIPANT);
 
-        List<? extends ReportIndex> indices = service.getReportIndices(TEST_STUDY, ReportType.PARTICIPANT);
+        ReportTypeResourceList<? extends ReportIndex> indices = service.getReportIndices(TEST_STUDY, ReportType.PARTICIPANT);
         
-        assertEquals(IDENTIFIER, indices.get(0).getIdentifier());
+        assertEquals(IDENTIFIER, indices.getItems().get(0).getIdentifier());
+        assertEquals(ReportType.PARTICIPANT, indices.getReportType());
         verify(mockReportIndexDao).getIndices(TEST_STUDY, ReportType.PARTICIPANT);
     }
     

--- a/test/org/sagebionetworks/bridge/services/ReportServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ReportServiceTest.java
@@ -72,6 +72,9 @@ public class ReportServiceTest {
     @Captor
     ArgumentCaptor<ReportIndex> reportIndexCaptor;
     
+    @Captor
+    ArgumentCaptor<ReportDataKey> reportDataKeyCaptor;
+    
     ReportService service;
     
     DateRangeResourceList<? extends ReportData> results;
@@ -233,6 +236,19 @@ public class ReportServiceTest {
         
         verify(mockReportDataDao).deleteReportData(PARTICIPANT_REPORT_DATA_KEY);
         verifyNoMoreInteractions(mockReportIndexDao);
+    }
+    
+    
+    @Test
+    public void deleteParticipantIndex() {
+        service.deleteParticipantReportIndex(TEST_STUDY, IDENTIFIER);
+        
+        verify(mockReportIndexDao).removeIndex(reportDataKeyCaptor.capture());
+        verifyNoMoreInteractions(mockReportDataDao);
+        
+        ReportDataKey key = reportDataKeyCaptor.getValue();
+        assertEquals(TEST_STUDY, key.getStudyId());
+        assertEquals(IDENTIFIER, key.getIdentifier());
     }
     
     @Test


### PR DESCRIPTION
Tweaking permissions of some endpoints to allow administration of reports in the research manager;

Adding APIs to delete individual report records (again mostly for admin purposes). 

Split some routes for permissions reasons (e.g. only participants need to submit consent-related headers).

Revised the report URL namespace because some of the URLs were definitely incorrect and I think participant reports are a logical sub-resource of participants, and the URLs are clearer if they are.
