### PR TITLE
Do not sign user in after verifying email. 

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/AccountDao.java
+++ b/app/org/sagebionetworks/bridge/dao/AccountDao.java
@@ -24,7 +24,7 @@ public interface AccountDao {
      * Verify an email address using a supplied, one-time token for verification.
      * @return
      */
-    public Account verifyEmail(StudyIdentifier study, EmailVerification verification);
+    public void verifyEmail(EmailVerification verification);
     
     /**
      * Sign up sends an email address with a link that includes a one-time token for verification. That email

--- a/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
@@ -52,29 +52,11 @@ public class AuthenticationController extends BaseController {
     }
 
     public Result verifyEmail() throws Exception {
-        JsonNode json = requestToJSON(request());
         EmailVerification emailVerification = parseJson(request(), EmailVerification.class);
-        Study study = getStudyOrThrowException(json);
 
-        // Note: currently we support mobile applications, that send an email that users open in 
-        // a browser to verify their email address. NOT a mobile app using the Bridge SDK. So 
-        // User-Agent (and Accept-Language possibly) are incorrect and the session we are 
-        // returning can have incorrect consent information. See BRIDGE-1352 about why session
-        // handling exists here, along with a proposal to remove it.
-        CriteriaContext context = getCriteriaContext(study.getStudyIdentifier());
+        authenticationService.verifyEmail(emailVerification);
         
-        UserSession session = authenticationService.verifyEmail(study, context, emailVerification);
-        
-        writeSessionInfoToMetrics(session);
-        setSessionToken(session.getSessionToken());
-
-        // In normal course of events (verify email, consent to research),
-        // an exception is thrown. Code after this line will rarely execute
-        if (!session.doesConsent()) {
-            throw new ConsentRequiredException(session);
-        }
-
-        return okResult(UserSessionInfo.toJSON(session));
+        return okResult("Email address verified.");
     }
 
     public Result resendEmailVerification() throws Exception {

--- a/app/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -11,7 +11,6 @@ import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.config.BridgeConfig;
 import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
-import org.sagebionetworks.bridge.exceptions.ConsentRequiredException;
 import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.CriteriaContext;
@@ -176,17 +175,11 @@ public class AuthenticationService {
         return null;
     }
 
-    public UserSession verifyEmail(Study study, CriteriaContext context, EmailVerification verification) throws ConsentRequiredException {
-        checkNotNull(study);
-        checkNotNull(context);
+    public void verifyEmail(EmailVerification verification) {
         checkNotNull(verification);
 
         Validate.entityThrowingException(verificationValidator, verification);
-        
-        Account account = accountDao.verifyEmail(study, verification);
-        UserSession session = getSessionFromAccount(study, context, account);
-        cacheProvider.setUserSession(session);
-        return session;
+        accountDao.verifyEmail(verification);
     }
     
     public void resendEmailVerification(StudyIdentifier studyIdentifier, Email email) {

--- a/app/org/sagebionetworks/bridge/stormpath/StormpathAccountDao.java
+++ b/app/org/sagebionetworks/bridge/stormpath/StormpathAccountDao.java
@@ -182,17 +182,14 @@ public class StormpathAccountDao implements AccountDao {
     }
     
     @Override
-    public Account verifyEmail(StudyIdentifier study, EmailVerification verification) {
-        checkNotNull(study);
+    public void verifyEmail(EmailVerification verification) {
         checkNotNull(verification);
         
         try {
-            com.stormpath.sdk.account.Account acct = client.verifyAccountEmail(verification.getSptoken());
-            return (acct == null) ? null : constructAccount(study, acct);
+            client.verifyAccountEmail(verification.getSptoken());
         } catch(ResourceException e) {
             rethrowResourceException(e, null);
         }
-        return null;
     }
     
     @Override

--- a/test/org/sagebionetworks/bridge/play/controllers/AuthenticationControllerMockTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/AuthenticationControllerMockTest.java
@@ -412,53 +412,14 @@ public class AuthenticationControllerMockTest {
         TestUtils.mockPlayContextWithJson(requestJsonString);
 
         // mock AuthenticationService
-        UserSession session = createSession(TestConstants.REQUIRED_SIGNED_CURRENT, null);
         ArgumentCaptor<EmailVerification> emailVerifyCaptor = ArgumentCaptor.forClass(EmailVerification.class);
-        when(authenticationService.verifyEmail(same(study), any(), emailVerifyCaptor.capture())).thenReturn(session);
-
-        doReturn(TEST_CONTEXT).when(controller).getCriteriaContext(any(StudyIdentifier.class));
 
         // execute and validate
         Result result = controller.verifyEmail();
-        assertSessionInPlayResult(result);
-        assertSessionInfoInMetrics(metrics);
+        TestUtils.assertResult(result, 200, "Email address verified.");
 
         // validate email verification
-        EmailVerification emailVerify = emailVerifyCaptor.getValue();
-        assertEquals(TEST_VERIFY_EMAIL_TOKEN, emailVerify.getSptoken());
-    }
-
-    @Test
-    public void verifyEmailUnconsented() throws Exception {
-        doReturn(TEST_CONTEXT).when(controller).getCriteriaContext(any(StudyIdentifier.class));
-        
-        // mock getMetrics
-        Metrics metrics = new Metrics(TEST_REQUEST_ID);
-        doReturn(metrics).when(controller).getMetrics();
-
-        // mock request
-        String requestJsonString = "{\n" +
-                "   \"sptoken\":\"" + TEST_VERIFY_EMAIL_TOKEN + "\",\n" +
-                "   \"study\":\"" + TEST_STUDY_ID_STRING + "\"\n" +
-                "}";
-
-        TestUtils.mockPlayContextWithJson(requestJsonString);
-
-        // mock AuthenticationService
-        UserSession session = createSession(null, null);
-        ArgumentCaptor<EmailVerification> emailVerifyCaptor = ArgumentCaptor.forClass(EmailVerification.class);
-        when(authenticationService.verifyEmail(same(study), any(), emailVerifyCaptor.capture())).thenReturn(session);
-
-        // execute and validate
-        try {
-            controller.verifyEmail();
-            fail("expected exception");
-        } catch (ConsentRequiredException ex) {
-            // expected exception
-        }
-        assertSessionInfoInMetrics(metrics);
-
-        // validate email verification
+        verify(authenticationService).verifyEmail(emailVerifyCaptor.capture());
         EmailVerification emailVerify = emailVerifyCaptor.getValue();
         assertEquals(TEST_VERIFY_EMAIL_TOKEN, emailVerify.getSptoken());
     }

--- a/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoMockTest.java
@@ -368,17 +368,6 @@ public class StormpathAccountDaoMockTest {
     }
     
     @Test
-    public void verifyEmailCreatesHealthCode() {
-        mockAccountWithoutHealthCode();
-        
-        doReturn(stormpathAccount).when(client).verifyAccountEmail("spToken");
-        EmailVerification emailVerification = new EmailVerification("spToken");
-        
-        dao.verifyEmail(emailVerification);
-        verify(healthCodeService).createMapping(study);
-    }
-    
-    @Test
     public void authenticatedCreatesHealthCode() {
         mockAccountWithoutHealthCode();
         

--- a/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoMockTest.java
@@ -156,8 +156,7 @@ public class StormpathAccountDaoMockTest {
         when(stormpathAccount.getCustomData()).thenReturn(customData);
         when(healthCodeService.getMapping("healthId")).thenReturn(healthId);
 
-        Account account = dao.verifyEmail(study, verification);
-        assertNotNull(account);
+        dao.verifyEmail(verification);
         verify(client).verifyAccountEmail("tokenAAA");
     }
 
@@ -375,8 +374,7 @@ public class StormpathAccountDaoMockTest {
         doReturn(stormpathAccount).when(client).verifyAccountEmail("spToken");
         EmailVerification emailVerification = new EmailVerification("spToken");
         
-        Account account = dao.verifyEmail(study, emailVerification);
-        assertEquals("ABC", account.getHealthCode());
+        dao.verifyEmail(emailVerification);
         verify(healthCodeService).createMapping(study);
     }
     


### PR DESCRIPTION
UPDATE: want to confirm with Mike in person that we don't want this, since it will foreclose on a particular user experience working on desktop.

This request is not sent from the client and does not have the correct HTTP headers to accurately determine consent status. It is also one of the reasons we can't perform more validation of the CriteriaContext object.
