### PR TITLE
Integrate Surveys with Mutable Schemas; relax rules for Mutable Schemas

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/SurveyDao.java
+++ b/app/org/sagebionetworks/bridge/dao/SurveyDao.java
@@ -43,7 +43,7 @@ public interface SurveyDao {
      *         true if you want to cut a new survey schema, false if you should (attempt to) modify the existing one
      * @return published survey
      */
-    Survey publishSurvey(StudyIdentifier study, GuidCreatedOnVersionHolder keys, boolean newSchemaRev);
+    public Survey publishSurvey(StudyIdentifier study, GuidCreatedOnVersionHolder keys, boolean newSchemaRev);
 
     /**
      * Delete this survey. Survey still exists in system and can be retrieved by direct reference

--- a/app/org/sagebionetworks/bridge/dao/SurveyDao.java
+++ b/app/org/sagebionetworks/bridge/dao/SurveyDao.java
@@ -31,13 +31,19 @@ public interface SurveyDao {
     public Survey versionSurvey(GuidCreatedOnVersionHolder keys);
 
     /**
-     * Make this version of this survey available for scheduling. One scheduled for publishing, 
-     * a survey version can no longer be changed (it can still be the source of a new version).  
+     * Make this version of this survey available for scheduling. One scheduled for publishing,
+     * a survey version can no longer be changed (it can still be the source of a new version).
      * There can be more than one published version of a survey.
+     *
+     * @param study
+     *         study that the survey lives in
      * @param keys
-     * @return
+     *         survey ID and created-on timestamp, which identifies the survey you want to publish
+     * @param newSchemaRev
+     *         true if you want to cut a new survey schema, false if you should (attempt to) modify the existing one
+     * @return published survey
      */
-    public Survey publishSurvey(StudyIdentifier study, GuidCreatedOnVersionHolder keys);
+    Survey publishSurvey(StudyIdentifier study, GuidCreatedOnVersionHolder keys, boolean newSchemaRev);
 
     /**
      * Delete this survey. Survey still exists in system and can be retrieved by direct reference

--- a/app/org/sagebionetworks/bridge/dao/UploadSchemaDao.java
+++ b/app/org/sagebionetworks/bridge/dao/UploadSchemaDao.java
@@ -44,10 +44,12 @@ public interface UploadSchemaDao {
      *         study that the schema should be created or updated in, must be non-null and empty
      * @param survey
      *         survey to create the upload schema from
+     * @param newSchemaRev
+     *         true if you want to cut a new survey schema, false if you should (attempt to) modify the existing one
      * @return the created upload schema
      */
     @Nonnull UploadSchema createUploadSchemaFromSurvey(@Nonnull StudyIdentifier studyIdentifier,
-            @Nonnull Survey survey);
+            @Nonnull Survey survey, boolean newSchemaRev);
 
     /**
      * DAO method for deleting an upload schema with the specified study, schema ID, and revision. If the schema

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
@@ -222,14 +222,14 @@ public class DynamoSurveyDao implements SurveyDao {
     }
 
     @Override
-    public Survey publishSurvey(StudyIdentifier study, GuidCreatedOnVersionHolder keys) {
+    public Survey publishSurvey(StudyIdentifier study, GuidCreatedOnVersionHolder keys, boolean newSchemaRev) {
         Survey survey = getSurvey(keys);
         if (survey.isDeleted()) {
             throw new EntityNotFoundException(Survey.class);
         }
         if (!survey.isPublished()) {
             // make schema from survey
-            UploadSchema schema = uploadSchemaDao.createUploadSchemaFromSurvey(study, survey);
+            UploadSchema schema = uploadSchemaDao.createUploadSchemaFromSurvey(study, survey, newSchemaRev);
 
             // update survey
             survey.setPublished(true);

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDao.java
@@ -624,12 +624,12 @@ public class DynamoUploadSchemaDao implements UploadSchemaDao {
         Set<String> invalidAddedFieldNameSet = new TreeSet<>();
         for (String oneAddedFieldName : addedFieldNameSet) {
             UploadFieldDefinition addedField = newFieldMap.get(oneAddedFieldName);
-            if (addedField.isRequired() && addedField.getMinAppVersion() == null) {
+            if (addedField.isRequired()) {
                 invalidAddedFieldNameSet.add(oneAddedFieldName);
             }
         }
         if (!invalidAddedFieldNameSet.isEmpty()) {
-            errorMessageList.add("Required added fields must have minAppVersion set: " + BridgeUtils.COMMA_SPACE_JOINER
+            errorMessageList.add("Added fields must be optional: " + BridgeUtils.COMMA_SPACE_JOINER
                     .join(invalidAddedFieldNameSet));
         }
 

--- a/app/org/sagebionetworks/bridge/models/surveys/SurveyQuestionOption.java
+++ b/app/org/sagebionetworks/bridge/models/surveys/SurveyQuestionOption.java
@@ -4,8 +4,9 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang3.StringUtils;
 
-public class SurveyQuestionOption {
+public final class SurveyQuestionOption {
 
     private final String label;
     private final String detail;
@@ -13,16 +14,12 @@ public class SurveyQuestionOption {
     private final Image image;
     
     @JsonCreator
-    public SurveyQuestionOption(@JsonProperty("label") String label, @JsonProperty("detail") String detail, 
+    public SurveyQuestionOption(@JsonProperty("label") String label, @JsonProperty("detail") String detail,
         @JsonProperty("value") String value, @JsonProperty("image") Image image) {
         this.label = label;
         this.detail = detail;
         this.value = value;
         this.image = image;
-    }
-    
-    public SurveyQuestionOption(String label, String value) {
-        this(label, null, value, null);
     }
     
     public SurveyQuestionOption(String label) {
@@ -36,7 +33,7 @@ public class SurveyQuestionOption {
         return detail;
     }
     public String getValue() {
-        return value;
+        return StringUtils.isNotBlank(value) ? value : label;
     }
     public Image getImage() {
         return image;

--- a/app/org/sagebionetworks/bridge/models/surveys/Unit.java
+++ b/app/org/sagebionetworks/bridge/models/surveys/Unit.java
@@ -41,6 +41,11 @@ public enum Unit {
     LITERS,
     CUBIC_METERS;
     
-    public static EnumSet<Unit> DURATION_UNITS = EnumSet.of(SECONDS, MINUTES, HOURS, DAYS, WEEKS, MONTHS, YEARS);
-    
+    public static final EnumSet<Unit> DURATION_UNITS = EnumSet.of(SECONDS, MINUTES, HOURS, DAYS, WEEKS, MONTHS, YEARS);
+
+    /*
+     * We need to know what the longest unit is, so we can reserve the proper sized column in our schemas. Currently,
+     * this is cubic_centimeters. If this ever changes, we need to update this.
+     */
+    public static final int MAX_STRING_LENGTH = CUBIC_CENTIMETERS.name().length();
 }

--- a/app/org/sagebionetworks/bridge/play/controllers/SurveyController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/SurveyController.java
@@ -239,13 +239,13 @@ public class SurveyController extends BaseController {
         return okResult(new GuidCreatedOnVersionHolderImpl(survey));
     }
     
