### PR TITLE
Copying existing publication timestamp into a subpopulation before updating it,

### DIFF
--- a/app/org/sagebionetworks/bridge/services/SubpopulationService.java
+++ b/app/org/sagebionetworks/bridge/services/SubpopulationService.java
@@ -102,8 +102,12 @@ public class SubpopulationService {
         
         subpop.setStudyIdentifier(study.getIdentifier());
 
-        // Verify this subpopulation is part of the study
-        getSubpopulation(study, subpop.getGuid());
+        // Verify this subpopulation is part of the study. Existing code also doesn't submit
+        // this publication timestamp back to the server, so set if it doesn't exist.
+        Subpopulation existingSubpop = getSubpopulation(study, subpop.getGuid());
+        if (subpop.getPublishedConsentCreatedOn() == 0L) {
+            subpop.setPublishedConsentCreatedOn(existingSubpop.getPublishedConsentCreatedOn());
+        }
         // Verify that the consent createdOn field points to a real study consent.
         studyConsentService.getConsent(subpop.getGuid(), subpop.getPublishedConsentCreatedOn());
         

--- a/test/org/sagebionetworks/bridge/services/SubpopulationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SubpopulationServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -210,6 +211,23 @@ public class SubpopulationServiceTest {
         } catch(EntityNotFoundException e) {
             assertEquals("StudyConsent not found.", e.getMessage());
         }
+    }
+    
+    @Test
+    public void updateSubpopulationSetsConsentCreatedOn() {
+        doReturn(1000L).when(view).getCreatedOn();
+        when(studyConsentService.getConsent(anyObject(), anyLong())).thenReturn(view);
+        
+        Subpopulation subpop = Subpopulation.create();
+        subpop.setName("Name");
+        subpop.setGuidString("test-guid");
+        
+        Subpopulation existing = Subpopulation.create();
+        existing.setPublishedConsentCreatedOn(1000L);
+        when(dao.getSubpopulation(any(), any())).thenReturn(existing);
+        
+        Subpopulation updated = service.updateSubpopulation(study, subpop);
+        assertEquals(1000L, updated.getPublishedConsentCreatedOn());
     }
     
     @Test


### PR DESCRIPTION
if the value is zero. (Current clients do not submit it back, so this prevents them from breaking).
