### PR TITLE
S3 presigned URL for uploads, increase timeout to 24 hours

### DIFF
--- a/app/org/sagebionetworks/bridge/services/UploadService.java
+++ b/app/org/sagebionetworks/bridge/services/UploadService.java
@@ -48,7 +48,7 @@ public class UploadService {
 
     private static final Logger logger = LoggerFactory.getLogger(UploadService.class);
 
-    private static final long EXPIRATION = 60 * 1000; // 1 minute
+    private static final long EXPIRATION = 24 * 60 * 60 * 1000; // 24 hours
 
     // package-scoped to be available in unit tests
     static final String CONFIG_KEY_UPLOAD_BUCKET = "upload.bucket";

--- a/test/org/sagebionetworks/bridge/services/UploadServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/UploadServiceTest.java
@@ -99,7 +99,7 @@ public class UploadServiceTest {
 
         Upload upload = uploadService.getUpload(testUser.getStudyParticipant(), uploadId);
         uploadService.uploadComplete(TestConstants.TEST_STUDY, upload);
-        long expiration = DateTime.now(DateTimeZone.UTC).plusMinutes(1).getMillis();
+        long expiration = DateTime.now(DateTimeZone.UTC).plusDays(1).getMillis();
         assertTrue(expiration > uploadSession.getExpires());
         ObjectMetadata obj = s3Client.getObjectMetadata(BUCKET, uploadId);
         String sse = obj.getSSEAlgorithm();


### PR DESCRIPTION
The S3 presigned URLs are used for write only, so the risk of leaking personal data is nil. Additionally, they are locked by an MD5 hash, so it's exceedingly difficult for someone to stuff garbage data into this URL.

The S3 presigned URLs currently timeout at 1 min. For a variety of reasons, this is causing issues with some apps. We're increasing it to 24 hours.

Testing done:
- UploadService unit tests
- UploadTest integration tests
- manually verified upload session has a expiration time of 24 hours

Also requires update in integ tests https://github.com/Sage-Bionetworks/BridgeIntegrationTests/pull/47
