### PR TITLE
This little check, added late, causes big problems, because you have …

### DIFF
--- a/app/org/sagebionetworks/bridge/services/StudyConsentService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyConsentService.java
@@ -133,7 +133,6 @@ public class StudyConsentService {
      */
     public StudyConsentView getActiveConsent(Subpopulation subpop) {
         checkNotNull(subpop);
-        checkArgument(subpop.getPublishedConsentCreatedOn() > 0L);
         
         return getConsent(subpop.getGuid(), subpop.getPublishedConsentCreatedOn());
     }


### PR DESCRIPTION
…to create a subpopulation before you create a consent so you have a createdOn timestamp for the subpopulation.