-    public Result publishSurvey(String surveyGuid, String createdOnString) throws Exception {
+    public Result publishSurvey(String surveyGuid, String createdOnString, String newSchemaRev) throws Exception {
         UserSession session = getAuthenticatedSession(DEVELOPER);
         StudyIdentifier studyId = session.getStudyIdentifier();
          
         Survey survey = getSurveyWithoutCacheInternal(surveyGuid, createdOnString, session);
-        
-        survey = surveyService.publishSurvey(studyId, survey);
+
+        survey = surveyService.publishSurvey(studyId, survey, Boolean.parseBoolean(newSchemaRev));
         expireCache(surveyGuid, createdOnString, studyId);
         
         return okResult(new GuidCreatedOnVersionHolderImpl(survey));

--- a/app/org/sagebionetworks/bridge/services/SurveyService.java
+++ b/app/org/sagebionetworks/bridge/services/SurveyService.java
@@ -94,13 +94,15 @@ public class SurveyService {
      *            study ID of study to publish the survey to
      * @param keys
      *            survey keys (guid, created on timestamp)
+     * @param newSchemaRev
+     *         true if you want to cut a new survey schema, false if you should (attempt to) modify the existing one
      * @return published survey
      */
-    public Survey publishSurvey(StudyIdentifier study, GuidCreatedOnVersionHolder keys) {
+    public Survey publishSurvey(StudyIdentifier study, GuidCreatedOnVersionHolder keys, boolean newSchemaRev) {
         checkArgument(StringUtils.isNotBlank(keys.getGuid()), "Survey GUID cannot be null/blank");
         checkArgument(keys.getCreatedOn() != 0L, "Survey createdOn timestamp cannot be 0");
         
-        return surveyDao.publishSurvey(study, keys);
+        return surveyDao.publishSurvey(study, keys, newSchemaRev);
     }
     
     /**

--- a/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2.java
+++ b/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2.java
@@ -460,7 +460,7 @@ public class IosSchemaValidationHandler2 implements UploadValidationHandler {
             // if there's a unit, add it as well
             JsonNode unitNode = oneAnswerNode.get("unit");
             if (unitNode != null && !unitNode.isNull()) {
-                convertedSurveyMap.put(answerItem + "_unit", unitNode);
+                convertedSurveyMap.put(answerItem + UploadUtil.UNIT_FIELD_SUFFIX, unitNode);
             }
         }
 

--- a/app/org/sagebionetworks/bridge/upload/UploadUtil.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadUtil.java
@@ -1,6 +1,10 @@
 package org.sagebionetworks.bridge.upload;
 
 import java.math.BigDecimal;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -8,6 +12,7 @@ import com.fasterxml.jackson.databind.node.BigIntegerNode;
 import com.fasterxml.jackson.databind.node.BooleanNode;
 import com.fasterxml.jackson.databind.node.DecimalNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+import com.google.common.collect.Sets;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
@@ -18,12 +23,19 @@ import org.slf4j.LoggerFactory;
 
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.json.DateUtils;
+import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
 import org.sagebionetworks.bridge.models.upload.UploadFieldType;
 import org.sagebionetworks.bridge.schema.SchemaUtils;
 
 /** Utility class that contains static utility methods for handling uploads. */
 public class UploadUtil {
     private static final Logger logger = LoggerFactory.getLogger(UploadUtil.class);
+
+    /*
+     * Suffix used for unit fields in schemas. For example, if we had a field called "jogtime", we would have a field
+     * called "jogtime_unit".
+     */
+    public static final String UNIT_FIELD_SUFFIX = "_unit";
 
     /** Utility method for canonicalizing an upload JSON value given the schema's field type. */
     public static CanonicalizationResult canonicalize(final JsonNode valueNode, UploadFieldType type) {
@@ -265,6 +277,116 @@ public class UploadUtil {
         } else {
             return node.toString();
         }
+    }
+
+    // Helper method to test that two field defs are identical except for the maxAppVersion field (which can only be
+    // added to newFieldDef). This is because adding maxAppVersion is how we mark fields as deprecated. Package-scoped
+    // to facilitate unit tests.
+
+    /**
+     * Helper method to test whether a schema field definition can be modified as specified.
+     *
+     * @param oldFieldDef
+     *         the original field definition, before modification
+     * @param newFieldDef
+     *         the new field definition, representing the intended modification
+     * @return true if the fields can be modified, false otherwise
+     */
+    public static boolean isCompatibleFieldDef(UploadFieldDefinition oldFieldDef, UploadFieldDefinition newFieldDef) {
+        // Short-cut: If they are equal, then they are compatible.
+        if (oldFieldDef.equals(newFieldDef)) {
+            return true;
+        }
+
+        // Attributes that don't affect field def compatibility
+        // fileExtension - This is just a hint to BridgeEX for serializing the values. It doesn't affect the columns or
+        //   validation.
+        // mimeType - Similarly, this is also just a serialization hint.
+
+        // Different types are obviously not compatible.
+        // This is the most likely reason fields are incompatible. Check this first.
+        if (oldFieldDef.getType() != newFieldDef.getType()) {
+            return false;
+        }
+
+        // allowOther - You can flip this to true (adds a field), but you can't flip it from true to false.
+        Boolean oldAllowOther = oldFieldDef.getAllowOtherChoices();
+        Boolean newAllowOther = newFieldDef.getAllowOtherChoices();
+        if (oldAllowOther != null && oldAllowOther && (newAllowOther == null || !newAllowOther)) {
+            return false;
+        }
+
+        Integer oldMinAppVersion = oldFieldDef.getMinAppVersion();
+        Integer newMinAppVersion = newFieldDef.getMinAppVersion();
+        if (oldMinAppVersion != null && newMinAppVersion != null && newMinAppVersion < oldMinAppVersion) {
+            // If minAppVersion decreases, this means there are some appVersions that aren't sending this field that
+            // are suddenly required to send this field, which breaks Strict Validation.
+            return false;
+        } else if (oldMinAppVersion != null && newMinAppVersion == null) {
+            // Similarly, if we remove minAppVersion, old appVersions are suddenly required to pass this field.
+            return false;
+        }
+
+        // Similar but reversed logic for maxAppVersion.
+        Integer oldMaxAppVersion = oldFieldDef.getMaxAppVersion();
+        Integer newMaxAppVersion = newFieldDef.getMaxAppVersion();
+        if (oldMaxAppVersion != null && newMaxAppVersion != null && newMaxAppVersion > oldMaxAppVersion) {
+            return false;
+        } else if (oldMaxAppVersion != null && newMaxAppVersion == null) {
+            return false;
+        }
+
+        // Changing the maxLength will cause the Synapse column to be recreated, so we need to block this. (Strictly
+        // speaking, BridgeEX has code to prevent this by ignoring the new max length if it is different, for legacy
+        // reasons but this is confusing behavior, so we should just prevent this situation from happening to begin
+        // with.)
+        if (!Objects.equals(oldFieldDef.getMaxLength(), newFieldDef.getMaxLength())) {
+            return false;
+        }
+
+        List<String> oldMultiChoiceAnswerList = oldFieldDef.getMultiChoiceAnswerList();
+        List<String> newMultiChoiceAnswerList = newFieldDef.getMultiChoiceAnswerList();
+        if (oldMultiChoiceAnswerList != null && newMultiChoiceAnswerList != null) {
+            // Choices might have been re-ordered, so convert to sets so we can determine the choices that have been
+            // added, deleted, or retained.
+            Set<String> oldMultiChoiceAnswerSet = new HashSet<>(oldMultiChoiceAnswerList);
+            Set<String> newMultiChoiceAnswerSet = new HashSet<>(newMultiChoiceAnswerList);
+
+            // Adding choices is okay. Deleting choices is not. (Renaming is deleting one choice and adding another.)
+            Set<String> deletedChoiceSet = Sets.difference(oldMultiChoiceAnswerSet, newMultiChoiceAnswerSet);
+            if (!deletedChoiceSet.isEmpty()) {
+                return false;
+            }
+        } else if (oldMultiChoiceAnswerList != null || newMultiChoiceAnswerList != null) {
+            // This should never happen, but if we add or remove a multi-choice answer list, we should flag the field
+            // defs as incompatible.
+            return false;
+        }
+
+        // This should never happen, but if for some reason, the field name changes, the fields are incompatible.
+        if (!Objects.equals(oldFieldDef.getName(), newFieldDef.getName())) {
+            return false;
+        }
+
+        // Going from required to optional is fine. Going from optional to required is okay only if you're adding a
+        // minAppVerison.
+        if (!oldFieldDef.isRequired() && newFieldDef.isRequired() && (oldMinAppVersion != null ||
+                newMinAppVersion == null)) {
+            return false;
+        }
+
+        // isUnboundedText controls whether we use a String or LargeText in Synapse. So changing this is not
+        // compatible. (null defaults to false)
+        //noinspection ConstantConditions
+        boolean oldIsUnboundedText = oldFieldDef.isUnboundedText() != null ? oldFieldDef.isUnboundedText() : false;
+        //noinspection ConstantConditions
+        boolean newIsUnboundedText = newFieldDef.isUnboundedText() != null ? newFieldDef.isUnboundedText() : false;
+        if (oldIsUnboundedText != newIsUnboundedText) {
+            return false;
+        }
+
+        // If we passed all incompatibility checks, then we're compatible.
+        return true;
     }
 
     /**

--- a/app/org/sagebionetworks/bridge/upload/UploadUtil.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadUtil.java
@@ -302,6 +302,7 @@ public class UploadUtil {
         // fileExtension - This is just a hint to BridgeEX for serializing the values. It doesn't affect the columns or
         //   validation.
         // mimeType - Similarly, this is also just a serialization hint.
+        // min/maxAppVersion - These will be dummied out. TODO remove this comment when no longer needed
 
         // Different types are obviously not compatible.
         // This is the most likely reason fields are incompatible. Check this first.
@@ -313,26 +314,6 @@ public class UploadUtil {
         Boolean oldAllowOther = oldFieldDef.getAllowOtherChoices();
         Boolean newAllowOther = newFieldDef.getAllowOtherChoices();
         if (oldAllowOther != null && oldAllowOther && (newAllowOther == null || !newAllowOther)) {
-            return false;
-        }
-
-        Integer oldMinAppVersion = oldFieldDef.getMinAppVersion();
-        Integer newMinAppVersion = newFieldDef.getMinAppVersion();
-        if (oldMinAppVersion != null && newMinAppVersion != null && newMinAppVersion < oldMinAppVersion) {
-            // If minAppVersion decreases, this means there are some appVersions that aren't sending this field that
-            // are suddenly required to send this field, which breaks Strict Validation.
-            return false;
-        } else if (oldMinAppVersion != null && newMinAppVersion == null) {
-            // Similarly, if we remove minAppVersion, old appVersions are suddenly required to pass this field.
-            return false;
-        }
-
-        // Similar but reversed logic for maxAppVersion.
-        Integer oldMaxAppVersion = oldFieldDef.getMaxAppVersion();
-        Integer newMaxAppVersion = newFieldDef.getMaxAppVersion();
-        if (oldMaxAppVersion != null && newMaxAppVersion != null && newMaxAppVersion > oldMaxAppVersion) {
-            return false;
-        } else if (oldMaxAppVersion != null && newMaxAppVersion == null) {
             return false;
         }
 
@@ -370,8 +351,7 @@ public class UploadUtil {
 
         // Going from required to optional is fine. Going from optional to required is okay only if you're adding a
         // minAppVerison.
-        if (!oldFieldDef.isRequired() && newFieldDef.isRequired() && (oldMinAppVersion != null ||
-                newMinAppVersion == null)) {
+        if (!oldFieldDef.isRequired() && newFieldDef.isRequired()) {
             return false;
         }
 

--- a/app/org/sagebionetworks/bridge/validators/UploadSchemaValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/UploadSchemaValidator.java
@@ -131,6 +131,12 @@ public class UploadSchemaValidator implements Validator {
                             fieldNameList.add(fieldName + TIME_ZONE_FIELD_SUFFIX);
                         }
 
+                        //noinspection ConstantConditions
+                        if (fieldDef.isUnboundedText() != null && fieldDef.isUnboundedText() &&
+                                fieldDef.getMaxLength() != null) {
+                            errors.rejectValue("unboundedText", "cannot specify unboundedText=true with a maxLength");
+                        }
+
                         errors.popNestedPath();
                     }
                 }

--- a/conf/routes
+++ b/conf/routes
@@ -97,7 +97,7 @@ GET    /v3/surveys/:surveyGuid/revisions                     @org.sagebionetwork
 GET    /v3/surveys/:surveyGuid/revisions/recent              @org.sagebionetworks.bridge.play.controllers.SurveyController.getSurveyMostRecentVersion(surveyGuid: String)
 GET    /v3/surveys/:surveyGuid/revisions/published           @org.sagebionetworks.bridge.play.controllers.SurveyController.getSurveyMostRecentlyPublishedVersion(surveyGuid: String)
 POST   /v3/surveys/:surveyGuid/revisions/:createdOn/version  @org.sagebionetworks.bridge.play.controllers.SurveyController.versionSurvey(surveyGuid: String, createdOn: String)
-POST   /v3/surveys/:surveyGuid/revisions/:createdOn/publish  @org.sagebionetworks.bridge.play.controllers.SurveyController.publishSurvey(surveyGuid: String, createdOn: String)
+POST   /v3/surveys/:surveyGuid/revisions/:createdOn/publish  @org.sagebionetworks.bridge.play.controllers.SurveyController.publishSurvey(surveyGuid: String, createdOn: String, newSchemaRev: String ?= null)
 GET    /v3/surveys/:surveyGuid/revisions/:createdOn          @org.sagebionetworks.bridge.play.controllers.SurveyController.getSurvey(surveyGuid: String, createdOn: String)
 POST   /v3/surveys/:surveyGuid/revisions/:createdOn          @org.sagebionetworks.bridge.play.controllers.SurveyController.updateSurvey(surveyGuid: String, createdOn: String)
 DELETE /v3/surveys/:surveyGuid/revisions/:createdOn          @org.sagebionetworks.bridge.play.controllers.SurveyController.deleteSurvey(surveyGuid: String, createdOn: String, physical: String ?= "false")

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoMockTest.java
@@ -1,0 +1,67 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.dao.UploadSchemaDao;
+import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolder;
+import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolderImpl;
+import org.sagebionetworks.bridge.models.surveys.Survey;
+
+public class DynamoSurveyDaoMockTest {
+    private static final DateTime MOCK_NOW = DateTime.parse("2016-08-24T15:23:57.123-0700");
+    private static final long MOCK_NOW_MILLIS = MOCK_NOW.getMillis();
+
+    @BeforeClass
+    public static void mockNow() {
+        DateTimeUtils.setCurrentMillisFixed(MOCK_NOW_MILLIS);
+    }
+
+    @Test
+    public void publishSurvey() {
+        // test inputs and outputs
+        GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl("test-guid", 1337);
+        Survey survey = new DynamoSurvey();
+
+        DynamoUploadSchema schema = new DynamoUploadSchema();
+        schema.setRevision(42);
+
+        // mock survey mapper
+        DynamoDBMapper mockSurveyMapper = mock(DynamoDBMapper.class);
+
+        // mock schema dao
+        UploadSchemaDao mockSchemaDao = mock(UploadSchemaDao.class);
+        when(mockSchemaDao.createUploadSchemaFromSurvey(TestConstants.TEST_STUDY, survey, true)).thenReturn(schema);
+
+        // Set up DAO for test.
+        DynamoSurveyDao surveyDao = spy(new DynamoSurveyDao());
+        surveyDao.setSurveyMapper(mockSurveyMapper);
+        surveyDao.setUploadSchemaDao(mockSchemaDao);
+
+        // spy getSurvey() - There's a lot of complex logic in that query builder that's irrelevant to what we're
+        // trying to test. Rather than over-specify our test and make our tests overly complicated, we'll just spy out
+        // getSurvey().
+        doReturn(survey).when(surveyDao).getSurvey(keys);
+
+        // execute and validate
+        Survey retval = surveyDao.publishSurvey(TestConstants.TEST_STUDY, keys, true);
+        assertTrue(retval.isPublished());
+        assertEquals(MOCK_NOW_MILLIS, retval.getModifiedOn());
+        assertEquals(42, retval.getSchemaRevision().intValue());
+
+        verify(mockSurveyMapper).save(same(retval));
+    }
+}

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoTest.java
@@ -17,6 +17,8 @@ import java.util.Set;
 
 import javax.annotation.Resource;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,6 +33,7 @@ import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolder;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolderImpl;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
+import org.sagebionetworks.bridge.models.surveys.BooleanConstraints;
 import org.sagebionetworks.bridge.models.surveys.DateConstraints;
 import org.sagebionetworks.bridge.models.surveys.Survey;
 import org.sagebionetworks.bridge.models.surveys.SurveyQuestion;
@@ -95,7 +98,7 @@ public class DynamoSurveyDaoTest {
     }
     
     private Survey publishSurvey(StudyIdentifier studyIdentifier, Survey survey) {
-        Survey publishedSurvey = surveyDao.publishSurvey(studyIdentifier, survey);
+        Survey publishedSurvey = surveyDao.publishSurvey(studyIdentifier, survey, false);
         return publishedSurvey;
     }
 
@@ -104,6 +107,14 @@ public class DynamoSurveyDaoTest {
             setName(name);
             setIdentifier(TestUtils.randomName(DynamoSurveyDaoTest.class));
             setStudyIdentifier(TEST_STUDY_IDENTIFIER);
+
+            // need at least one element
+            DynamoSurveyQuestion question = new DynamoSurveyQuestion();
+            question.setIdentifier("test-q");
+            question.setUiHint(UIHint.CHECKBOX);
+            question.setPrompt("Yes or No?");
+            question.setConstraints(new BooleanConstraints());
+            setElements(ImmutableList.of(question));
         }
     }
     
@@ -425,8 +436,8 @@ public class DynamoSurveyDaoTest {
         // This should include firstVersion and nextVersion.
         List<Survey> surveys = surveyDao.getAllSurveysMostRecentlyPublishedVersion(TEST_STUDY);
         assertEquals(initialCount+2, surveys.size());
-        assertTrue(surveys.indexOf(firstSurvey) > -1);
-        assertTrue(surveys.indexOf(secondSurvey) > -1);
+        assertContainsAllKeys(ImmutableSet.of(new GuidCreatedOnVersionHolderImpl(firstSurvey),
+                new GuidCreatedOnVersionHolderImpl(secondSurvey)), surveys);
     }
     
     @Test
@@ -451,8 +462,8 @@ public class DynamoSurveyDaoTest {
         List<Survey> surveys = surveyDao.getAllSurveysMostRecentVersion(TEST_STUDY);
         
         assertEquals(initialCount + 2, surveys.size());
-        assertTrue(surveys.indexOf(firstSurvey) > -1);
-        assertTrue(surveys.indexOf(secondSurvey) > -1);
+        assertContainsAllKeys(ImmutableSet.of(new GuidCreatedOnVersionHolderImpl(firstSurvey),
+                new GuidCreatedOnVersionHolderImpl(secondSurvey)), surveys);
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDaoMockTest.java
@@ -1130,7 +1130,7 @@ public class DynamoUploadSchemaDaoMockTest {
         // This update fails for 4 reasons
         // - deleted fields
         // - modified non-compatible field
-        // - added required fields without minAppVersion
+        // - added required fields
         // - modified schema type
 
         // Make old schema - Only field def list and schema type matter for this test.
@@ -1157,9 +1157,9 @@ public class DynamoUploadSchemaDaoMockTest {
                 new DynamoUploadFieldDefinition.Builder().withName("modify-me-2").withType(UploadFieldType.FLOAT)
                         .withMaxLength(24).build(),
                 new DynamoUploadFieldDefinition.Builder().withName("add-me-1").withType(UploadFieldType.BOOLEAN)
-                        .withRequired(true).withMinAppVersion(null).build(),
+                        .withRequired(true).build(),
                 new DynamoUploadFieldDefinition.Builder().withName("add-me-2").withType(UploadFieldType.BOOLEAN)
-                        .withRequired(true).withMinAppVersion(null).build());
+                        .withRequired(true).build());
 
         DynamoUploadSchema newSchema = new DynamoUploadSchema();
         newSchema.setSchemaType(UploadSchemaType.IOS_SURVEY);
@@ -1183,7 +1183,7 @@ public class DynamoUploadSchemaDaoMockTest {
             errMsg = ex.getMessage();
         }
 
-        assertTrue(errMsg.contains("Required added fields must have minAppVersion set: add-me-1, add-me-2"));
+        assertTrue(errMsg.contains("Added fields must be optional: add-me-1, add-me-2"));
         assertTrue(errMsg.contains("Can't delete fields: delete-me-1, delete-me-2"));
         assertTrue(errMsg.contains("Incompatible changes to fields: modify-me-1, modify-me-2"));
         assertTrue(errMsg.contains("Can't modify schema type, old=IOS_DATA, new=IOS_SURVEY"));
@@ -1202,7 +1202,6 @@ public class DynamoUploadSchemaDaoMockTest {
         // Test update with
         // - unchanged field
         // - modified compatible field
-        // - added required field with minAppVersion
         // - added optional field
 
         // Make old schema - Only field def list and schema type matter for this test.
@@ -1220,8 +1219,6 @@ public class DynamoUploadSchemaDaoMockTest {
                 new DynamoUploadFieldDefinition.Builder().withName("always").withType(UploadFieldType.BOOLEAN).build(),
                 new DynamoUploadFieldDefinition.Builder().withName("modify-me").withType(UploadFieldType.MULTI_CHOICE)
                         .withMultiChoiceAnswerList("foo", "bar", "baz").withAllowOtherChoices(true).build(),
-                new DynamoUploadFieldDefinition.Builder().withName("added-required-field")
-                        .withType(UploadFieldType.BOOLEAN).withRequired(true).withMinAppVersion(42).build(),
                 new DynamoUploadFieldDefinition.Builder().withName("added-optional-field")
                         .withType(UploadFieldType.BOOLEAN).withRequired(false).build());
 

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDaoMockTest.java
@@ -8,10 +8,14 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.notNull;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -28,6 +32,9 @@ import com.google.common.collect.ImmutableMap;
 
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+
+import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.exceptions.ConcurrentModificationException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
@@ -46,13 +53,24 @@ import org.sagebionetworks.bridge.models.surveys.SurveyElement;
 import org.sagebionetworks.bridge.models.surveys.SurveyQuestion;
 import org.sagebionetworks.bridge.models.surveys.SurveyQuestionOption;
 import org.sagebionetworks.bridge.models.surveys.TimeConstraints;
+import org.sagebionetworks.bridge.models.surveys.Unit;
 import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
 import org.sagebionetworks.bridge.models.upload.UploadFieldType;
 import org.sagebionetworks.bridge.models.upload.UploadSchema;
 import org.sagebionetworks.bridge.models.upload.UploadSchemaType;
+import org.sagebionetworks.bridge.upload.UploadUtil;
 
-@SuppressWarnings({ "unchecked", "rawtypes", "RedundantCast" })
+@SuppressWarnings({ "ConstantConditions", "rawtypes", "RedundantCast", "unchecked" })
 public class DynamoUploadSchemaDaoMockTest {
+    private static final String SCHEMA_ID = "test-schema";
+    private static final int SCHEMA_REV = 3;
+
+    private static final long SURVEY_CREATED_ON = 1337;
+    private static final String SURVEY_GUID = "test-guid";
+    private static final String SURVEY_ID = "test-survey";
+    private static final String SURVEY_NAME = "Test Survey";
+    private static final long SURVEY_SCHEMA_DDB_VERSION = 2;
+
     @Test
     public void createNewSchema() {
         testCreateUpdate("createStudy", "newSchema", null, 0);
@@ -109,63 +127,60 @@ public class DynamoUploadSchemaDaoMockTest {
         assertSame(arg.getValue(), retVal);
     }
 
+    private static Survey makeSurveyWithElements(List<SurveyElement> surveyElementList) {
+        Survey survey = new DynamoSurvey();
+        survey.setGuid(SURVEY_GUID);
+        survey.setCreatedOn(SURVEY_CREATED_ON);
+        survey.setIdentifier(SURVEY_ID);
+        survey.setName(SURVEY_NAME);
+        survey.setElements(surveyElementList);
+        return survey;
+    }
+
     @Test
-    public void createUploadSchemaFromSurvey() {
+    public void createUploadSchemaFromSurveyAllFields() {
         // create survey questions
         List<SurveyElement> surveyElementList = new ArrayList<>();
 
-        // no constraints
-        {
-            SurveyQuestion q = new DynamoSurveyQuestion();
-            q.setIdentifier("no-constraints");
-            q.setConstraints(null);
-            surveyElementList.add(q);
-        }
-
-        // multi value string
+        // multi-choice
         {
             MultiValueConstraints constraints = new MultiValueConstraints();
             constraints.setDataType(DataType.STRING);
             constraints.setAllowMultiple(true);
+            constraints.setEnumeration(ImmutableList.of(new SurveyQuestionOption("foo"),
+                    new SurveyQuestionOption("bar"), new SurveyQuestionOption("baz")));
 
             SurveyQuestion q = new DynamoSurveyQuestion();
-            q.setIdentifier("multi-value-string");
+            q.setIdentifier("multi-choice");
             q.setConstraints(constraints);
             surveyElementList.add(q);
         }
 
-        // multi value int without options
+        // multi-choice, allow other
         {
             MultiValueConstraints constraints = new MultiValueConstraints();
-            constraints.setDataType(DataType.INTEGER);
+            constraints.setDataType(DataType.STRING);
             constraints.setAllowMultiple(true);
+            constraints.setEnumeration(ImmutableList.of(new SurveyQuestionOption("foo"),
+                    new SurveyQuestionOption("bar"), new SurveyQuestionOption("baz")));
+            constraints.setAllowOther(true);
 
             SurveyQuestion q = new DynamoSurveyQuestion();
-            q.setIdentifier("multi-value-int-without-options");
+            q.setIdentifier("multi-choice-allow-other");
             q.setConstraints(constraints);
             surveyElementList.add(q);
         }
 
-        // multi value string don't allow multiple
+        // single-choice
         {
             MultiValueConstraints constraints = new MultiValueConstraints();
             constraints.setDataType(DataType.STRING);
             constraints.setAllowMultiple(false);
+            constraints.setEnumeration(ImmutableList.of(new SurveyQuestionOption("short"),
+                    new SurveyQuestionOption("medium"), new SurveyQuestionOption("long")));
 
             SurveyQuestion q = new DynamoSurveyQuestion();
-            q.setIdentifier("multi-value-single-choice-string");
-            q.setConstraints(constraints);
-            surveyElementList.add(q);
-        }
-
-        // multi value int don't allow multiple
-        {
-            MultiValueConstraints constraints = new MultiValueConstraints();
-            constraints.setDataType(DataType.INTEGER);
-            constraints.setAllowMultiple(false);
-
-            SurveyQuestion q = new DynamoSurveyQuestion();
-            q.setIdentifier("multi-value-single-choice-int");
+            q.setIdentifier("single-choice");
             q.setConstraints(constraints);
             surveyElementList.add(q);
         }
@@ -259,253 +274,572 @@ public class DynamoUploadSchemaDaoMockTest {
             surveyElementList.add(q);
         }
 
-        // multi value int short
-        {
-            MultiValueConstraints constraints = new MultiValueConstraints();
-            constraints.setDataType(DataType.INTEGER);
-            constraints.setAllowMultiple(true);
-            constraints.setEnumeration(generateOptionList(15));
+        Survey survey = makeSurveyWithElements(surveyElementList);
 
-            SurveyQuestion q = new DynamoSurveyQuestion();
-            q.setIdentifier("multi-value-int-short");
-            q.setConstraints(constraints);
-            surveyElementList.add(q);
-        }
-
-        // multi value int long
-        {
-            MultiValueConstraints constraints = new MultiValueConstraints();
-            constraints.setDataType(DataType.INTEGER);
-            constraints.setAllowMultiple(true);
-            constraints.setEnumeration(generateOptionList(25));
-
-            SurveyQuestion q = new DynamoSurveyQuestion();
-            q.setIdentifier("multi-value-int-long");
-            q.setConstraints(constraints);
-            surveyElementList.add(q);
-        }
-
-        // make survey
-        Survey survey = new DynamoSurvey();
-        survey.setIdentifier("test-survey");
-        survey.setName("Test Survey");
-        survey.setElements(surveyElementList);
-
-        // Mock DDB mapper - This is the new schema case, so setting up the mock mapper with null is fine.
-        DynamoDBMapper mockMapper = setupMockMapperWithSchema(null);
+        // There's a lot of complex logic under test. To de-couple the "create a schema from a survey" part from the
+        // "interface with DDB" part, we're just going to spy out getUploadSchemaNoThrow(), createSchemaV4() and
+        // updateSchemaV4().
+        UploadSchema dummy = new DynamoUploadSchema();
+        DynamoUploadSchemaDao dao = spy(new DynamoUploadSchemaDao());
+        doReturn(null).when(dao).getUploadSchemaNoThrow(any(), any());
+        doReturn(dummy).when(dao).createSchemaRevisionV4(any(), any());
 
         // set up test dao and execute
-        DynamoUploadSchemaDao dao = new DynamoUploadSchemaDao();
-        dao.setDdbMapper(mockMapper);
-        DynamoUploadSchema createdSchema = (DynamoUploadSchema) dao.createUploadSchemaFromSurvey(
-                new StudyIdentifierImpl("survey-study"), survey);
+        DynamoUploadSchema retval = (DynamoUploadSchema) dao.createUploadSchemaFromSurvey(TestConstants.TEST_STUDY,
+                survey, false);
+        assertSame(dummy, retval);
+
+        // verify calls
+        verify(dao).getUploadSchemaNoThrow(TestConstants.TEST_STUDY_IDENTIFIER, SURVEY_ID);
+        verify(dao, never()).updateSchemaRevisionV4(any(), any(), anyInt(), any());
+
+        ArgumentCaptor<UploadSchema> createdSchemaCaptor = ArgumentCaptor.forClass(UploadSchema.class);
+        verify(dao).createSchemaRevisionV4(eq(TestConstants.TEST_STUDY), createdSchemaCaptor.capture());
 
         // validate schema
-        assertEquals("Test Survey", createdSchema.getName());
-        assertEquals(1, createdSchema.getRevision());
-        assertEquals("test-survey", createdSchema.getSchemaId());
+        UploadSchema createdSchema = createdSchemaCaptor.getValue();
+        assertEquals(SURVEY_NAME, createdSchema.getName());
+        assertEquals(SURVEY_ID, createdSchema.getSchemaId());
         assertEquals(UploadSchemaType.IOS_SURVEY, createdSchema.getSchemaType());
-        assertEquals("survey-study", createdSchema.getStudyId());
+        assertEquals(SURVEY_GUID, createdSchema.getSurveyGuid());
+        assertEquals(SURVEY_CREATED_ON, createdSchema.getSurveyCreatedOn().longValue());
 
         List<UploadFieldDefinition> fieldDefList = createdSchema.getFieldDefinitions();
-        assertEquals(17, fieldDefList.size());
+        assertEquals(16, fieldDefList.size());
 
-        assertEquals("no-constraints", fieldDefList.get(0).getName());
-        assertEquals(UploadFieldType.INLINE_JSON_BLOB, fieldDefList.get(0).getType());
+        // validate that none of the fields are required
+        for (UploadFieldDefinition oneFieldDef : fieldDefList) {
+            assertFalse(oneFieldDef.isRequired());
+        }
 
-        assertEquals("multi-value-string", fieldDefList.get(1).getName());
-        assertEquals(UploadFieldType.ATTACHMENT_JSON_BLOB, fieldDefList.get(1).getType());
+        // validate individual fields
+        assertEquals("multi-choice", fieldDefList.get(0).getName());
+        assertEquals(UploadFieldType.MULTI_CHOICE, fieldDefList.get(0).getType());
+        assertEquals(ImmutableList.of("foo", "bar", "baz"), fieldDefList.get(0).getMultiChoiceAnswerList());
+        assertFalse(fieldDefList.get(0).getAllowOtherChoices());
 
-        assertEquals("multi-value-int-without-options", fieldDefList.get(2).getName());
-        assertEquals(UploadFieldType.INLINE_JSON_BLOB, fieldDefList.get(2).getType());
+        assertEquals("multi-choice-allow-other", fieldDefList.get(1).getName());
+        assertEquals(UploadFieldType.MULTI_CHOICE, fieldDefList.get(1).getType());
+        assertEquals(ImmutableList.of("foo", "bar", "baz"), fieldDefList.get(1).getMultiChoiceAnswerList());
+        assertTrue(fieldDefList.get(1).getAllowOtherChoices());
 
-        assertEquals("multi-value-single-choice-string", fieldDefList.get(3).getName());
-        assertEquals(UploadFieldType.INLINE_JSON_BLOB, fieldDefList.get(3).getType());
+        assertEquals("single-choice", fieldDefList.get(2).getName());
+        assertEquals(UploadFieldType.SINGLE_CHOICE, fieldDefList.get(2).getType());
+        assertEquals(6, fieldDefList.get(2).getMaxLength().intValue());
 
-        assertEquals("multi-value-single-choice-int", fieldDefList.get(4).getName());
-        assertEquals(UploadFieldType.INLINE_JSON_BLOB, fieldDefList.get(4).getType());
+        assertEquals("duration", fieldDefList.get(3).getName());
+        assertEquals(UploadFieldType.INT, fieldDefList.get(3).getType());
 
-        assertEquals("duration", fieldDefList.get(5).getName());
+        assertEquals("duration" + UploadUtil.UNIT_FIELD_SUFFIX, fieldDefList.get(4).getName());
+        assertEquals(UploadFieldType.STRING, fieldDefList.get(4).getType());
+        assertEquals(Unit.MAX_STRING_LENGTH, fieldDefList.get(4).getMaxLength().intValue());
+
+        assertEquals("unbounded-string", fieldDefList.get(5).getName());
         assertEquals(UploadFieldType.STRING, fieldDefList.get(5).getType());
+        assertTrue(fieldDefList.get(5).isUnboundedText());
 
-        assertEquals("unbounded-string", fieldDefList.get(6).getName());
-        assertEquals(UploadFieldType.ATTACHMENT_BLOB, fieldDefList.get(6).getType());
+        assertEquals("long-string", fieldDefList.get(6).getName());
+        assertEquals(UploadFieldType.STRING, fieldDefList.get(6).getType());
+        assertEquals(1000, fieldDefList.get(6).getMaxLength().intValue());
 
-        assertEquals("long-string", fieldDefList.get(7).getName());
-        assertEquals(UploadFieldType.ATTACHMENT_BLOB, fieldDefList.get(7).getType());
+        assertEquals("short-string", fieldDefList.get(7).getName());
+        assertEquals(UploadFieldType.STRING, fieldDefList.get(7).getType());
+        assertEquals(24, fieldDefList.get(7).getMaxLength().intValue());
 
-        assertEquals("short-string", fieldDefList.get(8).getName());
-        assertEquals(UploadFieldType.STRING, fieldDefList.get(8).getType());
+        assertEquals("int", fieldDefList.get(8).getName());
+        assertEquals(UploadFieldType.INT, fieldDefList.get(8).getType());
 
-        assertEquals("int", fieldDefList.get(9).getName());
-        assertEquals(UploadFieldType.INT, fieldDefList.get(9).getType());
+        assertEquals("int" + UploadUtil.UNIT_FIELD_SUFFIX, fieldDefList.get(9).getName());
+        assertEquals(UploadFieldType.STRING, fieldDefList.get(9).getType());
+        assertEquals(Unit.MAX_STRING_LENGTH, fieldDefList.get(9).getMaxLength().intValue());
 
         assertEquals("decimal", fieldDefList.get(10).getName());
         assertEquals(UploadFieldType.FLOAT, fieldDefList.get(10).getType());
 
-        assertEquals("boolean", fieldDefList.get(11).getName());
-        assertEquals(UploadFieldType.BOOLEAN, fieldDefList.get(11).getType());
+        assertEquals("decimal" + UploadUtil.UNIT_FIELD_SUFFIX, fieldDefList.get(11).getName());
+        assertEquals(UploadFieldType.STRING, fieldDefList.get(11).getType());
+        assertEquals(Unit.MAX_STRING_LENGTH, fieldDefList.get(11).getMaxLength().intValue());
 
-        assertEquals("calendar-date", fieldDefList.get(12).getName());
-        assertEquals(UploadFieldType.CALENDAR_DATE, fieldDefList.get(12).getType());
+        assertEquals("boolean", fieldDefList.get(12).getName());
+        assertEquals(UploadFieldType.BOOLEAN, fieldDefList.get(12).getType());
 
-        assertEquals("local-time", fieldDefList.get(13).getName());
-        assertEquals(UploadFieldType.STRING, fieldDefList.get(13).getType());
+        assertEquals("calendar-date", fieldDefList.get(13).getName());
+        assertEquals(UploadFieldType.CALENDAR_DATE, fieldDefList.get(13).getType());
 
-        assertEquals("timestamp", fieldDefList.get(14).getName());
-        assertEquals(UploadFieldType.TIMESTAMP, fieldDefList.get(14).getType());
+        assertEquals("local-time", fieldDefList.get(14).getName());
+        assertEquals(UploadFieldType.TIME_V2, fieldDefList.get(14).getType());
 
-        assertEquals("multi-value-int-short", fieldDefList.get(15).getName());
-        assertEquals(UploadFieldType.INLINE_JSON_BLOB, fieldDefList.get(15).getType());
-
-        assertEquals("multi-value-int-long", fieldDefList.get(16).getName());
-        assertEquals(UploadFieldType.ATTACHMENT_JSON_BLOB, fieldDefList.get(16).getType());
-
-        // Validate call to DDB - make sure returned schema same as the one sent to DDB.
-        ArgumentCaptor<DynamoUploadSchema> arg = ArgumentCaptor.forClass(DynamoUploadSchema.class);
-        verify(mockMapper).save(arg.capture(), notNull(DynamoDBSaveExpression.class));
-        assertSame(createdSchema, arg.getValue());
+        assertEquals("timestamp", fieldDefList.get(15).getName());
+        assertEquals(UploadFieldType.TIMESTAMP, fieldDefList.get(15).getType());
     }
 
-    private List<SurveyQuestionOption> generateOptionList(int count) {
-        List<SurveyQuestionOption> optionList = new ArrayList<>();
-        for (int i = 0; i < count; i++) {
-            optionList.add(new SurveyQuestionOption(String.valueOf(i)));
+    private static DynamoUploadSchema makeSchemaForSurveyTests() {
+        // 2 simple fields, one multi-choice, one bool
+        List<UploadFieldDefinition> fieldDefList = ImmutableList.of(
+                new DynamoUploadFieldDefinition.Builder().withName("multi-choice-q")
+                        .withType(UploadFieldType.MULTI_CHOICE).withRequired(false)
+                        .withMultiChoiceAnswerList("always", "remove-me-choice").withAllowOtherChoices(true).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("remove-me-q").withType(UploadFieldType.BOOLEAN)
+                        .withRequired(false).build());
+
+        // For these tests, we don't need all fields, just the field def list, type, ddb version, and revision.
+        DynamoUploadSchema schema = new DynamoUploadSchema();
+        schema.setFieldDefinitions(fieldDefList);
+        schema.setRevision(SCHEMA_REV);
+        schema.setSchemaType(UploadSchemaType.IOS_SURVEY);
+        schema.setVersion(SURVEY_SCHEMA_DDB_VERSION);
+        return schema;
+    }
+
+    @Test
+    public void schemaFromSurveyCompatibleUpdate() {
+        // The new survey removes a choice and adds a choice, removes a field and adds a field. This is successfully
+        // merged into the new schema.
+        List<SurveyElement> surveyElementList = new ArrayList<>();
+        {
+            MultiValueConstraints constraints = new MultiValueConstraints();
+            constraints.setDataType(DataType.STRING);
+            constraints.setAllowMultiple(true);
+            constraints.setAllowOther(false);
+            constraints.setEnumeration(ImmutableList.of(new SurveyQuestionOption("always"),
+                    new SurveyQuestionOption("added-choice")));
+
+            SurveyQuestion q = new DynamoSurveyQuestion();
+            q.setIdentifier("multi-choice-q");
+            q.setConstraints(constraints);
+            surveyElementList.add(q);
         }
-        return optionList;
+        {
+            StringConstraints constraints = new StringConstraints();
+            constraints.setMaxLength(24);
+
+            SurveyQuestion q = new DynamoSurveyQuestion();
+            q.setIdentifier("added-q");
+            q.setConstraints(constraints);
+            surveyElementList.add(q);
+        }
+
+        Survey survey = makeSurveyWithElements(surveyElementList);
+
+        // Similarly, spy UploadSchemaDao.
+        UploadSchema dummy = new DynamoUploadSchema();
+        DynamoUploadSchemaDao dao = spy(new DynamoUploadSchemaDao());
+        doReturn(makeSchemaForSurveyTests()).when(dao).getUploadSchemaNoThrow(any(), any());
+        doReturn(dummy).when(dao).updateSchemaRevisionV4(any(), any(), anyInt(), any());
+
+        // set up test dao and execute
+        DynamoUploadSchema retval = (DynamoUploadSchema) dao.createUploadSchemaFromSurvey(TestConstants.TEST_STUDY,
+                survey, false);
+        assertSame(dummy, retval);
+
+        // verify calls
+        verify(dao).getUploadSchemaNoThrow(TestConstants.TEST_STUDY_IDENTIFIER, SURVEY_ID);
+        verify(dao, never()).createSchemaRevisionV4(any(), any());
+
+        ArgumentCaptor<UploadSchema> updatedSchemaCaptor = ArgumentCaptor.forClass(UploadSchema.class);
+        verify(dao).updateSchemaRevisionV4(eq(TestConstants.TEST_STUDY), eq(SURVEY_ID), eq(SCHEMA_REV),
+                updatedSchemaCaptor.capture());
+
+        // validate schema - Don't need to validate everything, just the essentials.
+        UploadSchema updatedSchema = updatedSchemaCaptor.getValue();
+        assertEquals(SURVEY_ID, updatedSchema.getSchemaId());
+        assertEquals(SURVEY_SCHEMA_DDB_VERSION, updatedSchema.getVersion().longValue());
+
+        // validate fields - Merged field def list (and answer choice) list has new fields, then old fields.
+        List<UploadFieldDefinition> fieldDefList = updatedSchema.getFieldDefinitions();
+        assertEquals(3, fieldDefList.size());
+
+        assertEquals("multi-choice-q", fieldDefList.get(0).getName());
+        assertEquals(UploadFieldType.MULTI_CHOICE, fieldDefList.get(0).getType());
+        assertTrue(fieldDefList.get(0).getAllowOtherChoices());
+        assertEquals(ImmutableList.of("always", "added-choice", "remove-me-choice"), fieldDefList.get(0)
+                .getMultiChoiceAnswerList());
+
+        assertEquals("added-q", fieldDefList.get(1).getName());
+        assertEquals(UploadFieldType.STRING, fieldDefList.get(1).getType());
+
+        assertEquals("remove-me-q", fieldDefList.get(2).getName());
+        assertEquals(UploadFieldType.BOOLEAN, fieldDefList.get(2).getType());
     }
 
     @Test
-    public void updateUploadSchemaFromSurvey() {
-        // create survey questions - We already tested all the survey question types, so we don't need a big huge list.
-        SurveyQuestion q = new DynamoSurveyQuestion();
-        q.setIdentifier("one-more-question");
-        q.setConstraints(new IntegerConstraints());
-        List<SurveyElement> surveyElementList = ImmutableList.<SurveyElement>of(q);
+    public void schemaFromSurveyIdenticalUpdate() {
+        // This schema is identical to makeSchemaForSurveyTests, but is in reverse order.
+        List<SurveyElement> surveyElementList = new ArrayList<>();
+        {
+            SurveyQuestion q = new DynamoSurveyQuestion();
+            q.setIdentifier("remove-me-q");
+            q.setConstraints(new BooleanConstraints());
+            surveyElementList.add(q);
+        }
+        {
+            MultiValueConstraints constraints = new MultiValueConstraints();
+            constraints.setDataType(DataType.STRING);
+            constraints.setAllowMultiple(true);
+            constraints.setAllowOther(true);
+            constraints.setEnumeration(ImmutableList.of(new SurveyQuestionOption("always"),
+                    new SurveyQuestionOption("remove-me-choice")));
 
-        // make survey
-        Survey survey = new DynamoSurvey();
-        survey.setIdentifier("test-survey");
-        survey.setName("Test Survey (Updated)");
-        survey.setElements(surveyElementList);
+            SurveyQuestion q = new DynamoSurveyQuestion();
+            q.setIdentifier("multi-choice-q");
+            q.setConstraints(constraints);
+            surveyElementList.add(q);
+        }
 
-        // old schema - has different questions
-        DynamoUploadSchema oldSchema = makeUploadSchema("survey-study", "test-survey", 2);
-        oldSchema.setFieldDefinitions(ImmutableList.of(new DynamoUploadFieldDefinition.Builder()
-                .withName("different-question").withType(UploadFieldType.STRING).withRequired(false).build()));
+        Survey survey = makeSurveyWithElements(surveyElementList);
 
-        // Mock DDB mapper - This is only used for rev, so we don't need a fully fleshed out schema.
-        DynamoDBMapper mockMapper = setupMockMapperWithSchema(oldSchema);
+        // Similarly, spy UploadSchemaDao.
+        UploadSchema oldSchema = makeSchemaForSurveyTests();
+        DynamoUploadSchemaDao dao = spy(new DynamoUploadSchemaDao());
+        doReturn(oldSchema).when(dao).getUploadSchemaNoThrow(any(), any());
 
         // set up test dao and execute
-        DynamoUploadSchemaDao dao = new DynamoUploadSchemaDao();
-        dao.setDdbMapper(mockMapper);
-        DynamoUploadSchema createdSchema = (DynamoUploadSchema) dao.createUploadSchemaFromSurvey(
-                new StudyIdentifierImpl("survey-study"), survey);
+        DynamoUploadSchema retval = (DynamoUploadSchema) dao.createUploadSchemaFromSurvey(TestConstants.TEST_STUDY,
+                survey, false);
+        assertSame(oldSchema, retval);
 
-        // validate schema
-        assertEquals("Test Survey (Updated)", createdSchema.getName());
-        assertEquals(3, createdSchema.getRevision());
-        assertEquals("test-survey", createdSchema.getSchemaId());
-        assertEquals(UploadSchemaType.IOS_SURVEY, createdSchema.getSchemaType());
-        assertEquals("survey-study", createdSchema.getStudyId());
+        // verify calls
+        verify(dao).getUploadSchemaNoThrow(TestConstants.TEST_STUDY_IDENTIFIER, SURVEY_ID);
+        verify(dao, never()).createSchemaRevisionV4(any(), any());
+        verify(dao, never()).updateSchemaRevisionV4(any(), any(), anyInt(), any());
 
+        // Don't need to validate the schema. We know it's the same as the old one.
+    }
+
+    @Test
+    public void schemaFromSurveyIncompatibleUpdate() {
+        // The new survey changes the answer list in multi-choice-q, which is fine. But it also changes the type of
+        // remove-me-q, which is not fine.
+        List<SurveyElement> surveyElementList = new ArrayList<>();
+        {
+            MultiValueConstraints constraints = new MultiValueConstraints();
+            constraints.setDataType(DataType.STRING);
+            constraints.setAllowMultiple(true);
+            constraints.setAllowOther(false);
+            constraints.setEnumeration(ImmutableList.of(new SurveyQuestionOption("always"),
+                    new SurveyQuestionOption("added-choice")));
+
+            SurveyQuestion q = new DynamoSurveyQuestion();
+            q.setIdentifier("multi-choice-q");
+            q.setConstraints(constraints);
+            surveyElementList.add(q);
+        }
+        {
+            StringConstraints constraints = new StringConstraints();
+            constraints.setMaxLength(24);
+
+            SurveyQuestion q = new DynamoSurveyQuestion();
+            q.setIdentifier("remove-me-q");
+            q.setConstraints(constraints);
+            surveyElementList.add(q);
+        }
+
+        Survey survey = makeSurveyWithElements(surveyElementList);
+
+        // Similarly, spy UploadSchemaDao.
+        UploadSchema dummy = new DynamoUploadSchema();
+        DynamoUploadSchemaDao dao = spy(new DynamoUploadSchemaDao());
+        doReturn(makeSchemaForSurveyTests()).when(dao).getUploadSchemaNoThrow(any(), any());
+        doReturn(dummy).when(dao).createSchemaRevisionV4(any(), any());
+
+        // set up test dao and execute
+        DynamoUploadSchema retval = (DynamoUploadSchema) dao.createUploadSchemaFromSurvey(TestConstants.TEST_STUDY,
+                survey, false);
+        assertSame(dummy, retval);
+
+        // verify calls
+        verify(dao).getUploadSchemaNoThrow(TestConstants.TEST_STUDY_IDENTIFIER, SURVEY_ID);
+        verify(dao, never()).updateSchemaRevisionV4(any(), any(), anyInt(), any());
+
+        ArgumentCaptor<UploadSchema> createdSchemaCaptor = ArgumentCaptor.forClass(UploadSchema.class);
+        verify(dao).createSchemaRevisionV4(eq(TestConstants.TEST_STUDY), createdSchemaCaptor.capture());
+
+        // validate schema - Don't need to validate everything, just the essentials.
+        UploadSchema createdSchema = createdSchemaCaptor.getValue();
+        assertEquals(SURVEY_ID, createdSchema.getSchemaId());
+
+        // validate fields - It's an incompatible change, so just the new field def list.
         List<UploadFieldDefinition> fieldDefList = createdSchema.getFieldDefinitions();
-        assertEquals(1, fieldDefList.size());
-        assertEquals("one-more-question", fieldDefList.get(0).getName());
-        assertEquals(UploadFieldType.INT, fieldDefList.get(0).getType());
+        assertEquals(2, fieldDefList.size());
 
-        // Validate call to DDB - make sure returned schema same as the one sent to DDB.
-        ArgumentCaptor<DynamoUploadSchema> arg = ArgumentCaptor.forClass(DynamoUploadSchema.class);
-        verify(mockMapper).save(arg.capture(), notNull(DynamoDBSaveExpression.class));
-        assertSame(createdSchema, arg.getValue());
+        assertEquals("multi-choice-q", fieldDefList.get(0).getName());
+        assertEquals(UploadFieldType.MULTI_CHOICE, fieldDefList.get(0).getType());
+        assertFalse(fieldDefList.get(0).getAllowOtherChoices());
+        assertEquals(ImmutableList.of("always", "added-choice"), fieldDefList.get(0).getMultiChoiceAnswerList());
+
+        assertEquals("remove-me-q", fieldDefList.get(1).getName());
+        assertEquals(UploadFieldType.STRING, fieldDefList.get(1).getType());
     }
 
     @Test
-    public void updateUploadSchemaFromSurveySameFields() {
-        // create survey questions - We already tested all the survey question types, so we don't need a big huge list.
-        SurveyQuestion q1 = new DynamoSurveyQuestion();
-        q1.setIdentifier("foo-question");
-        q1.setConstraints(new BooleanConstraints());
+    public void schemaFromSurveyExplicitNewRev() {
+        // This survey is compatible with the old schema, but we explicitly ask for a new rev.
+        List<SurveyElement> surveyElementList = new ArrayList<>();
+        {
+            MultiValueConstraints constraints = new MultiValueConstraints();
+            constraints.setDataType(DataType.STRING);
+            constraints.setAllowMultiple(true);
+            constraints.setAllowOther(false);
+            constraints.setEnumeration(ImmutableList.of(new SurveyQuestionOption("always"),
+                    new SurveyQuestionOption("added-choice")));
 
-        SurveyQuestion q2 = new DynamoSurveyQuestion();
-        q2.setIdentifier("bar-question");
-        q2.setConstraints(new IntegerConstraints());
+            SurveyQuestion q = new DynamoSurveyQuestion();
+            q.setIdentifier("multi-choice-q");
+            q.setConstraints(constraints);
+            surveyElementList.add(q);
+        }
+        {
+            StringConstraints constraints = new StringConstraints();
+            constraints.setMaxLength(24);
 
-        List<SurveyElement> surveyElementList = ImmutableList.<SurveyElement>of(q1, q2);
+            SurveyQuestion q = new DynamoSurveyQuestion();
+            q.setIdentifier("added-q");
+            q.setConstraints(constraints);
+            surveyElementList.add(q);
+        }
 
-        // make survey
-        Survey survey = new DynamoSurvey();
-        survey.setIdentifier("same-survey");
-        survey.setName("Test Survey (Same Fields)");
-        survey.setElements(surveyElementList);
+        Survey survey = makeSurveyWithElements(surveyElementList);
 
-        // old schema - has same questions, but in the opposite order. (This should still be treated as same schema
-        // fields.)
-        DynamoUploadSchema oldSchema = makeUploadSchema("survey-study", "same-survey", 4);
-        oldSchema.setName("Old Name");
-        oldSchema.setFieldDefinitions(ImmutableList.of(
-                new DynamoUploadFieldDefinition.Builder().withName("bar-question").withType(UploadFieldType.INT)
-                        .withRequired(false).build(),
-                new DynamoUploadFieldDefinition.Builder().withName("foo-question").withType(UploadFieldType.BOOLEAN)
-                        .withRequired(false).build()));
-
-        // Mock DDB mapper - This is only used for rev, so we don't need a fully fleshed out schema.
-        DynamoDBMapper mockMapper = setupMockMapperWithSchema(oldSchema);
-
-        // set up test dao and execute
-        DynamoUploadSchemaDao dao = new DynamoUploadSchemaDao();
-        dao.setDdbMapper(mockMapper);
-        DynamoUploadSchema createdSchema = (DynamoUploadSchema) dao.createUploadSchemaFromSurvey(
-                new StudyIdentifierImpl("survey-study"), survey);
-
-        // validate schema - it should be the same as the old one
-        assertSame(oldSchema, createdSchema);
-
-        // Make sure we don't save anything to DDB.
-        verify(mockMapper, never()).save(any());
-    }
-
-    @Test
-    public void surveySchemasHaveOptionalFields() {
-        // create survey questions - We already tested all the survey question types, so we don't need a big huge list.
-        SurveyQuestion q = new DynamoSurveyQuestion();
-        q.setIdentifier("always-optional");
-        q.setConstraints(new DecimalConstraints());
-        List<SurveyElement> surveyElementList = ImmutableList.<SurveyElement>of(q);
-
-        // make survey
-        Survey survey = new DynamoSurvey();
-        survey.setIdentifier("test-survey");
-        survey.setName("Optional Question Survey");
-        survey.setElements(surveyElementList);
-
-        // Mock DDB mapper - This is the new schema case, so setting up the mock mapper with null is fine.
-        DynamoDBMapper mockMapper = setupMockMapperWithSchema(null);
+        // Similarly, spy UploadSchemaDao.
+        UploadSchema dummy = new DynamoUploadSchema();
+        DynamoUploadSchemaDao dao = spy(new DynamoUploadSchemaDao());
+        doReturn(dummy).when(dao).createSchemaRevisionV4(any(), any());
 
         // set up test dao and execute
-        DynamoUploadSchemaDao dao = new DynamoUploadSchemaDao();
-        dao.setDdbMapper(mockMapper);
-        DynamoUploadSchema createdSchema = (DynamoUploadSchema) dao.createUploadSchemaFromSurvey(
-                new StudyIdentifierImpl("survey-study"), survey);
+        DynamoUploadSchema retval = (DynamoUploadSchema) dao.createUploadSchemaFromSurvey(TestConstants.TEST_STUDY,
+                survey, true);
+        assertSame(dummy, retval);
 
-        // validate schema
-        assertEquals("Optional Question Survey", createdSchema.getName());
-        assertEquals(1, createdSchema.getRevision());
-        assertEquals("test-survey", createdSchema.getSchemaId());
-        assertEquals(UploadSchemaType.IOS_SURVEY, createdSchema.getSchemaType());
-        assertEquals("survey-study", createdSchema.getStudyId());
+        // verify calls - Note that because we ask for a new rev, we never call to get the old schema.
+        verify(dao, never()).getUploadSchemaNoThrow(any(), any());
+        verify(dao, never()).updateSchemaRevisionV4(any(), any(), anyInt(), any());
 
+        ArgumentCaptor<UploadSchema> createdSchemaCaptor = ArgumentCaptor.forClass(UploadSchema.class);
+        verify(dao).createSchemaRevisionV4(eq(TestConstants.TEST_STUDY), createdSchemaCaptor.capture());
+
+        // validate schema - Don't need to validate everything, just the essentials.
+        UploadSchema createdSchema = createdSchemaCaptor.getValue();
+        assertEquals(SURVEY_ID, createdSchema.getSchemaId());
+
+        // validate fields
         List<UploadFieldDefinition> fieldDefList = createdSchema.getFieldDefinitions();
-        assertEquals(1, fieldDefList.size());
-        assertEquals("always-optional", fieldDefList.get(0).getName());
-        assertEquals(UploadFieldType.FLOAT, fieldDefList.get(0).getType());
-        assertFalse(fieldDefList.get(0).isRequired());
+        assertEquals(2, fieldDefList.size());
 
-        // Validate call to DDB - make sure returned schema same as the one sent to DDB.
-        ArgumentCaptor<DynamoUploadSchema> arg = ArgumentCaptor.forClass(DynamoUploadSchema.class);
-        verify(mockMapper).save(arg.capture(), notNull(DynamoDBSaveExpression.class));
-        assertSame(createdSchema, arg.getValue());
+        assertEquals("multi-choice-q", fieldDefList.get(0).getName());
+        assertEquals(UploadFieldType.MULTI_CHOICE, fieldDefList.get(0).getType());
+        assertFalse(fieldDefList.get(0).getAllowOtherChoices());
+        assertEquals(ImmutableList.of("always", "added-choice"), fieldDefList.get(0).getMultiChoiceAnswerList());
+
+        assertEquals("added-q", fieldDefList.get(1).getName());
+        assertEquals(UploadFieldType.STRING, fieldDefList.get(1).getType());
+    }
+
+    @Test
+    public void schemaFromSurveyOldSchemaIsDataSchema() {
+        // This survey would have been compatible with the old schema, except the old schema is a non-survey schema.
+        List<SurveyElement> surveyElementList = new ArrayList<>();
+        {
+            MultiValueConstraints constraints = new MultiValueConstraints();
+            constraints.setDataType(DataType.STRING);
+            constraints.setAllowMultiple(true);
+            constraints.setAllowOther(false);
+            constraints.setEnumeration(ImmutableList.of(new SurveyQuestionOption("always"),
+                    new SurveyQuestionOption("added-choice")));
+
+            SurveyQuestion q = new DynamoSurveyQuestion();
+            q.setIdentifier("multi-choice-q");
+            q.setConstraints(constraints);
+            surveyElementList.add(q);
+        }
+        {
+            StringConstraints constraints = new StringConstraints();
+            constraints.setMaxLength(24);
+
+            SurveyQuestion q = new DynamoSurveyQuestion();
+            q.setIdentifier("added-q");
+            q.setConstraints(constraints);
+            surveyElementList.add(q);
+        }
+
+        Survey survey = makeSurveyWithElements(surveyElementList);
+
+        // Similarly, spy UploadSchemaDao.
+        DynamoUploadSchema oldSchema = makeSchemaForSurveyTests();
+        oldSchema.setSchemaType(UploadSchemaType.IOS_DATA);
+
+        UploadSchema dummy = new DynamoUploadSchema();
+        DynamoUploadSchemaDao dao = spy(new DynamoUploadSchemaDao());
+        doReturn(oldSchema).when(dao).getUploadSchemaNoThrow(any(), any());
+        doReturn(dummy).when(dao).createSchemaRevisionV4(any(), any());
+
+        // set up test dao and execute
+        DynamoUploadSchema retval = (DynamoUploadSchema) dao.createUploadSchemaFromSurvey(TestConstants.TEST_STUDY,
+                survey, false);
+        assertSame(dummy, retval);
+
+        // verify calls
+        verify(dao).getUploadSchemaNoThrow(TestConstants.TEST_STUDY_IDENTIFIER, SURVEY_ID);
+        verify(dao, never()).updateSchemaRevisionV4(any(), any(), anyInt(), any());
+
+        ArgumentCaptor<UploadSchema> createdSchemaCaptor = ArgumentCaptor.forClass(UploadSchema.class);
+        verify(dao).createSchemaRevisionV4(eq(TestConstants.TEST_STUDY), createdSchemaCaptor.capture());
+
+        // validate schema - Don't need to validate everything, just the essentials.
+        UploadSchema createdSchema = createdSchemaCaptor.getValue();
+        assertEquals(SURVEY_ID, createdSchema.getSchemaId());
+
+        // validate fields
+        List<UploadFieldDefinition> fieldDefList = createdSchema.getFieldDefinitions();
+        assertEquals(2, fieldDefList.size());
+
+        assertEquals("multi-choice-q", fieldDefList.get(0).getName());
+        assertEquals(UploadFieldType.MULTI_CHOICE, fieldDefList.get(0).getType());
+        assertFalse(fieldDefList.get(0).getAllowOtherChoices());
+        assertEquals(ImmutableList.of("always", "added-choice"), fieldDefList.get(0).getMultiChoiceAnswerList());
+
+        assertEquals("added-q", fieldDefList.get(1).getName());
+        assertEquals(UploadFieldType.STRING, fieldDefList.get(1).getType());
+    }
+
+    @Test
+    public void mergeSurveySchemaFields() {
+        // List of fields that can be successfully merged:
+        // * same field in both lists
+        // * added field
+        // * removed field
+        // * multi-choice, where the new field has different answers and allowOther true -> false
+        // * string with maxLength reduced
+        // * unbounded string changed to bounded string
+
+        List<UploadFieldDefinition> oldFieldDefList = new ArrayList<>();
+        List<UploadFieldDefinition> newFieldDefList = new ArrayList<>();
+
+        // same field in both
+        {
+            UploadFieldDefinition field = new DynamoUploadFieldDefinition.Builder().withName("same")
+                    .withType(UploadFieldType.BOOLEAN).withRequired(false).build();
+            oldFieldDefList.add(field);
+            newFieldDefList.add(field);
+        }
+
+        // added field
+        {
+            UploadFieldDefinition field = new DynamoUploadFieldDefinition.Builder().withName("added")
+                    .withType(UploadFieldType.BOOLEAN).withRequired(false).build();
+            // not added to old
+            newFieldDefList.add(field);
+        }
+
+        // removed field
+        {
+            UploadFieldDefinition field = new DynamoUploadFieldDefinition.Builder().withName("removed")
+                    .withType(UploadFieldType.BOOLEAN).withRequired(false).build();
+            oldFieldDefList.add(field);
+            // not added to new
+        }
+
+        // multi-choice
+        {
+            UploadFieldDefinition oldField = new DynamoUploadFieldDefinition.Builder().withName("multi-choice")
+                    .withType(UploadFieldType.MULTI_CHOICE).withRequired(false)
+                    .withMultiChoiceAnswerList("same", "removed").withAllowOtherChoices(true).build();
+            oldFieldDefList.add(oldField);
+
+            UploadFieldDefinition newField = new DynamoUploadFieldDefinition.Builder().withName("multi-choice")
+                    .withType(UploadFieldType.MULTI_CHOICE).withRequired(false)
+                    .withMultiChoiceAnswerList("same", "added").withAllowOtherChoices(false).build();
+            newFieldDefList.add(newField);
+        }
+
+        // string, maxLength reduced
+        {
+            UploadFieldDefinition oldField = new DynamoUploadFieldDefinition.Builder().withName("string-with-length")
+                    .withType(UploadFieldType.STRING).withRequired(false).withMaxLength(128).build();
+            oldFieldDefList.add(oldField);
+
+            UploadFieldDefinition newField = new DynamoUploadFieldDefinition.Builder().withName("string-with-length")
+                    .withType(UploadFieldType.STRING).withRequired(false).withMaxLength(24).build();
+            newFieldDefList.add(newField);
+        }
+
+        // string, bounded to unbounded
+        {
+            UploadFieldDefinition oldField = new DynamoUploadFieldDefinition.Builder().withName("unbounded-string")
+                    .withType(UploadFieldType.STRING).withRequired(false).withUnboundedText(true).build();
+            oldFieldDefList.add(oldField);
+
+            UploadFieldDefinition newField = new DynamoUploadFieldDefinition.Builder().withName("unbounded-string")
+                    .withType(UploadFieldType.STRING).withRequired(false).withMaxLength(128).build();
+            newFieldDefList.add(newField);
+        }
+
+        // sanity check setup
+        assertEquals(5, oldFieldDefList.size());
+        assertEquals(5, newFieldDefList.size());
+
+        // execute and validate - Removed fields show up last.
+        DynamoUploadSchemaDao.MergeSurveySchemaResult mergeResult = DynamoUploadSchemaDao.mergeSurveySchemaFields(
+                oldFieldDefList, newFieldDefList);
+        assertTrue(mergeResult.isSuccess());
+
+        List<UploadFieldDefinition> mergedFieldDefList = mergeResult.getFieldDefinitionList();
+        assertEquals(6, mergedFieldDefList.size());
+
+        assertEquals("same", mergedFieldDefList.get(0).getName());
+        assertEquals(UploadFieldType.BOOLEAN, mergedFieldDefList.get(0).getType());
+
+        assertEquals("added", mergedFieldDefList.get(1).getName());
+        assertEquals(UploadFieldType.BOOLEAN, mergedFieldDefList.get(1).getType());
+
+        assertEquals("multi-choice", mergedFieldDefList.get(2).getName());
+        assertEquals(UploadFieldType.MULTI_CHOICE, mergedFieldDefList.get(2).getType());
+        assertEquals(ImmutableList.of("same", "added", "removed"), mergedFieldDefList.get(2)
+                .getMultiChoiceAnswerList());
+        assertTrue(mergedFieldDefList.get(2).getAllowOtherChoices());
+
+        assertEquals("string-with-length", mergedFieldDefList.get(3).getName());
+        assertEquals(UploadFieldType.STRING, mergedFieldDefList.get(3).getType());
+        assertEquals(128, mergedFieldDefList.get(3).getMaxLength().intValue());
+
+        assertEquals("unbounded-string", mergedFieldDefList.get(4).getName());
+        assertEquals(UploadFieldType.STRING, mergedFieldDefList.get(4).getType());
+        assertTrue(mergedFieldDefList.get(4).isUnboundedText());
+        assertNull(mergedFieldDefList.get(4).getMaxLength());
+
+        assertEquals("removed", mergedFieldDefList.get(5).getName());
+        assertEquals(UploadFieldType.BOOLEAN, mergedFieldDefList.get(5).getType());
+    }
+
+    @Test
+    public void mergeSurveySchemaFieldsNotCompatible() {
+        // incompatible field, like changing a short string to an unbounded string
+        List<UploadFieldDefinition> oldFieldDefList = ImmutableList.of(new DynamoUploadFieldDefinition.Builder()
+                .withName("field").withType(UploadFieldType.STRING).withMaxLength(24).build());
+        List<UploadFieldDefinition> newFieldDefList = ImmutableList.of(new DynamoUploadFieldDefinition.Builder()
+                .withName("field").withType(UploadFieldType.STRING).withUnboundedText(true).build());
+
+        // execute and validate
+        DynamoUploadSchemaDao.MergeSurveySchemaResult mergeResult = DynamoUploadSchemaDao.mergeSurveySchemaFields(
+                oldFieldDefList, newFieldDefList);
+        assertFalse(mergeResult.isSuccess());
+        assertEquals(newFieldDefList, mergeResult.getFieldDefinitionList());
+
+    }
+
+    @Test
+    public void mergeSurveySchemaFieldsDifferentType() {
+        // changing the field type will cause things to break.
+        List<UploadFieldDefinition> oldFieldDefList = ImmutableList.of(new DynamoUploadFieldDefinition.Builder()
+                .withName("field").withType(UploadFieldType.STRING).withMaxLength(24).build());
+        List<UploadFieldDefinition> newFieldDefList = ImmutableList.of(new DynamoUploadFieldDefinition.Builder()
+                .withName("field").withType(UploadFieldType.BOOLEAN).build());
+
+        // execute and validate
+        DynamoUploadSchemaDao.MergeSurveySchemaResult mergeResult = DynamoUploadSchemaDao.mergeSurveySchemaFields(
+                oldFieldDefList, newFieldDefList);
+        assertFalse(mergeResult.isSuccess());
+        assertEquals(newFieldDefList, mergeResult.getFieldDefinitionList());
+
     }
 
     @Test
@@ -792,48 +1126,134 @@ public class DynamoUploadSchemaDaoMockTest {
     }
 
     @Test
-    public void fieldDefsEqual() {
-        UploadFieldDefinition oldFieldDef = new DynamoUploadFieldDefinition.Builder().withName("foo")
-                .withType(UploadFieldType.STRING).build();
-        UploadFieldDefinition newFieldDef = new DynamoUploadFieldDefinition.Builder().withName("foo")
-                .withType(UploadFieldType.STRING).build();
-        assertTrue(DynamoUploadSchemaDao.equalsExceptMaxAppVersion(oldFieldDef, newFieldDef));
+    public void updateV4IncompatibleChange() {
+        // This update fails for 4 reasons
+        // - deleted fields
+        // - modified non-compatible field
+        // - added required fields without minAppVersion
+        // - modified schema type
+
+        // Make old schema - Only field def list and schema type matter for this test.
+        List<UploadFieldDefinition> oldFieldDefList = ImmutableList.of(
+                new DynamoUploadFieldDefinition.Builder().withName("always").withType(UploadFieldType.BOOLEAN).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("delete-me-1").withType(UploadFieldType.BOOLEAN)
+                        .build(),
+                new DynamoUploadFieldDefinition.Builder().withName("delete-me-2").withType(UploadFieldType.INT)
+                        .build(),
+                new DynamoUploadFieldDefinition.Builder().withName("modify-me-1").withType(UploadFieldType.STRING)
+                        .withUnboundedText(true).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("modify-me-2").withType(UploadFieldType.STRING)
+                        .withUnboundedText(true).build());
+
+        DynamoUploadSchema oldSchema = new DynamoUploadSchema();
+        oldSchema.setSchemaType(UploadSchemaType.IOS_DATA);
+        oldSchema.setFieldDefinitions(oldFieldDefList);
+
+        // Make new schema
+        List<UploadFieldDefinition> newFieldDefList = ImmutableList.of(
+                new DynamoUploadFieldDefinition.Builder().withName("always").withType(UploadFieldType.BOOLEAN).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("modify-me-1").withType(UploadFieldType.STRING)
+                        .withMaxLength(24).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("modify-me-2").withType(UploadFieldType.FLOAT)
+                        .withMaxLength(24).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("add-me-1").withType(UploadFieldType.BOOLEAN)
+                        .withRequired(true).withMinAppVersion(null).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("add-me-2").withType(UploadFieldType.BOOLEAN)
+                        .withRequired(true).withMinAppVersion(null).build());
+
+        DynamoUploadSchema newSchema = new DynamoUploadSchema();
+        newSchema.setSchemaType(UploadSchemaType.IOS_SURVEY);
+        newSchema.setFieldDefinitions(newFieldDefList);
+
+        // set up mock mapper
+        DynamoDBMapper mockMapper = mock(DynamoDBMapper.class);
+        ArgumentCaptor<DynamoUploadSchema> getSchemaKeyCaptor = ArgumentCaptor.forClass(DynamoUploadSchema.class);
+        when(mockMapper.load(getSchemaKeyCaptor.capture())).thenReturn(oldSchema);
+
+        // set up dao
+        DynamoUploadSchemaDao dao = new DynamoUploadSchemaDao();
+        dao.setDdbMapper(mockMapper);
+
+        // execute and validate
+        String errMsg = null;
+        try {
+            dao.updateSchemaRevisionV4(TestConstants.TEST_STUDY, SCHEMA_ID, SCHEMA_REV, newSchema);
+            fail("expected exception");
+        } catch (BadRequestException ex) {
+            errMsg = ex.getMessage();
+        }
+
+        assertTrue(errMsg.contains("Required added fields must have minAppVersion set: add-me-1, add-me-2"));
+        assertTrue(errMsg.contains("Can't delete fields: delete-me-1, delete-me-2"));
+        assertTrue(errMsg.contains("Incompatible changes to fields: modify-me-1, modify-me-2"));
+        assertTrue(errMsg.contains("Can't modify schema type, old=IOS_DATA, new=IOS_SURVEY"));
+
+        // validate calls to DDB
+        DynamoUploadSchema getSchemaKey = getSchemaKeyCaptor.getValue();
+        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, getSchemaKey.getStudyId());
+        assertEquals(SCHEMA_ID, getSchemaKey.getSchemaId());
+        assertEquals(SCHEMA_REV, getSchemaKey.getRevision());
+
+        verify(mockMapper, never()).save(any());
     }
 
     @Test
-    public void fieldDefsEqualWithAddedMaxAppVersion() {
-        UploadFieldDefinition oldFieldDef = new DynamoUploadFieldDefinition.Builder().withName("foo")
-                .withType(UploadFieldType.STRING).build();
-        UploadFieldDefinition newFieldDef = new DynamoUploadFieldDefinition.Builder().withName("foo")
-                .withType(UploadFieldType.STRING).withMaxAppVersion(13).build();
-        assertTrue(DynamoUploadSchemaDao.equalsExceptMaxAppVersion(oldFieldDef, newFieldDef));
-    }
+    public void updateV4Success() {
+        // Test update with
+        // - unchanged field
+        // - modified compatible field
+        // - added required field with minAppVersion
+        // - added optional field
 
-    @Test
-    public void fieldDefsEqualExceptModifiedMaxAppVersion() {
-        UploadFieldDefinition oldFieldDef = new DynamoUploadFieldDefinition.Builder().withName("foo")
-                .withType(UploadFieldType.STRING).withMaxAppVersion(37).build();
-        UploadFieldDefinition newFieldDef = new DynamoUploadFieldDefinition.Builder().withName("foo")
-                .withType(UploadFieldType.STRING).withMaxAppVersion(42).build();
-        assertFalse(DynamoUploadSchemaDao.equalsExceptMaxAppVersion(oldFieldDef, newFieldDef));
-    }
+        // Make old schema - Only field def list and schema type matter for this test.
+        List<UploadFieldDefinition> oldFieldDefList = ImmutableList.of(
+                new DynamoUploadFieldDefinition.Builder().withName("always").withType(UploadFieldType.BOOLEAN).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("modify-me").withType(UploadFieldType.MULTI_CHOICE)
+                        .withMultiChoiceAnswerList("foo", "bar").withAllowOtherChoices(false).build());
 
-    @Test
-    public void fieldDefsEqualExceptRemovedMaxAppVersion() {
-        UploadFieldDefinition oldFieldDef = new DynamoUploadFieldDefinition.Builder().withName("foo")
-                .withType(UploadFieldType.STRING).withMaxAppVersion(7).build();
-        UploadFieldDefinition newFieldDef = new DynamoUploadFieldDefinition.Builder().withName("foo")
-                .withType(UploadFieldType.STRING).build();
-        assertFalse(DynamoUploadSchemaDao.equalsExceptMaxAppVersion(oldFieldDef, newFieldDef));
-    }
+        DynamoUploadSchema oldSchema = new DynamoUploadSchema();
+        oldSchema.setSchemaType(UploadSchemaType.IOS_SURVEY);
+        oldSchema.setFieldDefinitions(oldFieldDefList);
 
-    @Test
-    public void fieldDefsUnequalOnOtherField() {
-        UploadFieldDefinition oldFieldDef = new DynamoUploadFieldDefinition.Builder().withName("foo")
-                .withType(UploadFieldType.INT).build();
-        UploadFieldDefinition newFieldDef = new DynamoUploadFieldDefinition.Builder().withName("foo")
-                .withType(UploadFieldType.BOOLEAN).build();
-        assertFalse(DynamoUploadSchemaDao.equalsExceptMaxAppVersion(oldFieldDef, newFieldDef));
+        // Make new schema
+        List<UploadFieldDefinition> newFieldDefList = ImmutableList.of(
+                new DynamoUploadFieldDefinition.Builder().withName("always").withType(UploadFieldType.BOOLEAN).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("modify-me").withType(UploadFieldType.MULTI_CHOICE)
+                        .withMultiChoiceAnswerList("foo", "bar", "baz").withAllowOtherChoices(true).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("added-required-field")
+                        .withType(UploadFieldType.BOOLEAN).withRequired(true).withMinAppVersion(42).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("added-optional-field")
+                        .withType(UploadFieldType.BOOLEAN).withRequired(false).build());
+
+        DynamoUploadSchema newSchema = new DynamoUploadSchema();
+        newSchema.setSchemaType(UploadSchemaType.IOS_SURVEY);
+        newSchema.setFieldDefinitions(newFieldDefList);
+
+        // set up mock mapper
+        DynamoDBMapper mockMapper = mock(DynamoDBMapper.class);
+        ArgumentCaptor<DynamoUploadSchema> getSchemaKeyCaptor = ArgumentCaptor.forClass(DynamoUploadSchema.class);
+        when(mockMapper.load(getSchemaKeyCaptor.capture())).thenReturn(oldSchema);
+
+        // set up dao
+        DynamoUploadSchemaDao dao = new DynamoUploadSchemaDao();
+        dao.setDdbMapper(mockMapper);
+
+        // execute and validate
+        UploadSchema updatedSchema = dao.updateSchemaRevisionV4(TestConstants.TEST_STUDY, SCHEMA_ID, SCHEMA_REV,
+                newSchema);
+        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, updatedSchema.getStudyId());
+        assertEquals(SCHEMA_ID, updatedSchema.getSchemaId());
+        assertEquals(SCHEMA_REV, updatedSchema.getRevision());
+        assertEquals(UploadSchemaType.IOS_SURVEY, updatedSchema.getSchemaType());
+        assertEquals(newFieldDefList, updatedSchema.getFieldDefinitions());
+
+        // validate calls to DDB
+        DynamoUploadSchema getSchemaKey = getSchemaKeyCaptor.getValue();
+        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, getSchemaKey.getStudyId());
+        assertEquals(SCHEMA_ID, getSchemaKey.getSchemaId());
+        assertEquals(SCHEMA_REV, getSchemaKey.getRevision());
+
+        verify(mockMapper).save(same(updatedSchema));
     }
 
     private static DynamoDBMapper setupMockMapperWithSchema(DynamoUploadSchema schema) {

--- a/test/org/sagebionetworks/bridge/models/surveys/SurveyQuestionOptionTest.java
+++ b/test/org/sagebionetworks/bridge/models/surveys/SurveyQuestionOptionTest.java
@@ -1,0 +1,48 @@
+package org.sagebionetworks.bridge.models.surveys;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
+
+public class SurveyQuestionOptionTest {
+    private static final Image DUMMY_IMAGE = new Image("dummy-source", 42, 42);
+
+    @Test
+    public void allValues() {
+        SurveyQuestionOption option = new SurveyQuestionOption("test-label", "test-detail", "test-value", DUMMY_IMAGE);
+        assertEquals("test-label", option.getLabel());
+        assertEquals("test-detail", option.getDetail());
+        assertEquals("test-value", option.getValue());
+        assertEquals(DUMMY_IMAGE, option.getImage());
+
+        String optionString = option.toString();
+        assertTrue(optionString.contains(option.getLabel()));
+        assertTrue(optionString.contains(option.getDetail()));
+        assertTrue(optionString.contains(option.getValue()));
+        assertTrue(optionString.contains(option.getImage().toString()));
+    }
+
+    @Test
+    public void blankValue() {
+        String[] testCaseArr = { null, "", "   " };
+        for (String oneTestCase : testCaseArr) {
+            SurveyQuestionOption option = new SurveyQuestionOption("test-label", null, oneTestCase, null);
+            assertEquals("test-label", option.getValue());
+        }
+    }
+
+    @Test
+    public void equalsVerifier() {
+        EqualsVerifier.forClass(SurveyQuestionOption.class).allFieldsShouldBeUsed().verify();
+    }
+
+    @Test
+    public void toStringAllNulls() {
+        // Make sure toString() doesn't throw if all fields are null.
+        SurveyQuestionOption option = new SurveyQuestionOption(null, null, null, null);
+        assertNotNull(option.toString());
+    }
+}

--- a/test/org/sagebionetworks/bridge/services/SurveyServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/SurveyServiceMockTest.java
@@ -1,0 +1,35 @@
+package org.sagebionetworks.bridge.services;
+
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.dao.SurveyDao;
+import org.sagebionetworks.bridge.dynamodb.DynamoSurvey;
+import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolder;
+import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolderImpl;
+import org.sagebionetworks.bridge.models.surveys.Survey;
+
+public class SurveyServiceMockTest {
+    @Test
+    public void publishSurvey() {
+        // test inputs and outputs
+        GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl("test-guid", 1337);
+        Survey survey = new DynamoSurvey();
+
+        // mock DAO
+        SurveyDao mockDao = mock(SurveyDao.class);
+        when(mockDao.publishSurvey(TestConstants.TEST_STUDY, keys, true)).thenReturn(survey);
+
+        // set up test
+        SurveyService svc = new SurveyService();
+        svc.setSurveyDao(mockDao);
+
+        // execute and validate
+        Survey retval = svc.publishSurvey(TestConstants.TEST_STUDY, keys, true);
+        assertSame(survey, retval);
+    }
+}

--- a/test/org/sagebionetworks/bridge/services/SurveyServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SurveyServiceTest.java
@@ -211,7 +211,7 @@ public class SurveyServiceTest {
     public void cannotUpdatePublishedSurveys() {
         Survey survey = surveyService.createSurvey(testSurvey);
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(survey));
-        surveyService.publishSurvey(TEST_STUDY, survey);
+        surveyService.publishSurvey(TEST_STUDY, survey, false);
 
         survey.setName("This is a new name");
         surveyService.updateSurvey(survey);
@@ -223,7 +223,7 @@ public class SurveyServiceTest {
     public void canVersionASurveyEvenIfPublished() {
         Survey survey = surveyService.createSurvey(testSurvey);
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(survey));
-        surveyService.publishSurvey(TEST_STUDY, survey);
+        surveyService.publishSurvey(TEST_STUDY, survey, false);
 
         Long originalVersion = survey.getCreatedOn();
         survey = surveyService.versionSurvey(survey);
@@ -257,7 +257,7 @@ public class SurveyServiceTest {
     public void canPublishASurvey() {
         Survey survey = surveyService.createSurvey(testSurvey);
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(survey));
-        survey = surveyService.publishSurvey(TEST_STUDY, survey);
+        survey = surveyService.publishSurvey(TEST_STUDY, survey, false);
 
         assertTrue("Survey is marked published", survey.isPublished());
 
@@ -268,7 +268,7 @@ public class SurveyServiceTest {
         assertTrue("Published testSurvey is marked published", pubSurvey.isPublished());
 
         // Publishing again is harmless
-        survey = surveyService.publishSurvey(TEST_STUDY, survey);
+        survey = surveyService.publishSurvey(TEST_STUDY, survey, false);
         pubSurvey = surveyService.getSurveyMostRecentlyPublishedVersion(TEST_STUDY, survey.getGuid());
         assertEquals("Same testSurvey GUID", survey.getGuid(), pubSurvey.getGuid());
         assertEquals("Same testSurvey createdOn", survey.getCreatedOn(), pubSurvey.getCreatedOn());
@@ -279,14 +279,14 @@ public class SurveyServiceTest {
     public void canPublishANewerVersionOfASurvey() {
         Survey survey = surveyService.createSurvey(testSurvey);
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(survey));
-        survey = surveyService.publishSurvey(TEST_STUDY, survey);
+        survey = surveyService.publishSurvey(TEST_STUDY, survey, false);
 
         Survey laterSurvey = surveyService.versionSurvey(survey);
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(laterSurvey));
         assertNotEquals("Surveys do not have the same createdOn", survey.getCreatedOn(),
                 laterSurvey.getCreatedOn());
 
-        laterSurvey = surveyService.publishSurvey(TEST_STUDY, laterSurvey);
+        laterSurvey = surveyService.publishSurvey(TEST_STUDY, laterSurvey, false);
 
         Survey pubSurvey = surveyService.getSurveyMostRecentlyPublishedVersion(TEST_STUDY, survey.getGuid());
         assertEquals("Later testSurvey is the published testSurvey", laterSurvey.getCreatedOn(), pubSurvey.getCreatedOn());
@@ -351,7 +351,7 @@ public class SurveyServiceTest {
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(survey3));
 
         // Publish one version
-        surveyService.publishSurvey(TEST_STUDY, survey1);
+        surveyService.publishSurvey(TEST_STUDY, survey1, false);
 
         // Must pause because the underlying query uses a global secondary index, and
         // this does not support consistent reads
@@ -368,7 +368,7 @@ public class SurveyServiceTest {
         assertTrue(foundSurvey1);
 
         // Publish a later version
-        surveyService.publishSurvey(TEST_STUDY, survey2);
+        surveyService.publishSurvey(TEST_STUDY, survey2, false);
         
         // Must pause because the underlying query uses a global secondary index, and
         // this does not support consistent reads
@@ -389,15 +389,15 @@ public class SurveyServiceTest {
     public void canRetrieveMostRecentPublishedSurveysWithManySurveys() throws Exception {
         Survey survey1 = surveyService.createSurvey(new TestSurvey(SurveyServiceTest.class, true));
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(survey1));
-        surveyService.publishSurvey(TEST_STUDY, survey1);
+        surveyService.publishSurvey(TEST_STUDY, survey1, false);
 
         Survey survey2 = surveyService.createSurvey(new TestSurvey(SurveyServiceTest.class, true));
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(survey2));
-        surveyService.publishSurvey(TEST_STUDY, survey2);
+        surveyService.publishSurvey(TEST_STUDY, survey2, false);
 
         Survey survey3 = surveyService.createSurvey(new TestSurvey(SurveyServiceTest.class, true));
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(survey3));
-        surveyService.publishSurvey(TEST_STUDY, survey3);
+        surveyService.publishSurvey(TEST_STUDY, survey3, false);
 
         // Must pause because the underlying query uses a global secondary index, and
         // this does not support consistent reads

--- a/test/org/sagebionetworks/bridge/upload/UploadUtilTest.java
+++ b/test/org/sagebionetworks/bridge/upload/UploadUtilTest.java
@@ -362,47 +362,23 @@ public class UploadUtilTest {
     }
 
     @Test
-    public void isCompatibleFieldDefIntValueTests() {
-        // { oldValue, newValue, expected (minAppVersion), expected (maxAppVersion), expected (maxLength) }
+    public void isCompatibleFieldDefMaxLengthTests() {
+        // { oldValue, newValue, expected }
         Object[][] testCases = {
-                { null, null, true, true, true },
-                { null, 10, true, true, false },
-                { 10, null, false, false, false },
-                { 10, 10, true, true, true },
-                { 10, 15, true, false, false },
-                { 10, 5, false, true, false },
+                { null, null, true },
+                { null, 10, false },
+                { 10, null, false },
+                { 10, 10, true },
+                { 10, 15,  false },
+                { 10, 5, false },
         };
 
         for (Object[] oneTestCase : testCases) {
-            Integer oldValue = (Integer) oneTestCase[0];
-            Integer newValue = (Integer) oneTestCase[1];
-
-            // minAppVersion
-            {
-                UploadFieldDefinition oldFieldDef = new DynamoUploadFieldDefinition.Builder().withName("field")
-                        .withType(UploadFieldType.INT).withMinAppVersion(oldValue).build();
-                UploadFieldDefinition newFieldDef = new DynamoUploadFieldDefinition.Builder().withName("field")
-                        .withType(UploadFieldType.INT).withMinAppVersion(newValue).build();
-                assertEquals(oneTestCase[2], UploadUtil.isCompatibleFieldDef(oldFieldDef, newFieldDef));
-            }
-
-            // maxAppVersion
-            {
-                UploadFieldDefinition oldFieldDef = new DynamoUploadFieldDefinition.Builder().withName("field")
-                        .withType(UploadFieldType.INT).withMaxAppVersion(oldValue).build();
-                UploadFieldDefinition newFieldDef = new DynamoUploadFieldDefinition.Builder().withName("field")
-                        .withType(UploadFieldType.INT).withMaxAppVersion(newValue).build();
-                assertEquals(oneTestCase[3], UploadUtil.isCompatibleFieldDef(oldFieldDef, newFieldDef));
-            }
-
-            // maxLength
-            {
-                UploadFieldDefinition oldFieldDef = new DynamoUploadFieldDefinition.Builder().withName("field")
-                        .withType(UploadFieldType.STRING).withMaxLength(oldValue).build();
-                UploadFieldDefinition newFieldDef = new DynamoUploadFieldDefinition.Builder().withName("field")
-                        .withType(UploadFieldType.STRING).withMaxLength(newValue).build();
-                assertEquals(oneTestCase[4], UploadUtil.isCompatibleFieldDef(oldFieldDef, newFieldDef));
-            }
+            UploadFieldDefinition oldFieldDef = new DynamoUploadFieldDefinition.Builder().withName("field")
+                    .withType(UploadFieldType.STRING).withMaxLength((Integer) oneTestCase[0]).build();
+            UploadFieldDefinition newFieldDef = new DynamoUploadFieldDefinition.Builder().withName("field")
+                    .withType(UploadFieldType.STRING).withMaxLength((Integer) oneTestCase[1]).build();
+            assertEquals(oneTestCase[2], UploadUtil.isCompatibleFieldDef(oldFieldDef, newFieldDef));
         }
     }
 
@@ -433,27 +409,20 @@ public class UploadUtilTest {
 
     @Test
     public void isCompatibleFieldDefRequired() {
-        // { oldRequired, newRequired, oldMinAppVersion, newMinAppVersion, expected }
+        // { oldRequired, newRequired, expected }
         Object[][] testCases = {
-                { false, false, null, null, true },
-                { true, true, null, null, true },
-                { true, false, null, null, true },
-                { false, true, null, null, false },
-                { false, true, 10, null, false },
-                { false, true, null, 10, true },
-                { false, true, 10, 10, false },
-                { false, true, 10, 5, false },
-                { false, true, 10, 15, false },
+                { false, false, true },
+                { true, true, true },
+                { true, false, true },
+                { false, true, false },
         };
 
         for (Object[] oneTestCase : testCases) {
             UploadFieldDefinition oldFieldDef = new DynamoUploadFieldDefinition.Builder().withName("field")
-                    .withType(UploadFieldType.INT).withRequired((boolean) oneTestCase[0])
-                    .withMinAppVersion((Integer) oneTestCase[2]).build();
+                    .withType(UploadFieldType.INT).withRequired((boolean) oneTestCase[0]).build();
             UploadFieldDefinition newFieldDef = new DynamoUploadFieldDefinition.Builder().withName("field")
-                    .withType(UploadFieldType.INT).withRequired((boolean) oneTestCase[1])
-                    .withMinAppVersion((Integer) oneTestCase[3]).build();
-            assertEquals(oneTestCase[4], UploadUtil.isCompatibleFieldDef(oldFieldDef, newFieldDef));
+                    .withType(UploadFieldType.INT).withRequired((boolean) oneTestCase[1]).build();
+            assertEquals(oneTestCase[2], UploadUtil.isCompatibleFieldDef(oldFieldDef, newFieldDef));
         }
     }
 

--- a/test/org/sagebionetworks/bridge/upload/UploadUtilTest.java
+++ b/test/org/sagebionetworks/bridge/upload/UploadUtilTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.List;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.BigIntegerNode;
@@ -18,14 +19,17 @@ import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.LongNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+import com.google.common.collect.ImmutableList;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.junit.Test;
 
+import org.sagebionetworks.bridge.dynamodb.DynamoUploadFieldDefinition;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
 import org.sagebionetworks.bridge.models.upload.UploadFieldType;
 
-@SuppressWarnings("ConstantConditions")
+@SuppressWarnings({ "ConstantConditions", "unchecked" })
 public class UploadUtilTest {
     @Test
     public void canonicalize() throws Exception {
@@ -276,6 +280,183 @@ public class UploadUtilTest {
             assertEquals(inputNode, resultNestedJson);
         }
     }
+
+    @Test
+    public void isCompatibleFieldDef() {
+        // { old, new, expected }
+        Object[][] testCases = {
+                {
+                        new DynamoUploadFieldDefinition.Builder().withName("field").withType(UploadFieldType.INT)
+                                .build(),
+                        new DynamoUploadFieldDefinition.Builder().withName("field").withType(UploadFieldType.INT)
+                                .build(),
+                        true
+                },
+                {
+                        new DynamoUploadFieldDefinition.Builder().withName("field")
+                                .withType(UploadFieldType.ATTACHMENT_V2).withFileExtension(".txt")
+                                .withMimeType("text/plain").build(),
+                        new DynamoUploadFieldDefinition.Builder().withName("field")
+                                .withType(UploadFieldType.ATTACHMENT_V2).withFileExtension(".json")
+                                .withMimeType("text/json").build(),
+                        true
+                },
+                {
+                        new DynamoUploadFieldDefinition.Builder().withName("field").withType(UploadFieldType.INT)
+                                .build(),
+                        new DynamoUploadFieldDefinition.Builder().withName("field").withType(UploadFieldType.BOOLEAN)
+                                .build(),
+                        false
+                },
+                {
+                        new DynamoUploadFieldDefinition.Builder().withName("foo-field").withType(UploadFieldType.INT)
+                                .build(),
+                        new DynamoUploadFieldDefinition.Builder().withName("bar-field").withType(UploadFieldType.INT)
+                                .build(),
+                        false
+                },
+        };
+
+        for (Object[] oneTestCase : testCases) {
+            assertEquals(oneTestCase[2], UploadUtil.isCompatibleFieldDef((UploadFieldDefinition) oneTestCase[0],
+                    (UploadFieldDefinition) oneTestCase[1]));
+        }
+    }
+
+    @Test
+    public void isCompatibleFieldDefBoolValueTests() {
+        // { oldValue, newValue, expected (allowOther), expected (unboundedText }
+        Boolean[][] testCases = {
+                { null, null, true, true },
+                { null, false, true, true },
+                { null, true, true, false },
+                { false, null, true, true },
+                { false, false, true, true },
+                { false, true, true, false },
+                { true, null, false, false },
+                { true, false, false, false },
+                { true, true, true, true },
+        };
+
+        for (Boolean[] oneTestCase : testCases) {
+            // allowOther
+            {
+                UploadFieldDefinition oldFieldDef = new DynamoUploadFieldDefinition.Builder().withName("field")
+                        .withType(UploadFieldType.MULTI_CHOICE).withMultiChoiceAnswerList("foo", "bar", "baz")
+                        .withAllowOtherChoices(oneTestCase[0]).build();
+                UploadFieldDefinition newFieldDef = new DynamoUploadFieldDefinition.Builder().withName("field")
+                        .withType(UploadFieldType.MULTI_CHOICE).withMultiChoiceAnswerList("foo", "bar", "baz")
+                        .withAllowOtherChoices(oneTestCase[1]).build();
+                assertEquals(oneTestCase[2], UploadUtil.isCompatibleFieldDef(oldFieldDef, newFieldDef));
+            }
+
+            // unboundedText
+            {
+                UploadFieldDefinition oldFieldDef = new DynamoUploadFieldDefinition.Builder().withName("field")
+                        .withType(UploadFieldType.STRING).withUnboundedText(oneTestCase[0]).build();
+                UploadFieldDefinition newFieldDef = new DynamoUploadFieldDefinition.Builder().withName("field")
+                        .withType(UploadFieldType.STRING).withUnboundedText(oneTestCase[1]).build();
+                assertEquals(oneTestCase[3], UploadUtil.isCompatibleFieldDef(oldFieldDef, newFieldDef));
+            }
+        }
+    }
+
+    @Test
+    public void isCompatibleFieldDefIntValueTests() {
+        // { oldValue, newValue, expected (minAppVersion), expected (maxAppVersion), expected (maxLength) }
+        Object[][] testCases = {
+                { null, null, true, true, true },
+                { null, 10, true, true, false },
+                { 10, null, false, false, false },
+                { 10, 10, true, true, true },
+                { 10, 15, true, false, false },
+                { 10, 5, false, true, false },
+        };
+
+        for (Object[] oneTestCase : testCases) {
+            Integer oldValue = (Integer) oneTestCase[0];
+            Integer newValue = (Integer) oneTestCase[1];
+
+            // minAppVersion
+            {
+                UploadFieldDefinition oldFieldDef = new DynamoUploadFieldDefinition.Builder().withName("field")
+                        .withType(UploadFieldType.INT).withMinAppVersion(oldValue).build();
+                UploadFieldDefinition newFieldDef = new DynamoUploadFieldDefinition.Builder().withName("field")
+                        .withType(UploadFieldType.INT).withMinAppVersion(newValue).build();
+                assertEquals(oneTestCase[2], UploadUtil.isCompatibleFieldDef(oldFieldDef, newFieldDef));
+            }
+
+            // maxAppVersion
+            {
+                UploadFieldDefinition oldFieldDef = new DynamoUploadFieldDefinition.Builder().withName("field")
+                        .withType(UploadFieldType.INT).withMaxAppVersion(oldValue).build();
+                UploadFieldDefinition newFieldDef = new DynamoUploadFieldDefinition.Builder().withName("field")
+                        .withType(UploadFieldType.INT).withMaxAppVersion(newValue).build();
+                assertEquals(oneTestCase[3], UploadUtil.isCompatibleFieldDef(oldFieldDef, newFieldDef));
+            }
+
+            // maxLength
+            {
+                UploadFieldDefinition oldFieldDef = new DynamoUploadFieldDefinition.Builder().withName("field")
+                        .withType(UploadFieldType.STRING).withMaxLength(oldValue).build();
+                UploadFieldDefinition newFieldDef = new DynamoUploadFieldDefinition.Builder().withName("field")
+                        .withType(UploadFieldType.STRING).withMaxLength(newValue).build();
+                assertEquals(oneTestCase[4], UploadUtil.isCompatibleFieldDef(oldFieldDef, newFieldDef));
+            }
+        }
+    }
+
+    @Test
+    public void isCompatibleFieldDefAnswerList() {
+        // { oldList, newList, expected }
+        Object[][] testCases = {
+                { null, null, true },
+                { null, ImmutableList.of("foo", "bar"), false },
+                { ImmutableList.of("foo", "bar"), null, false },
+                { ImmutableList.of("foo", "bar"), ImmutableList.of("foo", "bar"), true },
+                { ImmutableList.of("foo", "bar"), ImmutableList.of("foo"), false },
+                { ImmutableList.of("foo", "bar"), ImmutableList.of("foo", "bar", "baz"), true },
+                { ImmutableList.of("foo", "bar"), ImmutableList.of("foo", "baz"), false },
+        };
+
+        for (Object[] oneTestCase : testCases) {
+            UploadFieldDefinition oldFieldDef = new DynamoUploadFieldDefinition.Builder().withName("field")
+                    .withType(UploadFieldType.MULTI_CHOICE).withMultiChoiceAnswerList((List<String>) oneTestCase[0])
+                    .build();
+            UploadFieldDefinition newFieldDef = new DynamoUploadFieldDefinition.Builder().withName("field")
+                    .withType(UploadFieldType.MULTI_CHOICE).withMultiChoiceAnswerList((List<String>) oneTestCase[1])
+                    .build();
+            assertEquals(oneTestCase[2], UploadUtil.isCompatibleFieldDef(oldFieldDef, newFieldDef));
+        }
+    }
+
+
+    @Test
+    public void isCompatibleFieldDefRequired() {
+        // { oldRequired, newRequired, oldMinAppVersion, newMinAppVersion, expected }
+        Object[][] testCases = {
+                { false, false, null, null, true },
+                { true, true, null, null, true },
+                { true, false, null, null, true },
+                { false, true, null, null, false },
+                { false, true, 10, null, false },
+                { false, true, null, 10, true },
+                { false, true, 10, 10, false },
+                { false, true, 10, 5, false },
+                { false, true, 10, 15, false },
+        };
+
+        for (Object[] oneTestCase : testCases) {
+            UploadFieldDefinition oldFieldDef = new DynamoUploadFieldDefinition.Builder().withName("field")
+                    .withType(UploadFieldType.INT).withRequired((boolean) oneTestCase[0])
+                    .withMinAppVersion((Integer) oneTestCase[2]).build();
+            UploadFieldDefinition newFieldDef = new DynamoUploadFieldDefinition.Builder().withName("field")
+                    .withType(UploadFieldType.INT).withRequired((boolean) oneTestCase[1])
+                    .withMinAppVersion((Integer) oneTestCase[3]).build();
+            assertEquals(oneTestCase[4], UploadUtil.isCompatibleFieldDef(oldFieldDef, newFieldDef));
+        }
+    }
+
 
     @Test
     public void nullCalendarDate() {


### PR DESCRIPTION
Last code change needed to finish off https://sagebionetworks.jira.com/browse/BRIDGE-1289

This change integrate surveys with mutable schemas. We also relax some of the rules for mutable schemas to make them easier to work with.

Testing done:
- unit tests updated
- integ tests (survey, upload schema, upload)
- manual tests

Manual test cases:
- create a new survey schema
- compatible update to survey schema
- incompatible update to survey schema
- explicitly ask for a new schema rev for a survey schema
- attempt to modify a schema field with an incompatible change
- successfully modify a schema field with a compatible change
- attempt to add a required field without minAppVersion to a schema
- successfully add a required field with minAppVersion to a schema

Note: https://github.com/Sage-Bionetworks/BridgeIntegrationTests/pull/76 needs to be pushed out before we can check this in.

TODO: Additional integ tests to test the updated functionality.
