### PR TITLE
Finish consent migration

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/StudyConsentDao.java
+++ b/app/org/sagebionetworks/bridge/dao/StudyConsentDao.java
@@ -18,20 +18,7 @@ public interface StudyConsentDao {
      * @param createdOn
      */
     StudyConsent addConsent(SubpopulationGuid subpopGuid, String storagePath, DateTime createdOn);
-
-    /**
-     * Set this consent to be the one and only activate consent record.
-     * @param studyConsent
-     * @return
-     */
-    StudyConsent publish(StudyConsent studyConsent);
     
-    /**
-     * Gets the active consent.
-     * @param subpopGuid
-     */
-    StudyConsent getActiveConsent(SubpopulationGuid subpopGuid);
-
     /**
      * Gets the most recent consent (active or not).
      * @param subpopGuid

--- a/app/org/sagebionetworks/bridge/dao/StudyConsentDao.java
+++ b/app/org/sagebionetworks/bridge/dao/StudyConsentDao.java
@@ -2,45 +2,34 @@ package org.sagebionetworks.bridge.dao;
 
 import java.util.List;
 
-import org.joda.time.DateTime;
-
 import org.sagebionetworks.bridge.models.subpopulations.StudyConsent;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 
 public interface StudyConsentDao {
 
     /**
-     * Adds a consent to the study. Must provide either a path to a filesystem resource (deprecated), or the 
-     * name of an S3 bucket as the storagePath for the document content. Note the consent is added as
-     * inactive. Must explicitly set it active.
-     * @param subpopGuid
-     * @param storagePath
-     * @param createdOn
+     * Adds a consent to the study.
      */
-    StudyConsent addConsent(SubpopulationGuid subpopGuid, String storagePath, DateTime createdOn);
+    StudyConsent addConsent(SubpopulationGuid subpopGuid, String storagePath, long createdOn);
     
     /**
-     * Gets the most recent consent (active or not).
-     * @param subpopGuid
+     * Gets the most recent consent (consent with the most recent createdOn timestamp).
      */
     StudyConsent getMostRecentConsent(SubpopulationGuid subpopGuid);
     
     /**
-     * Gets the consent, activate or inactive, of the specified timestamp.
-     * @param subpopGuid
-     * @param timestamp
+     * Gets the consent created at the specified timestamp.
      */
-    StudyConsent getConsent(SubpopulationGuid subpopGuid, long timestamp);
+    StudyConsent getConsent(SubpopulationGuid subpopGuid, long consentCreatedOn);
 
     /**
-     * Delete all the consents for a study. Only call when deleting a study.
-     * @param subpopGuid
+     * Delete all the consents for a subpopulation. Only call when physically deleting a subpopulation
+     * (usually as part of a test).
      */
     void deleteAllConsents(SubpopulationGuid subpopGuid);
     
     /**
-     * Gets all the consents, active and inactive, in reverse order of the timestamp, of a particular study.
-     * @param subpopGuid
+     * Gets all the consents in reverse order of the timestamp, for a particularly subpopulation.
      */
     List<StudyConsent> getConsents(SubpopulationGuid subpopGuid);
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoStudyConsent1.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoStudyConsent1.java
@@ -20,7 +20,6 @@ public final class DynamoStudyConsent1 implements StudyConsent {
 
     private String subpopGuid;
     private long createdOn;
-    private boolean active;
     private String storagePath;
     private Long version;
 
@@ -42,15 +41,6 @@ public final class DynamoStudyConsent1 implements StudyConsent {
     @JsonDeserialize(using = DateTimeToPrimitiveLongDeserializer.class)
     public void setCreatedOn(long timestamp) {
         this.createdOn = timestamp;
-    }
-    
-    @Override
-    @DynamoDBAttribute
-    public boolean getActive() {
-        return active;
-    }
-    public void setActive(boolean active) {
-        this.active = active;    
     }
 
     @Override
@@ -74,7 +64,7 @@ public final class DynamoStudyConsent1 implements StudyConsent {
     
     @Override
     public int hashCode() {
-        return Objects.hash(active, createdOn, storagePath, subpopGuid, version);
+        return Objects.hash(createdOn, storagePath, subpopGuid, version);
     }
     @Override
     public boolean equals(Object obj) {
@@ -83,14 +73,13 @@ public final class DynamoStudyConsent1 implements StudyConsent {
         if (obj == null || getClass() != obj.getClass())
             return false;
         DynamoStudyConsent1 other = (DynamoStudyConsent1) obj;
-        return (Objects.equals(active, other.active) && Objects.equals(createdOn, other.createdOn)
-                && Objects.equals(storagePath, other.storagePath) && Objects.equals(subpopGuid, other.subpopGuid)
-                && Objects.equals(version, other.version));
+        return (Objects.equals(createdOn, other.createdOn) && Objects.equals(storagePath, other.storagePath) 
+                && Objects.equals(subpopGuid, other.subpopGuid) && Objects.equals(version, other.version));
     }
     
     @Override
     public String toString() {
-        return String.format("DynamoStudyConsent1 [subpopGuid=%s, createdOn=%s, active=%s, storagePath=%s, version=%s]",
-            subpopGuid, createdOn, active, storagePath, version);
+        return String.format("DynamoStudyConsent1 [subpopGuid=%s, createdOn=%s, storagePath=%s, version=%s]",
+            subpopGuid, createdOn, storagePath, version);
     }
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoStudyConsentDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoStudyConsentDao.java
@@ -87,11 +87,7 @@ public class DynamoStudyConsentDao implements StudyConsentDao {
                 .withHashKeyValues(hashKey)
                 .withScanIndexForward(false);
         
-        PaginatedQueryList<DynamoStudyConsent1> consents = mapper.query(DynamoStudyConsent1.class, queryExpression);
-        List<StudyConsent> consentsToDelete = new ArrayList<StudyConsent>();
-        for (DynamoStudyConsent1 consent : consents) {
-            consentsToDelete.add(consent);
-        }
+        List<? extends StudyConsent> consentsToDelete = mapper.query(DynamoStudyConsent1.class, queryExpression);
         if (!consentsToDelete.isEmpty()) {
             List<FailedBatch> failures = mapper.batchDelete(consentsToDelete);
             BridgeUtils.ifFailuresThrowException(failures);

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoStudyConsentDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoStudyConsentDao.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import javax.annotation.Resource;
 
-import org.joda.time.DateTime;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.dao.StudyConsentDao;
 import org.sagebionetworks.bridge.models.subpopulations.StudyConsent;
@@ -29,10 +28,10 @@ public class DynamoStudyConsentDao implements StudyConsentDao {
     }
     
     @Override
-    public StudyConsent addConsent(SubpopulationGuid subpopGuid, String storagePath, DateTime createdOn) {
+    public StudyConsent addConsent(SubpopulationGuid subpopGuid, String storagePath, long createdOn) {
         DynamoStudyConsent1 consent = new DynamoStudyConsent1();
         consent.setSubpopulationGuid(subpopGuid.getGuid());
-        consent.setCreatedOn(createdOn.getMillis());
+        consent.setCreatedOn(createdOn);
         consent.setStoragePath(storagePath);
         mapper.save(consent);
         return consent;
@@ -55,10 +54,10 @@ public class DynamoStudyConsentDao implements StudyConsentDao {
     }
     
     @Override
-    public StudyConsent getConsent(SubpopulationGuid subpopGuid, long timestamp) {
+    public StudyConsent getConsent(SubpopulationGuid subpopGuid, long consentCreatedOn) {
         DynamoStudyConsent1 consent = new DynamoStudyConsent1();
         consent.setSubpopulationGuid(subpopGuid.getGuid());
-        consent.setCreatedOn(timestamp);
+        consent.setCreatedOn(consentCreatedOn);
         return mapper.load(consent);
     }
 

--- a/app/org/sagebionetworks/bridge/models/subpopulations/StudyConsent.java
+++ b/app/org/sagebionetworks/bridge/models/subpopulations/StudyConsent.java
@@ -17,11 +17,6 @@ public interface StudyConsent extends BridgeEntity {
     long getCreatedOn();
 
     /**
-     * Whether the consent is active.
-     */
-    boolean getActive();
-
-    /**
      * Get the path to the storage of the consent document (probably in S3).
      */
     String getStoragePath();

--- a/app/org/sagebionetworks/bridge/models/subpopulations/StudyConsentView.java
+++ b/app/org/sagebionetworks/bridge/models/subpopulations/StudyConsentView.java
@@ -35,10 +35,6 @@ public class StudyConsentView {
         return consent.getCreatedOn();
     }
 
-    public boolean getActive() {
-        return consent.getActive();
-    }
-
     @JsonIgnore
     public StudyConsent getStudyConsent() {
         return consent;

--- a/app/org/sagebionetworks/bridge/play/controllers/StudyConsentController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/StudyConsentController.java
@@ -98,7 +98,7 @@ public class StudyConsentController extends BaseController {
         // Throws 404 exception if this subpopulation is not part of the caller's study
         Subpopulation subpop = subpopService.getSubpopulation(studyId, subpopGuid);
         
-        StudyConsentView consent = studyConsentService.getActiveConsent(studyId, subpop);
+        StudyConsentView consent = studyConsentService.getActiveConsent(subpop);
         return okResult(consent);
     }
     

--- a/app/org/sagebionetworks/bridge/services/ConsentService.java
+++ b/app/org/sagebionetworks/bridge/services/ConsentService.java
@@ -146,7 +146,7 @@ public class ConsentService {
         Validate.entityThrowingException(validator, consentSignature);
 
         Subpopulation subpop = subpopService.getSubpopulation(study.getStudyIdentifier(), subpopGuid);
-        StudyConsentView studyConsent = studyConsentService.getActiveConsent(study.getStudyIdentifier(), subpop);
+        StudyConsentView studyConsent = studyConsentService.getActiveConsent(subpop);
         
         // If there's a signature to the current and active consent, user cannot consent again. They can sign
         // any other consent, including more recent consents.
@@ -302,8 +302,7 @@ public class ConsentService {
         SharingScope sharingScope = participant.getSharingScope();
         Subpopulation subpop = subpopService.getSubpopulation(study.getStudyIdentifier(), subpopGuid);
         
-        String htmlTemplate = studyConsentService.getActiveConsent(study.getStudyIdentifier(), subpop)
-                .getDocumentContent();
+        String htmlTemplate = studyConsentService.getActiveConsent(subpop).getDocumentContent();
         
         MimeTypeEmailProvider consentEmail = new ConsentEmailProvider(study, participant.getEmail(), consentSignature,
                 sharingScope, htmlTemplate, consentTemplate);

--- a/app/org/sagebionetworks/bridge/services/ConsentService.java
+++ b/app/org/sagebionetworks/bridge/services/ConsentService.java
@@ -22,10 +22,8 @@ import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
-import org.sagebionetworks.bridge.models.accounts.UserConsentHistory;
 import org.sagebionetworks.bridge.models.accounts.Withdrawal;
 import org.sagebionetworks.bridge.models.studies.Study;
-import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
 import org.sagebionetworks.bridge.models.subpopulations.StudyConsentView;
 import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
@@ -33,7 +31,6 @@ import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 import org.sagebionetworks.bridge.services.email.ConsentEmailProvider;
 import org.sagebionetworks.bridge.services.email.MimeTypeEmailProvider;
 import org.sagebionetworks.bridge.services.email.WithdrawConsentEmailProvider;
-import org.sagebionetworks.bridge.util.BridgeCollectors;
 import org.sagebionetworks.bridge.validators.ConsentAgeValidator;
 import org.sagebionetworks.bridge.validators.Validate;
 
@@ -45,7 +42,7 @@ import org.springframework.stereotype.Component;
 
 /**
  * Methods to consent a user to one of the subpopulations of a study. After calling most of these methods, the user's
- * session should be updated in part or in whole.
+ * session should be updated.
  */
 @Component
 public class ConsentService {
@@ -197,12 +194,11 @@ public class ConsentService {
         
         ImmutableMap.Builder<SubpopulationGuid, ConsentStatus> builder = new ImmutableMap.Builder<>();
         for (Subpopulation subpop : subpopService.getSubpopulationForUser(context)) {
-
-            List<ConsentSignature> signatures = account.getConsentSignatureHistory(subpop.getGuid());
-            ConsentSignature last = (signatures.isEmpty()) ? null : signatures.get(signatures.size()-1);
             
-            boolean hasConsented = (last != null && last.getWithdrewOn() == null);
-            boolean hasSignedActiveConsent = hasUserSignedActiveConsent(study.getStudyIdentifier(), last, subpop.getGuid());
+            ConsentSignature signature = account.getActiveConsentSignature(subpop.getGuid());
+            boolean hasConsented = (signature != null);
+            boolean hasSignedActiveConsent = (hasConsented && 
+                    signature.getConsentCreatedOn() == subpop.getPublishedConsentCreatedOn());
             
             ConsentStatus status = new ConsentStatus.Builder().withName(subpop.getName())
                     .withGuid(subpop.getGuid()).withRequired(subpop.isRequired())
@@ -292,30 +288,6 @@ public class ConsentService {
     }
     
     /**
-     * Get a history of all consent records for a given subpopulation, whether user is withdrawn or not. 
-     * 
-     * @param account
-     * @param subpopGuid
-     */
-    public List<UserConsentHistory> getUserConsentHistory(Account account, SubpopulationGuid subpopGuid) {
-        return account.getConsentSignatureHistory(subpopGuid).stream().map(signature -> {
-            boolean hasSignedActiveConsent = hasUserSignedActiveConsent(account.getStudyIdentifier(), signature, subpopGuid);
-            
-            return new UserConsentHistory.Builder()
-                .withName(signature.getName())
-                .withSubpopulationGuid(subpopGuid)
-                .withBirthdate(signature.getBirthdate())
-                .withImageData(signature.getImageData())
-                .withImageMimeType(signature.getImageMimeType())
-                .withSignedOn(signature.getSignedOn())
-                .withHealthCode(account.getHealthCode())
-                .withWithdrewOn(signature.getWithdrewOn())
-                .withConsentCreatedOn(signature.getConsentCreatedOn())
-                .withHasSignedActiveConsent(hasSignedActiveConsent).build();
-        }).collect(BridgeCollectors.toImmutableList());
-    }
-    
-    /**
      * Email the participant's signed consent agreement to the user's email address.
      * @param study
      * @param subpopGuid
@@ -354,27 +326,5 @@ public class ConsentService {
             }
         }
         return withdrewConsent;
-    }
-    
-    /**
-     * Verify the timestamp of the consent the user has signed is the currently active consent for this subpopulation. 
-     * Once storing this timestamp is migrated to the subpopulation, this entire method can be removed. 
-     * @param studyIdentifier
-     * @param signature
-     * @param subpopGuid
-     * @return
-     */
-    private boolean hasUserSignedActiveConsent(StudyIdentifier studyIdentifier, ConsentSignature signature,
-            SubpopulationGuid subpopGuid) {
-        checkNotNull(studyIdentifier);
-        checkNotNull(subpopGuid);
-        
-        Subpopulation subpop = subpopService.getSubpopulation(studyIdentifier, subpopGuid);
-        StudyConsentView mostRecentConsent = studyConsentService.getActiveConsent(studyIdentifier, subpop);
-        
-        if (mostRecentConsent != null && signature != null) {
-            return signature.getConsentCreatedOn() == mostRecentConsent.getCreatedOn();
-        }
-        return false;
     }
 }

--- a/app/org/sagebionetworks/bridge/services/StudyConsentService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyConsentService.java
@@ -135,22 +135,11 @@ public class StudyConsentService {
      *          the subpopulation associated with this consent
      * @return the currently active StudyConsent along with its document content
      */
-    // NOTE: After migrating publication consent timestamp to the subpopulation, this method can
-    // go away, as it's just a variant of getConsent() with a special timestamp.
     public StudyConsentView getActiveConsent(StudyIdentifier studyIdentifier, Subpopulation subpop) {
         checkNotNull(studyIdentifier);
         checkNotNull(subpop);
         
-        StudyConsent consent = null;
-        if (subpop.getPublishedConsentCreatedOn() > 0L) {
-            consent = studyConsentDao.getConsent(subpop.getGuid(), subpop.getPublishedConsentCreatedOn());
-        }
-        if (consent == null) {
-            consent = studyConsentDao.getActiveConsent(subpop.getGuid());
-            if (consent != null) {
-                subpop.setPublishedConsentCreatedOn(consent.getCreatedOn());
-            }
-        }
+        StudyConsent consent = studyConsentDao.getConsent(subpop.getGuid(), subpop.getPublishedConsentCreatedOn());
         if (consent == null) {
             throw new EntityNotFoundException(StudyConsent.class);
         }
@@ -240,7 +229,6 @@ public class StudyConsentService {
             subpop.setPublishedConsentCreatedOn(timestamp);
             subpopService.updateSubpopulation(study, subpop);
 
-            consent = studyConsentDao.publish(consent);
         } catch(IOException | DocumentException e) {
             throw new BridgeServiceException(e.getMessage());
         }

--- a/app/org/sagebionetworks/bridge/services/StudyConsentService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyConsentService.java
@@ -19,7 +19,6 @@ import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import org.apache.commons.io.IOUtils;
-import org.joda.time.DateTime;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Document.OutputSettings.Syntax;
@@ -33,7 +32,6 @@ import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.models.studies.MimeType;
 import org.sagebionetworks.bridge.models.studies.Study;
-import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.subpopulations.StudyConsent;
 import org.sagebionetworks.bridge.models.subpopulations.StudyConsentForm;
 import org.sagebionetworks.bridge.models.subpopulations.StudyConsentView;
@@ -115,8 +113,8 @@ public class StudyConsentService {
         String sanitizedContent = sanitizeHTML(form.getDocumentContent());
         Validate.entityThrowingException(validator, new StudyConsentForm(sanitizedContent));
 
-        DateTime createdOn = DateUtils.getCurrentDateTime();
-        String storagePath = subpopGuid.getGuid() + "." + createdOn.getMillis();
+        long createdOn = DateUtils.getCurrentMillisFromEpoch();
+        String storagePath = subpopGuid.getGuid() + "." + createdOn;
         try {
             s3Helper.writeBytesToS3(CONSENTS_BUCKET, storagePath, sanitizedContent.getBytes());
             StudyConsent consent = studyConsentDao.addConsent(subpopGuid, storagePath, createdOn);
@@ -127,24 +125,17 @@ public class StudyConsentService {
     }
 
     /**
-     * Gets the currently active consent document for the study.
+     * Gets the currently active consent document for this subpopulation.
      *
-     * @param studyIdentifier
-     *          the study this subpopulation is found in.
      * @param subpop
      *          the subpopulation associated with this consent
      * @return the currently active StudyConsent along with its document content
      */
-    public StudyConsentView getActiveConsent(StudyIdentifier studyIdentifier, Subpopulation subpop) {
-        checkNotNull(studyIdentifier);
+    public StudyConsentView getActiveConsent(Subpopulation subpop) {
         checkNotNull(subpop);
+        checkArgument(subpop.getPublishedConsentCreatedOn() > 0L);
         
-        StudyConsent consent = studyConsentDao.getConsent(subpop.getGuid(), subpop.getPublishedConsentCreatedOn());
-        if (consent == null) {
-            throw new EntityNotFoundException(StudyConsent.class);
-        }
-        String documentContent = loadDocumentContent(consent);
-        return new StudyConsentView(consent, documentContent);
+        return getConsent(subpop.getGuid(), subpop.getPublishedConsentCreatedOn());
     }
     
     /**

--- a/app/org/sagebionetworks/bridge/services/backfill/ConsentCreatedOnBackfill.java
+++ b/app/org/sagebionetworks/bridge/services/backfill/ConsentCreatedOnBackfill.java
@@ -49,7 +49,8 @@ public class ConsentCreatedOnBackfill extends AsyncBackfillTemplate {
             
             List<Subpopulation> subpopulations = subpopulationService.getSubpopulations(study.getStudyIdentifier());
             for (Subpopulation subpopulation : subpopulations) {
-                StudyConsent consent = studyConsentDao.getActiveConsent(subpopulation.getGuid());
+                StudyConsent consent = studyConsentDao.getConsent(subpopulation.getGuid(),
+                        subpopulation.getPublishedConsentCreatedOn());
                 if (consent != null) {
                     callback.newRecords(getBackfillRecordFactory().createOnly(task, "Updating subpopulation " + subpopulation.getGuidString() + "..."));
                     subpopulation.setPublishedConsentCreatedOn(consent.getCreatedOn());

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyConsentDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyConsentDaoTest.java
@@ -1,8 +1,6 @@
 package org.sagebionetworks.bridge.dynamodb;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyConsentDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyConsentDaoTest.java
@@ -7,7 +7,6 @@ import java.util.List;
 
 import javax.annotation.Resource;
 
-import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,17 +35,17 @@ public class DynamoStudyConsentDaoTest {
 
     @Test
     public void crudStudyConsentWithFileBasedContent() {
-        DateTime datetime = DateUtils.getCurrentDateTime();
+        long createdOn = DateUtils.getCurrentMillisFromEpoch();
         
         // Add consent version 1, inactive
-        StudyConsent consent1 = studyConsentDao.addConsent(SUBPOP_GUID, SUBPOP_GUID+"."+datetime.getMillis(), datetime);
-        assertEquals(datetime.getMillis(), consent1.getCreatedOn());
+        StudyConsent consent1 = studyConsentDao.addConsent(SUBPOP_GUID, SUBPOP_GUID+"."+createdOn, createdOn);
+        assertEquals(createdOn, consent1.getCreatedOn());
         
-        datetime = DateUtils.getCurrentDateTime();
+        createdOn = DateUtils.getCurrentMillisFromEpoch();
         
         // Add version 2
-        StudyConsent consent2 = studyConsentDao.addConsent(SUBPOP_GUID, SUBPOP_GUID+"."+datetime.getMillis(), datetime);
-        assertEquals(datetime.getMillis(), consent2.getCreatedOn());
+        StudyConsent consent2 = studyConsentDao.addConsent(SUBPOP_GUID, SUBPOP_GUID+"."+createdOn, createdOn);
+        assertEquals(createdOn, consent2.getCreatedOn());
         
         // The most recent consent should be version 2
         StudyConsent consent = studyConsentDao.getMostRecentConsent(SUBPOP_GUID);
@@ -57,8 +56,8 @@ public class DynamoStudyConsentDaoTest {
         assertConsentsEqual(consent1, consent, false);
         
         // Add a third consent to test list of consents
-        datetime = DateUtils.getCurrentDateTime();
-        final StudyConsent consent3 = studyConsentDao.addConsent(SUBPOP_GUID, SUBPOP_GUID+"."+datetime.getMillis(), datetime);
+        createdOn = DateUtils.getCurrentMillisFromEpoch();
+        final StudyConsent consent3 = studyConsentDao.addConsent(SUBPOP_GUID, SUBPOP_GUID+"."+createdOn, createdOn);
         
         // Get all consents. Should return in reverse order
         List<? extends StudyConsent> all = studyConsentDao.getConsents(SUBPOP_GUID);
@@ -70,8 +69,8 @@ public class DynamoStudyConsentDaoTest {
     
     @Test
     public void crudStudyConsentWithS3Content() throws Exception {
-        DateTime createdOn = DateTime.now();
-        String key = SUBPOP_GUID + "." + createdOn.getMillis();
+        long createdOn = DateUtils.getCurrentMillisFromEpoch();
+        String key = SUBPOP_GUID + "." + createdOn;
         StudyConsent consent = studyConsentDao.addConsent(SUBPOP_GUID, key, createdOn);
         assertEquals(key, consent.getStoragePath());
     }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyConsentTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyConsentTest.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.bridge.dynamodb;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -25,7 +24,6 @@ public class DynamoStudyConsentTest {
     @Test
     public void canSerialize() throws Exception {
        DynamoStudyConsent1 consent = new DynamoStudyConsent1();
-       consent.setActive(true);
        consent.setCreatedOn(123L);
        consent.setStoragePath("storagePath");
        consent.setSubpopulationGuid("ABC");
@@ -35,7 +33,6 @@ public class DynamoStudyConsentTest {
        JsonNode node = BridgeObjectMapper.get().readTree(json);
        
        assertEquals("1970-01-01T00:00:00.123Z", node.get("createdOn").asText());
-       assertTrue(node.get("active").asBoolean());
        assertEquals("ABC", node.get("subpopulationGuid").asText());
        assertEquals("StudyConsent", node.get("type").asText());
        assertEquals(4, node.size());

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyConsentTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyConsentTest.java
@@ -35,7 +35,7 @@ public class DynamoStudyConsentTest {
        assertEquals("1970-01-01T00:00:00.123Z", node.get("createdOn").asText());
        assertEquals("ABC", node.get("subpopulationGuid").asText());
        assertEquals("StudyConsent", node.get("type").asText());
-       assertEquals(4, node.size());
+       assertEquals(3, node.size());
     }
     
 }

--- a/test/org/sagebionetworks/bridge/models/subpopulations/StudyConsentViewTest.java
+++ b/test/org/sagebionetworks/bridge/models/subpopulations/StudyConsentViewTest.java
@@ -18,7 +18,6 @@ public class StudyConsentViewTest {
         long createdOn = 200L;
         
         DynamoStudyConsent1 consent = new DynamoStudyConsent1();
-        consent.setActive(true);
         consent.setCreatedOn(createdOn);
         consent.setSubpopulationGuid("test");
         consent.setStoragePath("test."+createdOn);

--- a/test/org/sagebionetworks/bridge/models/subpopulations/StudyConsentViewTest.java
+++ b/test/org/sagebionetworks/bridge/models/subpopulations/StudyConsentViewTest.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.bridge.models.subpopulations;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudyConsent1;

--- a/test/org/sagebionetworks/bridge/models/subpopulations/StudyConsentViewTest.java
+++ b/test/org/sagebionetworks/bridge/models/subpopulations/StudyConsentViewTest.java
@@ -29,7 +29,6 @@ public class StudyConsentViewTest {
         JsonNode node = BridgeObjectMapper.get().readTree(json);
         
         assertEquals("<document/>", node.get("documentContent").asText());
-        assertTrue(node.get("active").asBoolean());
         assertEquals("1970-01-01T00:00:00.200Z", node.get("createdOn").asText());
         assertEquals("test", node.get("subpopulationGuid").asText());
         assertEquals("StudyConsent", node.get("type").asText());

--- a/test/org/sagebionetworks/bridge/play/controllers/StudyConsentControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/StudyConsentControllerTest.java
@@ -101,7 +101,7 @@ public class StudyConsentControllerTest {
     @Test
     public void getActiveConsentV2() throws Exception {
         StudyConsentView view = new StudyConsentView(new DynamoStudyConsent1(), "<document/>");
-        when(studyConsentService.getActiveConsent(eq(STUDY_ID), any())).thenReturn(view);
+        when(studyConsentService.getActiveConsent(any())).thenReturn(view);
         
         Result result = controller.getActiveConsentV2(GUID);
         

--- a/test/org/sagebionetworks/bridge/services/ConsentServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/ConsentServiceMockTest.java
@@ -99,7 +99,7 @@ public class ConsentServiceMockTest {
         
         StudyConsentView studyConsentView = mock(StudyConsentView.class);
         when(studyConsentView.getCreatedOn()).thenReturn(CONSENT_CREATED_ON);
-        when(studyConsentService.getActiveConsent(study.getStudyIdentifier(), subpopulation)).thenReturn(studyConsentView);
+        when(studyConsentService.getActiveConsent(subpopulation)).thenReturn(studyConsentView);
         when(subpopService.getSubpopulation(study.getStudyIdentifier(), SUBPOP_GUID)).thenReturn(subpopulation);
     }
     
@@ -137,7 +137,7 @@ public class ConsentServiceMockTest {
         StudyConsentView view = mock(StudyConsentView.class);
         when(view.getStudyConsent()).thenReturn(consent);
         when(view.getCreatedOn()).thenReturn(CONSENT_CREATED_ON);
-        when(studyConsentService.getActiveConsent(study.getStudyIdentifier(), subpopulation)).thenReturn(view);
+        when(studyConsentService.getActiveConsent(subpopulation)).thenReturn(view);
         
         ConsentSignature sigWithStudyCreatedOn = new ConsentSignature.Builder()
                 .withConsentSignature(consentSignature)

--- a/test/org/sagebionetworks/bridge/services/ConsentServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ConsentServiceTest.java
@@ -321,8 +321,7 @@ public class ConsentServiceTest {
         assertNotNull(withdrawnConsent.getWithdrewOn());
         assertNull(activeConsent.getWithdrewOn());
         
-        StudyConsent studyConsent = studyConsentService
-                .getActiveConsent(testUser.getStudyIdentifier(), defaultSubpopulation).getStudyConsent();
+        StudyConsent studyConsent = studyConsentService.getActiveConsent(defaultSubpopulation).getStudyConsent();
 
         assertEquals(testUser.getHealthCode(), withdrawnConsent.getHealthCode());
         assertEquals(defaultSubpopulation.getGuidString(), withdrawnConsent.getSubpopulationGuid());

--- a/test/org/sagebionetworks/bridge/services/SendEmailIntegTest.java
+++ b/test/org/sagebionetworks/bridge/services/SendEmailIntegTest.java
@@ -64,8 +64,7 @@ public class SendEmailIntegTest {
         final Study study = studyService.getStudy(TEST_STUDY_IDENTIFIER);
         
         Subpopulation subpopulation = subpopService.getSubpopulation(TEST_STUDY, SUBPOP_GUID);
-        String htmlTemplate = studyConsentService.getActiveConsent(study.getStudyIdentifier(), subpopulation)
-                .getDocumentContent();
+        String htmlTemplate = studyConsentService.getActiveConsent(subpopulation).getDocumentContent();
         sendEmailService.sendEmail(new ConsentEmailProvider(study, "bridge-testing@sagebase.org",
                 signature, SharingScope.SPONSORS_AND_PARTNERS, htmlTemplate, consentBodyTemplate));
     }

--- a/test/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceConsentTest.java
+++ b/test/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceConsentTest.java
@@ -79,7 +79,7 @@ public class SendMailViaAmazonServiceConsentTest {
             "<document>Had this been a real study: @@name@@ @@signing.date@@ @@email@@ @@sharing@@</document>");
         
         studyConsentService = mock(StudyConsentService.class);
-        when(studyConsentService.getActiveConsent(study.getStudyIdentifier(), subpopulation)).thenReturn(view);
+        when(studyConsentService.getActiveConsent(subpopulation)).thenReturn(view);
     }
 
     @Test
@@ -92,7 +92,7 @@ public class SendMailViaAmazonServiceConsentTest {
         ConsentSignature consent = new ConsentSignature.Builder().withName("Test 2").withBirthdate("1950-05-05")
                 .withSignedOn(DateUtils.getCurrentMillisFromEpoch()).build();
         
-        String htmlTemplate = studyConsentService.getActiveConsent(study.getStudyIdentifier(), subpopulation).getDocumentContent();
+        String htmlTemplate = studyConsentService.getActiveConsent(subpopulation).getDocumentContent();
         
         ConsentEmailProvider provider = new ConsentEmailProvider(study, "test-user@sagebase.org", consent,
                 SharingScope.SPONSORS_AND_PARTNERS, htmlTemplate, consentBodyTemplate);
@@ -130,7 +130,7 @@ public class SendMailViaAmazonServiceConsentTest {
                 .withBirthdate("1970-05-01").withImageData(TestConstants.DUMMY_IMAGE_DATA)
                 .withImageMimeType("image/fake").withSignedOn(DateUtils.getCurrentMillisFromEpoch()).build();
         
-        String htmlTemplate = studyConsentService.getActiveConsent(study.getStudyIdentifier(), subpopulation).getDocumentContent();
+        String htmlTemplate = studyConsentService.getActiveConsent(subpopulation).getDocumentContent();
         
         ConsentEmailProvider provider = new ConsentEmailProvider(study, "test-user@sagebase.org", consent,
                 SharingScope.SPONSORS_AND_PARTNERS, htmlTemplate, consentBodyTemplate);
@@ -170,7 +170,7 @@ public class SendMailViaAmazonServiceConsentTest {
         ConsentSignature consent = new ConsentSignature.Builder().withName("Test 2").withBirthdate("1950-05-05")
                 .withSignedOn(DateUtils.getCurrentMillisFromEpoch()).build();
         
-        String htmlTemplate = studyConsentService.getActiveConsent(study.getStudyIdentifier(), subpopulation).getDocumentContent();
+        String htmlTemplate = studyConsentService.getActiveConsent(subpopulation).getDocumentContent();
 
         ConsentEmailProvider provider = new ConsentEmailProvider(study, "test-user@sagebase.org", consent,
                 SharingScope.SPONSORS_AND_PARTNERS, htmlTemplate, consentBodyTemplate);
@@ -192,7 +192,7 @@ public class SendMailViaAmazonServiceConsentTest {
         ConsentSignature consent = new ConsentSignature.Builder().withName("Test 2").withBirthdate("1950-05-05")
                 .withSignedOn(DateUtils.getCurrentMillisFromEpoch()).build();
         
-        String htmlTemplate = studyConsentService.getActiveConsent(study.getStudyIdentifier(), subpopulation).getDocumentContent();
+        String htmlTemplate = studyConsentService.getActiveConsent(subpopulation).getDocumentContent();
 
         ConsentEmailProvider provider = new ConsentEmailProvider(study, "test-user@sagebase.org", consent,
                 SharingScope.SPONSORS_AND_PARTNERS, htmlTemplate, consentBodyTemplate);

--- a/test/org/sagebionetworks/bridge/services/StudyConsentServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyConsentServiceTest.java
@@ -35,7 +35,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 @ContextConfiguration("classpath:test-context.xml")
 @RunWith(SpringJUnit4ClassRunner.class)
 public class StudyConsentServiceTest {
-    
+
     private static final String BUCKET = BridgeConfigFactory.getConfig().getConsentsBucket();
 
     @Resource
@@ -107,8 +107,7 @@ public class StudyConsentServiceTest {
         String key = subpopulation.getGuidString() + "." + createdOn.getMillis();
         s3Helper.writeBytesToS3(BUCKET, key, "<document/>".getBytes());
         
-        StudyConsent consent = studyConsentDao.addConsent(subpopulation.getGuid(), key, createdOn);
-        studyConsentDao.publish(consent);
+        studyConsentDao.addConsent(subpopulation.getGuid(), key, createdOn);
         // The junk path should not prevent the service from getting the S3 content.
         // We actually wouldn't get here if it tried to load from disk with the path we've provided.
         StudyConsentView view = studyConsentService.getConsent(subpopulation.getGuid(), createdOn.getMillis());
@@ -165,8 +164,7 @@ public class StudyConsentServiceTest {
         StudyConsentForm form = new StudyConsentForm(documentContent);
         StudyConsentView view = studyConsentService.addConsent(subpopulation.getGuid(), form);        
         studyConsentService.publishConsent(study, subpopulation, view.getCreatedOn());
-        
-        subpopulation.setPublishedConsentCreatedOn(0L);
+
         view = studyConsentService.getActiveConsent(study.getStudyIdentifier(), subpopulation);
         assertEquals(subpopulation.getPublishedConsentCreatedOn(), view.getCreatedOn());
     }

--- a/test/org/sagebionetworks/bridge/services/StudyServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceTest.java
@@ -134,7 +134,7 @@ public class StudyServiceTest {
         // A default, active consent should be created for the study.
         Subpopulation subpop = subpopService.getSubpopulation(study.getStudyIdentifier(),
                 SubpopulationGuid.create(study.getIdentifier()));
-        StudyConsentView view = studyConsentService.getActiveConsent(study.getStudyIdentifier(), subpop);
+        StudyConsentView view = studyConsentService.getActiveConsent(subpop);
         assertTrue(view.getDocumentContent().contains("This is a placeholder for your consent document."));
         
         Study newStudy = studyService.getStudy(study.getIdentifier());

--- a/test/org/sagebionetworks/bridge/services/StudyServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceTest.java
@@ -136,7 +136,6 @@ public class StudyServiceTest {
                 SubpopulationGuid.create(study.getIdentifier()));
         StudyConsentView view = studyConsentService.getActiveConsent(study.getStudyIdentifier(), subpop);
         assertTrue(view.getDocumentContent().contains("This is a placeholder for your consent document."));
-        assertTrue(view.getActive());
         
         Study newStudy = studyService.getStudy(study.getIdentifier());
         assertTrue(newStudy.isActive());


### PR DESCRIPTION
- remove active flag from study consent
- no longer setting this in the DAO
- removing getActiveConsent() and publishConsent(), which involved queries without timestamps
- move getUserConsentHistory() to the ParticipantService, as that's the only place that uses it.
- removed calls to the studyConsentService to determine if a signed consent is up-to-date (signed against the currently published consent).
