### PR TITLE
move uploadComplete ConcurrentModification check to prevent a nastier race condition

### DIFF
--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoUploadDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoUploadDaoTest.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge.dynamodb;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 
@@ -24,6 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import org.sagebionetworks.bridge.exceptions.ConcurrentModificationException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.DateTimeRangeResourceList;
 import org.sagebionetworks.bridge.models.upload.Upload;
@@ -104,8 +106,13 @@ public class DynamoUploadDaoTest {
         // upload complete
         dao.uploadComplete(UploadCompletionClient.S3_WORKER, fetchedUpload);
 
-        // subsequent call to upload should succeed
-        dao.uploadComplete(UploadCompletionClient.S3_WORKER, fetchedUpload2);
+        // second call to upload complete throws ConcurrentModificationException
+        try {
+            dao.uploadComplete(UploadCompletionClient.APP, fetchedUpload2);
+            fail("expected exception");
+        } catch (ConcurrentModificationException ex) {
+            // expected exception
+        }
 
         // fetch completed upload
         DynamoUpload2 completedUpload = (DynamoUpload2) dao.getUpload(upload.getUploadId());

--- a/test/org/sagebionetworks/bridge/services/UploadServiceUploadCompleteMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/UploadServiceUploadCompleteMockTest.java
@@ -1,7 +1,10 @@
 package org.sagebionetworks.bridge.services;
 
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
@@ -18,7 +21,10 @@ import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.config.BridgeConfig;
 import org.sagebionetworks.bridge.dao.UploadDao;
 import org.sagebionetworks.bridge.dynamodb.DynamoUpload2;
+import org.sagebionetworks.bridge.exceptions.ConcurrentModificationException;
 import org.sagebionetworks.bridge.exceptions.NotFoundException;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
+import org.sagebionetworks.bridge.models.upload.Upload;
 import org.sagebionetworks.bridge.models.upload.UploadStatus;
 
 @SuppressWarnings("unchecked")
@@ -98,6 +104,28 @@ public class UploadServiceUploadCompleteMockTest {
 
         // Verify S3, upload DAO and validation aren't called.
         verifyZeroInteractions(mockUploadDao, mockUploadValidationService, mockS3Client);
+    }
+
+    @Test
+    public void concurrentModification() {
+        // set up input
+        DynamoUpload2 upload = new DynamoUpload2();
+        upload.setUploadId(TEST_UPLOAD_ID);
+        upload.setStatus(UploadStatus.REQUESTED);
+
+        // mock S3
+        ObjectMetadata mockObjMetadata = mock(ObjectMetadata.class);
+        when(mockObjMetadata.getSSEAlgorithm()).thenReturn(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
+        when(mockS3Client.getObjectMetadata(TEST_BUCKET, TEST_UPLOAD_ID)).thenReturn(mockObjMetadata);
+
+        // mock uploadDao.uploadComplete()
+        doThrow(ConcurrentModificationException.class).when(mockUploadDao).uploadComplete(APP, upload);
+
+        // execute
+        svc.uploadComplete(TestConstants.TEST_STUDY, APP, upload);
+
+        // Verify upload DAO and validation.
+        verify(mockUploadValidationService, never()).validateUpload(any(StudyIdentifier.class), any(Upload.class));
     }
 
     @Test


### PR DESCRIPTION
In squelching the 409 ConcurrentModificationException from uploadComplete, we inadvertently opened ourselves up to a far more sinister race condition:
https://github.com/Sage-Bionetworks/BridgePF/blob/develop/app/org/sagebionetworks/bridge/services/UploadService.java#L271

Specifically, previously, the call to uploadDao.uploadComplete() (UploadService line 291) would throw a 409, thus ending the request entirely. With the code change https://github.com/Sage-Bionetworks/BridgePF/pull/1212, this now squelches the 409, and both requests proceed to call uploadService.validateUpload() (UploadService line 294). This causes the Bridge to validate the same upload twice, concurrently, and then one of the uploads tries to upload the validation status and fails. However, both validation calls still manage to create separate duplicate records, which are then both exported to Synapse.

The fix is to move the ConcurrentModificationException check to UploadService.uploadComplete(), which can then short-circuit and prevent from calling validateUpload().

Testing done:
- added unit tests
- UploadTest integration tests
- manually tested race condition by injecting a 30-second sleep before the UploadComplete call, verified that the ConcurrentModificationException was being caught and squelched, and that Upload Validation was only being invoked once
