### PR TITLE
Active consent in subpopulation

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulation.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulation.java
@@ -4,6 +4,8 @@ import java.util.Objects;
 
 import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 import org.sagebionetworks.bridge.json.BridgeTypeName;
+import org.sagebionetworks.bridge.json.DateTimeToLongDeserializer;
+import org.sagebionetworks.bridge.json.DateTimeToLongSerializer;
 import org.sagebionetworks.bridge.models.Criteria;
 import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
@@ -16,6 +18,8 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBVersionAttribute;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 /**
  * A sub-population of the study participants who will receive a unique consent based on selection by a data group, 
@@ -35,6 +39,7 @@ public final class DynamoSubpopulation implements Subpopulation {
     private boolean deleted;
     private boolean defaultGroup;
     private Long version;
+    private long activeConsentCreatedOn;
     private Criteria criteria;
 
     public DynamoSubpopulation() {
@@ -117,6 +122,17 @@ public final class DynamoSubpopulation implements Subpopulation {
     public void setDefaultGroup(boolean defaultGroup) {
         this.defaultGroup = defaultGroup;
     }
+    @DynamoDBAttribute
+    @JsonSerialize(using = DateTimeToLongSerializer.class)
+    @Override
+    public long getActiveConsentCreatedOn() {
+        return activeConsentCreatedOn;
+    }
+    @JsonDeserialize(using = DateTimeToLongDeserializer.class)
+    @Override
+    public void setActiveConsentCreatedOn(long consentCreatedOn) {
+        this.activeConsentCreatedOn = consentCreatedOn;
+    }
     @DynamoDBVersionAttribute
     @Override
     public Long getVersion() {
@@ -151,8 +167,8 @@ public final class DynamoSubpopulation implements Subpopulation {
     
     @Override
     public int hashCode() {
-        return Objects.hash(name, description, required, deleted, defaultGroup, guid, studyIdentifier, version,
-                criteria);
+        return Objects.hash(name, description, required, deleted, defaultGroup, guid, studyIdentifier,
+                activeConsentCreatedOn, version, criteria);
     }
     @Override
     public boolean equals(Object obj) {
@@ -164,6 +180,7 @@ public final class DynamoSubpopulation implements Subpopulation {
         return Objects.equals(name, other.name) && Objects.equals(description, other.description)
                 && Objects.equals(guid, other.guid) && Objects.equals(required, other.required)
                 && Objects.equals(deleted, other.deleted) && Objects.equals(studyIdentifier, other.studyIdentifier)
+                && Objects.equals(activeConsentCreatedOn, other.activeConsentCreatedOn)
                 && Objects.equals(version, other.version) && Objects.equals(defaultGroup, other.defaultGroup)
                 && Objects.equals(criteria, other.criteria);
     }
@@ -171,7 +188,7 @@ public final class DynamoSubpopulation implements Subpopulation {
     public String toString() {
         return "DynamoSubpopulation [studyIdentifier=" + studyIdentifier + ", guid=" + guid + ", name=" + name
                 + ", description=" + description + ", required=" + required + ", deleted=" + deleted + ", criteria="
-                + criteria + ", version=" + version + "]";
+                + criteria + ", activeConsentCreatedOn=" + activeConsentCreatedOn + ", version=" + version + "]";
     }
 
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulation.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulation.java
@@ -39,7 +39,7 @@ public final class DynamoSubpopulation implements Subpopulation {
     private boolean deleted;
     private boolean defaultGroup;
     private Long version;
-    private long activeConsentCreatedOn;
+    private long publishedConsentCreatedOn;
     private Criteria criteria;
 
     public DynamoSubpopulation() {
@@ -125,13 +125,13 @@ public final class DynamoSubpopulation implements Subpopulation {
     @DynamoDBAttribute
     @JsonSerialize(using = DateTimeToLongSerializer.class)
     @Override
-    public long getActiveConsentCreatedOn() {
-        return activeConsentCreatedOn;
+    public long getPublishedConsentCreatedOn() {
+        return publishedConsentCreatedOn;
     }
     @JsonDeserialize(using = DateTimeToLongDeserializer.class)
     @Override
-    public void setActiveConsentCreatedOn(long consentCreatedOn) {
-        this.activeConsentCreatedOn = consentCreatedOn;
+    public void setPublishedConsentCreatedOn(long consentCreatedOn) {
+        this.publishedConsentCreatedOn = consentCreatedOn;
     }
     @DynamoDBVersionAttribute
     @Override
@@ -168,7 +168,7 @@ public final class DynamoSubpopulation implements Subpopulation {
     @Override
     public int hashCode() {
         return Objects.hash(name, description, required, deleted, defaultGroup, guid, studyIdentifier,
-                activeConsentCreatedOn, version, criteria);
+                publishedConsentCreatedOn, version, criteria);
     }
     @Override
     public boolean equals(Object obj) {
@@ -180,7 +180,7 @@ public final class DynamoSubpopulation implements Subpopulation {
         return Objects.equals(name, other.name) && Objects.equals(description, other.description)
                 && Objects.equals(guid, other.guid) && Objects.equals(required, other.required)
                 && Objects.equals(deleted, other.deleted) && Objects.equals(studyIdentifier, other.studyIdentifier)
-                && Objects.equals(activeConsentCreatedOn, other.activeConsentCreatedOn)
+                && Objects.equals(publishedConsentCreatedOn, other.publishedConsentCreatedOn)
                 && Objects.equals(version, other.version) && Objects.equals(defaultGroup, other.defaultGroup)
                 && Objects.equals(criteria, other.criteria);
     }
@@ -188,7 +188,7 @@ public final class DynamoSubpopulation implements Subpopulation {
     public String toString() {
         return "DynamoSubpopulation [studyIdentifier=" + studyIdentifier + ", guid=" + guid + ", name=" + name
                 + ", description=" + description + ", required=" + required + ", deleted=" + deleted + ", criteria="
-                + criteria + ", activeConsentCreatedOn=" + activeConsentCreatedOn + ", version=" + version + "]";
+                + criteria + ", publishedConsentCreatedOn=" + publishedConsentCreatedOn + ", version=" + version + "]";
     }
 
 }

--- a/app/org/sagebionetworks/bridge/models/subpopulations/Subpopulation.java
+++ b/app/org/sagebionetworks/bridge/models/subpopulations/Subpopulation.java
@@ -59,6 +59,9 @@ public interface Subpopulation extends BridgeEntity {
     public void setCriteria(Criteria criteria);
     public Criteria getCriteria();
     
+    public void setActiveConsentCreatedOn(long consentCreatedOn);
+    public long getActiveConsentCreatedOn();
+    
     /**
      * URL for retrieving the HTML version of the published consent for this study.
      * @return

--- a/app/org/sagebionetworks/bridge/models/subpopulations/Subpopulation.java
+++ b/app/org/sagebionetworks/bridge/models/subpopulations/Subpopulation.java
@@ -59,8 +59,8 @@ public interface Subpopulation extends BridgeEntity {
     public void setCriteria(Criteria criteria);
     public Criteria getCriteria();
     
-    public void setActiveConsentCreatedOn(long consentCreatedOn);
-    public long getActiveConsentCreatedOn();
+    public void setPublishedConsentCreatedOn(long consentCreatedOn);
+    public long getPublishedConsentCreatedOn();
     
     /**
      * URL for retrieving the HTML version of the published consent for this study.

--- a/app/org/sagebionetworks/bridge/play/controllers/ConsentController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ConsentController.java
@@ -111,7 +111,7 @@ public class ConsentController extends BaseController {
         consentService.withdrawConsent(study, SubpopulationGuid.create(guid), session.getParticipant(), withdrawal,
                 withdrewOn);
         
-        UserSession updatedSession = authenticationService.updateSession(study, getCriteriaContext(session));
+        UserSession updatedSession = authenticationService.getSession(study, getCriteriaContext(session));
         if (!updatedSession.doesConsent()) {
             updateSharingStatusAndSession(study, updatedSession, SharingScope.NO_SHARING);
         } else {
@@ -171,7 +171,7 @@ public class ConsentController extends BaseController {
         consentService.consentToResearch(study, subpopGuid, session.getParticipant(), consentSignature,
                 sharing.getSharingScope(), true);
         
-        UserSession updatedSession = authenticationService.updateSession(study, getCriteriaContext(session));
+        UserSession updatedSession = authenticationService.getSession(study, getCriteriaContext(session));
         updateSession(updatedSession);
         return createdResult("Consent to research has been recorded.");
     }

--- a/app/org/sagebionetworks/bridge/play/controllers/ConsentController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ConsentController.java
@@ -113,7 +113,7 @@ public class ConsentController extends BaseController {
         
         UserSession updatedSession = authenticationService.updateSession(study, getCriteriaContext(session));
         if (!updatedSession.doesConsent()) {
-            updateSharingStatusAndSession(study, session, SharingScope.NO_SHARING);
+            updateSharingStatusAndSession(study, updatedSession, SharingScope.NO_SHARING);
         } else {
             updateSession(updatedSession);    
         }

--- a/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
@@ -74,7 +74,7 @@ public class ParticipantController extends BaseController {
         participantService.updateParticipant(study, NO_CALLER_ROLES, updated);
         
         CriteriaContext context = getCriteriaContext(session);
-        session = authenticationService.updateSession(study, context, session.getId());
+        session = authenticationService.updateSession(study, context);
         updateSession(session);
         
         return okResult(UserSessionInfo.toJSON(session));

--- a/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
@@ -74,7 +74,7 @@ public class ParticipantController extends BaseController {
         participantService.updateParticipant(study, NO_CALLER_ROLES, updated);
         
         CriteriaContext context = getCriteriaContext(session);
-        session = authenticationService.updateSession(study, context);
+        session = authenticationService.getSession(study, context);
         updateSession(session);
         
         return okResult(UserSessionInfo.toJSON(session));

--- a/app/org/sagebionetworks/bridge/play/controllers/StudyConsentController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/StudyConsentController.java
@@ -11,6 +11,7 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.subpopulations.StudyConsent;
 import org.sagebionetworks.bridge.models.subpopulations.StudyConsentForm;
 import org.sagebionetworks.bridge.models.subpopulations.StudyConsentView;
+import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 import org.sagebionetworks.bridge.services.StudyConsentService;
 import org.sagebionetworks.bridge.services.SubpopulationService;
@@ -95,9 +96,9 @@ public class StudyConsentController extends BaseController {
         SubpopulationGuid subpopGuid = SubpopulationGuid.create(guid);
         
         // Throws 404 exception if this subpopulation is not part of the caller's study
-        subpopService.getSubpopulation(studyId, subpopGuid);
+        Subpopulation subpop = subpopService.getSubpopulation(studyId, subpopGuid);
         
-        StudyConsentView consent = studyConsentService.getActiveConsent(subpopGuid);
+        StudyConsentView consent = studyConsentService.getActiveConsent(studyId, subpop);
         return okResult(consent);
     }
     
@@ -145,10 +146,10 @@ public class StudyConsentController extends BaseController {
         SubpopulationGuid subpopGuid = SubpopulationGuid.create(guid);
         
         // Throws 404 exception if this subpopulation is not part of the caller's study
-        subpopService.getSubpopulation(study.getStudyIdentifier(), subpopGuid);
+        Subpopulation subpop = subpopService.getSubpopulation(study.getStudyIdentifier(), subpopGuid);
 
         long timestamp = DateUtils.convertToMillisFromEpoch(createdOn);
-        studyConsentService.publishConsent(study, subpopGuid, timestamp);
+        studyConsentService.publishConsent(study, subpop, timestamp);
         return okResult("Consent document set as active.");
     }
     

--- a/app/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -1,10 +1,8 @@
 package org.sagebionetworks.bridge.services;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.sagebionetworks.bridge.BridgeConstants.NO_CALLER_ROLES;
 import static org.sagebionetworks.bridge.dao.ParticipantOption.LANGUAGES;
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.cache.CacheProvider;
@@ -118,18 +116,14 @@ public class AuthenticationService {
      *      the user's study
      * @param context
      *      an updated set of criteria for calculating the user's consent status
-     * @param userId
-     *      the ID of the user
      * @return
      *      newly created session object (not persisted)
      */
