### PR TITLE
Revising withdrawal code

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
@@ -26,7 +26,6 @@ import org.sagebionetworks.bridge.models.accounts.Withdrawal;
 import org.sagebionetworks.bridge.models.schedules.ScheduledActivity;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
-import org.sagebionetworks.bridge.services.ConsentService;
 import org.sagebionetworks.bridge.services.ParticipantService;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -40,16 +39,9 @@ public class ParticipantController extends BaseController {
     
     private ParticipantService participantService;
     
-    private ConsentService consentService;
-    
     @Autowired
     final void setParticipantService(ParticipantService participantService) {
         this.participantService = participantService;
-    }
-    
-    @Autowired
-    final void setConsentService(ConsentService consentService) {
-        this.consentService = consentService;
     }
     
     public Result getSelfParticipant() throws Exception {
@@ -202,7 +194,7 @@ public class ParticipantController extends BaseController {
         Withdrawal withdrawal = parseJson(request(), Withdrawal.class);
         long withdrewOn = DateTime.now().getMillis();
         
-        consentService.withdrawAllConsents(study, userId, withdrawal, withdrewOn);
+        participantService.withdrawAllConsents(study, userId, withdrawal, withdrewOn);
         
         return okResult("User has been withdrawn from the study.");
     }

--- a/app/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -255,9 +255,9 @@ public class AuthenticationService {
         boolean repaired = false;
         
         // If there is an active signature, there should be a consent record that has not been withdrawn.
-        // If there is no consent record (entity not found), or it constains a withdrawal timestamp, 
-        // then we need to create a new consent. Note that we are specifically looking for a record with
-        // the signedOn value of the signature (now: this is new).
+        // If there is no consent record (entity not found), or it contains a withdrawal timestamp, 
+        // then we need to create a new consent. Even if the consent is the same in every way except it 
+        // contains no withdrawal timestamp. 
         Map<SubpopulationGuid,ConsentStatus> statuses = session.getConsentStatuses();
         for (Map.Entry<SubpopulationGuid,ConsentStatus> entry : statuses.entrySet()) {
             ConsentSignature activeSignature = account.getActiveConsentSignature(entry.getKey());
@@ -276,8 +276,7 @@ public class AuthenticationService {
                 repaired = true;
             }
         }
-        
-        // These are incorrect since they are based on looking up DDB records, so re-create them.
+        // Recreate these records because they were created from DDB which we've established does not match the signatures
         if (repaired) {
             session.setConsentStatuses(consentService.getConsentStatuses(context));
         }

--- a/app/org/sagebionetworks/bridge/services/ConsentService.java
+++ b/app/org/sagebionetworks/bridge/services/ConsentService.java
@@ -316,7 +316,7 @@ public class ConsentService {
             List<ConsentSignature> signatures = account.getConsentSignatureHistory(subpopGuid);
             
             for (ConsentSignature aSignature : signatures) {
-                if (aSignature.getWithdrewOn() == null || aSignature.getWithdrewOn() == 0L) {
+                if (aSignature.getWithdrewOn() == null) {
                     // Withdraw this signature. There should be only one, but I want to be absolutely sure.
                     ConsentSignature withdrawn = new ConsentSignature.Builder()
                             .withConsentSignature(aSignature)

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -39,6 +39,7 @@ import org.sagebionetworks.bridge.models.accounts.IdentifierHolder;
 import org.sagebionetworks.bridge.models.accounts.ParticipantOptionsLookup;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserConsentHistory;
+import org.sagebionetworks.bridge.models.accounts.Withdrawal;
 import org.sagebionetworks.bridge.models.schedules.ScheduledActivity;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
@@ -220,6 +221,17 @@ public class ParticipantService {
         StudyParticipant participant = getParticipant(study, userId, false);
         Email email = new Email(study.getIdentifier(), participant.getEmail());
         accountDao.resendEmailVerificationToken(study.getStudyIdentifier(), email);
+    }
+    
+    public void withdrawAllConsents(Study study, String userId, Withdrawal withdrawal, long withdrewOn) {
+        checkNotNull(study);
+        checkNotNull(userId);
+        checkNotNull(withdrawal);
+        checkArgument(withdrewOn > 0);
+        
+        Account account = getAccountThrowingException(study, userId);
+        
+        consentService.withdrawAllConsents(study, account, withdrawal, withdrewOn);
     }
     
     public void resendConsentAgreement(Study study, SubpopulationGuid subpopGuid, String userId) {

--- a/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
@@ -54,7 +54,6 @@ import org.sagebionetworks.bridge.models.schedules.ScheduledActivity;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 import org.sagebionetworks.bridge.services.AuthenticationService;
-import org.sagebionetworks.bridge.services.ConsentService;
 import org.sagebionetworks.bridge.services.ParticipantService;
 import org.sagebionetworks.bridge.services.StudyService;
 
@@ -100,9 +99,6 @@ public class ParticipantControllerTest {
     @Mock
     private CacheProvider cacheProvider;
     
-    @Mock
-    private ConsentService consentService;
-    
     @Captor
     private ArgumentCaptor<Map<ParticipantOption,String>> optionMapCaptor;
     
@@ -147,7 +143,6 @@ public class ParticipantControllerTest {
         controller.setStudyService(studyService);
         controller.setAuthenticationService(authService);
         controller.setCacheProvider(cacheProvider);
-        controller.setConsentService(consentService);
         
         mockPlayContext();
     }
@@ -533,7 +528,7 @@ public class ParticipantControllerTest {
             
             controller.withdrawFromAllConsents(ID);
             
-            verify(consentService).withdrawAllConsents(study, ID, new Withdrawal("Because, reasons."), 20000);
+            verify(participantService).withdrawAllConsents(study, ID, new Withdrawal("Because, reasons."), 20000);
         } finally {
             DateTimeUtils.setCurrentMillisSystem();
         }

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -59,6 +59,7 @@ import org.sagebionetworks.bridge.models.accounts.ParticipantOptionsLookup;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserConsentHistory;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
+import org.sagebionetworks.bridge.models.accounts.Withdrawal;
 import org.sagebionetworks.bridge.models.studies.PasswordPolicy;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
@@ -830,6 +831,18 @@ public class ParticipantServiceTest {
         
         StudyParticipant participant = participantCaptor.getValue();
         assertEquals(ID, participant.getId());
+    }
+    
+    @Test
+    public void withdrawAllConsents() {
+        mockHealthCodeAndAccountRetrieval();
+        
+        Withdrawal withdrawal = new Withdrawal("Reasons");
+        long withdrewOn = DateTime.now().getMillis();
+        
+        participantService.withdrawAllConsents(STUDY, ID, withdrawal, withdrewOn);
+        
+        verify(consentService).withdrawAllConsents(STUDY, account, withdrawal, withdrewOn);
     }
     
     private void verifyStatusCreate(Set<Roles> callerRoles) {


### PR DESCRIPTION
- much more aggressively look for signatures and UserConsent records to withdraw;
- use ParticipantService so we throw proper exception if a user ID does not exist;
- clearer now that on sign in, we're repairing record integrity for consent and withdrawal, so less checking during withdrawal

These changes don't change much, but might change the timing of events in a way that helps on UAT. UAT seems pretty stable but still has a timing issue, possibly around a call to one machine not being finished while another is being processed, there's no indication that Stormpath eventual consistency issues are involved.

(Note: UAT is stable because I've introduced a 3 second delay in the tests. The issue is probably still there.)
