### PR TITLE
add isUnboundedText to upload field defs

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadFieldDefinition.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadFieldDefinition.java
@@ -28,12 +28,13 @@ public final class DynamoUploadFieldDefinition implements UploadFieldDefinition 
     private final @Nonnull String name;
     private final boolean required;
     private final @Nonnull UploadFieldType type;
+    private final @Nonnull Boolean unboundedText;
 
     /** Private constructor. Construction of a DynamoUploadFieldDefinition should go through the Builder. */
     private DynamoUploadFieldDefinition(@Nullable String fileExtension, @Nullable String mimeType,
             @Nullable Integer minAppVersion, @Nullable Integer maxAppVersion, @Nullable Integer maxLength,
             @Nullable List<String> multiChoiceAnswerList, @Nonnull String name, boolean required,
-            @Nonnull UploadFieldType type) {
+            @Nonnull UploadFieldType type, @Nonnull Boolean unboundedText) {
         this.fileExtension = fileExtension;
         this.mimeType = mimeType;
         this.minAppVersion = minAppVersion;
@@ -43,6 +44,7 @@ public final class DynamoUploadFieldDefinition implements UploadFieldDefinition 
         this.name = name;
         this.required = required;
         this.type = type;
+        this.unboundedText = unboundedText;
     }
 
     /** {@inheritDoc} */
@@ -100,6 +102,12 @@ public final class DynamoUploadFieldDefinition implements UploadFieldDefinition 
     }
 
     /** {@inheritDoc} */
+    @Nonnull
+    public Boolean isUnboundedText() {
+        return unboundedText;
+    }
+
+    /** {@inheritDoc} */
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -117,14 +125,15 @@ public final class DynamoUploadFieldDefinition implements UploadFieldDefinition 
                 Objects.equals(maxLength, that.maxLength) &&
                 Objects.equals(multiChoiceAnswerList, that.multiChoiceAnswerList) &&
                 Objects.equals(name, that.name) &&
-                type == that.type;
+                type == that.type &&
+                Objects.equals(unboundedText, that.unboundedText);
     }
 
     /** {@inheritDoc} */
     @Override
     public int hashCode() {
         return Objects.hash(fileExtension, mimeType, minAppVersion, maxAppVersion, maxLength, multiChoiceAnswerList,
-                name, required, type);
+                name, required, type, unboundedText);
     }
 
     /** Builder for DynamoUploadFieldDefinition */
@@ -138,6 +147,7 @@ public final class DynamoUploadFieldDefinition implements UploadFieldDefinition 
         private String name;
         private Boolean required;
         private UploadFieldType type;
+        private Boolean unboundedText;
 
         /** Copies attributes from the given field definition. */
         public Builder copyOf(UploadFieldDefinition other) {
@@ -150,6 +160,7 @@ public final class DynamoUploadFieldDefinition implements UploadFieldDefinition 
             this.name = other.getName();
             this.required = other.isRequired();
             this.type = other.getType();
+            this.unboundedText = other.isUnboundedText();
             return this;
         }
 
@@ -214,6 +225,12 @@ public final class DynamoUploadFieldDefinition implements UploadFieldDefinition 
             return this;
         }
 
+        /** @see org.sagebionetworks.bridge.models.upload.UploadFieldDefinition#isUnboundedText */
+        public Builder withUnboundedText(Boolean unboundedText) {
+            this.unboundedText = unboundedText;
+            return this;
+        }
+
         /**
          * Builds and validates a DynamoUploadFieldDefinition. name must be non-null and non-empty. type must be
          * non-null. required may be null and defaults to true. If this is called with invalid fields, it will throw an
@@ -235,7 +252,7 @@ public final class DynamoUploadFieldDefinition implements UploadFieldDefinition 
             }
 
             return new DynamoUploadFieldDefinition(fileExtension, mimeType, minAppVersion, maxAppVersion, maxLength,
-                    multiChoiceAnswerListCopy, name, required, type);
+                    multiChoiceAnswerListCopy, name, required, type, unboundedText);
         }
     }
 }

--- a/app/org/sagebionetworks/bridge/models/upload/UploadFieldDefinition.java
+++ b/app/org/sagebionetworks/bridge/models/upload/UploadFieldDefinition.java
@@ -72,4 +72,11 @@ public interface UploadFieldDefinition extends BridgeEntity {
      * @see org.sagebionetworks.bridge.models.upload.UploadFieldType
      */
     @Nonnull UploadFieldType getType();
