### PR TITLE
ConsentSignature change

### DIFF
--- a/app/org/sagebionetworks/bridge/models/subpopulations/ConsentSignature.java
+++ b/app/org/sagebionetworks/bridge/models/subpopulations/ConsentSignature.java
@@ -25,7 +25,7 @@ public final class ConsentSignature implements BridgeEntity {
 
     public static final ObjectWriter SIGNATURE_WRITER = new BridgeObjectMapper().writer(
             new SimpleFilterProvider().addFilter("filter",
-            SimpleBeanPropertyFilter.serializeAllExcept("signedOn")));
+            SimpleBeanPropertyFilter.serializeAllExcept("signedOn", "consentCreatedOn")));
 
     private static final ConsentSignatureValidator VALIDATOR = new ConsentSignatureValidator();
 
@@ -33,15 +33,18 @@ public final class ConsentSignature implements BridgeEntity {
     private final @Nonnull String birthdate;
     private final @Nullable String imageData;
     private final @Nullable String imageMimeType;
+    private final @Nonnull long consentCreatedOn;
     private final @Nonnull long signedOn;
     private final @Nullable Long withdrewOn;
 
     /** Private constructor. Instances should be constructed using factory methods create() or createFromJson(). */
-    private ConsentSignature(String name, String birthdate, String imageData, String imageMimeType, long signedOn, Long withdrewOn) {
+    private ConsentSignature(String name, String birthdate, String imageData, String imageMimeType,
+            long consentCreatedOn, long signedOn, Long withdrewOn) {
         this.name = name;
         this.birthdate = birthdate;
         this.imageData = imageData;
         this.imageMimeType = imageMimeType;
+        this.consentCreatedOn = consentCreatedOn;
         this.signedOn = signedOn;
         this.withdrewOn = withdrewOn;
     }
@@ -66,27 +69,27 @@ public final class ConsentSignature implements BridgeEntity {
         return imageMimeType;
     }
     
+    /**
+     * The timestamp of the consent the user has signed. May not be the timestamp of the currently active version of the
+     * consent.
+     */
+    public @Nonnull long getConsentCreatedOn() {
+        return consentCreatedOn;
+    }
+    
     /** The date and time recorded for this signature. */
-    public long getSignedOn() {
+    public @Nonnull long getSignedOn() {
         return signedOn;
     }
     
     /** The date and time the user withdrew this consent (can be null if active). */
-    public Long getWithdrewOn() {
+    public @Nullable Long getWithdrewOn() {
         return withdrewOn;
     }
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + Objects.hashCode(birthdate);
-        result = prime * result + Objects.hashCode(imageData);
-        result = prime * result + Objects.hashCode(imageMimeType);
-        result = prime * result + Objects.hashCode(name);
-        result = prime * result + Objects.hashCode(signedOn);
-        result = prime * result + Objects.hashCode(withdrewOn);
-        return result;
+        return Objects.hash(birthdate, imageData, imageMimeType, name, consentCreatedOn, signedOn, withdrewOn);
     }
 
     @Override
@@ -98,13 +101,14 @@ public final class ConsentSignature implements BridgeEntity {
         ConsentSignature other = (ConsentSignature) obj;
         return Objects.equals(birthdate, other.birthdate) && Objects.equals(imageData, other.imageData)
                 && Objects.equals(imageMimeType, other.imageMimeType) && Objects.equals(name, other.name) 
-                && Objects.equals(signedOn, other.signedOn) && Objects.equals(withdrewOn, other.withdrewOn);
+                && Objects.equals(consentCreatedOn, other.consentCreatedOn) && Objects.equals(signedOn, other.signedOn) 
+                && Objects.equals(withdrewOn, other.withdrewOn);
     }
 
     @Override
     public String toString() {
-        return String.format("ConsentSignature [name=%s, birthdate=%s, imageData=%s, imageMimeType=%s, signedOn=%s, withdrewOn=%s]", 
-                name, birthdate, imageData, imageMimeType, signedOn, withdrewOn);
+        return String.format("ConsentSignature [name=%s, birthdate=%s, imageData=%s, imageMimeType=%s, consentCreatedOn=%s, signedOn=%s, withdrewOn=%s]", 
+                name, birthdate, imageData, imageMimeType, consentCreatedOn, signedOn, withdrewOn);
     }
     
     public static class Builder {
@@ -112,6 +116,7 @@ public final class ConsentSignature implements BridgeEntity {
         private String birthdate;
         private String imageData;
         private String imageMimeType;
+        private long consentCreatedOn;
         private long signedOn;
         private Long withdrewOn;
         
@@ -121,6 +126,7 @@ public final class ConsentSignature implements BridgeEntity {
             this.birthdate = signature.birthdate;
             this.imageData = signature.imageData;
             this.imageMimeType = signature.imageMimeType;
+            this.consentCreatedOn = signature.consentCreatedOn;
             this.signedOn = signature.signedOn;
             this.withdrewOn = signature.withdrewOn;
             return this;
@@ -141,6 +147,10 @@ public final class ConsentSignature implements BridgeEntity {
             this.imageMimeType = imageMimeType;
             return this;
         }
+        public Builder withConsentCreatedOn(long consentCreatedOn) {
+            this.consentCreatedOn = consentCreatedOn;
+            return this;
+        }
         public Builder withSignedOn(long signedOn) {
             this.signedOn = signedOn;
             return this;
@@ -151,7 +161,8 @@ public final class ConsentSignature implements BridgeEntity {
         }
         public ConsentSignature build() {
             long signatureTime = (signedOn > 0L) ? signedOn : DateTime.now().getMillis();
-            ConsentSignature signature = new ConsentSignature(name, birthdate, imageData, imageMimeType, signatureTime, withdrewOn);
+            ConsentSignature signature = new ConsentSignature(name, birthdate, imageData, imageMimeType,
+                    consentCreatedOn, signatureTime, withdrewOn);
             Validate.entityThrowingException(VALIDATOR, signature);
             return signature;
         }

--- a/app/org/sagebionetworks/bridge/services/backfill/ConsentCreatedOnBackfill.java
+++ b/app/org/sagebionetworks/bridge/services/backfill/ConsentCreatedOnBackfill.java
@@ -1,0 +1,123 @@
+package org.sagebionetworks.bridge.services.backfill;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.sagebionetworks.bridge.dao.AccountDao;
+import org.sagebionetworks.bridge.dao.StudyConsentDao;
+import org.sagebionetworks.bridge.dao.UserConsentDao;
+import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
+import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountSummary;
+import org.sagebionetworks.bridge.models.accounts.UserConsent;
+import org.sagebionetworks.bridge.models.backfill.BackfillTask;
+import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
+import org.sagebionetworks.bridge.models.subpopulations.StudyConsent;
+import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
+import org.sagebionetworks.bridge.services.StudyService;
+
+@Component("consentCreatedOnBackfill")
+public class ConsentCreatedOnBackfill extends AsyncBackfillTemplate {
+
+    private StudyService studyService;
+    private AccountDao accountDao;
+    private StudyConsentDao studyConsentDao;
+    private UserConsentDao userConsentDao;
+    
+    @Autowired
+    public void setStudyService(StudyService studyService) {
+        this.studyService = studyService;
+    }
+    @Autowired
+    public void setAccountDao(AccountDao accountDao) {
+        this.accountDao = accountDao;
+    }
+    @Autowired
+    public void setStudyConsentDao(StudyConsentDao studyConsentDao) {
+        this.studyConsentDao = studyConsentDao;
+    }
+    @Autowired
+    public void setUserConsentDao(UserConsentDao userConsentDao) {
+        this.userConsentDao = userConsentDao;
+    }
+
+    @Override
+    int getLockExpireInSeconds() {
+        return 60*60*5; 
+    }
+
+    @Override
+    void doBackfill(BackfillTask task, BackfillCallback callback) {
+        /*
+        List<Study> studies = studyService.getStudies();
+        for (Study study : studies) {
+            backfillStudy(task, callback, study);
+        }
+        */
+        Study study = studyService.getStudy("api");
+        backfillStudy(task, callback, study);
+    }
+    
+    private void backfillStudy(BackfillTask task, BackfillCallback callback, Study study) {
+        callback.newRecords(getBackfillRecordFactory().createOnly(task, "Examining study " + study.getIdentifier() + "..."));
+        
+        Iterator<AccountSummary> summaries = accountDao.getStudyAccounts(study);
+        while(summaries.hasNext()) {
+            AccountSummary summary = summaries.next();
+
+            Account account = accountDao.getAccount(study, summary.getId());
+            if (account == null) {
+                callback.newRecords(getBackfillRecordFactory().createOnly(task, "Account " + summary.getId() + " not found."));
+            } else if (processAccount(study, account)) {
+                accountDao.updateAccount(account);
+                callback.newRecords(getBackfillRecordFactory().createOnly(task, "Account " + summary.getId() + " updated."));
+            }
+        }
+    }
+
+    private boolean processAccount(Study study, Account account) {
+        boolean accountUpdated = false;
+
+        Map<SubpopulationGuid,List<ConsentSignature>> map = account.getAllConsentSignatureHistories();
+        for (SubpopulationGuid guid : map.keySet()) {
+            
+            List<ConsentSignature> list = map.get(guid);
+            for (int i=0; i < list.size(); i++) {
+                ConsentSignature existingSig = list.get(i);
+                
+                ConsentSignature updatedSig = fixConsentCreatedOn(guid, account, existingSig);
+                
+                // BTW given the signature constructor, just instantiating a signature means it will gain a signed
+                // on timestamp if it doesn't exist. So that's repaired by this as well.
+                if (!existingSig.equals(updatedSig)) {
+                    list.set(i, updatedSig);
+                    accountUpdated = true;
+                }
+            }
+        }
+        return accountUpdated;
+    }
+    
+    private ConsentSignature fixConsentCreatedOn(SubpopulationGuid guid, Account account, ConsentSignature signature) {
+        if (signature.getConsentCreatedOn() == 0L) {
+            try {
+                UserConsent consent = userConsentDao.getUserConsent(account.getHealthCode(), guid, signature.getSignedOn());
+                signature = new ConsentSignature.Builder().withConsentSignature(signature)
+                        .withConsentCreatedOn(consent.getConsentCreatedOn()).build();
+            } catch(EntityNotFoundException e) {
+                // get what is likely to be the consent, the last saved consent, and use that.
+                StudyConsent studyConsent = studyConsentDao.getActiveConsent(guid);
+                if (studyConsent != null) {
+                    signature = new ConsentSignature.Builder().withConsentSignature(signature)
+                            .withConsentCreatedOn(studyConsent.getCreatedOn()).build();
+                }
+            }
+        }
+        return signature;
+    }
+}

--- a/test/org/sagebionetworks/bridge/models/subpopulations/ConsentSignatureTest.java
+++ b/test/org/sagebionetworks/bridge/models/subpopulations/ConsentSignatureTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -21,7 +22,8 @@ import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
 import com.fasterxml.jackson.databind.JsonMappingException;
 
 public class ConsentSignatureTest {
-    private static final long UNIX_TIMESTAMP = DateUtils.getCurrentMillisFromEpoch();
+    private static final long CONSENT_CREATED_ON_TIMESTAMP = DateTime.now().minusDays(1).getMillis();
+    private static final long SIGNED_ON_TIMESTAMP = DateUtils.getCurrentMillisFromEpoch();
     
     private void assertMessage(InvalidEntityException e, String fieldName, String message) {
         assertEquals(message, e.getErrors().get(fieldName).get(0));
@@ -29,7 +31,7 @@ public class ConsentSignatureTest {
     
     @Before
     public void before() {
-        DateTimeUtils.setCurrentMillisFixed(UNIX_TIMESTAMP);
+        DateTimeUtils.setCurrentMillisFixed(SIGNED_ON_TIMESTAMP);
     }
     
     @After
@@ -40,7 +42,7 @@ public class ConsentSignatureTest {
     @Test
     public void nullName() {
         try {
-            new ConsentSignature.Builder().withBirthdate("1970-01-01").withSignedOn(UNIX_TIMESTAMP).build();
+            new ConsentSignature.Builder().withBirthdate("1970-01-01").withSignedOn(SIGNED_ON_TIMESTAMP).build();
             fail("Should have thrown an exception");
         } catch(InvalidEntityException e) {
             assertMessage(e, "name", "name cannot be missing, null, or blank");
@@ -50,7 +52,7 @@ public class ConsentSignatureTest {
     @Test
     public void emptyName() {
         try {
-            new ConsentSignature.Builder().withBirthdate("1970-01-01").withSignedOn(UNIX_TIMESTAMP).build();
+            new ConsentSignature.Builder().withBirthdate("1970-01-01").withSignedOn(SIGNED_ON_TIMESTAMP).build();
             fail("Should have thrown an exception");
         } catch(InvalidEntityException e) {
             assertMessage(e, "name", "name cannot be missing, null, or blank");
@@ -60,7 +62,7 @@ public class ConsentSignatureTest {
     @Test
     public void nullBirthdate() {
         try {
-            new ConsentSignature.Builder().withName("test name").withSignedOn(UNIX_TIMESTAMP).build();
+            new ConsentSignature.Builder().withName("test name").withSignedOn(SIGNED_ON_TIMESTAMP).build();
             fail("Should have thrown an exception");
         } catch(InvalidEntityException e) {
             assertMessage(e, "birthdate", "birthdate cannot be missing, null, or blank");
@@ -70,7 +72,7 @@ public class ConsentSignatureTest {
     @Test
     public void emptyBirthdate() {
         try {
-            new ConsentSignature.Builder().withName("test name").withBirthdate("").withSignedOn(UNIX_TIMESTAMP).build();
+            new ConsentSignature.Builder().withName("test name").withBirthdate("").withSignedOn(SIGNED_ON_TIMESTAMP).build();
             fail("Should have thrown an exception");
         } catch(InvalidEntityException e) {
             assertMessage(e, "birthdate", "birthdate cannot be missing, null, or blank");
@@ -81,7 +83,7 @@ public class ConsentSignatureTest {
     public void emptyImageData() {
         try {
             new ConsentSignature.Builder().withName("test name").withBirthdate("1970-01-01")
-                .withImageData("").withImageMimeType("image/fake").withSignedOn(UNIX_TIMESTAMP).build();
+                .withImageData("").withImageMimeType("image/fake").withSignedOn(SIGNED_ON_TIMESTAMP).build();
             fail("Should have thrown an exception");
         } catch(InvalidEntityException e) {
             assertMessage(e, "imageData", "imageData cannot be an empty string");
@@ -92,7 +94,7 @@ public class ConsentSignatureTest {
     public void emptyImageMimeType() {
         try {
             new ConsentSignature.Builder().withName("test name").withBirthdate("1970-01-01")
-                .withImageData(TestConstants.DUMMY_IMAGE_DATA).withImageMimeType("").withSignedOn(UNIX_TIMESTAMP).build();
+                .withImageData(TestConstants.DUMMY_IMAGE_DATA).withImageMimeType("").withSignedOn(SIGNED_ON_TIMESTAMP).build();
             fail("Should have thrown an exception");
         } catch(InvalidEntityException e) {
             assertMessage(e, "imageMimeType", "imageMimeType cannot be an empty string");
@@ -103,7 +105,7 @@ public class ConsentSignatureTest {
     public void imageDataWithoutMimeType() {
         try {
             new ConsentSignature.Builder().withName("test name").withBirthdate("1970-01-01")
-                .withImageData(TestConstants.DUMMY_IMAGE_DATA).withSignedOn(UNIX_TIMESTAMP).build();
+                .withImageData(TestConstants.DUMMY_IMAGE_DATA).withSignedOn(SIGNED_ON_TIMESTAMP).build();
             fail("Should have thrown an exception");
         } catch(InvalidEntityException e) {
             assertTrue(e.getMessage().contains("ConsentSignature If you specify one of imageData or imageMimeType, you must specify both"));
@@ -114,7 +116,7 @@ public class ConsentSignatureTest {
     public void imageMimeTypeWithoutData() {
         try {
             new ConsentSignature.Builder().withName("test name").withBirthdate("1970-01-01")
-                .withImageMimeType("image/fake").withSignedOn(UNIX_TIMESTAMP).build();
+                .withImageMimeType("image/fake").withSignedOn(SIGNED_ON_TIMESTAMP).build();
             fail("Should have thrown an exception");
         } catch(InvalidEntityException e) {
             assertTrue(e.getMessage().contains("ConsentSignature If you specify one of imageData or imageMimeType, you must specify both"));
@@ -124,9 +126,10 @@ public class ConsentSignatureTest {
     @Test
     public void happyCase() {
         ConsentSignature sig = new ConsentSignature.Builder().withName("test name").withBirthdate("1970-01-01")
-            .withSignedOn(UNIX_TIMESTAMP).build();
+            .withConsentCreatedOn(CONSENT_CREATED_ON_TIMESTAMP).withSignedOn(SIGNED_ON_TIMESTAMP).build();
         assertEquals("test name", sig.getName());
         assertEquals("1970-01-01", sig.getBirthdate());
+        assertEquals(CONSENT_CREATED_ON_TIMESTAMP, sig.getConsentCreatedOn());
         assertNull(sig.getImageData());
         assertNull(sig.getImageMimeType());
     }
@@ -135,7 +138,7 @@ public class ConsentSignatureTest {
     public void withImage() {
         ConsentSignature sig = new ConsentSignature.Builder().withName("test name").withBirthdate("1970-01-01")
                 .withImageData(TestConstants.DUMMY_IMAGE_DATA).withImageMimeType("image/fake")
-                .withSignedOn(UNIX_TIMESTAMP).build();
+                .withSignedOn(SIGNED_ON_TIMESTAMP).build();
         assertEquals("test name", sig.getName());
         assertEquals("1970-01-01", sig.getBirthdate());
         assertEquals(TestConstants.DUMMY_IMAGE_DATA, sig.getImageData());
@@ -321,7 +324,7 @@ public class ConsentSignatureTest {
         assertEquals("1970-01-01", sig.getBirthdate());
         assertEquals(TestConstants.DUMMY_IMAGE_DATA, sig.getImageData());
         assertEquals("image/fake", sig.getImageMimeType());
-        assertEquals(UNIX_TIMESTAMP, sig.getSignedOn());
+        assertEquals(SIGNED_ON_TIMESTAMP, sig.getSignedOn());
     }
     
     @Test
@@ -330,7 +333,7 @@ public class ConsentSignatureTest {
         ConsentSignature sig = BridgeObjectMapper.get().readValue(json, ConsentSignature.class);
         assertEquals("test name", sig.getName());
         assertEquals("1970-01-01", sig.getBirthdate());
-        assertEquals(UNIX_TIMESTAMP, sig.getSignedOn());
+        assertEquals(SIGNED_ON_TIMESTAMP, sig.getSignedOn());
     }
     
     @Test
@@ -338,14 +341,14 @@ public class ConsentSignatureTest {
         String json = "{\"name\":\"test name\",\"birthdate\":\"1970-01-01\"}";
         ConsentSignature sig = BridgeObjectMapper.get().readValue(json, ConsentSignature.class);
 
-        ConsentSignature updated = new ConsentSignature.Builder().withConsentSignature(sig).withSignedOn(UNIX_TIMESTAMP).build();
+        ConsentSignature updated = new ConsentSignature.Builder().withConsentSignature(sig).withSignedOn(SIGNED_ON_TIMESTAMP).build();
         assertEquals("test name", updated.getName());
         assertEquals("1970-01-01", updated.getBirthdate());
-        assertEquals(UNIX_TIMESTAMP, updated.getSignedOn());
+        assertEquals(SIGNED_ON_TIMESTAMP, updated.getSignedOn());
         
         json = "{\"name\":\"test name\",\"birthdate\":\"1970-01-01\",\"signedOn\":-10}";
         sig = BridgeObjectMapper.get().readValue(json, ConsentSignature.class);
-        assertEquals(UNIX_TIMESTAMP, sig.getSignedOn());
+        assertEquals(SIGNED_ON_TIMESTAMP, sig.getSignedOn());
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/services/backfill/ConsentCreatedOnBackfillTest.java
+++ b/test/org/sagebionetworks/bridge/services/backfill/ConsentCreatedOnBackfillTest.java
@@ -1,0 +1,182 @@
+package org.sagebionetworks.bridge.services.backfill;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import org.sagebionetworks.bridge.dao.AccountDao;
+import org.sagebionetworks.bridge.dao.BackfillDao;
+import org.sagebionetworks.bridge.dao.DistributedLockDao;
+import org.sagebionetworks.bridge.dao.StudyConsentDao;
+import org.sagebionetworks.bridge.dao.UserConsentDao;
+import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountSummary;
+import org.sagebionetworks.bridge.models.accounts.UserConsent;
+import org.sagebionetworks.bridge.models.backfill.BackfillTask;
+import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
+import org.sagebionetworks.bridge.models.subpopulations.StudyConsent;
+import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
+import org.sagebionetworks.bridge.services.StudyService;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConsentCreatedOnBackfillTest {
+    
+    private static final SubpopulationGuid SUBPOP_GUID = SubpopulationGuid.create("subpop");
+    
+    private static final long NOW = 1467742872087L;
+    private static final long CONSENT_CREATED_ON_TIMESTAMP = 1467741848921L;
+    private static final long SIGNED_ON_TIMESTAMP = 1467741906474L;
+
+    private ConsentCreatedOnBackfill backfill;
+
+    @Mock
+    private AccountDao accountDao;
+    @Mock
+    private BackfillDao backfillDao;
+    @Mock
+    private BackfillRecordFactory backfillRecordFactory;
+    @Mock
+    private DistributedLockDao lockDao;
+    @Mock
+    private StudyConsentDao studyConsentDao;
+    @Mock
+    private StudyService studyService;
+    @Mock
+    private UserConsentDao userConsentDao;
+    
+    @Mock
+    private Study study;
+    @Mock
+    private Account account;
+    @Mock
+    private BackfillTask task;
+    @Mock
+    private BackfillCallback callback;
+    @Mock
+    private UserConsent userConsent;
+    @Mock
+    private StudyConsent studyConsent;
+    
+    @Captor
+    private ArgumentCaptor<Account> accountCaptor;
+    
+    private Map<SubpopulationGuid,List<ConsentSignature>> map;
+
+    private AccountSummary summary;
+
+    @Before
+    public void before() {
+        DateTimeUtils.setCurrentMillisFixed(NOW);
+        backfill = new ConsentCreatedOnBackfill();
+        backfill.setAccountDao(accountDao);
+        backfill.setBackfillDao(backfillDao);
+        backfill.setBackfillRecordFactory(backfillRecordFactory);
+        backfill.setDistributedLockDao(lockDao);
+        backfill.setStudyConsentDao(studyConsentDao);
+        backfill.setStudyService(studyService);
+        backfill.setUserConsentDao(userConsentDao);
+        
+        // Mock study service
+        List<Study> studies = Lists.newArrayList(study);
+        doReturn("id").when(study).getIdentifier();
+        doReturn(studies).when(studyService).getStudies();
+        doReturn(study).when(studyService).getStudy("api"); // for variant doing one study at a time.
+        
+        // Mock account
+        doReturn("healthCode").when(account).getHealthCode();
+        doReturn("userId").when(account).getId();
+        doReturn(new DateTime(SIGNED_ON_TIMESTAMP)).when(account).getCreatedOn();
+        map = Maps.newHashMap();
+        map.put(SUBPOP_GUID, Lists.newArrayList());
+        doReturn(map).when(account).getAllConsentSignatureHistories();
+        doReturn(map.get(SUBPOP_GUID)).when(account).getConsentSignatureHistory(SUBPOP_GUID);
+        when(account.getActiveConsentSignature(SUBPOP_GUID)).thenAnswer(guid -> {
+            return map.get(SUBPOP_GUID).get(0);
+        });
+        
+        // Mock account DAO
+        doReturn(account).when(accountDao).getAccount(study, "userId");
+        
+        // Mock account summaries
+        summary = new AccountSummary(null, null, null, "userId", null, null, null);
+        List<AccountSummary> summaries = Lists.newArrayList(summary);
+        doReturn(summaries.iterator()).when(accountDao).getStudyAccounts(study);
+        
+        // Mock study consent
+        doReturn(CONSENT_CREATED_ON_TIMESTAMP).when(studyConsent).getCreatedOn();
+        doReturn(studyConsent).when(studyConsentDao).getMostRecentConsent(SUBPOP_GUID);
+
+        // Mock user consent
+        doReturn(NOW).when(userConsent).getSignedOn();
+        doReturn(CONSENT_CREATED_ON_TIMESTAMP).when(userConsent).getConsentCreatedOn();
+    }
+    
+    @After
+    public void after() {
+        DateTimeUtils.setCurrentMillisSystem();
+    }
+    
+    // This works, but it uses the "now" timestamp which we don't really want, do we? We can at least do better if this 
+    // comes up.
+    @Test
+    public void updatesVeryBrokenSignature() {
+        map.get(SUBPOP_GUID).add(new ConsentSignature.Builder().withBirthdate("2010-10-10").withName("Test User").build());
+        doReturn(userConsent).when(userConsentDao).getUserConsent("healthCode", SUBPOP_GUID, NOW);
+
+        backfill.doBackfill(task, callback);
+
+        verify(accountDao).updateAccount(accountCaptor.capture());
+        Account account = accountCaptor.getValue();
+        
+        ConsentSignature signature = account.getActiveConsentSignature(SUBPOP_GUID);
+        assertEquals(CONSENT_CREATED_ON_TIMESTAMP, signature.getConsentCreatedOn());
+        assertEquals(NOW, signature.getSignedOn());
+    }
+    
+    @Test
+    public void updatePreservesSignedOnValue() {
+        map.get(SUBPOP_GUID).add(new ConsentSignature.Builder().withBirthdate("2010-10-10")
+                .withSignedOn(SIGNED_ON_TIMESTAMP).withName("Test User").build());
+        doReturn(userConsent).when(userConsentDao).getUserConsent("healthCode", SUBPOP_GUID, SIGNED_ON_TIMESTAMP);
+        
+        backfill.doBackfill(task, callback);
+
+        verify(accountDao).updateAccount(accountCaptor.capture());
+        Account account = accountCaptor.getValue();
+        
+        ConsentSignature signature = account.getActiveConsentSignature(SUBPOP_GUID);
+        assertEquals(CONSENT_CREATED_ON_TIMESTAMP, signature.getConsentCreatedOn());
+        assertEquals(SIGNED_ON_TIMESTAMP, signature.getSignedOn());
+    }
+    
+    @Test
+    public void leavesValidSignaturesAlone() {
+        map.get(SUBPOP_GUID).add(new ConsentSignature.Builder().withBirthdate("2010-10-10")
+                .withConsentCreatedOn(CONSENT_CREATED_ON_TIMESTAMP)
+                .withSignedOn(SIGNED_ON_TIMESTAMP).withName("Test User").build());
+        
+        backfill.doBackfill(task, callback);
+        verify(accountDao, never()).updateAccount(accountCaptor.capture());
+    }
+    
+}


### PR DESCRIPTION
Start adding the study consent's createdOn timestamp to signatures. This is the only value in the DynamoDB UserConsent record, and those DDB records can be entirely removed if we just keep it with the signature.

Add a backfill to move this study consent createdOn timestamp into existing signatures. Currently will only do API study so we can test.
