### PR TITLE
field and choice name sanitization; allow other for multi-choice fields; better schema field name validation

### DIFF
--- a/app/org/sagebionetworks/bridge/models/upload/UploadFieldDefinition.java
+++ b/app/org/sagebionetworks/bridge/models/upload/UploadFieldDefinition.java
@@ -18,6 +18,13 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 @BridgeTypeName("UploadFieldDefinition")
 public interface UploadFieldDefinition extends BridgeEntity {
     /**
+     * Used for MULTI_CHOICE. True if the multi-choice field allows an "other" answer with user freeform text. This
+     * tells BridgeEX to reserve an "other" column for this field. Can be null, so that the number of field parameters
+     * doesn't explode.
+     */
+    @Nullable Boolean getAllowOtherChoices();
+
+    /**
      * Used for ATTACHMENT_V2 types. Used as a hint by BridgeEX to preserve the file extension as a quality-of-life
      * improvement. Optional, defaults to ".tmp".
      * */

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ libraryDependencies ++= Seq(
   cache,
   filters,
   // Sage packages
-  "org.sagebionetworks" % "bridge-base" % "2.0",
+  "org.sagebionetworks" % "bridge-base" % "2.4",
   // AWS
   "com.amazonaws" % "aws-java-sdk-s3" % "1.10.20",
   "com.amazonaws" % "aws-java-sdk-sqs" % "1.10.20",

--- a/test/org/sagebionetworks/bridge/validators/UploadSchemaValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/UploadSchemaValidatorTest.java
@@ -114,7 +114,7 @@ public class UploadSchemaValidatorTest {
         fieldDefList.add(new DynamoUploadFieldDefinition.Builder().withName("bar-field")
                 .withType(UploadFieldType.STRING).build());
         fieldDefList.add(new DynamoUploadFieldDefinition.Builder().withName("baz-field")
-                .withType(UploadFieldType.MULTI_CHOICE).withMultiChoiceAnswerList("asdf", "jkl;").build());
+                .withType(UploadFieldType.MULTI_CHOICE).withMultiChoiceAnswerList("asdf", "jkl").build());
         schema.setFieldDefinitions(fieldDefList);
 
         // validate
@@ -344,6 +344,15 @@ public class UploadSchemaValidatorTest {
                 .withType(UploadFieldType.STRING).build());
         fieldDefList.add(new DynamoUploadFieldDefinition.Builder().withName("foo-field")
                 .withType(UploadFieldType.INT).build());
+        fieldDefList.add(new DynamoUploadFieldDefinition.Builder().withName("bar")
+                .withType(UploadFieldType.MULTI_CHOICE).withMultiChoiceAnswerList("bar", "other")
+                .withAllowOtherChoices(true).build());
+        fieldDefList.add(new DynamoUploadFieldDefinition.Builder().withName("bar.bar").withType(UploadFieldType.STRING)
+                .build());
+        fieldDefList.add(new DynamoUploadFieldDefinition.Builder().withName("baz").withType(UploadFieldType.TIMESTAMP)
+                .build());
+        fieldDefList.add(new DynamoUploadFieldDefinition.Builder().withName("baz.timezone")
+                .withType(UploadFieldType.STRING).build());
         schema.setFieldDefinitions(fieldDefList);
 
         // validate
@@ -354,7 +363,8 @@ public class UploadSchemaValidatorTest {
         } catch (InvalidEntityException ex) {
             thrownEx = ex;
         }
-        assertTrue(thrownEx.getMessage().contains("cannot use foo-field (used by another field)"));
+        assertTrue(thrownEx.getMessage().contains("conflict in field names or sub-field names: bar.bar, bar.other, " +
+                "baz.timezone, foo-field"));
     }
 
     @Test

--- a/test/org/sagebionetworks/bridge/validators/UploadSchemaValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/UploadSchemaValidatorTest.java
@@ -353,6 +353,10 @@ public class UploadSchemaValidatorTest {
                 .build());
         fieldDefList.add(new DynamoUploadFieldDefinition.Builder().withName("baz.timezone")
                 .withType(UploadFieldType.STRING).build());
+        fieldDefList.add(new DynamoUploadFieldDefinition.Builder().withName("#underscore")
+                .withType(UploadFieldType.STRING).build());
+        fieldDefList.add(new DynamoUploadFieldDefinition.Builder().withName("!underscore")
+                .withType(UploadFieldType.STRING).build());
         schema.setFieldDefinitions(fieldDefList);
 
         // validate
@@ -363,8 +367,8 @@ public class UploadSchemaValidatorTest {
         } catch (InvalidEntityException ex) {
             thrownEx = ex;
         }
-        assertTrue(thrownEx.getMessage().contains("conflict in field names or sub-field names: bar.bar, bar.other, " +
-                "baz.timezone, foo-field"));
+        assertTrue(thrownEx.getMessage().contains("conflict in field names or sub-field names: _underscore, bar.bar, "
+                + "bar.other, baz.timezone, foo-field"));
     }
 
     @Test


### PR DESCRIPTION
A few changes here:
- sanitization for schema field names, choice enumeration, and submitted upload values (https://sagebionetworks.jira.com/browse/BRIDGE-1392)
- allowOtherChoices in multi-choice schema fields - This is needed to combine Mutable Schemas and the new Upload Fields with Surveys (https://sagebionetworks.jira.com/browse/BRIDGE-1289)
- improved validation for schema field name collisions

Testing done:
- updated unit tests
- added sanitization scenarios to the UploadHandlersEndToEndTest
- ran integ tests UploadSchemaTest and UploadTest against local server
- manually tested schema with allowOther and basic field name sanitization
