### PR TITLE
fix DynamoBackupHandlerIntegrationTest

### DIFF
--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoBackupHandlerIntegrationTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoBackupHandlerIntegrationTest.java
@@ -113,7 +113,7 @@ public class DynamoBackupHandlerIntegrationTest {
 
         // find activities using our data sources as inputs
         Map<String, PipelineObject> tableSourceIdToActivity =
-                typeToObject.get(DynamoDataPipelineHelper.PipelineObjectType.EMR_ACTIVITY).stream()
+                typeToObject.get(DynamoDataPipelineHelper.PipelineObjectType.HADOOP_ACTIVITY).stream()
                         .collect(Collectors.toMap(o -> DynamoDataPipelineHelper.getRefValue(o, "input").orElse(""), Function.identity()));
 
         PipelineObject table1BackupActivity = tableSourceIdToActivity.get(table1Source.getId());


### PR DESCRIPTION
It looks like https://github.com/Sage-Bionetworks/BridgePF/pull/1167 pulled in https://github.com/Sage-Bionetworks/bridge-base/pull/20, previously unused in BridgePF. This broke DynamoBackupHandlerIntegrationTest.

This simple one-line fix fixes the test.