-    public UserSession updateSession(Study study, CriteriaContext context, String userId) {
+    public UserSession updateSession(Study study, CriteriaContext context) {
         checkNotNull(study);
         checkNotNull(context);
-        checkArgument(isNotBlank(userId));
         
-        Account account = accountDao.getAccount(study, userId);
-        cacheProvider.removeSessionByUserId(userId);
+        Account account = accountDao.getAccount(study, context.getUserId());
         return getSessionFromAccount(study, context, account);
     }
 

--- a/app/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -119,7 +119,7 @@ public class AuthenticationService {
      * @return
      *      newly created session object (not persisted)
      */
-    public UserSession updateSession(Study study, CriteriaContext context) {
+    public UserSession getSession(Study study, CriteriaContext context) {
         checkNotNull(study);
         checkNotNull(context);
         

--- a/app/org/sagebionetworks/bridge/services/StudyConsentService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyConsentService.java
@@ -99,14 +99,13 @@ public class StudyConsentService {
     }
     
     /**
-     * Adds a new consent document to the study, and sets that consent document
-     * as active.
+     * Adds a new consent document to the study, and sets that consent document as active.
      *
      * @param subpopGuid
      *            the subpopulation associated with this consent
      * @param form
-     *            form filled out by researcher including the path to the
-     *            consent document and the minimum age required to consent.
+     *            form filled out by researcher including the path to the consent document and the minimum age required
+     *            to consent.
      * @return the added consent document of type StudyConsent along with its document content
      */
     public StudyConsentView addConsent(SubpopulationGuid subpopGuid, StudyConsentForm form) {

--- a/app/org/sagebionetworks/bridge/services/StudyConsentService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyConsentService.java
@@ -146,7 +146,10 @@ public class StudyConsentService {
             consent = studyConsentDao.getConsent(subpop.getGuid(), subpop.getActiveConsentCreatedOn());
         }
         if (consent == null) {
-            consent = studyConsentDao.getActiveConsent(subpop.getGuid());    
+            consent = studyConsentDao.getActiveConsent(subpop.getGuid());
+            if (consent != null) {
+                subpop.setActiveConsentCreatedOn(consent.getCreatedOn());
+            }
         }
         if (consent == null) {
             throw new EntityNotFoundException(StudyConsent.class);

--- a/app/org/sagebionetworks/bridge/services/StudyConsentService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyConsentService.java
@@ -142,13 +142,13 @@ public class StudyConsentService {
         checkNotNull(subpop);
         
         StudyConsent consent = null;
-        if (subpop.getActiveConsentCreatedOn() > 0L) {
-            consent = studyConsentDao.getConsent(subpop.getGuid(), subpop.getActiveConsentCreatedOn());
+        if (subpop.getPublishedConsentCreatedOn() > 0L) {
+            consent = studyConsentDao.getConsent(subpop.getGuid(), subpop.getPublishedConsentCreatedOn());
         }
         if (consent == null) {
             consent = studyConsentDao.getActiveConsent(subpop.getGuid());
             if (consent != null) {
-                subpop.setActiveConsentCreatedOn(consent.getCreatedOn());
+                subpop.setPublishedConsentCreatedOn(consent.getCreatedOn());
             }
         }
         if (consent == null) {
@@ -237,7 +237,7 @@ public class StudyConsentService {
         try {
             publishFormatsToS3(study, subpop.getGuid(), documentContent);
             
-            subpop.setActiveConsentCreatedOn(timestamp);
+            subpop.setPublishedConsentCreatedOn(timestamp);
             subpopService.updateSubpopulation(study, subpop);
 
             consent = studyConsentDao.publish(consent);

--- a/app/org/sagebionetworks/bridge/services/SubpopulationService.java
+++ b/app/org/sagebionetworks/bridge/services/SubpopulationService.java
@@ -63,11 +63,13 @@ public class SubpopulationService {
         Validator validator = new SubpopulationValidator(study.getDataGroups());
         Validate.entityThrowingException(validator, subpop);
         
+        Subpopulation created = subpopDao.createSubpopulation(subpop);
+        
         // Create a default consent for this subpopulation.
         StudyConsentView view = studyConsentService.addConsent(subpop.getGuid(), defaultConsentDocument);
-        studyConsentService.publishConsent(study, subpop.getGuid(), view.getCreatedOn());
+        studyConsentService.publishConsent(study, subpop, view.getCreatedOn());
         
-        return subpopDao.createSubpopulation(subpop);
+        return created;
     }
     
     /**
@@ -77,13 +79,15 @@ public class SubpopulationService {
      */
     public Subpopulation createDefaultSubpopulation(Study study) {
         SubpopulationGuid subpopGuid = SubpopulationGuid.create(study.getIdentifier());
+        Subpopulation created = subpopDao.createDefaultSubpopulation(study.getStudyIdentifier());
+        
         // Migrating, studies will already have consents so don't create and publish a new one
         // unless this is part of the creation of a new study after the introduction of subpopulations.
         if (studyConsentService.getAllConsents(subpopGuid).isEmpty()) {
             StudyConsentView view = studyConsentService.addConsent(subpopGuid, defaultConsentDocument);
-            studyConsentService.publishConsent(study, subpopGuid, view.getCreatedOn());
+            studyConsentService.publishConsent(study, created, view.getCreatedOn());
         }
-        return subpopDao.createDefaultSubpopulation(study.getStudyIdentifier());
+        return created;
     }
     
     /**

--- a/app/org/sagebionetworks/bridge/services/UserAdminService.java
+++ b/app/org/sagebionetworks/bridge/services/UserAdminService.java
@@ -139,7 +139,7 @@ public class UserAdminService {
                         }
                     }
                 }
-                newUserSession = authenticationService.updateSession(study, context);
+                newUserSession = authenticationService.getSession(study, context);
             }
             if (!signUserIn) {
                 authenticationService.signOut(newUserSession);

--- a/app/org/sagebionetworks/bridge/services/UserAdminService.java
+++ b/app/org/sagebionetworks/bridge/services/UserAdminService.java
@@ -16,6 +16,7 @@ import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
+import org.sagebionetworks.bridge.models.accounts.IdentifierHolder;
 import org.sagebionetworks.bridge.models.accounts.ParticipantOptionsLookup;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
@@ -111,10 +112,11 @@ public class UserAdminService {
         checkNotNull(participant, "Participant cannot be null");
         checkNotNull(participant.getEmail(), "Sign up email cannot be null");
         
-        participantService.createParticipant(study, ADMIN_ROLE, participant, false);
+        IdentifierHolder identifier = participantService.createParticipant(study, ADMIN_ROLE, participant, false);
 
         // We don't filter users by any of these filtering criteria in the admin API.
         CriteriaContext context = new CriteriaContext.Builder()
+                .withUserId(identifier.getIdentifier())
                 .withStudyIdentifier(study.getStudyIdentifier()).build();
         
         UserSession newUserSession = null;
@@ -128,17 +130,17 @@ public class UserAdminService {
                         .withBirthdate("1989-08-19").withSignedOn(DateUtils.getCurrentMillisFromEpoch()).build();
                 
                 if (subpopGuid != null) {
-                    consentService.consentToResearch(study, subpopGuid, newUserSession, signature, NO_SHARING, false);
+                    consentService.consentToResearch(study, subpopGuid, newUserSession.getParticipant(), signature, NO_SHARING, false);
                 } else {
                     for (ConsentStatus consentStatus : newUserSession.getConsentStatuses().values()) {
                         if (consentStatus.isRequired()) {
                             SubpopulationGuid guid = SubpopulationGuid.create(consentStatus.getSubpopulationGuid());
-                            consentService.consentToResearch(study, guid, newUserSession, signature, NO_SHARING, false);
+                            consentService.consentToResearch(study, guid, newUserSession.getParticipant(), signature, NO_SHARING, false);
                         }
                     }
                 }
+                newUserSession = authenticationService.updateSession(study, context);
             }
-
             if (!signUserIn) {
                 authenticationService.signOut(newUserSession);
                 newUserSession.setAuthenticated(false);

--- a/app/org/sagebionetworks/bridge/services/backfill/ConsentCreatedOnBackfill.java
+++ b/app/org/sagebionetworks/bridge/services/backfill/ConsentCreatedOnBackfill.java
@@ -52,7 +52,7 @@ public class ConsentCreatedOnBackfill extends AsyncBackfillTemplate {
                 StudyConsent consent = studyConsentDao.getActiveConsent(subpopulation.getGuid());
                 if (consent != null) {
                     callback.newRecords(getBackfillRecordFactory().createOnly(task, "Updating subpopulation " + subpopulation.getGuidString() + "..."));
-                    subpopulation.setActiveConsentCreatedOn(consent.getCreatedOn());
+                    subpopulation.setPublishedConsentCreatedOn(consent.getCreatedOn());
                     subpopulationService.updateSubpopulation(study, subpopulation);
                 } else {
                     callback.newRecords(getBackfillRecordFactory().createOnly(task, "Can't update subpopulation " + subpopulation.getGuidString() + "..."));

--- a/app/org/sagebionetworks/bridge/services/backfill/ConsentCreatedOnBackfill.java
+++ b/app/org/sagebionetworks/bridge/services/backfill/ConsentCreatedOnBackfill.java
@@ -1,0 +1,66 @@
+package org.sagebionetworks.bridge.services.backfill;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.sagebionetworks.bridge.dao.AccountDao;
+import org.sagebionetworks.bridge.dao.StudyConsentDao;
+import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountSummary;
+import org.sagebionetworks.bridge.models.backfill.BackfillTask;
+import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.subpopulations.StudyConsent;
+import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
+import org.sagebionetworks.bridge.services.StudyService;
+import org.sagebionetworks.bridge.services.SubpopulationService;
+
+@Component("consentCreatedOn")
+public class ConsentCreatedOnBackfill extends AsyncBackfillTemplate {
+    private StudyService studyService;
+    private SubpopulationService subpopulationService;
+    private StudyConsentDao studyConsentDao;
+    
+    @Autowired
+    public void setStudyService(StudyService studyService) {
+        this.studyService = studyService;
+    }
+    @Autowired
+    public void setSubpopulationService(SubpopulationService subpopulationService) {
+        this.subpopulationService = subpopulationService;
+    }
+    @Autowired
+    public void setStudyConsentDao(StudyConsentDao studyConsentDao) {
+        this.studyConsentDao = studyConsentDao;
+    }
+
+    @Override
+    int getLockExpireInSeconds() {
+        return 30 * 60;
+    }
+    
+    private List<Study> getStudies() {
+        return studyService.getStudies();
+    }
+
+    @Override
+    void doBackfill(final BackfillTask task, BackfillCallback callback) {
+        List<Study> studies = getStudies();
+        for (Study study : studies) {
+            callback.newRecords(getBackfillRecordFactory().createOnly(task, "Examining study " + study.getIdentifier() + "..."));
+            
+            List<Subpopulation> subpopulations = subpopulationService.getSubpopulations(study.getStudyIdentifier());
+            for (Subpopulation subpopulation : subpopulations) {
+                
+                StudyConsent consent = studyConsentDao.getActiveConsent(subpopulation.getGuid());
+                subpopulation.setActiveConsentCreatedOn(consent.getCreatedOn());
+                
+                subpopulationService.updateSubpopulation(study, subpopulation);
+            }
+        }
+    }
+
+}

--- a/app/org/sagebionetworks/bridge/services/email/ConsentEmailProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/ConsentEmailProvider.java
@@ -22,9 +22,6 @@ import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
-import org.sagebionetworks.bridge.models.subpopulations.StudyConsentView;
-import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
-import org.sagebionetworks.bridge.services.StudyConsentService;
 
 import org.jsoup.Jsoup;
 import org.jsoup.safety.Whitelist;
@@ -46,21 +43,19 @@ public class ConsentEmailProvider implements MimeTypeEmailProvider {
     private static final String MIME_TYPE_PDF = "application/pdf";
 
     private Study study;
-    private SubpopulationGuid subpopGuid;
     private String userEmail;
     private ConsentSignature consentSignature;
     private SharingScope sharingScope;
-    private StudyConsentService studyConsentService;
+    private String consentAgreementHTML;
     private String consentTemplate;
 
-    public ConsentEmailProvider(Study study, SubpopulationGuid subpopGuid, String userEmail, ConsentSignature consentSignature, SharingScope sharingScope,
-        StudyConsentService studyConsentService, String consentTemplate) {
+    public ConsentEmailProvider(Study study, String userEmail, ConsentSignature consentSignature,
+            SharingScope sharingScope, String consentAgreementHTML, String consentTemplate) {
         this.study = study;
-        this.subpopGuid = subpopGuid;
         this.userEmail = userEmail;
         this.consentSignature = consentSignature;
         this.sharingScope = sharingScope;
-        this.studyConsentService = studyConsentService;
+        this.consentAgreementHTML = consentAgreementHTML;
         this.consentTemplate = consentTemplate;
     }
 
@@ -131,8 +126,6 @@ public class ConsentEmailProvider implements MimeTypeEmailProvider {
      * runtime. Here we branch based on the detection of a complete HTML document and do either one or the other.
      */
     private String createSignedDocument() {
-        StudyConsentView consent = studyConsentService.getActiveConsent(subpopGuid);
-        String consentAgreementHTML = consent.getDocumentContent();
         String signingDate = FORMATTER.print(DateUtils.getCurrentMillisFromEpoch());
         String sharingLabel = (sharingScope == null) ? "" : sharingScope.getLabel();
 

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Set;
 
+import org.joda.time.DateTime;
 import org.junit.Test;
 
 import org.sagebionetworks.bridge.TestUtils;
@@ -27,6 +28,7 @@ public class DynamoSubpopulationTest {
     
     private static final Set<String> ALL_OF_GROUPS = Sets.newHashSet("requiredGroup");
     private static final Set<String> NONE_OF_GROUPS = Sets.newHashSet("prohibitedGroup");
+    private static final DateTime ACTIVE_CONSENT_TIMESTAMP = DateTime.parse("2016-07-12T19:49:07.415Z");
 
     @Test
     public void hashCodeEquals() {
@@ -43,6 +45,7 @@ public class DynamoSubpopulationTest {
         subpop.setStudyIdentifier("study-key");
         subpop.setRequired(true);
         subpop.setDefaultGroup(true);
+        subpop.setActiveConsentCreatedOn(ACTIVE_CONSENT_TIMESTAMP.getMillis());
         subpop.setDeleted(true);
         subpop.setVersion(3L);
         
@@ -57,6 +60,7 @@ public class DynamoSubpopulationTest {
         assertEquals("Name", node.get("name").asText());
         assertEquals("Description", node.get("description").asText());
         assertEquals("guid", node.get("guid").asText());
+        assertEquals(ACTIVE_CONSENT_TIMESTAMP.toString(), node.get("activeConsentCreatedOn").asText());
         assertTrue(node.get("required").asBoolean());
         assertTrue(node.get("defaultGroup").asBoolean());
         assertNull(node.get("deleted")); // users do not see this flag, they never get deleted items

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationTest.java
@@ -28,7 +28,7 @@ public class DynamoSubpopulationTest {
     
     private static final Set<String> ALL_OF_GROUPS = Sets.newHashSet("requiredGroup");
     private static final Set<String> NONE_OF_GROUPS = Sets.newHashSet("prohibitedGroup");
-    private static final DateTime ACTIVE_CONSENT_TIMESTAMP = DateTime.parse("2016-07-12T19:49:07.415Z");
+    private static final DateTime PUBLISHED_CONSENT_TIMESTAMP = DateTime.parse("2016-07-12T19:49:07.415Z");
 
     @Test
     public void hashCodeEquals() {
@@ -45,7 +45,7 @@ public class DynamoSubpopulationTest {
         subpop.setStudyIdentifier("study-key");
         subpop.setRequired(true);
         subpop.setDefaultGroup(true);
-        subpop.setActiveConsentCreatedOn(ACTIVE_CONSENT_TIMESTAMP.getMillis());
+        subpop.setPublishedConsentCreatedOn(PUBLISHED_CONSENT_TIMESTAMP.getMillis());
         subpop.setDeleted(true);
         subpop.setVersion(3L);
         
@@ -60,7 +60,7 @@ public class DynamoSubpopulationTest {
         assertEquals("Name", node.get("name").asText());
         assertEquals("Description", node.get("description").asText());
         assertEquals("guid", node.get("guid").asText());
-        assertEquals(ACTIVE_CONSENT_TIMESTAMP.toString(), node.get("activeConsentCreatedOn").asText());
+        assertEquals(PUBLISHED_CONSENT_TIMESTAMP.toString(), node.get("publishedConsentCreatedOn").asText());
         assertTrue(node.get("required").asBoolean());
         assertTrue(node.get("defaultGroup").asBoolean());
         assertNull(node.get("deleted")); // users do not see this flag, they never get deleted items

--- a/test/org/sagebionetworks/bridge/play/controllers/ConsentControllerMockedTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ConsentControllerMockedTest.java
@@ -108,7 +108,7 @@ public class ConsentControllerMockedTest {
         doReturn(session).when(controller).getAuthenticatedAndConsentedSession();
         doReturn(session).when(controller).getAuthenticatedSession();
         
-        doReturn(session).when(authenticationService).updateSession(eq(study), any(CriteriaContext.class));
+        doReturn(session).when(authenticationService).getSession(eq(study), any(CriteriaContext.class));
     }
 
     @After
@@ -242,7 +242,7 @@ public class ConsentControllerMockedTest {
 
     @Test
     public void consentUpdatesSession() throws Exception {
-        doReturn(updatedSession).when(authenticationService).updateSession(eq(study), any(CriteriaContext.class));
+        doReturn(updatedSession).when(authenticationService).getSession(eq(study), any(CriteriaContext.class));
         
         String json = "{\"name\":\"Jack Aubrey\",\"birthdate\":\"1970-10-10\",\"imageData\":\"data:asdf\",\"imageMimeType\":\"image/png\",\"scope\":\"no_sharing\"}";
         TestUtils.mockPlayContextWithJson(json);
@@ -253,7 +253,7 @@ public class ConsentControllerMockedTest {
         verify(consentService).consentToResearch(eq(study), any(SubpopulationGuid.class), eq(participant),
                 signatureCaptor.capture(), any(SharingScope.class), eq(true));
         
-        verify(authenticationService).updateSession(eq(study), any(CriteriaContext.class));
+        verify(authenticationService).getSession(eq(study), any(CriteriaContext.class));
         verify(cacheProvider).setUserSession(updatedSession);
     }
     
@@ -296,14 +296,14 @@ public class ConsentControllerMockedTest {
         // Session that is returned no longer consents
         doReturn(false).when(updatedSession).doesConsent();
         doReturn(participant).when(updatedSession).getParticipant();
-        doReturn(updatedSession).when(authenticationService).updateSession(eq(study), any(CriteriaContext.class));
+        doReturn(updatedSession).when(authenticationService).getSession(eq(study), any(CriteriaContext.class));
         
         Result result = controller.withdrawConsentV2(SUBPOP_GUID.getGuid());
         assertResult(result, 200, "User has been withdrawn from the study.");
         
         // Should call the service and withdraw
         verify(consentService).withdrawConsent(study, SUBPOP_GUID, participant, new Withdrawal("Because, reasons."), 20000);
-        verify(authenticationService).updateSession(eq(study), any(CriteriaContext.class));
+        verify(authenticationService).getSession(eq(study), any(CriteriaContext.class));
         verify(cacheProvider).setUserSession(updatedSession);
         DateTimeUtils.setCurrentMillisSystem();
     }

--- a/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
@@ -135,7 +135,7 @@ public class ParticipantControllerTest {
         summaries.add(SUMMARY);
         PagedResourceList<AccountSummary> page = new PagedResourceList<AccountSummary>(summaries, 10, 20, 30).withFilter("emailFilter", "foo");
         
-        when(authService.updateSession(eq(study), any(), eq(ID))).thenReturn(session);
+        when(authService.updateSession(eq(study), any())).thenReturn(session);
         
         when(participantService.getPagedAccountSummaries(eq(study), anyInt(), anyInt(), any())).thenReturn(page);
         
@@ -332,7 +332,7 @@ public class ParticipantControllerTest {
                 .withHealthCode("healthCode").build();
         
         doReturn(participant).when(participantService).getParticipant(study, ID, false);
-        doReturn(new UserSession(participant)).when(authService).updateSession(eq(study), any(), eq(ID));
+        doReturn(new UserSession(participant)).when(authService).updateSession(eq(study), any());
         
         String json = MAPPER.writeValueAsString(participant);
         mockPlayContextWithJson(json);
@@ -353,7 +353,7 @@ public class ParticipantControllerTest {
         
         // verify the object is passed to service, one field is sufficient
         verify(cacheProvider).setUserSession(any());
-        verify(authService).updateSession(eq(study), any(), eq(ID));
+        verify(authService).updateSession(eq(study), any());
         verify(participantService).updateParticipant(eq(study), eq(NO_CALLER_ROLES), participantCaptor.capture());
 
         // Just test the different types and verify they are there.
@@ -402,7 +402,7 @@ public class ParticipantControllerTest {
         JsonNode node = MAPPER.readTree(Helpers.contentAsString(result));
         assertEquals("UserSessionInfo", node.get("type").asText());
 
-        verify(authService).updateSession(eq(study), any(), eq(ID));
+        verify(authService).updateSession(eq(study), any());
         verify(participantService).updateParticipant(eq(study), eq(NO_CALLER_ROLES), participantCaptor.capture());
         StudyParticipant captured = participantCaptor.getValue();
         assertEquals(ID, captured.getId());

--- a/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
@@ -135,7 +135,7 @@ public class ParticipantControllerTest {
         summaries.add(SUMMARY);
         PagedResourceList<AccountSummary> page = new PagedResourceList<AccountSummary>(summaries, 10, 20, 30).withFilter("emailFilter", "foo");
         
-        when(authService.updateSession(eq(study), any())).thenReturn(session);
+        when(authService.getSession(eq(study), any())).thenReturn(session);
         
         when(participantService.getPagedAccountSummaries(eq(study), anyInt(), anyInt(), any())).thenReturn(page);
         
@@ -332,7 +332,7 @@ public class ParticipantControllerTest {
                 .withHealthCode("healthCode").build();
         
         doReturn(participant).when(participantService).getParticipant(study, ID, false);
-        doReturn(new UserSession(participant)).when(authService).updateSession(eq(study), any());
+        doReturn(new UserSession(participant)).when(authService).getSession(eq(study), any());
         
         String json = MAPPER.writeValueAsString(participant);
         mockPlayContextWithJson(json);
@@ -353,7 +353,7 @@ public class ParticipantControllerTest {
         
         // verify the object is passed to service, one field is sufficient
         verify(cacheProvider).setUserSession(any());
-        verify(authService).updateSession(eq(study), any());
+        verify(authService).getSession(eq(study), any());
         verify(participantService).updateParticipant(eq(study), eq(NO_CALLER_ROLES), participantCaptor.capture());
 
         // Just test the different types and verify they are there.
@@ -402,7 +402,7 @@ public class ParticipantControllerTest {
         JsonNode node = MAPPER.readTree(Helpers.contentAsString(result));
         assertEquals("UserSessionInfo", node.get("type").asText());
 
-        verify(authService).updateSession(eq(study), any());
+        verify(authService).getSession(eq(study), any());
         verify(participantService).updateParticipant(eq(study), eq(NO_CALLER_ROLES), participantCaptor.capture());
         StudyParticipant captured = participantCaptor.getValue();
         assertEquals(ID, captured.getId());

--- a/test/org/sagebionetworks/bridge/play/controllers/StudyConsentControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/StudyConsentControllerTest.java
@@ -98,7 +98,7 @@ public class StudyConsentControllerTest {
     @Test
     public void getActiveConsentV2() throws Exception {
         StudyConsentView view = new StudyConsentView(new DynamoStudyConsent1(), "<document/>");
-        when(studyConsentService.getActiveConsent(SUBPOP_GUID)).thenReturn(view);
+        when(studyConsentService.getActiveConsent(eq(STUDY_ID), any())).thenReturn(view);
         
         Result result = controller.getActiveConsentV2(GUID);
         
@@ -150,7 +150,7 @@ public class StudyConsentControllerTest {
         
         assertResult(result, 200, "Consent document set as active.");
 
-        verify(studyConsentService).publishConsent(STUDY, SUBPOP_GUID, DateTime.parse(DATETIME_STRING).getMillis());
+        verify(studyConsentService).publishConsent(STUDY, subpopulation, DateTime.parse(DATETIME_STRING).getMillis());
     }
     
 }

--- a/test/org/sagebionetworks/bridge/play/controllers/StudyConsentControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/StudyConsentControllerTest.java
@@ -54,6 +54,9 @@ public class StudyConsentControllerTest {
     private static final SubpopulationGuid SUBPOP_GUID = SubpopulationGuid.create(GUID);
     private static final StudyIdentifier STUDY_ID = new StudyIdentifierImpl("test-study");
     private static final Study STUDY = new DynamoStudy();
+    static {
+        STUDY.setIdentifier("test-study");
+    }
 
     @Mock
     private StudyService studyService;

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
@@ -429,7 +429,7 @@ public class AuthenticationServiceTest {
         // Now update the session, these changes should be reflected
         CriteriaContext context = new CriteriaContext.Builder().withStudyIdentifier(study.getStudyIdentifier())
                 .withUserId(userId).build();
-        Set<String> retrievedSessionDataGroups = authService.updateSession(study, context)
+        Set<String> retrievedSessionDataGroups = authService.getSession(study, context)
                 .getParticipant().getDataGroups();
 
         assertEquals(UPDATED_DATA_GROUPS, retrievedSessionDataGroups);

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
@@ -427,8 +427,9 @@ public class AuthenticationServiceTest {
         participantService.updateParticipant(study, CALLER_ROLES, updated);
         
         // Now update the session, these changes should be reflected
-        CriteriaContext context = new CriteriaContext.Builder().withStudyIdentifier(study.getStudyIdentifier()).build();
-        Set<String> retrievedSessionDataGroups = authService.updateSession(study, context, userId)
+        CriteriaContext context = new CriteriaContext.Builder().withStudyIdentifier(study.getStudyIdentifier())
+                .withUserId(userId).build();
+        Set<String> retrievedSessionDataGroups = authService.updateSession(study, context)
                 .getParticipant().getDataGroups();
 
         assertEquals(UPDATED_DATA_GROUPS, retrievedSessionDataGroups);

--- a/test/org/sagebionetworks/bridge/services/ConsentServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/ConsentServiceMockTest.java
@@ -68,6 +68,8 @@ public class ConsentServiceMockTest {
     private ActivityEventService activityEventService;
     @Mock
     private SubpopulationService subpopService;
+    @Mock
+    private Subpopulation subpopulation;
 
     private Study study;
     private UserSession session;
@@ -103,7 +105,7 @@ public class ConsentServiceMockTest {
         
         StudyConsentView studyConsentView = mock(StudyConsentView.class);
         when(studyConsentView.getCreatedOn()).thenReturn(1000L);
-        when(studyConsentService.getActiveConsent(SUBPOP_GUID)).thenReturn(studyConsentView);
+        when(studyConsentService.getActiveConsent(study.getStudyIdentifier(), subpopulation)).thenReturn(studyConsentView);
     }
     
     @Test
@@ -139,7 +141,7 @@ public class ConsentServiceMockTest {
         StudyConsentView view = mock(StudyConsentView.class);
         when(view.getStudyConsent()).thenReturn(consent);
         when(view.getCreatedOn()).thenReturn(CONSENT_CREATED_ON);
-        when(studyConsentService.getActiveConsent(SUBPOP_GUID)).thenReturn(view);
+        when(studyConsentService.getActiveConsent(study.getStudyIdentifier(), subpopulation)).thenReturn(view);
         
         ConsentSignature sigWithStudyCreatedOn = new ConsentSignature.Builder()
                 .withConsentSignature(consentSignature)

--- a/test/org/sagebionetworks/bridge/services/ConsentServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/ConsentServiceMockTest.java
@@ -98,7 +98,7 @@ public class ConsentServiceMockTest {
         when(accountDao.getAccount(any(Study.class), any(String.class))).thenReturn(account);
         
         StudyConsentView studyConsentView = mock(StudyConsentView.class);
-        when(studyConsentView.getCreatedOn()).thenReturn(1000L);
+        when(studyConsentView.getCreatedOn()).thenReturn(CONSENT_CREATED_ON);
         when(studyConsentService.getActiveConsent(study.getStudyIdentifier(), subpopulation)).thenReturn(studyConsentView);
         when(subpopService.getSubpopulation(study.getStudyIdentifier(), SUBPOP_GUID)).thenReturn(subpopulation);
     }
@@ -165,7 +165,7 @@ public class ConsentServiceMockTest {
     @Test
     public void noActivityEventIfAlreadyConsented() {
         account.getConsentSignatureHistory(SUBPOP_GUID)
-                .add(new ConsentSignature.Builder().withConsentCreatedOn(DateTime.now().getMillis())
+                .add(new ConsentSignature.Builder().withConsentCreatedOn(CONSENT_CREATED_ON)
                         .withSignedOn(DateTime.now().getMillis()).withName("A Name").withBirthdate("1960-10-10")
                         .build());
         try {

--- a/test/org/sagebionetworks/bridge/services/ConsentServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/ConsentServiceMockTest.java
@@ -1,12 +1,12 @@
 package org.sagebionetworks.bridge.services;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -31,8 +31,6 @@ import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.models.accounts.Account;
-import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
-import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.accounts.ParticipantOptionsLookup;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.Withdrawal;
@@ -72,7 +70,7 @@ public class ConsentServiceMockTest {
     private Subpopulation subpopulation;
 
     private Study study;
-    private UserSession session;
+    private StudyParticipant participant;
     private ConsentSignature consentSignature;
     private Account account;
     
@@ -88,17 +86,13 @@ public class ConsentServiceMockTest {
         
         study = TestUtils.getValidStudy(ConsentServiceMockTest.class);
         
-        StudyParticipant participant = new StudyParticipant.Builder()
+        participant = new StudyParticipant.Builder()
                 .withHealthCode("BBB")
                 .withId("user-id")
                 .withEmail("bbb@bbb.com").build();
-        session = new UserSession(participant);
         
         consentSignature = new ConsentSignature.Builder().withName("Test User").withBirthdate("1990-01-01")
                 .withSignedOn(SIGNED_ON).build();
-        
-        session.setConsentStatuses(TestUtils.toMap(
-                new ConsentStatus.Builder().withName("Name").withGuid(SUBPOP_GUID).withConsented(false).withRequired(true).build()));
         
         account = spy(new SimpleAccount()); // mock(Account.class);
         when(accountDao.getAccount(any(Study.class), any(String.class))).thenReturn(account);
@@ -106,6 +100,7 @@ public class ConsentServiceMockTest {
         StudyConsentView studyConsentView = mock(StudyConsentView.class);
         when(studyConsentView.getCreatedOn()).thenReturn(1000L);
         when(studyConsentService.getActiveConsent(study.getStudyIdentifier(), subpopulation)).thenReturn(studyConsentView);
+        when(subpopService.getSubpopulation(study.getStudyIdentifier(), SUBPOP_GUID)).thenReturn(subpopulation);
     }
     
     @Test
@@ -114,7 +109,7 @@ public class ConsentServiceMockTest {
         
         when(subpopService.getSubpopulation(study, badGuid)).thenThrow(new EntityNotFoundException(Subpopulation.class));
         try {
-            consentService.getConsentSignature(study, SubpopulationGuid.create("not-correct"), session.getId());
+            consentService.getConsentSignature(study, SubpopulationGuid.create("not-correct"), participant.getId());
             fail("Should have thrown exception.");
         } catch(EntityNotFoundException e) {
             assertEquals("Subpopulation not found.", e.getMessage());
@@ -125,8 +120,9 @@ public class ConsentServiceMockTest {
     public void userCannotConsentToSubpopulationToWhichTheyAreNotMapped() {
         SubpopulationGuid badGuid = SubpopulationGuid.create("not-correct");
         
+        doThrow(new EntityNotFoundException(Subpopulation.class)).when(subpopService).getSubpopulation(study.getStudyIdentifier(), badGuid);
         try {
-            consentService.consentToResearch(study, badGuid, session, consentSignature, SharingScope.NO_SHARING, false);
+            consentService.consentToResearch(study, badGuid, participant, consentSignature, SharingScope.NO_SHARING, false);
             fail("Should have thrown exception.");
         } catch(EntityNotFoundException e) {
             assertEquals("Subpopulation not found.", e.getMessage());
@@ -147,9 +143,9 @@ public class ConsentServiceMockTest {
                 .withConsentSignature(consentSignature)
                 .withConsentCreatedOn(consent.getCreatedOn()).build();
         
-        consentService.consentToResearch(study, SUBPOP_GUID, session, consentSignature, SharingScope.NO_SHARING, false);
+        consentService.consentToResearch(study, SUBPOP_GUID, participant, consentSignature, SharingScope.NO_SHARING, false);
         
-        verify(activityEventService).publishEnrollmentEvent(session.getParticipant().getHealthCode(), sigWithStudyCreatedOn);
+        verify(activityEventService).publishEnrollmentEvent(participant.getHealthCode(), sigWithStudyCreatedOn);
     }
 
     @Test
@@ -159,7 +155,7 @@ public class ConsentServiceMockTest {
         study.setMinAgeOfConsent(30); // Test is good until 2044. So there.
         
         try {
-            consentService.consentToResearch(study, SUBPOP_GUID, session, consentSignature, SharingScope.NO_SHARING, false);
+            consentService.consentToResearch(study, SUBPOP_GUID, participant, consentSignature, SharingScope.NO_SHARING, false);
             fail("Exception expected.");
         } catch(InvalidEntityException e) {
             verifyNoMoreInteractions(activityEventService);
@@ -168,11 +164,12 @@ public class ConsentServiceMockTest {
     
     @Test
     public void noActivityEventIfAlreadyConsented() {
-        ConsentStatus status = new ConsentStatus.Builder().withName("name").withGuid(SUBPOP_GUID)
-                .withConsented(true).withRequired(true).withSignedMostRecentConsent(true).build();
-        session.setConsentStatuses(TestUtils.toMap(status));
+        account.getConsentSignatureHistory(SUBPOP_GUID)
+                .add(new ConsentSignature.Builder().withConsentCreatedOn(DateTime.now().getMillis())
+                        .withSignedOn(DateTime.now().getMillis()).withName("A Name").withBirthdate("1960-10-10")
+                        .build());
         try {
-            consentService.consentToResearch(study, SUBPOP_GUID, session, consentSignature, SharingScope.NO_SHARING, false);
+            consentService.consentToResearch(study, SUBPOP_GUID, participant, consentSignature, SharingScope.NO_SHARING, false);
             fail("Exception expected.");
         } catch(EntityAlreadyExistsException e) {
             verifyNoMoreInteractions(activityEventService);
@@ -182,7 +179,7 @@ public class ConsentServiceMockTest {
     @Test
     public void noActivityEventIfDaoFails() {
         try {
-            consentService.consentToResearch(study, SubpopulationGuid.create("badGuid"), session, consentSignature, SharingScope.NO_SHARING, false);
+            consentService.consentToResearch(study, SubpopulationGuid.create("badGuid"), participant, consentSignature, SharingScope.NO_SHARING, false);
             fail("Exception expected.");
         } catch(Throwable e) {
             verifyNoMoreInteractions(activityEventService);
@@ -193,16 +190,16 @@ public class ConsentServiceMockTest {
     public void withdrawConsent() throws Exception {
         account.setEmail("bbb@bbb.com");
         
-        doReturn(new ParticipantOptionsLookup(ImmutableMap.of())).when(optionsService).getOptions(session.getParticipant().getHealthCode());
+        doReturn(new ParticipantOptionsLookup(ImmutableMap.of())).when(optionsService).getOptions(participant.getHealthCode());
         
         List<ConsentSignature> history = account.getConsentSignatureHistory(SUBPOP_GUID);
         history.add(consentSignature);
-        consentService.withdrawConsent(study, SUBPOP_GUID, session, new Withdrawal("For reasons."), SIGNED_ON);
+        consentService.withdrawConsent(study, SUBPOP_GUID, participant, new Withdrawal("For reasons."), SIGNED_ON);
         
         ArgumentCaptor<Account> captor = ArgumentCaptor.forClass(Account.class);
         ArgumentCaptor<MimeTypeEmailProvider> emailCaptor = ArgumentCaptor.forClass(MimeTypeEmailProvider.class);
         
-        verify(accountDao).getAccount(study, session.getParticipant().getId());
+        verify(accountDao).getAccount(study, participant.getId());
         verify(accountDao).updateAccount(captor.capture());
         // It happens twice because we do it the first time to set up the test properly
         //verify(account, times(2)).getConsentSignatures(setterCaptor.capture());
@@ -214,7 +211,6 @@ public class ConsentServiceMockTest {
         assertNull(account.getActiveConsentSignature(SUBPOP_GUID));
         assertNotNull(account.getConsentSignatureHistory(SUBPOP_GUID).get(0).getWithdrewOn());
         assertEquals(1, account.getConsentSignatureHistory(SUBPOP_GUID).size());
-        assertFalse(session.doesConsent());
         
         MimeTypeEmailProvider provider = emailCaptor.getValue();
         MimeTypeEmail email = provider.getMimeTypeEmail();
@@ -224,9 +220,6 @@ public class ConsentServiceMockTest {
         assertEquals("Notification of consent withdrawal for Test Study [ConsentServiceMockTest]", email.getSubject());
         assertEquals("<p>User   &lt;bbb@bbb.com&gt; withdrew from the study on October 28, 2015. </p><p>Reason:</p><p>For reasons.</p>", 
                     email.getMessageParts().get(0).getContent());
-        
-        assertFalse(session.doesConsent());
-        assertEquals(SharingScope.NO_SHARING, session.getParticipant().getSharingScope());
     }
     
     @Test
@@ -234,7 +227,7 @@ public class ConsentServiceMockTest {
         when(accountDao.getAccount(any(), any())).thenThrow(new BridgeServiceException("Something bad happend", 500));
         
         try {
-            consentService.withdrawConsent(study, SUBPOP_GUID, session, new Withdrawal("For reasons."), DateTime.now().getMillis());
+            consentService.withdrawConsent(study, SUBPOP_GUID, participant, new Withdrawal("For reasons."), DateTime.now().getMillis());
             fail("Should have thrown an exception");
         } catch(BridgeServiceException e) {
         }

--- a/test/org/sagebionetworks/bridge/services/ConsentServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ConsentServiceTest.java
@@ -36,6 +36,7 @@ import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.accounts.UserConsentHistory;
+import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.accounts.Withdrawal;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
@@ -69,6 +70,9 @@ public class ConsentServiceTest {
 
     @Resource
     private ParticipantOptionsService optionsService;
+    
+    @Resource
+    private AuthenticationService authenticationService;
 
     @Resource
     private SubpopulationService subpopService;
@@ -121,8 +125,7 @@ public class ConsentServiceTest {
     @Test
     public void userHasNotGivenConsent() {
         // These are all the consents that apply to the user, and none of them are signed
-        Map<SubpopulationGuid,ConsentStatus> statuses = consentService.getConsentStatuses(context);
-        assertNotConsented(statuses);
+        assertNotConsented();
         
         Account account = accountDao.getAccount(testUser.getStudy(), testUser.getId());
         List<UserConsentHistory> histories = consentService.getUserConsentHistory(account,
@@ -150,7 +153,7 @@ public class ConsentServiceTest {
         SharingScope scope = optionsService.getOptions(testUser.getHealthCode()).getEnum(SHARING_SCOPE, SharingScope.class);
         assertEquals(SharingScope.NO_SHARING, scope);
         
-        consentService.consentToResearch(testUser.getStudy(), defaultSubpopulation.getGuid(), testUser.getSession(),
+        consentService.consentToResearch(testUser.getStudy(), defaultSubpopulation.getGuid(), testUser.getStudyParticipant(),
                 signature, SharingScope.ALL_QUALIFIED_RESEARCHERS, false);
         
         // Verify we just set the options
@@ -169,15 +172,11 @@ public class ConsentServiceTest {
         assertEquals(signedOn, returnedSig.getSignedOn());
 
         // Withdraw consent and verify.
-        consentService.withdrawConsent(testUser.getStudy(), defaultSubpopulation.getGuid(), testUser.getSession(), WITHDRAWAL, WITHDRAWAL_TIMESTAMP);
+        consentService.withdrawConsent(testUser.getStudy(), defaultSubpopulation.getGuid(), testUser.getStudyParticipant(), WITHDRAWAL, WITHDRAWAL_TIMESTAMP);
         
         // No longer consented.
         statuses = consentService.getConsentStatuses(context);
         assertFalse(ConsentStatus.isUserConsented(statuses));
-        
-        // No more sharing status
-        scope = optionsService.getOptions(testUser.getHealthCode()).getEnum(SHARING_SCOPE, SharingScope.class);
-        assertEquals(SharingScope.NO_SHARING, scope);
         
         // Consent signature is no longer found, it's effectively deleted
         try {
@@ -206,21 +205,21 @@ public class ConsentServiceTest {
         // This will work
         ConsentSignature sig = new ConsentSignature.Builder().withName("Test User")
                 .withBirthdate(DateUtils.getCalendarDateString(today18YearsAgo)).build();
-        consentService.consentToResearch(study, defaultSubpopulation.getGuid(), testUser.getSession(), sig, sharingScope, false);
+        consentService.consentToResearch(study, defaultSubpopulation.getGuid(), testUser.getStudyParticipant(), sig, sharingScope, false);
 
-        consentService.withdrawConsent(study, defaultSubpopulation.getGuid(), testUser.getSession(), WITHDRAWAL, WITHDRAWAL_TIMESTAMP);
+        consentService.withdrawConsent(study, defaultSubpopulation.getGuid(), testUser.getStudyParticipant(), WITHDRAWAL, WITHDRAWAL_TIMESTAMP);
 
         // Also okay
         sig = new ConsentSignature.Builder().withName("Test User")
                 .withBirthdate(DateUtils.getCalendarDateString(yesterday18YearsAgo)).build();
-        consentService.consentToResearch(study, defaultSubpopulation.getGuid(), testUser.getSession(), sig, sharingScope, false);
-        consentService.withdrawConsent(study, defaultSubpopulation.getGuid(), testUser.getSession(), WITHDRAWAL, WITHDRAWAL_TIMESTAMP);
+        consentService.consentToResearch(study, defaultSubpopulation.getGuid(), testUser.getStudyParticipant(), sig, sharingScope, false);
+        consentService.withdrawConsent(study, defaultSubpopulation.getGuid(), testUser.getStudyParticipant(), WITHDRAWAL, WITHDRAWAL_TIMESTAMP);
 
         // But this is not, one day to go
         try {
             sig = new ConsentSignature.Builder().withName("Test User")
                     .withBirthdate(DateUtils.getCalendarDateString(tomorrow18YearsAgo)).build();
-            consentService.consentToResearch(study, defaultSubpopulation.getGuid(), testUser.getSession(), sig, sharingScope, false);
+            consentService.consentToResearch(study, defaultSubpopulation.getGuid(), testUser.getStudyParticipant(), sig, sharingScope, false);
             fail("This should throw an exception");
         } catch (InvalidEntityException e) {
             assertTrue(e.getMessage().contains("years of age or older"));
@@ -234,19 +233,17 @@ public class ConsentServiceTest {
         ConsentSignature consent = new ConsentSignature.Builder().withName("John Smith")
                 .withBirthdate("1990-11-11").build();
 
-        consentService.consentToResearch(testUser.getStudy(), defaultSubpopulation.getGuid(), testUser.getSession(), consent,
+        consentService.consentToResearch(testUser.getStudy(), defaultSubpopulation.getGuid(), testUser.getStudyParticipant(), consent,
                 SharingScope.SPONSORS_AND_PARTNERS, false);
 
         // There are two places where you can get statuses, the original service, or the user. Verify both each time
-        assertConsented(consentService.getConsentStatuses(context), true);
-        assertConsented(testUser.getSession().getConsentStatuses(), true);
+        assertConsented(true);
 
         // Create new study consent, but do not activate it. User is consented and has still signed most recent consent.
         StudyConsent newStudyConsent = studyConsentService.addConsent(defaultSubpopulation.getGuid(), defaultConsentDocument)
                 .getStudyConsent();
 
-        assertConsented(consentService.getConsentStatuses(context), true);
-        assertConsented(testUser.getSession().getConsentStatuses(), true);
+        assertConsented(true);
 
         // Public the new study consent. User is consented and but has no longer signed the most recent consent.
         newStudyConsent = studyConsentService
@@ -256,18 +253,16 @@ public class ConsentServiceTest {
         // or subpopulations. Not until the session is refreshed.
         testUser.getSession().setConsentStatuses(consentService.getConsentStatuses(context));
         
-        assertConsented(consentService.getConsentStatuses(context), false);
-        assertConsented(testUser.getSession().getConsentStatuses(), false);
+        assertConsented(false);
 
         // To consent again, first need to withdraw. User is consented and has now signed most recent consent.
-        consentService.withdrawConsent(testUser.getStudy(), defaultSubpopulation.getGuid(), testUser.getSession(), WITHDRAWAL, WITHDRAWAL_TIMESTAMP);
+        consentService.withdrawConsent(testUser.getStudy(), defaultSubpopulation.getGuid(), testUser.getStudyParticipant(), WITHDRAWAL, WITHDRAWAL_TIMESTAMP);
         
-        consentService.consentToResearch(testUser.getStudy(), defaultSubpopulation.getGuid(), testUser.getSession(),
+        consentService.consentToResearch(testUser.getStudy(), defaultSubpopulation.getGuid(), testUser.getStudyParticipant(),
             new ConsentSignature.Builder().withConsentSignature(consent).withSignedOn(DateTime.now().getMillis()).build(),
             SharingScope.SPONSORS_AND_PARTNERS, false);
 
-        assertConsented(consentService.getConsentStatuses(context), true);
-        assertConsented(testUser.getSession().getConsentStatuses(), true);
+        assertConsented(true);
     }
     
     @Test
@@ -275,20 +270,18 @@ public class ConsentServiceTest {
         long originalSignedOn = DateTime.now().getMillis();
         ConsentSignature consent = makeSignature(originalSignedOn);
 
-        consentService.consentToResearch(testUser.getStudy(), defaultSubpopulation.getGuid(), testUser.getSession(), consent,
+        consentService.consentToResearch(testUser.getStudy(), defaultSubpopulation.getGuid(), testUser.getStudyParticipant(), consent,
                 SharingScope.SPONSORS_AND_PARTNERS, false);
 
         // Consent exists, user is consented
-        Map<SubpopulationGuid,ConsentStatus> statuses = consentService.getConsentStatuses(context);
-        assertConsented(statuses, true);
+        assertConsented(true);
         assertNotNull(consentService.getConsentSignature(testUser.getStudy(), defaultSubpopulation.getGuid(), testUser.getId()));
         
         // Now withdraw consent
-        consentService.withdrawConsent(testUser.getStudy(), defaultSubpopulation.getGuid(), testUser.getSession(), WITHDRAWAL, WITHDRAWAL_TIMESTAMP);
+        consentService.withdrawConsent(testUser.getStudy(), defaultSubpopulation.getGuid(), testUser.getStudyParticipant(), WITHDRAWAL, WITHDRAWAL_TIMESTAMP);
         
         // Now user is not consented
-        statuses = consentService.getConsentStatuses(context);
-        assertNotConsented(statuses);
+        assertNotConsented();
         try {
             consentService.getConsentSignature(testUser.getStudy(), defaultSubpopulation.getGuid(), testUser.getId());            
         } catch(EntityNotFoundException e) {
@@ -307,10 +300,10 @@ public class ConsentServiceTest {
         
         long newSignedOn = DateTime.now().getMillis();
         consent = new ConsentSignature.Builder().withConsentSignature(consent).withSignedOn(newSignedOn).build();
-        consentService.consentToResearch(testUser.getStudy(), defaultSubpopulation.getGuid(), testUser.getSession(), consent,
+        consentService.consentToResearch(testUser.getStudy(), defaultSubpopulation.getGuid(), testUser.getStudyParticipant(), consent,
                 SharingScope.SPONSORS_AND_PARTNERS, false);
 
-        assertConsented(testUser.getSession().getConsentStatuses(), true);
+        assertConsented(true);
         
         // The account object is not updated at this point. Actually the session isn't either.
         account = accountDao.getAccount(testUser.getStudy(), testUser.getId());
@@ -359,43 +352,39 @@ public class ConsentServiceTest {
         
         Map<SubpopulationGuid,ConsentStatus> statuses = consentService.getConsentStatuses(context);
         assertEquals(3, statuses.size());
-        assertNotConsented(statuses);
+        assertNotConsented();
         
-        consentService.consentToResearch(study, defaultSubpopulation.getGuid(), testUser.getSession(),
+        consentService.consentToResearch(study, defaultSubpopulation.getGuid(), testUser.getStudyParticipant(),
                 makeSignature(DateTime.now().getMillis()), SharingScope.ALL_QUALIFIED_RESEARCHERS, false);
         
-        statuses = consentService.getConsentStatuses(context);
-        assertNotConsented(statuses);
+        assertNotConsented();
         
-        consentService.consentToResearch(study, requiredSubpop.getGuid(), testUser.getSession(),
+        consentService.consentToResearch(study, requiredSubpop.getGuid(), testUser.getStudyParticipant(),
                 makeSignature(DateTime.now().getMillis()), SharingScope.ALL_QUALIFIED_RESEARCHERS, false);        
         
-        statuses = consentService.getConsentStatuses(context);
-        assertConsented(statuses, true);
+        assertConsented(true);
         
-        consentService.withdrawConsent(study, defaultSubpopulation.getGuid(), testUser.getSession(), WITHDRAWAL,
+        consentService.withdrawConsent(study, defaultSubpopulation.getGuid(), testUser.getStudyParticipant(), WITHDRAWAL,
                 DateTime.now().getMillis());
         
-        // your sharing has been turned off because not all required consents are signed
-        SharingScope scope = optionsService.getOptions(testUser.getHealthCode()).getEnum(SHARING_SCOPE, SharingScope.class);
-        assertEquals(SharingScope.NO_SHARING, scope);
-        
+        assertNotConsented();
         statuses = consentService.getConsentStatuses(context);
-        assertNotConsented(statuses);
         assertFalse(statuses.get(defaultSubpopulation.getGuid()).isConsented());
         assertTrue(statuses.get(requiredSubpop.getGuid()).isConsented());
         assertFalse(statuses.get(optionalSubpop.getGuid()).isConsented());
         // Just verify that it now doesn't appear to exist, so this is an exception
         try {
-            consentService.withdrawConsent(study, defaultSubpopulation.getGuid(), testUser.getSession(), WITHDRAWAL, WITHDRAWAL_TIMESTAMP);
+            consentService.withdrawConsent(study, defaultSubpopulation.getGuid(), testUser.getStudyParticipant(),
+                    WITHDRAWAL, WITHDRAWAL_TIMESTAMP);
             fail("Should have thrown exception");
         } catch(EntityNotFoundException e) {
         }
         
-        consentService.withdrawConsent(study, requiredSubpop.getGuid(), testUser.getSession(), WITHDRAWAL, WITHDRAWAL_TIMESTAMP);
+        consentService.withdrawConsent(study, requiredSubpop.getGuid(), testUser.getStudyParticipant(), WITHDRAWAL,
+                WITHDRAWAL_TIMESTAMP);
         
+        assertNotConsented();
         statuses = consentService.getConsentStatuses(context);
-        assertNotConsented(statuses);
         assertFalse(statuses.get(defaultSubpopulation.getGuid()).isConsented());
         assertFalse(statuses.get(requiredSubpop.getGuid()).isConsented());
         assertFalse(statuses.get(optionalSubpop.getGuid()).isConsented()); // still false
@@ -418,10 +407,10 @@ public class ConsentServiceTest {
         Map<SubpopulationGuid,ConsentStatus> statuses = consentService.getConsentStatuses(context);
         testUser.getSession().setConsentStatuses(statuses);
         
-        consentService.consentToResearch(study, defaultSubpopulation.getGuid(), testUser.getSession(),
+        consentService.consentToResearch(study, defaultSubpopulation.getGuid(), testUser.getStudyParticipant(),
                 makeSignature(DateTime.now().getMillis()), SharingScope.ALL_QUALIFIED_RESEARCHERS, false);
         
-        consentService.consentToResearch(study, secondRequiredSubpop.getGuid(), testUser.getSession(),
+        consentService.consentToResearch(study, secondRequiredSubpop.getGuid(), testUser.getStudyParticipant(),
                 makeSignature(DateTime.now().getMillis()), SharingScope.ALL_QUALIFIED_RESEARCHERS, false);
         
         // The third we leave alone, but we want to be sure this doesn't break withdrawing from the other consents.
@@ -432,9 +421,6 @@ public class ConsentServiceTest {
         consentService.withdrawAllConsents(study, testUser.getId(), WITHDRAWAL, WITHDRAWAL_TIMESTAMP);
         count = consentService.getConsentStatuses(context).values().stream().filter(ConsentStatus::isConsented).count();
         assertEquals(0, count);
-
-        SharingScope scope = optionsService.getOptions(testUser.getHealthCode()).getEnum(SHARING_SCOPE, SharingScope.class);
-        assertEquals(SharingScope.NO_SHARING, scope);
     }
     
     @Test
@@ -446,12 +432,12 @@ public class ConsentServiceTest {
         long firstSignatureTimestamp = DateTime.now().getMillis()-1500;
         long secondSignatureTimestamp = DateTime.now().getMillis();
         
-        consentService.consentToResearch(study, subpopGuid, testUser.getSession(),
+        consentService.consentToResearch(study, subpopGuid, testUser.getStudyParticipant(),
                 makeSignature(firstSignatureTimestamp), SharingScope.ALL_QUALIFIED_RESEARCHERS, false);
 
         // This doesn't work, consent is prevented
         try {
-            consentService.consentToResearch(study, subpopGuid, testUser.getSession(),
+            consentService.consentToResearch(study, subpopGuid, testUser.getStudyParticipant(),
                     makeSignature(secondSignatureTimestamp), SharingScope.ALL_QUALIFIED_RESEARCHERS, false);
             fail("Should have thrown exception");
         } catch(EntityAlreadyExistsException e) {
@@ -460,7 +446,7 @@ public class ConsentServiceTest {
         
         // withdraw your consent. This now withdraws all consents that don't have a withdrawnOn timestamp, 
         // so despite the conflict generated above, the rest of these tests will pass.
-        consentService.withdrawConsent(study, subpopGuid, testUser.getSession(),
+        consentService.withdrawConsent(study, subpopGuid, testUser.getStudyParticipant(),
                 new Withdrawal("Test user withdrawn."), DateTime.now().getMillis());        
         
         // You shouldn't be consented.
@@ -472,23 +458,42 @@ public class ConsentServiceTest {
         assertNull(account.getActiveConsentSignature(subpopGuid));
     }
     
-    private void assertConsented(Map<SubpopulationGuid,ConsentStatus> statuses, boolean signedMostRecent) {
-        assertTrue(ConsentStatus.isUserConsented(statuses));
-        assertTrue(testUser.getSession().doesConsent());
-        assertTrue(ConsentStatus.isUserConsented(testUser.getSession().getConsentStatuses()));
+    private void assertConsented(boolean signedMostRecent) {
+        // This is mostly about the user's session, which is no longer updated in the consent service. But the test
+        // is still useful to verify the changes have been persisted and will be present in an updated session, 
+        // so get and test that here...
+        UserSession session = testUser.getSession();
+        CriteriaContext context = new CriteriaContext.Builder()
+                .withHealthCode(session.getHealthCode())
+                .withUserId(session.getId())
+                .withUserDataGroups(session.getParticipant().getDataGroups())
+                .withStudyIdentifier(session.getStudyIdentifier())
+                .build();
+        UserSession updatedSession = authenticationService.updateSession(study, context);
+
+        assertTrue(ConsentStatus.isUserConsented(updatedSession.getConsentStatuses()));
+        assertTrue(updatedSession.doesConsent());
         if (signedMostRecent) {
-            assertTrue(ConsentStatus.isConsentCurrent(statuses));
-            assertTrue(testUser.getSession().hasSignedMostRecentConsent());
+            assertTrue(ConsentStatus.isConsentCurrent(updatedSession.getConsentStatuses()));
+            assertTrue(updatedSession.hasSignedMostRecentConsent());
         } else {
-            assertFalse(ConsentStatus.isConsentCurrent(statuses));
-            assertFalse(testUser.getSession().hasSignedMostRecentConsent());
+            assertFalse(ConsentStatus.isConsentCurrent(updatedSession.getConsentStatuses()));
+            assertFalse(updatedSession.hasSignedMostRecentConsent());
         }
     }
     
-    private void assertNotConsented(Map<SubpopulationGuid,ConsentStatus> statuses) {
-        assertFalse(ConsentStatus.isUserConsented(statuses));
-        assertFalse(testUser.getSession().doesConsent());
-        assertFalse(ConsentStatus.isUserConsented(testUser.getSession().getConsentStatuses()));
+    private void assertNotConsented() {
+        UserSession session = testUser.getSession();
+        CriteriaContext context = new CriteriaContext.Builder()
+                .withHealthCode(session.getHealthCode())
+                .withUserId(session.getId())
+                .withUserDataGroups(session.getParticipant().getDataGroups())
+                .withStudyIdentifier(session.getStudyIdentifier())
+                .build();
+        UserSession updatedSession = authenticationService.updateSession(study, context);
+        
+        assertFalse(ConsentStatus.isUserConsented(updatedSession.getConsentStatuses()));
+        assertFalse(updatedSession.doesConsent());
     }
     
     private ConsentSignature makeSignature(long originalSignedOn) {

--- a/test/org/sagebionetworks/bridge/services/ConsentServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ConsentServiceTest.java
@@ -250,7 +250,7 @@ public class ConsentServiceTest {
 
         // Public the new study consent. User is consented and but has no longer signed the most recent consent.
         newStudyConsent = studyConsentService
-                .publishConsent(study, defaultSubpopulation.getGuid(), newStudyConsent.getCreatedOn()).getStudyConsent();
+                .publishConsent(study, defaultSubpopulation, newStudyConsent.getCreatedOn()).getStudyConsent();
 
         // We need to manually update because the users consent status won't change due to changes in consents 
         // or subpopulations. Not until the session is refreshed.
@@ -323,7 +323,8 @@ public class ConsentServiceTest {
         assertNotNull(withdrawnConsent.getWithdrewOn());
         assertNull(activeConsent.getWithdrewOn());
         
-        StudyConsent studyConsent = studyConsentService.getActiveConsent(defaultSubpopulation.getGuid()).getStudyConsent();
+        StudyConsent studyConsent = studyConsentService
+                .getActiveConsent(testUser.getStudyIdentifier(), defaultSubpopulation).getStudyConsent();
 
         assertEquals(testUser.getHealthCode(), withdrawnConsent.getHealthCode());
         assertEquals(defaultSubpopulation.getGuidString(), withdrawnConsent.getSubpopulationGuid());

--- a/test/org/sagebionetworks/bridge/services/ConsentServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ConsentServiceTest.java
@@ -469,7 +469,7 @@ public class ConsentServiceTest {
                 .withUserDataGroups(session.getParticipant().getDataGroups())
                 .withStudyIdentifier(session.getStudyIdentifier())
                 .build();
-        UserSession updatedSession = authenticationService.updateSession(study, context);
+        UserSession updatedSession = authenticationService.getSession(study, context);
 
         assertTrue(ConsentStatus.isUserConsented(updatedSession.getConsentStatuses()));
         assertTrue(updatedSession.doesConsent());
@@ -490,7 +490,7 @@ public class ConsentServiceTest {
                 .withUserDataGroups(session.getParticipant().getDataGroups())
                 .withStudyIdentifier(session.getStudyIdentifier())
                 .build();
-        UserSession updatedSession = authenticationService.updateSession(study, context);
+        UserSession updatedSession = authenticationService.getSession(study, context);
         
         assertFalse(ConsentStatus.isUserConsented(updatedSession.getConsentStatuses()));
         assertFalse(updatedSession.doesConsent());

--- a/test/org/sagebionetworks/bridge/services/SendEmailIntegTest.java
+++ b/test/org/sagebionetworks/bridge/services/SendEmailIntegTest.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.services;
 
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 
 import java.io.IOException;
@@ -14,6 +15,7 @@ import org.sagebionetworks.bridge.dao.ParticipantOption.SharingScope;
 import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
+import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 import org.sagebionetworks.bridge.services.email.ConsentEmailProvider;
 import org.springframework.beans.factory.annotation.Value;
@@ -43,6 +45,9 @@ public class SendEmailIntegTest {
     
     @Resource
     private SendMailService sendEmailService;
+    
+    @Resource
+    private SubpopulationService subpopService;
 
     private String consentBodyTemplate;
     
@@ -58,8 +63,11 @@ public class SendEmailIntegTest {
                 .withSignedOn(DateUtils.getCurrentMillisFromEpoch()).build();
         final Study study = studyService.getStudy(TEST_STUDY_IDENTIFIER);
         
-        sendEmailService.sendEmail(new ConsentEmailProvider(study, SUBPOP_GUID, "bridge-testing@sagebase.org",
-                signature, SharingScope.SPONSORS_AND_PARTNERS, studyConsentService, consentBodyTemplate));
+        Subpopulation subpopulation = subpopService.getSubpopulation(TEST_STUDY, SUBPOP_GUID);
+        String htmlTemplate = studyConsentService.getActiveConsent(study.getStudyIdentifier(), subpopulation)
+                .getDocumentContent();
+        sendEmailService.sendEmail(new ConsentEmailProvider(study, "bridge-testing@sagebase.org",
+                signature, SharingScope.SPONSORS_AND_PARTNERS, htmlTemplate, consentBodyTemplate));
     }
     
 }

--- a/test/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceConsentTest.java
+++ b/test/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceConsentTest.java
@@ -26,6 +26,7 @@ import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
 import org.sagebionetworks.bridge.models.subpopulations.StudyConsent;
 import org.sagebionetworks.bridge.models.subpopulations.StudyConsentView;
+import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 import org.sagebionetworks.bridge.services.email.ConsentEmailProvider;
 
@@ -51,6 +52,7 @@ public class SendMailViaAmazonServiceConsentTest {
     private ArgumentCaptor<SendRawEmailRequest> argument;
     private Study study;
     private String consentBodyTemplate;
+    private Subpopulation subpopulation;
     
     @Before
     public void setUp() throws Exception {
@@ -71,11 +73,14 @@ public class SendMailViaAmazonServiceConsentTest {
         service.setSupportEmail(FROM_DEFAULT_UNFORMATTED);
         service.setEmailClient(emailClient);
         
+        subpopulation = Subpopulation.create();
+        subpopulation.setGuidString("api");
+        
         StudyConsentView view = new StudyConsentView(mock(StudyConsent.class), 
             "<document>Had this been a real study: @@name@@ @@signing.date@@ @@email@@ @@sharing@@</document>");
         
         studyConsentService = mock(StudyConsentService.class);
-        when(studyConsentService.getActiveConsent(SubpopulationGuid.create("api"))).thenReturn(view);
+        when(studyConsentService.getActiveConsent(study.getStudyIdentifier(), subpopulation)).thenReturn(view);
     }
 
     @Test
@@ -88,9 +93,10 @@ public class SendMailViaAmazonServiceConsentTest {
         ConsentSignature consent = new ConsentSignature.Builder().withName("Test 2").withBirthdate("1950-05-05")
                 .withSignedOn(DateUtils.getCurrentMillisFromEpoch()).build();
         
-        ConsentEmailProvider provider = new ConsentEmailProvider(study, SubpopulationGuid.create(study.getIdentifier()),
-                "test-user@sagebase.org", consent, SharingScope.SPONSORS_AND_PARTNERS, studyConsentService,
-                consentBodyTemplate);
+        String htmlTemplate = studyConsentService.getActiveConsent(study.getStudyIdentifier(), subpopulation).getDocumentContent();
+        
+        ConsentEmailProvider provider = new ConsentEmailProvider(study, "test-user@sagebase.org", consent,
+                SharingScope.SPONSORS_AND_PARTNERS, htmlTemplate, consentBodyTemplate);
         service.sendEmail(provider);
 
         verify(emailClient).setRegion(any(Region.class));
@@ -125,9 +131,10 @@ public class SendMailViaAmazonServiceConsentTest {
                 .withBirthdate("1970-05-01").withImageData(TestConstants.DUMMY_IMAGE_DATA)
                 .withImageMimeType("image/fake").withSignedOn(DateUtils.getCurrentMillisFromEpoch()).build();
         
-        ConsentEmailProvider provider = new ConsentEmailProvider(study, SubpopulationGuid.create(study.getIdentifier()),
-                "test-user@sagebase.org", consent, SharingScope.SPONSORS_AND_PARTNERS, studyConsentService,
-                consentBodyTemplate);
+        String htmlTemplate = studyConsentService.getActiveConsent(study.getStudyIdentifier(), subpopulation).getDocumentContent();
+        
+        ConsentEmailProvider provider = new ConsentEmailProvider(study, "test-user@sagebase.org", consent,
+                SharingScope.SPONSORS_AND_PARTNERS, htmlTemplate, consentBodyTemplate);
         service.sendEmail(provider);
 
         verify(emailClient).setRegion(any(Region.class));
@@ -163,10 +170,11 @@ public class SendMailViaAmazonServiceConsentTest {
         // set up inputs
         ConsentSignature consent = new ConsentSignature.Builder().withName("Test 2").withBirthdate("1950-05-05")
                 .withSignedOn(DateUtils.getCurrentMillisFromEpoch()).build();
+        
+        String htmlTemplate = studyConsentService.getActiveConsent(study.getStudyIdentifier(), subpopulation).getDocumentContent();
 
-        ConsentEmailProvider provider = new ConsentEmailProvider(study, SubpopulationGuid.create(study.getIdentifier()),
-                "test-user@sagebase.org", consent, SharingScope.SPONSORS_AND_PARTNERS, studyConsentService,
-                consentBodyTemplate);
+        ConsentEmailProvider provider = new ConsentEmailProvider(study, "test-user@sagebase.org", consent,
+                SharingScope.SPONSORS_AND_PARTNERS, htmlTemplate, consentBodyTemplate);
 
         // execute
         service.sendEmail(provider);
@@ -184,10 +192,11 @@ public class SendMailViaAmazonServiceConsentTest {
         // set up inputs
         ConsentSignature consent = new ConsentSignature.Builder().withName("Test 2").withBirthdate("1950-05-05")
                 .withSignedOn(DateUtils.getCurrentMillisFromEpoch()).build();
+        
+        String htmlTemplate = studyConsentService.getActiveConsent(study.getStudyIdentifier(), subpopulation).getDocumentContent();
 
-        ConsentEmailProvider provider = new ConsentEmailProvider(study, SubpopulationGuid.create(study.getIdentifier()),
-                "test-user@sagebase.org", consent, SharingScope.SPONSORS_AND_PARTNERS, studyConsentService,
-                consentBodyTemplate);
+        ConsentEmailProvider provider = new ConsentEmailProvider(study, "test-user@sagebase.org", consent,
+                SharingScope.SPONSORS_AND_PARTNERS, htmlTemplate, consentBodyTemplate);
 
         // execute
         service.sendEmail(provider);

--- a/test/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceConsentTest.java
+++ b/test/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceConsentTest.java
@@ -27,7 +27,6 @@ import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
 import org.sagebionetworks.bridge.models.subpopulations.StudyConsent;
 import org.sagebionetworks.bridge.models.subpopulations.StudyConsentView;
 import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
-import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 import org.sagebionetworks.bridge.services.email.ConsentEmailProvider;
 
 import com.amazonaws.regions.Region;

--- a/test/org/sagebionetworks/bridge/services/StudyConsentServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyConsentServiceTest.java
@@ -3,7 +3,6 @@ package org.sagebionetworks.bridge.services;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.net.URL;
@@ -29,7 +28,6 @@ import org.sagebionetworks.bridge.models.subpopulations.StudyConsent;
 import org.sagebionetworks.bridge.models.subpopulations.StudyConsentForm;
 import org.sagebionetworks.bridge.models.subpopulations.StudyConsentView;
 import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
-import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 import org.sagebionetworks.bridge.s3.S3Helper;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -39,7 +37,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 public class StudyConsentServiceTest {
     
     private static final String BUCKET = BridgeConfigFactory.getConfig().getConsentsBucket();
-    private static final SubpopulationGuid SUBPOP_GUID = SubpopulationGuid.create("ABC");
+    //private static final SubpopulationGuid SUBPOP_GUID = SubpopulationGuid.create("ABC");
 
     @Resource
     private StudyConsentDao studyConsentDao;
@@ -53,7 +51,12 @@ public class StudyConsentServiceTest {
     @Resource
     private StudyConsentService studyConsentService;
     
+    @Resource
+    private SubpopulationService subpopService;
+    
     private Study study;
+    
+    private Subpopulation subpopulation;
     
     @Before
     public void before() {
@@ -63,11 +66,16 @@ public class StudyConsentServiceTest {
         study.setIdentifier(id);
         study.setName("StudyConsentServiceTest Name");
         study.setSponsorName("StudyConsentServiceTest Sponsor");
+        
+        subpopulation = Subpopulation.create();
+        subpopulation.setName("Subpopulation for StudyConsentServiceTest");
+        subpopService.createSubpopulation(study, subpopulation);
     }
     
     @After
     public void after() {
-        studyConsentDao.deleteAllConsents(SUBPOP_GUID);
+        studyConsentDao.deleteAllConsents(subpopulation.getGuid());
+        subpopService.deleteSubpopulation(study.getStudyIdentifier(), subpopulation.getGuid(), true);
     }
 
     @Test
@@ -75,48 +83,43 @@ public class StudyConsentServiceTest {
         String documentContent = "<p>This is a consent document.</p><p>This is the second paragraph of same.</p>";
         StudyConsentForm form = new StudyConsentForm(documentContent);
 
-        // addConsent should return a non-null consent object.
-        StudyConsentView addedConsent1 = studyConsentService.addConsent(SUBPOP_GUID, form);
-        assertNotNull(addedConsent1);
-
-        try {
-            studyConsentService.getActiveConsent(SUBPOP_GUID);
-            fail("getActiveConsent should throw exception, as there is no currently active consent.");
-        } catch (Exception e) {
-        }
-
-        // Get active consent returns the most recently activated consent document.
-        StudyConsentView activatedConsent = studyConsentService.publishConsent(study, SUBPOP_GUID, addedConsent1.getCreatedOn());
-        StudyConsentView getActiveConsent = studyConsentService.getActiveConsent(SUBPOP_GUID);
-        assertTrue(activatedConsent.getCreatedOn() == getActiveConsent.getCreatedOn());
+        StudyConsentView view = studyConsentService.getActiveConsent(study.getStudyIdentifier(), subpopulation);
+        assertEquals("<p>This is a placeholder for your consent document.</p>", view.getDocumentContent());
+        
+        view = studyConsentService.addConsent(subpopulation.getGuid(), form);
+        assertNotNull(view);
+        studyConsentService.publishConsent(study, subpopulation, view.getCreatedOn());
+        
+        StudyConsentView getActiveConsent = studyConsentService.getActiveConsent(study.getStudyIdentifier(), subpopulation);
+        assertTrue(view.getCreatedOn() == getActiveConsent.getCreatedOn());
         
         // This is "fixed" by the XML and sanitizing parse that happens. It's fine.
         assertEquals("<p>This is a consent document.</p>\n<p>This is the second paragraph of same.</p>", getActiveConsent.getDocumentContent());
         assertNotNull(getActiveConsent.getStudyConsent().getStoragePath());
-        
+
         // Get all consents returns one consent document (addedConsent).
-        List<StudyConsent> allConsents = studyConsentService.getAllConsents(SUBPOP_GUID);
-        assertTrue(allConsents.size() == 1);
+        List<StudyConsent> allConsents = studyConsentService.getAllConsents(subpopulation.getGuid());
+        assertEquals(2, allConsents.size());
     }
     
     @Test
     public void studyConsentWithFileAndS3ContentTakesS3Content() throws Exception {
         DateTime createdOn = DateTime.now();
-        String key = SUBPOP_GUID + "." + createdOn.getMillis();
+        String key = subpopulation.getGuidString() + "." + createdOn.getMillis();
         s3Helper.writeBytesToS3(BUCKET, key, "<document/>".getBytes());
         
-        StudyConsent consent = studyConsentDao.addConsent(SUBPOP_GUID, key, createdOn);
+        StudyConsent consent = studyConsentDao.addConsent(subpopulation.getGuid(), key, createdOn);
         studyConsentDao.publish(consent);
         // The junk path should not prevent the service from getting the S3 content.
         // We actually wouldn't get here if it tried to load from disk with the path we've provided.
-        StudyConsentView view = studyConsentService.getConsent(SUBPOP_GUID, createdOn.getMillis());
+        StudyConsentView view = studyConsentService.getConsent(subpopulation.getGuid(), createdOn.getMillis());
         assertEquals("<document/>", view.getDocumentContent());
     }
     
     @Test
     public void invalidMarkupIsFixed() {
         StudyConsentForm form = new StudyConsentForm("<cml><p>This is not valid XML.</cml>");
-        StudyConsentView view = studyConsentService.addConsent(SUBPOP_GUID, form);
+        StudyConsentView view = studyConsentService.addConsent(subpopulation.getGuid(), form);
         assertEquals("<p>This is not valid XML.</p>", view.getDocumentContent());
     }
     
@@ -125,7 +128,7 @@ public class StudyConsentServiceTest {
         String doc = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\"><html xmlns=\"http://www.w3.org/1999/xhtml\"><head><title></title></head><body><p>This is all the content that should be kept.</p><br><p>And this makes it a fragment.</p></body></html>";
         
         StudyConsentForm form = new StudyConsentForm(doc);
-        StudyConsentView view = studyConsentService.addConsent(SUBPOP_GUID, form);
+        StudyConsentView view = studyConsentService.addConsent(subpopulation.getGuid(), form);
         assertEquals("<p>This is all the content that should be kept.</p>\n<br />\n<p>And this makes it a fragment.</p>", view.getDocumentContent());
     }
     
@@ -137,7 +140,7 @@ public class StudyConsentServiceTest {
     @Test
     public void evenVeryBrokenContentIsFixed() {
         StudyConsentForm form = new StudyConsentForm("</script><div ankle='foo'>This just isn't a SGML-based document no matter how you slice it.</p><h4><img>");
-        StudyConsentView view = studyConsentService.addConsent(SUBPOP_GUID, form);
+        StudyConsentView view = studyConsentService.addConsent(subpopulation.getGuid(), form);
         assertEquals("<div>\n This just isn't a SGML-based document no matter how you slice it.\n <p></p>\n <h4><img /></h4>\n</div>", view.getDocumentContent());
     }
     
@@ -146,13 +149,11 @@ public class StudyConsentServiceTest {
         String content = "<p>"+BridgeUtils.generateGuid()+"</p>";
 
         StudyConsentForm form = new StudyConsentForm(content);
-        StudyConsentView view = studyConsentService.addConsent(SUBPOP_GUID, form);
-        studyConsentService.publishConsent(study, SUBPOP_GUID, view.getCreatedOn());
+        StudyConsentView view = studyConsentService.addConsent(subpopulation.getGuid(), form);
+        studyConsentService.publishConsent(study, subpopulation, view.getCreatedOn());
 
         // Now retrieve the HTML version of the document and verify it has been updated.
         // Removing SSL because IOUtils doesn't support it and although we do it, we don't need to.
-        Subpopulation subpopulation = Subpopulation.create();
-        subpopulation.setGuid(SUBPOP_GUID);
         String htmlURL = subpopulation.getConsentHTML();
         
         String retrievedContent = IOUtils.toString(new URL(htmlURL).openStream(), Charset.forName("UTF-8"));

--- a/test/org/sagebionetworks/bridge/services/StudyConsentServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyConsentServiceTest.java
@@ -166,9 +166,9 @@ public class StudyConsentServiceTest {
         StudyConsentView view = studyConsentService.addConsent(subpopulation.getGuid(), form);        
         studyConsentService.publishConsent(study, subpopulation, view.getCreatedOn());
         
-        subpopulation.setActiveConsentCreatedOn(0L);
+        subpopulation.setPublishedConsentCreatedOn(0L);
         view = studyConsentService.getActiveConsent(study.getStudyIdentifier(), subpopulation);
-        assertEquals(subpopulation.getActiveConsentCreatedOn(), view.getCreatedOn());
+        assertEquals(subpopulation.getPublishedConsentCreatedOn(), view.getCreatedOn());
     }
     
     @Test
@@ -177,9 +177,9 @@ public class StudyConsentServiceTest {
         StudyConsentView view = studyConsentService.addConsent(subpopulation.getGuid(), form);        
         studyConsentService.publishConsent(study, subpopulation, view.getCreatedOn());
         
-        assertTrue(subpopulation.getActiveConsentCreatedOn() > 0L);
+        assertTrue(subpopulation.getPublishedConsentCreatedOn() > 0L);
         view = studyConsentService.getActiveConsent(study.getStudyIdentifier(), subpopulation);
-        assertEquals(subpopulation.getActiveConsentCreatedOn(), view.getCreatedOn());
+        assertEquals(subpopulation.getPublishedConsentCreatedOn(), view.getCreatedOn());
     }
     
     @Test
@@ -189,7 +189,7 @@ public class StudyConsentServiceTest {
         StudyConsentView view = studyConsentService.addConsent(subpopulation.getGuid(), form);
 
         studyConsentService.publishConsent(study, subpopulation, view.getCreatedOn());
-        assertEquals(subpopulation.getActiveConsentCreatedOn(), view.getCreatedOn());
+        assertEquals(subpopulation.getPublishedConsentCreatedOn(), view.getCreatedOn());
     }
     
     //- verify the get* methods all continue to work even with a subpopulation that has 0L timestamp

--- a/test/org/sagebionetworks/bridge/services/StudyServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceTest.java
@@ -33,6 +33,7 @@ import org.sagebionetworks.bridge.models.studies.MimeType;
 import org.sagebionetworks.bridge.models.studies.PasswordPolicy;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.subpopulations.StudyConsentView;
+import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,6 +51,9 @@ public class StudyServiceTest {
     
     @Resource
     StudyConsentService studyConsentService;
+    
+    @Resource
+    SubpopulationService subpopService;
     
     @Resource
     DirectoryDao directoryDao;
@@ -128,7 +132,9 @@ public class StudyServiceTest {
         reset(mockCache);
         
         // A default, active consent should be created for the study.
-        StudyConsentView view = studyConsentService.getActiveConsent(SubpopulationGuid.create(study.getIdentifier()));
+        Subpopulation subpop = subpopService.getSubpopulation(study.getStudyIdentifier(),
+                SubpopulationGuid.create(study.getIdentifier()));
+        StudyConsentView view = studyConsentService.getActiveConsent(study.getStudyIdentifier(), subpop);
         assertTrue(view.getDocumentContent().contains("This is a placeholder for your consent document."));
         assertTrue(view.getActive());
         

--- a/test/org/sagebionetworks/bridge/services/SubpopulationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SubpopulationServiceTest.java
@@ -122,7 +122,7 @@ public class SubpopulationServiceTest {
         
         verify(dao).createSubpopulation(subpop);
         verify(studyConsentService).addConsent(eq(result.getGuid()), any());
-        verify(studyConsentService).publishConsent(study, result.getGuid(), CONSENT_CREATED_ON);
+        verify(studyConsentService).publishConsent(study, result, CONSENT_CREATED_ON);
     }
     
     @Test
@@ -133,6 +133,7 @@ public class SubpopulationServiceTest {
         StudyConsentView view = new StudyConsentView(new DynamoStudyConsent1(), "");
         Subpopulation subpop = Subpopulation.create();
         SubpopulationGuid defaultGuid = SubpopulationGuid.create("test-study");
+        subpop.setGuid(defaultGuid);
         
         ArgumentCaptor<StudyConsentForm> captor = ArgumentCaptor.forClass(StudyConsentForm.class);
         
@@ -143,7 +144,7 @@ public class SubpopulationServiceTest {
         // No consents, so we add and publish one.
         Subpopulation returnValue = service.createDefaultSubpopulation(study);
         verify(studyConsentService).addConsent(any(), captor.capture());
-        verify(studyConsentService).publishConsent(eq(study), eq(defaultGuid), any(Long.class));
+        verify(studyConsentService).publishConsent(eq(study), eq(subpop), any(Long.class));
         assertEquals(subpop, returnValue);
         
         // This used the default document.

--- a/test/org/sagebionetworks/bridge/services/UserAdminServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/UserAdminServiceMockTest.java
@@ -98,7 +98,7 @@ public class UserAdminServiceMockTest {
         assertEquals(participant.getPassword(), signIn.getPassword());
         
         for (SubpopulationGuid guid : session.getConsentStatuses().keySet()) {
-            verify(consentService).consentToResearch(eq(study), eq(guid), eq(session), any(), eq(SharingScope.NO_SHARING), eq(false));
+            verify(consentService).consentToResearch(eq(study), eq(guid), any(StudyParticipant.class), any(), eq(SharingScope.NO_SHARING), eq(false));
         }
     }
     
@@ -113,11 +113,11 @@ public class UserAdminServiceMockTest {
         verify(participantService).createParticipant(study, Sets.newHashSet(Roles.ADMIN), participant, false);
         
         // consented to the indicated subpopulation
-        verify(consentService).consentToResearch(eq(study), eq(consentedGuid), eq(session), any(), eq(SharingScope.NO_SHARING), eq(false));
+        verify(consentService).consentToResearch(eq(study), eq(consentedGuid), any(StudyParticipant.class), any(), eq(SharingScope.NO_SHARING), eq(false));
         // but not to the other two
         for (SubpopulationGuid guid : session.getConsentStatuses().keySet()) {
             if (guid != consentedGuid) {
-                verify(consentService, never()).consentToResearch(eq(study), eq(guid), eq(session), any(), eq(SharingScope.NO_SHARING), eq(false));    
+                verify(consentService, never()).consentToResearch(eq(study), eq(guid), eq(participant), any(), eq(SharingScope.NO_SHARING), eq(false));    
             }
         }
     }


### PR DESCRIPTION
- Moving the consentCreatedOn value of the active consent to the subpopulation. We're using it to find the active consent once it has been set (need to run migration). Now there can only be one active consent because it is treated as a foreign key, not a flag we need to scan for in the StudyConsent table
- Pushed UserSession out of the ConsentService, as well as updating the session in the service. This is now done in the controller after methods that logically update the session. This makes refactoring ConsentService easier, and I don't believe session should be passed to any service.
- Added a migration to find and copy the active consentCreatedOn value to the subpopulations.
- moved StudyConsentService out of the ConsentEmailProvider, which simplifies that provider and was made possible by the above changes.
