### PR TITLE
Stop renewing session every time it is accessed.

### DIFF
--- a/app/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/app/org/sagebionetworks/bridge/BridgeConstants.java
@@ -42,8 +42,8 @@ public class BridgeConstants {
 
     public static final DateTimeZone LOCAL_TIME_ZONE = DateTimeZone.forID("America/Los_Angeles");
 
-    // 24 hrs after last activity
-    public static final int BRIDGE_SESSION_EXPIRE_IN_SECONDS = 24 * 60 * 60;
+    // 12 hrs after last activity
+    public static final int BRIDGE_SESSION_EXPIRE_IN_SECONDS = 12 * 60 * 60;
 
     // 5 minutes
     public static final int BRIDGE_UPDATE_ATTEMPT_EXPIRE_IN_SECONDS = 5 * 60;

--- a/app/org/sagebionetworks/bridge/cache/CacheProvider.java
+++ b/app/org/sagebionetworks/bridge/cache/CacheProvider.java
@@ -3,27 +3,21 @@ package org.sagebionetworks.bridge.cache;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.List;
-import java.util.Map;
 
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
-import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.studies.Study;
-import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 import org.sagebionetworks.bridge.redis.JedisOps;
 import org.sagebionetworks.bridge.redis.JedisTransaction;
 import org.sagebionetworks.bridge.redis.RedisKey;
 
-import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
@@ -32,8 +26,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 @Component
 public class CacheProvider {
-
-    private static final TypeReference<Map<SubpopulationGuid, ConsentStatus>> CONSENT_MAP_REFERENCE = new TypeReference<Map<SubpopulationGuid, ConsentStatus>>() {};
     
     private ObjectMapper bridgeObjectMapper;
     private JedisOps jedisOps;
@@ -88,34 +80,7 @@ public class CacheProvider {
             if (ser == null) {
                 return null;
             }
-            JsonNode node = bridgeObjectMapper.readTree(ser);
-            UserSession session = bridgeObjectMapper.treeToValue(node, UserSession.class);
-            // This is special processing to migrate old versions of the session (that have a user object)
-            // to the newer session structure. Once we're sure we're rotating sessions, and this no longer
-            // exists in any session, it can be removed.
-            if (node.has("user")) {
-                JsonNode userNode = node.get("user");
-                JsonNode consentNode = node.get("user").get("consentStatuses");
-                
-                StudyParticipant participant = bridgeObjectMapper.treeToValue(userNode, StudyParticipant.class);
-                if (userNode.has("accountCreatedOn")) {
-                    DateTime createdOn = DateTime.parse(userNode.get("accountCreatedOn").asText());
-                    participant = new StudyParticipant.Builder().copyOf(participant)
-                            .withCreatedOn(createdOn).build();
-                }
-                session.setParticipant(participant);
-                
-                Map<SubpopulationGuid,ConsentStatus> statuses = bridgeObjectMapper.convertValue(consentNode, CONSENT_MAP_REFERENCE);
-                session.setConsentStatuses(statuses);
-            }
-            final String userKey = RedisKey.USER_SESSION.getRedisKey(session.getId());
-            try (JedisTransaction transaction = jedisOps.getTransaction(sessionKey)) {
-                transaction
-                        .expire(userKey, BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS)
-                        .expire(sessionKey, BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS)
-                        .exec();
-            }
-            return session;
+            return bridgeObjectMapper.readValue(ser, UserSession.class);
         } catch (Throwable e) {
             promptToStartRedisIfLocal(e);
             throw new BridgeServiceException(e);

--- a/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
+++ b/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
@@ -37,6 +37,7 @@ import org.springframework.context.annotation.Configuration;
 
 import org.springframework.context.annotation.FilterType;
 
+import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.crypto.AesGcmEncryptor;
 import org.sagebionetworks.bridge.crypto.BridgeEncryptor;
 import org.sagebionetworks.bridge.crypto.CmsEncryptor;
@@ -419,4 +420,10 @@ public class BridgeSpringConfig {
     public Application getStormpathApplication(BridgeConfig bridgeConfig, Client stormpathClient) {
         return stormpathClient.getResource(bridgeConfig.getStormpathApplicationHref(), Application.class);
     }
+    
+    @Bean(name = "sessionExpireInSeconds")
+    public int getSessionExpireInSeconds() {
+        return BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS;
+    }
+
 }

--- a/test/org/sagebionetworks/bridge/cache/CacheProviderMockTest.java
+++ b/test/org/sagebionetworks/bridge/cache/CacheProviderMockTest.java
@@ -1,0 +1,326 @@
+package org.sagebionetworks.bridge.cache;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.BridgeConstants;
+import org.sagebionetworks.bridge.Roles;
+import org.sagebionetworks.bridge.TestUtils;
+import org.sagebionetworks.bridge.config.BridgeConfigFactory;
+import org.sagebionetworks.bridge.config.Environment;
+import org.sagebionetworks.bridge.crypto.AesGcmEncryptor;
+import org.sagebionetworks.bridge.crypto.Encryptor;
+import org.sagebionetworks.bridge.dao.ParticipantOption.SharingScope;
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
+import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
+import org.sagebionetworks.bridge.models.accounts.UserSession;
+import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
+import org.sagebionetworks.bridge.redis.JedisOps;
+import org.sagebionetworks.bridge.redis.JedisTransaction;
+import org.sagebionetworks.bridge.redis.RedisKey;
+
+import redis.clients.jedis.JedisPool;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+
+public class CacheProviderMockTest {
+
+    private static final Encryptor ENCRYPTOR = new AesGcmEncryptor(BridgeConfigFactory.getConfig().getProperty("bridge.healthcode.redis.key"));
+    private static final String USER_ID = "userId";
+    private static final String SESSION_TOKEN = "sessionToken";
+    private static final String ENCRYPTED_SESSION_TOKEN = "TFMkaVFKPD48WissX0bgcD3esBMEshxb3MVgKxHnkXLSEPN4FQMKc01tDbBAVcXx94kMX6ckXVYUZ8wx4iICl08uE+oQr9gorE1hlgAyLAM=";
+    private static final String DECRYPTED_SESSION_TOKEN = "ccea2978-f5b9-4377-8194-f887a3e2a19b";
+    private JedisTransaction transaction;
+    private CacheProvider cacheProvider;
+
+    @Before
+    public void before() {
+        transaction = mock(JedisTransaction.class);
+        when(transaction.setex(any(String.class), anyInt(), any(String.class))).thenReturn(transaction);
+        when(transaction.expire(any(String.class), anyInt())).thenReturn(transaction);
+        when(transaction.del(any(String.class))).thenReturn(transaction);
+        when(transaction.exec()).thenReturn(Arrays.asList((Object)"OK", "OK"));
+        
+        JedisOps jedisOps = mock(JedisOps.class);
+        when(jedisOps.getTransaction()).thenReturn(transaction);
+        
+        String userKey = RedisKey.USER_SESSION.getRedisKey(USER_ID);
+        when(jedisOps.get(userKey)).thenReturn(SESSION_TOKEN);
+        
+        cacheProvider = new CacheProvider();
+        cacheProvider.setJedisOps(jedisOps);
+        cacheProvider.setBridgeObjectMapper(BridgeObjectMapper.get());
+    }
+
+    @Test
+    public void testSetUserSession() throws Exception {
+        StudyParticipant participant = new StudyParticipant.Builder()
+                .withEmail("userEmail")
+                .withId(USER_ID)
+                .withHealthCode("healthCode").build();
+        
+        UserSession session = new UserSession(participant);
+        session.setSessionToken(SESSION_TOKEN);
+        cacheProvider.setUserSession(session);
+
+        String sessionKey = RedisKey.SESSION.getRedisKey(SESSION_TOKEN);
+        String userKey = RedisKey.USER_SESSION.getRedisKey(USER_ID);
+        verify(transaction, times(1)).setex(eq(sessionKey), anyInt(), anyString());
+        verify(transaction, times(1)).setex(eq(userKey), anyInt(), eq(SESSION_TOKEN));
+        verify(transaction, times(1)).exec();
+    }
+
+    @Test
+    public void testSetUserSessionNullSessionToken() throws Exception {
+        StudyParticipant participant = new StudyParticipant.Builder()
+                .withEmail("userEmail")
+                .withId(USER_ID)
+                .withHealthCode("healthCode").build();
+        
+        UserSession session = new UserSession(participant);
+        try {
+            cacheProvider.setUserSession(session);
+        } catch(NullPointerException e) {
+            assertTrue("NPE expected.", true);
+        } catch(Throwable e) {
+            fail(e.getMessage());
+        }
+        String sessionKey = RedisKey.SESSION.getRedisKey(SESSION_TOKEN);
+        String userKey = RedisKey.USER_SESSION.getRedisKey(USER_ID);
+        verify(transaction, times(0)).setex(eq(sessionKey), anyInt(), anyString());
+        verify(transaction, times(0)).setex(eq(userKey), anyInt(), eq(SESSION_TOKEN));
+        verify(transaction, times(0)).exec();
+    }
+
+    @Test
+    public void testSetUserSessionNullUser() throws Exception {
+        UserSession session = new UserSession();
+        session.setSessionToken(SESSION_TOKEN);
+        try {
+            cacheProvider.setUserSession(session);
+        } catch(NullPointerException e) {
+            assertTrue("NPE expected.", true);
+        } catch(Throwable e) {
+            fail(e.getMessage());
+        }
+        String sessionKey = RedisKey.SESSION.getRedisKey(SESSION_TOKEN);
+        String userKey = RedisKey.USER_SESSION.getRedisKey(USER_ID);
+        verify(transaction, times(0)).setex(eq(sessionKey), anyInt(), anyString());
+        verify(transaction, times(0)).setex(eq(userKey), anyInt(), eq(SESSION_TOKEN));
+        verify(transaction, times(0)).exec();
+    }
+
+    @Test
+    public void testSetUserSessionNullUserId() throws Exception {
+        StudyParticipant participant = new StudyParticipant.Builder()
+                .withEmail("userEmail")
+                .withHealthCode("healthCode").build();        
+        
+        UserSession session = new UserSession(participant);
+        session.setSessionToken(SESSION_TOKEN);
+        try {
+            cacheProvider.setUserSession(session);
+        } catch(NullPointerException e) {
+            assertTrue("NPE expected.", true);
+        } catch(Throwable e) {
+            fail(e.getMessage());
+        }
+        String sessionKey = RedisKey.SESSION.getRedisKey(SESSION_TOKEN);
+        String userKey = RedisKey.USER_SESSION.getRedisKey(USER_ID);
+        verify(transaction, times(0)).setex(eq(sessionKey), anyInt(), anyString());
+        verify(transaction, times(0)).setex(eq(userKey), anyInt(), eq(SESSION_TOKEN));
+        verify(transaction, times(0)).exec();
+    }
+
+    @Test
+    public void testGetUserSessionByUserId() throws Exception {
+        CacheProvider mockCacheProvider = spy(cacheProvider);
+        mockCacheProvider.getUserSessionByUserId(USER_ID);
+        verify(mockCacheProvider, times(1)).getUserSession(SESSION_TOKEN);
+    }
+
+    @Test
+    public void testRemoveSession() {
+        StudyParticipant participant = new StudyParticipant.Builder().withId(USER_ID).build();
+
+        UserSession session = new UserSession(participant);
+        session.setSessionToken(SESSION_TOKEN);
+        
+        cacheProvider.removeSession(session);
+        cacheProvider.getUserSession(SESSION_TOKEN);
+        String sessionKey = RedisKey.SESSION.getRedisKey(SESSION_TOKEN);
+        String userKey = RedisKey.USER_SESSION.getRedisKey(USER_ID);
+        verify(transaction, times(1)).del(sessionKey);
+        verify(transaction, times(1)).del(userKey);
+        verify(transaction, times(1)).exec();
+    }
+
+    @Test
+    public void testRemoveSessionByUserId() {
+        cacheProvider.removeSessionByUserId(USER_ID);
+        String sessionKey = RedisKey.SESSION.getRedisKey(SESSION_TOKEN);
+        String userKey = RedisKey.USER_SESSION.getRedisKey(USER_ID);
+        verify(transaction, times(1)).del(sessionKey);
+        verify(transaction, times(1)).del(userKey);
+        verify(transaction, times(1)).exec();
+    }
+
+    @Test
+    public void addAndRemoveViewFromCacheProvider() throws Exception {
+        final CacheProvider simpleCacheProvider = new CacheProvider();
+        simpleCacheProvider.setJedisOps(getJedisOps());
+        simpleCacheProvider.setBridgeObjectMapper(BridgeObjectMapper.get());
+
+        final Study study = TestUtils.getValidStudy(CacheProviderMockTest.class);
+        study.setIdentifier("test");
+        study.setName("This is a test study");
+        String json = BridgeObjectMapper.get().writeValueAsString(study);
+        assertTrue(json != null && json.length() > 0);
+
+        final String cacheKey = study.getIdentifier() + ":Study";
+        simpleCacheProvider.setString(cacheKey, json, BridgeConstants.BRIDGE_VIEW_EXPIRE_IN_SECONDS);
+
+        String cachedString = simpleCacheProvider.getString(cacheKey);
+        assertEquals(json, cachedString);
+
+        // Remove something that's not the key
+        simpleCacheProvider.removeString(cacheKey+"2");
+        cachedString = simpleCacheProvider.getString(cacheKey);
+        assertEquals(json, cachedString);
+
+        simpleCacheProvider.removeString(cacheKey);
+        cachedString = simpleCacheProvider.getString(cacheKey);
+        assertNull(cachedString);
+    }
+
+    @Test
+    public void newUserSessionDeserializes() {
+        String json = TestUtils.createJson("{'authenticated':true,"+
+                "'environment':'local',"+
+                "'sessionToken':'"+DECRYPTED_SESSION_TOKEN+"',"+
+                "'internalSessionToken':'4f0937a5-6ebf-451b-84bc-fbf649b9e93c',"+
+                "'studyIdentifier':{'identifier':'api',"+
+                    "'type':'StudyIdentifier'},"+
+                "'consentStatuses':{"+
+                    "'api':{'name':'Default Consent Group',"+
+                        "'subpopulationGuid':'api',"+
+                        "'required':true,"+
+                        "'consented':false,"+
+                        "'signedMostRecentConsent':true,"+
+                        "'type':'ConsentStatus'}},"+
+                "'participant':{'firstName':'Bridge',"+
+                    "'lastName':'IT',"+
+                    "'email':'bridgeit@sagebase.org',"+
+                    "'sharingScope':'no_sharing',"+
+                    "'notifyByEmail':false,"+
+                    "'externalId':'ABC',"+
+                    "'dataGroups':['group1'],"+
+                    "'encryptedHealthCode':'"+ENCRYPTED_SESSION_TOKEN+"',"+
+                    "'attributes':{},"+
+                    "'consentHistories':{},"+
+                    "'roles':['admin'],"+
+                    "'languages':['en','fr'],"+
+                    "'createdOn':'2016-04-21T16:48:22.386Z',"+
+                    "'id':'6gq4jGXLmAxVbLLmVifKN4',"+
+                    "'type':'StudyParticipant'},"+
+                "'type':'UserSession'}");
+
+        assertSession(json);
+    }
+
+    private void assertSession(String json) {
+        JedisOps jedisOps = mock(JedisOps.class);
+        
+        String sessionKey = RedisKey.SESSION.getRedisKey("sessionToken");
+        doReturn(sessionKey).when(jedisOps).get("sessionToken");
+        doReturn(transaction).when(jedisOps).getTransaction(sessionKey);
+        doReturn(json).when(jedisOps).get(sessionKey);
+        
+        cacheProvider.setJedisOps(jedisOps);
+        cacheProvider.setBridgeObjectMapper(BridgeObjectMapper.get());
+        
+        UserSession session = cacheProvider.getUserSession("sessionToken");
+
+        assertTrue(session.isAuthenticated());
+        assertEquals(Environment.LOCAL, session.getEnvironment());
+        assertEquals(DECRYPTED_SESSION_TOKEN, session.getSessionToken());
+        assertEquals("4f0937a5-6ebf-451b-84bc-fbf649b9e93c", session.getInternalSessionToken());
+        assertEquals("6gq4jGXLmAxVbLLmVifKN4", session.getId());
+        assertEquals("api", session.getStudyIdentifier().getIdentifier());
+        
+        StudyParticipant participant = session.getParticipant();
+        assertEquals("Bridge", participant.getFirstName());
+        assertEquals("IT", participant.getLastName());
+        assertEquals("bridgeit@sagebase.org", participant.getEmail());
+        assertEquals(SharingScope.NO_SHARING, participant.getSharingScope());
+        assertEquals(DateTime.parse("2016-04-21T16:48:22.386Z"), participant.getCreatedOn());
+        assertEquals(Sets.newHashSet(Roles.ADMIN), participant.getRoles());
+        assertEquals(Sets.newHashSet("en","fr"), participant.getLanguages());
+        assertEquals("ABC", participant.getExternalId());
+        
+        assertEquals(participant.getHealthCode(), ENCRYPTOR.decrypt(ENCRYPTED_SESSION_TOKEN));
+        
+        SubpopulationGuid apiGuid = SubpopulationGuid.create("api");
+        Map<SubpopulationGuid,ConsentStatus> consentStatuses = session.getConsentStatuses();
+        ConsentStatus status = consentStatuses.get(apiGuid);
+        assertEquals("Default Consent Group", status.getName());
+        assertEquals(apiGuid.getGuid(), status.getSubpopulationGuid());
+        assertTrue(status.getSignedMostRecentConsent());
+        assertTrue(status.isRequired());
+        assertFalse(status.isConsented());
+    }
+    
+    private JedisOps getJedisOps() {
+        return new JedisOps(new JedisPool()) {
+            private Map<String,String> map = Maps.newHashMap();
+            @Override
+            public Long expire(final String key, final int seconds) {
+                return 1L;
+            }
+            @Override
+            public String setex(final String key, final int seconds, final String value) {
+                map.put(key, value);
+                return "OK";
+            }
+            @Override
+            public Long setnx(final String key, final String value) {
+                map.put(key, value);
+                return 1L;
+            }
+            @Override
+            public String get(final String key) {
+                return map.get(key);
+            }
+            @Override
+            public Long del(final String... keys) {
+                for (String key : keys) {
+                    map.remove(key);
+                }
+                return (long)keys.length;
+            }
+        };
+    }
+}

--- a/test/org/sagebionetworks/bridge/cache/CacheProviderTest.java
+++ b/test/org/sagebionetworks/bridge/cache/CacheProviderTest.java
@@ -215,39 +215,6 @@ public class CacheProviderTest {
         cachedString = simpleCacheProvider.getString(cacheKey);
         assertNull(cachedString);
     }
-    
-    @Test
-    public void oldUserSessionDeserializedToNewUserSession() {
-        String oldJSON = TestUtils.createJson("{'authenticated':true,"+
-                "'environment':'local',"+
-                "'sessionToken':'"+DECRYPTED_SESSION_TOKEN+"',"+
-                "'internalSessionToken':'4f0937a5-6ebf-451b-84bc-fbf649b9e93c',"+
-                "'user':{'id':'6gq4jGXLmAxVbLLmVifKN4',"+
-                    "'firstName':'Bridge',"+
-                    "'lastName':'IT',"+
-                    "'email':'bridgeit@sagebase.org',"+
-                    "'studyKey':'api',"+
-                    "'sharingScope':'no_sharing',"+
-                    "'accountCreatedOn':'2016-04-21T16:48:22.386Z',"+
-                    "'roles':['admin'],"+
-                    "'externalId':'ABC',"+
-                    "'dataGroups':['group1'],"+
-                    "'consentStatuses':{"+
-                        "'api':{'name':'Default Consent Group',"+
-                            "'subpopulationGuid':'api',"+
-                            "'required':true,"+
-                            "'consented':false,"+
-                            "'signedMostRecentConsent':true,"+
-                            "'type':'ConsentStatus'}},"+
-                    "'languages':['en','fr'],"+
-                    "'encryptedHealthCode':'"+ENCRYPTED_SESSION_TOKEN+"',"+
-                    "'type':'User'},"+
-                "'studyIdentifier':{'identifier':'api',"+
-                    "'type':'StudyIdentifier'},"+
-                "'type':'UserSession'}");
-        
-        assertSession(oldJSON);
-    }
 
     @Test
     public void newUserSessionDeserializes() {

--- a/test/org/sagebionetworks/bridge/cache/CacheProviderTest.java
+++ b/test/org/sagebionetworks/bridge/cache/CacheProviderTest.java
@@ -1,326 +1,104 @@
 package org.sagebionetworks.bridge.cache;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-import java.util.Arrays;
-import java.util.Map;
+import java.net.URI;
 
-import org.joda.time.DateTime;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import org.sagebionetworks.bridge.BridgeConstants;
-import org.sagebionetworks.bridge.Roles;
-import org.sagebionetworks.bridge.TestUtils;
-import org.sagebionetworks.bridge.config.BridgeConfigFactory;
-import org.sagebionetworks.bridge.config.Environment;
-import org.sagebionetworks.bridge.crypto.AesGcmEncryptor;
-import org.sagebionetworks.bridge.crypto.Encryptor;
-import org.sagebionetworks.bridge.dao.ParticipantOption.SharingScope;
-import org.sagebionetworks.bridge.json.BridgeObjectMapper;
-import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
+import org.sagebionetworks.bridge.config.BridgeConfig;
+import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.studies.Study;
-import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 import org.sagebionetworks.bridge.redis.JedisOps;
-import org.sagebionetworks.bridge.redis.JedisTransaction;
-import org.sagebionetworks.bridge.redis.RedisKey;
 
 import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
 
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-
+@ContextConfiguration("classpath:test-context.xml")
+@RunWith(SpringJUnit4ClassRunner.class)
 public class CacheProviderTest {
 
-    private static final Encryptor ENCRYPTOR = new AesGcmEncryptor(BridgeConfigFactory.getConfig().getProperty("bridge.healthcode.redis.key"));
-    private static final String USER_ID = "userId";
-    private static final String SESSION_TOKEN = "sessionToken";
-    private static final String ENCRYPTED_SESSION_TOKEN = "TFMkaVFKPD48WissX0bgcD3esBMEshxb3MVgKxHnkXLSEPN4FQMKc01tDbBAVcXx94kMX6ckXVYUZ8wx4iICl08uE+oQr9gorE1hlgAyLAM=";
-    private static final String DECRYPTED_SESSION_TOKEN = "ccea2978-f5b9-4377-8194-f887a3e2a19b";
-    private JedisTransaction transaction;
+    private static final String STRING_KEY = "cache-string-test";
+
+    private static final String STUDY_IDENTIFIER = "cache-study-test";
+
+    @Autowired
     private CacheProvider cacheProvider;
-
-    @Before
-    public void before() {
-        transaction = mock(JedisTransaction.class);
-        when(transaction.setex(any(String.class), anyInt(), any(String.class))).thenReturn(transaction);
-        when(transaction.expire(any(String.class), anyInt())).thenReturn(transaction);
-        when(transaction.del(any(String.class))).thenReturn(transaction);
-        when(transaction.exec()).thenReturn(Arrays.asList((Object)"OK", "OK"));
-        
-        JedisOps jedisOps = mock(JedisOps.class);
-        when(jedisOps.getTransaction()).thenReturn(transaction);
-        
-        String userKey = RedisKey.USER_SESSION.getRedisKey(USER_ID);
-        when(jedisOps.get(userKey)).thenReturn(SESSION_TOKEN);
-        
-        cacheProvider = new CacheProvider();
-        cacheProvider.setJedisOps(jedisOps);
-        cacheProvider.setBridgeObjectMapper(BridgeObjectMapper.get());
-    }
-
-    @Test
-    public void testSetUserSession() throws Exception {
-        StudyParticipant participant = new StudyParticipant.Builder()
-                .withEmail("userEmail")
-                .withId(USER_ID)
-                .withHealthCode("healthCode").build();
-        
-        UserSession session = new UserSession(participant);
-        session.setSessionToken(SESSION_TOKEN);
-        cacheProvider.setUserSession(session);
-
-        String sessionKey = RedisKey.SESSION.getRedisKey(SESSION_TOKEN);
-        String userKey = RedisKey.USER_SESSION.getRedisKey(USER_ID);
-        verify(transaction, times(1)).setex(eq(sessionKey), anyInt(), anyString());
-        verify(transaction, times(1)).setex(eq(userKey), anyInt(), eq(SESSION_TOKEN));
-        verify(transaction, times(1)).exec();
-    }
-
-    @Test
-    public void testSetUserSessionNullSessionToken() throws Exception {
-        StudyParticipant participant = new StudyParticipant.Builder()
-                .withEmail("userEmail")
-                .withId(USER_ID)
-                .withHealthCode("healthCode").build();
-        
-        UserSession session = new UserSession(participant);
-        try {
-            cacheProvider.setUserSession(session);
-        } catch(NullPointerException e) {
-            assertTrue("NPE expected.", true);
-        } catch(Throwable e) {
-            fail(e.getMessage());
-        }
-        String sessionKey = RedisKey.SESSION.getRedisKey(SESSION_TOKEN);
-        String userKey = RedisKey.USER_SESSION.getRedisKey(USER_ID);
-        verify(transaction, times(0)).setex(eq(sessionKey), anyInt(), anyString());
-        verify(transaction, times(0)).setex(eq(userKey), anyInt(), eq(SESSION_TOKEN));
-        verify(transaction, times(0)).exec();
-    }
-
-    @Test
-    public void testSetUserSessionNullUser() throws Exception {
-        UserSession session = new UserSession();
-        session.setSessionToken(SESSION_TOKEN);
-        try {
-            cacheProvider.setUserSession(session);
-        } catch(NullPointerException e) {
-            assertTrue("NPE expected.", true);
-        } catch(Throwable e) {
-            fail(e.getMessage());
-        }
-        String sessionKey = RedisKey.SESSION.getRedisKey(SESSION_TOKEN);
-        String userKey = RedisKey.USER_SESSION.getRedisKey(USER_ID);
-        verify(transaction, times(0)).setex(eq(sessionKey), anyInt(), anyString());
-        verify(transaction, times(0)).setex(eq(userKey), anyInt(), eq(SESSION_TOKEN));
-        verify(transaction, times(0)).exec();
-    }
-
-    @Test
-    public void testSetUserSessionNullUserId() throws Exception {
-        StudyParticipant participant = new StudyParticipant.Builder()
-                .withEmail("userEmail")
-                .withHealthCode("healthCode").build();        
-        
-        UserSession session = new UserSession(participant);
-        session.setSessionToken(SESSION_TOKEN);
-        try {
-            cacheProvider.setUserSession(session);
-        } catch(NullPointerException e) {
-            assertTrue("NPE expected.", true);
-        } catch(Throwable e) {
-            fail(e.getMessage());
-        }
-        String sessionKey = RedisKey.SESSION.getRedisKey(SESSION_TOKEN);
-        String userKey = RedisKey.USER_SESSION.getRedisKey(USER_ID);
-        verify(transaction, times(0)).setex(eq(sessionKey), anyInt(), anyString());
-        verify(transaction, times(0)).setex(eq(userKey), anyInt(), eq(SESSION_TOKEN));
-        verify(transaction, times(0)).exec();
-    }
-
-    @Test
-    public void testGetUserSessionByUserId() throws Exception {
-        CacheProvider mockCacheProvider = spy(cacheProvider);
-        mockCacheProvider.getUserSessionByUserId(USER_ID);
-        verify(mockCacheProvider, times(1)).getUserSession(SESSION_TOKEN);
-    }
-
-    @Test
-    public void testRemoveSession() {
-        StudyParticipant participant = new StudyParticipant.Builder().withId(USER_ID).build();
-
-        UserSession session = new UserSession(participant);
-        session.setSessionToken(SESSION_TOKEN);
-        
-        cacheProvider.removeSession(session);
-        cacheProvider.getUserSession(SESSION_TOKEN);
-        String sessionKey = RedisKey.SESSION.getRedisKey(SESSION_TOKEN);
-        String userKey = RedisKey.USER_SESSION.getRedisKey(USER_ID);
-        verify(transaction, times(1)).del(sessionKey);
-        verify(transaction, times(1)).del(userKey);
-        verify(transaction, times(1)).exec();
-    }
-
-    @Test
-    public void testRemoveSessionByUserId() {
-        cacheProvider.removeSessionByUserId(USER_ID);
-        String sessionKey = RedisKey.SESSION.getRedisKey(SESSION_TOKEN);
-        String userKey = RedisKey.USER_SESSION.getRedisKey(USER_ID);
-        verify(transaction, times(1)).del(sessionKey);
-        verify(transaction, times(1)).del(userKey);
-        verify(transaction, times(1)).exec();
-    }
-
-    @Test
-    public void addAndRemoveViewFromCacheProvider() throws Exception {
-        final CacheProvider simpleCacheProvider = new CacheProvider();
-        simpleCacheProvider.setJedisOps(getJedisOps());
-        simpleCacheProvider.setBridgeObjectMapper(BridgeObjectMapper.get());
-
-        final Study study = TestUtils.getValidStudy(CacheProviderTest.class);
-        study.setIdentifier("test");
-        study.setName("This is a test study");
-        String json = BridgeObjectMapper.get().writeValueAsString(study);
-        assertTrue(json != null && json.length() > 0);
-
-        final String cacheKey = study.getIdentifier() + ":Study";
-        simpleCacheProvider.setString(cacheKey, json, BridgeConstants.BRIDGE_VIEW_EXPIRE_IN_SECONDS);
-
-        String cachedString = simpleCacheProvider.getString(cacheKey);
-        assertEquals(json, cachedString);
-
-        // Remove something that's not the key
-        simpleCacheProvider.removeString(cacheKey+"2");
-        cachedString = simpleCacheProvider.getString(cacheKey);
-        assertEquals(json, cachedString);
-
-        simpleCacheProvider.removeString(cacheKey);
-        cachedString = simpleCacheProvider.getString(cacheKey);
-        assertNull(cachedString);
-    }
-
-    @Test
-    public void newUserSessionDeserializes() {
-        String json = TestUtils.createJson("{'authenticated':true,"+
-                "'environment':'local',"+
-                "'sessionToken':'"+DECRYPTED_SESSION_TOKEN+"',"+
-                "'internalSessionToken':'4f0937a5-6ebf-451b-84bc-fbf649b9e93c',"+
-                "'studyIdentifier':{'identifier':'api',"+
-                    "'type':'StudyIdentifier'},"+
-                "'consentStatuses':{"+
-                    "'api':{'name':'Default Consent Group',"+
-                        "'subpopulationGuid':'api',"+
-                        "'required':true,"+
-                        "'consented':false,"+
-                        "'signedMostRecentConsent':true,"+
-                        "'type':'ConsentStatus'}},"+
-                "'participant':{'firstName':'Bridge',"+
-                    "'lastName':'IT',"+
-                    "'email':'bridgeit@sagebase.org',"+
-                    "'sharingScope':'no_sharing',"+
-                    "'notifyByEmail':false,"+
-                    "'externalId':'ABC',"+
-                    "'dataGroups':['group1'],"+
-                    "'encryptedHealthCode':'"+ENCRYPTED_SESSION_TOKEN+"',"+
-                    "'attributes':{},"+
-                    "'consentHistories':{},"+
-                    "'roles':['admin'],"+
-                    "'languages':['en','fr'],"+
-                    "'createdOn':'2016-04-21T16:48:22.386Z',"+
-                    "'id':'6gq4jGXLmAxVbLLmVifKN4',"+
-                    "'type':'StudyParticipant'},"+
-                "'type':'UserSession'}");
-
-        assertSession(json);
-    }
-
-    private void assertSession(String json) {
-        JedisOps jedisOps = mock(JedisOps.class);
-        
-        String sessionKey = RedisKey.SESSION.getRedisKey("sessionToken");
-        doReturn(sessionKey).when(jedisOps).get("sessionToken");
-        doReturn(transaction).when(jedisOps).getTransaction(sessionKey);
-        doReturn(json).when(jedisOps).get(sessionKey);
-        
-        cacheProvider.setJedisOps(jedisOps);
-        cacheProvider.setBridgeObjectMapper(BridgeObjectMapper.get());
-        
-        UserSession session = cacheProvider.getUserSession("sessionToken");
-
-        assertTrue(session.isAuthenticated());
-        assertEquals(Environment.LOCAL, session.getEnvironment());
-        assertEquals(DECRYPTED_SESSION_TOKEN, session.getSessionToken());
-        assertEquals("4f0937a5-6ebf-451b-84bc-fbf649b9e93c", session.getInternalSessionToken());
-        assertEquals("6gq4jGXLmAxVbLLmVifKN4", session.getId());
-        assertEquals("api", session.getStudyIdentifier().getIdentifier());
-        
-        StudyParticipant participant = session.getParticipant();
-        assertEquals("Bridge", participant.getFirstName());
-        assertEquals("IT", participant.getLastName());
-        assertEquals("bridgeit@sagebase.org", participant.getEmail());
-        assertEquals(SharingScope.NO_SHARING, participant.getSharingScope());
-        assertEquals(DateTime.parse("2016-04-21T16:48:22.386Z"), participant.getCreatedOn());
-        assertEquals(Sets.newHashSet(Roles.ADMIN), participant.getRoles());
-        assertEquals(Sets.newHashSet("en","fr"), participant.getLanguages());
-        assertEquals("ABC", participant.getExternalId());
-        
-        assertEquals(participant.getHealthCode(), ENCRYPTOR.decrypt(ENCRYPTED_SESSION_TOKEN));
-        
-        SubpopulationGuid apiGuid = SubpopulationGuid.create("api");
-        Map<SubpopulationGuid,ConsentStatus> consentStatuses = session.getConsentStatuses();
-        ConsentStatus status = consentStatuses.get(apiGuid);
-        assertEquals("Default Consent Group", status.getName());
-        assertEquals(apiGuid.getGuid(), status.getSubpopulationGuid());
-        assertTrue(status.getSignedMostRecentConsent());
-        assertTrue(status.isRequired());
-        assertFalse(status.isConsented());
+    
+    @Autowired
+    private BridgeConfig config;
+    
+    @Autowired
+    private JedisOps testJedisOps;
+    
+    @After
+    public void after() {
+        cacheProvider.setJedisOps(testJedisOps);
     }
     
-    private JedisOps getJedisOps() {
-        return new JedisOps(new JedisPool()) {
-            private Map<String,String> map = Maps.newHashMap();
-            @Override
-            public Long expire(final String key, final int seconds) {
-                return 1L;
-            }
-            @Override
-            public String setex(final String key, final int seconds, final String value) {
-                map.put(key, value);
-                return "OK";
-            }
-            @Override
-            public Long setnx(final String key, final String value) {
-                map.put(key, value);
-                return 1L;
-            }
-            @Override
-            public String get(final String key) {
-                return map.get(key);
-            }
-            @Override
-            public Long del(final String... keys) {
-                for (String key : keys) {
-                    map.remove(key);
-                }
-                return (long)keys.length;
-            }
-        };
+    @Before
+    public void before() throws Exception {
+        final JedisPoolConfig poolConfig = new JedisPoolConfig();
+
+        URI redisURI = new URI(config.getProperty("redis.url"));
+        JedisPool jedisPool = new JedisPool(poolConfig, redisURI.getHost(), redisURI.getPort(), 10); //10 second timeout
+        JedisOps jedisOps = new JedisOps(jedisPool);
+        cacheProvider.setJedisOps(jedisOps);
+        cacheProvider.setSessionExpireInSeconds(4);
     }
+    
+    @Test
+    public void stringCachingWorks() {
+        cacheProvider.setString(STRING_KEY, "cache-test-value", BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS);
+        String retrieved = cacheProvider.getString(STRING_KEY);
+        assertEquals("cache-test-value", retrieved);
+    }
+    
+    @Test
+    public void studyCachingWorks() {
+        Study study = new DynamoStudy();
+        study.setIdentifier(STUDY_IDENTIFIER);
+        
+        cacheProvider.setStudy(study);
+        Study retrieved = cacheProvider.getStudy(STUDY_IDENTIFIER);
+        assertEquals(STUDY_IDENTIFIER, retrieved.getIdentifier());
+    }
+    
+    @Test
+    public void canSetAndResetSessionWithoutResettingExpiration() throws Exception {
+        StudyParticipant participant = new StudyParticipant.Builder()
+                .withHealthCode("ABC").withId("id")
+                .build(); 
+        UserSession session = new UserSession();
+        session.setParticipant(participant);
+        session.setSessionToken("cache-test-session-token");
+        
+        cacheProvider.setUserSession(session);
+        
+        // get works
+        UserSession retrieved = cacheProvider.getUserSession("cache-test-session-token");
+        assertNotNull(retrieved);
+
+        // Sleep for a total of 4 seconds, but set/get in the middle of that.
+        Thread.sleep(3000);
+        cacheProvider.getUserSession("cache-test-session-token");
+        cacheProvider.setUserSession(session);
+        Thread.sleep(1000);
+        
+        // still expired after 4 seconds.
+        retrieved = cacheProvider.getUserSession("cache-test-session-token");
+        assertNull(retrieved);
+    }
+    
 }


### PR DESCRIPTION
- remove migration code that's no longer necessary.
- change session lease to 12 hours (still asking around about desirable time for this, I would make it 6 or 8 hours)

Testing:
- Moved existing CacheProviderTest to CacheProviderMockTest for mock tests of provider
- Made the session timeout value an injected value in the CacheProvider, for testing,
- Added CacheProviderTest which creates a real JedisOps object, and using a very short TTL, verifies that a session set to expire at 4 seconds, does expire at 4 seconds, even when (in the middle of the period), we get and set the session again. TTL from Redis is correct to use as the EXPIRES value when calling "setter", and "get" does not update TTL value. 
- (also verifies the initial setex call sets an expiration period)
