### PR TITLE
Updates to Jedis connection pool based on advice from Redis Clound.

### DIFF
--- a/conf/bridge-server.conf
+++ b/conf/bridge-server.conf
@@ -4,9 +4,10 @@ aws.secret.key = dummy-value
 # Excludes the original try. For example, if this is set to 1, DDB will try a total of twice (one try, one retry)
 ddb.max.retries = 1
 
-# 10 is max number of connections allowed on the free-tier RedisCloud
-# so this default value 10 supports one host using the free-tier Redis
-redis.max.total = 10
+# Max number of connections under our current plan is 256
+redis.max.total = 50
+redis.min.idle = 3
+redis.max.idle = 50
 redis.timeout = 2000
 redis.url = redis://provider:password@localhost:6379
 


### PR DESCRIPTION
Their approach is to test when the connections are created, but just let them throw errors afterward rather than doing these additional ping checks (which aren't guaranteed anyway... you could still have an error between the ping and the actual request). But they do take up resources. Also increasing the pool size (limit is 256 in production).

See https://sagebionetworks.jira.com/browse/BRIDGE-1387