+
+    /**
+     * True if this field is a text-field with unbounded length. (Only applies to fields that are serialized as text,
+     * such as INLINE_JSON_BLOB, SINGLE_CHOICE, or STRING. Can be null, so that the number of field parameters doesn't
+     * explode.
+     */
+    @Nullable Boolean isUnboundedText();
 }

--- a/test/org/sagebionetworks/bridge/models/upload/UploadFieldDefinitionTest.java
+++ b/test/org/sagebionetworks/bridge/models/upload/UploadFieldDefinitionTest.java
@@ -77,7 +77,7 @@ public class UploadFieldDefinitionTest {
         UploadFieldDefinition fieldDef = new DynamoUploadFieldDefinition.Builder().withFileExtension(".test")
                 .withMimeType("text/plain").withMinAppVersion(10).withMaxAppVersion(13).withMaxLength(128)
                 .withMultiChoiceAnswerList(multiChoiceAnswerList).withName("optional-stuff").withRequired(false)
-                .withType(UploadFieldType.STRING).build();
+                .withType(UploadFieldType.STRING).withUnboundedText(true).build();
         assertEquals(".test", fieldDef.getFileExtension());
         assertEquals("text/plain", fieldDef.getMimeType());
         assertEquals(10, fieldDef.getMinAppVersion().intValue());
@@ -87,6 +87,7 @@ public class UploadFieldDefinitionTest {
         assertEquals("optional-stuff", fieldDef.getName());
         assertFalse(fieldDef.isRequired());
         assertEquals(UploadFieldType.STRING, fieldDef.getType());
+        assertTrue(fieldDef.isUnboundedText());
 
         // Also test copy constructor.
         UploadFieldDefinition copy = new DynamoUploadFieldDefinition.Builder().copyOf(fieldDef).build();
@@ -105,7 +106,8 @@ public class UploadFieldDefinitionTest {
                 "   \"multiChoiceAnswerList\":[\"asdf\", \"jkl;\"],\n" +
                 "   \"name\":\"test-field\",\n" +
                 "   \"required\":false,\n" +
-                "   \"type\":\"INT\"\n" +
+                "   \"type\":\"INT\",\n" +
+                "   \"unboundedText\":true\n" +
                 "}";
 
         // convert to POJO
@@ -120,13 +122,14 @@ public class UploadFieldDefinitionTest {
         assertEquals("test-field", fieldDef.getName());
         assertFalse(fieldDef.isRequired());
         assertEquals(UploadFieldType.INT, fieldDef.getType());
+        assertTrue(fieldDef.isUnboundedText());
 
         // convert back to JSON
         String convertedJson = BridgeObjectMapper.get().writeValueAsString(fieldDef);
 
         // then convert to a map so we can validate the raw JSON
         Map<String, Object> jsonMap = BridgeObjectMapper.get().readValue(convertedJson, JsonUtils.TYPE_REF_RAW_MAP);
-        assertEquals(9, jsonMap.size());
+        assertEquals(10, jsonMap.size());
         assertEquals(".json", jsonMap.get("fileExtension"));
         assertEquals("text/json", jsonMap.get("mimeType"));
         assertEquals(2, jsonMap.get("minAppVersion"));
@@ -136,6 +139,7 @@ public class UploadFieldDefinitionTest {
         assertEquals("test-field", jsonMap.get("name"));
         assertFalse((boolean) jsonMap.get("required"));
         assertEquals("int", jsonMap.get("type"));
+        assertTrue((boolean) jsonMap.get("unboundedText"));
     }
 
     @Test


### PR DESCRIPTION
I realized I had a gap in my design. There was no way to specify "this is a text field of unbounded length". You could specify a text field with length > 1000, but that's kinda hacky and requires us to pick an arbitrary number when specifying a truly unbounded text field. (For back-compat reasons, we couldn't just repurpose "null maxLength" to mean unbounded.)

This change adds isUnboundedText to upload schema fields.
