### PR TITLE
On updating a subpopulation, verify that the consent createdOn timest…

### DIFF
--- a/app/org/sagebionetworks/bridge/services/SubpopulationService.java
+++ b/app/org/sagebionetworks/bridge/services/SubpopulationService.java
@@ -104,6 +104,8 @@ public class SubpopulationService {
 
         // Verify this subpopulation is part of the study
         getSubpopulation(study, subpop.getGuid());
+        // Verify that the consent createdOn field points to a real study consent.
+        studyConsentService.getConsent(subpop.getGuid(), subpop.getPublishedConsentCreatedOn());
         
         Validator validator = new SubpopulationValidator(study.getDataGroups());
         Validate.entityThrowingException(validator, subpop);


### PR DESCRIPTION
…amp is valid (it points at an existing consent).
