### PR TITLE
Add platform support to the Criteria object

### DIFF
--- a/app/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/app/org/sagebionetworks/bridge/BridgeUtils.java
@@ -210,5 +210,17 @@ public class BridgeUtils {
         }
         return null;
     }
-
+    
+    /**
+     * Converts a string to an error key friendly string, e.g. "iPhone OS" is converted to "iphone_os".
+     * 
+     * @throws IllegalArgumentException
+     *             if the string cannot be converted to an error key.
+     */
+    public static String textToErrorKey(String text) {
+        if (StringUtils.isBlank(text)) {
+            throw new IllegalArgumentException("String is not translatable to an error key: " + text);
+        }
+        return text.toLowerCase().replaceAll(" ", "_").replaceAll("[^a-zA-Z0-9_-]", "");    
+    }
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoCriteria.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoCriteria.java
@@ -117,17 +117,17 @@ public final class DynamoCriteria implements Criteria {
     }
     @DynamoDBIgnore
     @Override
-    public Integer getMinAppVersion(String os) {
-        return minAppVersions.get(os);
+    public Integer getMinAppVersion(String osName) {
+        return minAppVersions.get(osName);
     }
     @DynamoDBIgnore
     @Override
-    public void setMinAppVersion(String os, Integer minAppVersion) {
-        checkArgument(isNotBlank(os));
+    public void setMinAppVersion(String osName, Integer minAppVersion) {
+        checkArgument(isNotBlank(osName));
         if (minAppVersion != null) {
-            minAppVersions.put(os, minAppVersion);    
+            minAppVersions.put(osName, minAppVersion);    
         } else {
-            minAppVersions.remove(os);
+            minAppVersions.remove(osName);
         }
     }
     
@@ -141,17 +141,17 @@ public final class DynamoCriteria implements Criteria {
     }
     @DynamoDBIgnore
     @Override
-    public Integer getMaxAppVersion(String os) {
-        return maxAppVersions.get(os);
+    public Integer getMaxAppVersion(String osName) {
+        return maxAppVersions.get(osName);
     }
     @DynamoDBIgnore
     @Override
-    public void setMaxAppVersion(String os, Integer maxAppVersion) {
-        Preconditions.checkArgument(StringUtils.isNotBlank(os));
+    public void setMaxAppVersion(String osName, Integer maxAppVersion) {
+        Preconditions.checkArgument(StringUtils.isNotBlank(osName));
         if (maxAppVersion != null) {
-            maxAppVersions.put(os, maxAppVersion);    
+            maxAppVersions.put(osName, maxAppVersion);    
         } else {
-            maxAppVersions.remove(os);
+            maxAppVersions.remove(osName);
         }
     }
     @DynamoDBIgnore

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoCriteria.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoCriteria.java
@@ -9,8 +9,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
-import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.json.BridgeTypeName;
 import org.sagebionetworks.bridge.models.Criteria;
 
@@ -120,7 +120,7 @@ public final class DynamoCriteria implements Criteria {
         return ImmutableMap.copyOf(minAppVersions);
     }
     public void setMinAppVersions(Map<String, Integer> minAppVersions) {
-        this.minAppVersions = (minAppVersions == null) ? new HashMap<>() : Maps.newHashMap(minAppVersions);
+        this.minAppVersions = (minAppVersions == null) ? new HashMap<>() : withoutNullEntries(minAppVersions);
     }
     @DynamoDBIgnore
     @Override
@@ -144,7 +144,7 @@ public final class DynamoCriteria implements Criteria {
         return ImmutableMap.copyOf(maxAppVersions);
     }
     public void setMaxAppVersions(Map<String, Integer> maxAppVersions) {
-        this.maxAppVersions = (minAppVersions == null) ? new HashMap<>() : Maps.newHashMap(maxAppVersions);
+        this.maxAppVersions = (minAppVersions == null) ? new HashMap<>() : withoutNullEntries(maxAppVersions);
     }
     @DynamoDBIgnore
     @Override
@@ -163,6 +163,13 @@ public final class DynamoCriteria implements Criteria {
         return new ImmutableSet.Builder<String>()
                 .addAll(minAppVersions.keySet())
                 .addAll(maxAppVersions.keySet()).build();
+    }
+    /**
+     * Creates a new copy of the map, removing any entries that have a null value (particularly easy to do this in JSON).
+     */
+    private Map<String,Integer> withoutNullEntries(Map<String, Integer> map) {
+        return map.entrySet().stream().filter(e -> e.getValue() != null)
+                .collect(Collectors.toMap(p -> p.getKey(), p -> p.getValue()));
     }
     private void putOrRemove(Map<String,Integer> map, String osName, Integer version) {
         checkArgument(isNotBlank(osName));

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoCriteria.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoCriteria.java
@@ -1,16 +1,31 @@
 package org.sagebionetworks.bridge.dynamodb;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.sagebionetworks.bridge.models.OperatingSystem.IOS;
+
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
 
 import org.sagebionetworks.bridge.json.BridgeTypeName;
 import org.sagebionetworks.bridge.models.Criteria;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIgnore;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMarshalling;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
+import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
 @DynamoDBTable(tableName = "Criteria")
@@ -19,10 +34,10 @@ public final class DynamoCriteria implements Criteria {
 
     private String key;
     private String language;
-    private Integer minAppVersion;
-    private Integer maxAppVersion;
     private Set<String> allOfGroups = Sets.newHashSet();
     private Set<String> noneOfGroups = Sets.newHashSet();
+    private Map<String, Integer> minAppVersions = Maps.newHashMap();
+    private Map<String, Integer> maxAppVersions = Maps.newHashMap();
     
     @Override
     @DynamoDBHashKey
@@ -41,21 +56,37 @@ public final class DynamoCriteria implements Criteria {
     public void setLanguage(String language) {
         this.language = language;
     }
-    @Override
-    @DynamoDBAttribute    
-    public Integer getMinAppVersion() {
-        return minAppVersion;
-    }
-    public void setMinAppVersion(Integer minAppVersion) {
-        this.minAppVersion = minAppVersion;
-    }
-    @Override
+    /**
+     * This property is supported for backwards compatibility with the existing table, 
+     * but is no longer visible, and the value is also stored in the map of min app versions
+     * by platform. Can be removed in a future release.
+     */
     @DynamoDBAttribute
-    public Integer getMaxAppVersion() {
-        return maxAppVersion;
+    @JsonIgnore
+    Integer getMinAppVersion() {
+        return minAppVersions.get(IOS);
     }
-    public void setMaxAppVersion(Integer maxAppVersion) {
-        this.maxAppVersion = maxAppVersion;
+    @JsonSetter
+    void setMinAppVersion(Integer minAppVersion) {
+        if (!minAppVersions.containsKey(IOS)) {
+            minAppVersions.put(IOS, minAppVersion);    
+        }
+    }
+    /**
+     * This property is supported for backwards compatibility with the existing table, 
+     * but is no longer visible, and the value is also stored in the map of max app versions
+     * by platform. Can be removed in a future release
+     */
+    @DynamoDBAttribute
+    @JsonIgnore
+    Integer getMaxAppVersion() {
+        return maxAppVersions.get(IOS);
+    }
+    @JsonSetter
+    void setMaxAppVersion(Integer maxAppVersion) {
+        if (!maxAppVersions.containsKey(IOS)) {
+            maxAppVersions.put(IOS, maxAppVersion);    
+        }
     }
     @Override
     @DynamoDBAttribute
@@ -76,9 +107,65 @@ public final class DynamoCriteria implements Criteria {
         this.noneOfGroups = (noneOfGroups == null) ? Sets.newHashSet() : noneOfGroups;
     }
     
+    @DynamoDBAttribute
+    @JsonGetter
+    public Map<String, Integer> getMinAppVersions() {
+        return ImmutableMap.copyOf(minAppVersions);
+    }
+    public void setMinAppVersions(Map<String, Integer> minAppVersions) {
+        this.minAppVersions = (minAppVersions == null) ? new HashMap<>() : minAppVersions;
+    }
+    @DynamoDBIgnore
+    @Override
+    public Integer getMinAppVersion(String os) {
+        return minAppVersions.get(os);
+    }
+    @DynamoDBIgnore
+    @Override
+    public void setMinAppVersion(String os, Integer minAppVersion) {
+        checkArgument(isNotBlank(os));
+        if (minAppVersion != null) {
+            minAppVersions.put(os, minAppVersion);    
+        } else {
+            minAppVersions.remove(os);
+        }
+    }
+    
+    @DynamoDBAttribute
+    @JsonGetter
+    public Map<String, Integer> getMaxAppVersions() {
+        return ImmutableMap.copyOf(maxAppVersions);
+    }
+    public void setMaxAppVersions(Map<String, Integer> maxAppVersions) {
+        this.maxAppVersions = (maxAppVersions == null) ? new HashMap<>() : maxAppVersions;
+    }
+    @DynamoDBIgnore
+    @Override
+    public Integer getMaxAppVersion(String os) {
+        return maxAppVersions.get(os);
+    }
+    @DynamoDBIgnore
+    @Override
+    public void setMaxAppVersion(String os, Integer maxAppVersion) {
+        Preconditions.checkArgument(StringUtils.isNotBlank(os));
+        if (maxAppVersion != null) {
+            maxAppVersions.put(os, maxAppVersion);    
+        } else {
+            maxAppVersions.remove(os);
+        }
+    }
+    @DynamoDBIgnore
+    @JsonIgnore
+    @Override
+    public Set<String> getAppVersionOperatingSystems() {
+        return new ImmutableSet.Builder<String>()
+                .addAll(minAppVersions.keySet())
+                .addAll(maxAppVersions.keySet()).build();
+    }
+    
     @Override
     public int hashCode() {
-        return Objects.hash(key, language, minAppVersion, maxAppVersion, allOfGroups, noneOfGroups);
+        return Objects.hash(key, language, maxAppVersions, minAppVersions, allOfGroups, noneOfGroups);
     }
     @Override
     public boolean equals(Object obj) {
@@ -91,14 +178,13 @@ public final class DynamoCriteria implements Criteria {
                 Objects.equals(language, other.language) && 
                 Objects.equals(noneOfGroups, other.noneOfGroups) && 
                 Objects.equals(allOfGroups, other.allOfGroups) && 
-                Objects.equals(minAppVersion, other.minAppVersion) && 
-                Objects.equals(maxAppVersion, other.maxAppVersion);
+                Objects.equals(minAppVersions, other.minAppVersions) && 
+                Objects.equals(maxAppVersions, other.maxAppVersions);
     }
     @Override
     public String toString() {
         return "DynamoCriteria [key=" + key + ", language=" + language + ", allOfGroups=" + allOfGroups
-                + ", noneOfGroups=" + noneOfGroups + ", minAppVersion=" + minAppVersion + ", maxAppVersion="
-                + maxAppVersion + "]";
+                + ", noneOfGroups=" + noneOfGroups + ", minAppVersions=" + minAppVersions + ", maxAppVersions="
+                + maxAppVersions + "]";
     }
-    
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDao.java
@@ -2,6 +2,8 @@ package org.sagebionetworks.bridge.dynamodb;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.sagebionetworks.bridge.util.BridgeCollectors.toImmutableList;
+import static org.sagebionetworks.bridge.models.OperatingSystem.ANDROID;
+import static org.sagebionetworks.bridge.models.OperatingSystem.IOS;
 
 import java.util.List;
 
@@ -19,7 +21,6 @@ import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.Criteria;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.CriteriaUtils;
-import org.sagebionetworks.bridge.models.OperatingSystem;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
@@ -137,7 +138,8 @@ public class DynamoSubpopulationDao implements SubpopulationDao {
         
         Criteria criteria = Criteria.create();
         criteria.setKey(getKey(subpop));
-        criteria.setMinAppVersion(OperatingSystem.IOS, 0);
+        criteria.setMinAppVersion(ANDROID, 0);
+        criteria.setMinAppVersion(IOS, 0);
 
         criteria = criteriaDao.createOrUpdateCriteria(criteria);
         subpop.setCriteria(criteria);

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDao.java
@@ -19,6 +19,7 @@ import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.Criteria;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.CriteriaUtils;
+import org.sagebionetworks.bridge.models.OperatingSystem;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
@@ -136,7 +137,7 @@ public class DynamoSubpopulationDao implements SubpopulationDao {
         
         Criteria criteria = Criteria.create();
         criteria.setKey(getKey(subpop));
-        criteria.setMinAppVersion(0);
+        criteria.setMinAppVersion(OperatingSystem.IOS, 0);
 
         criteria = criteriaDao.createOrUpdateCriteria(criteria);
         subpop.setCriteria(criteria);

--- a/app/org/sagebionetworks/bridge/models/ClientInfo.java
+++ b/app/org/sagebionetworks/bridge/models/ClientInfo.java
@@ -24,8 +24,9 @@ import com.google.common.cache.LoadingCache;
  * </p>
  * 
  * <p>
- * OS name and version are optional. SDK name and version are also optional, if clients are 
- * built against the REST API directly. Punctuation is removed as appropriate. Some examples:
+ * OS name and version are optional, but filtering of server content by application version requires 
+ * that the OS be specified. SDK name and version are optional, if clients are built against the REST 
+ * API directly. Punctuation is removed as appropriate. Some examples:
  * </p>
  * 
  * <ul>
@@ -78,16 +79,6 @@ public final class ClientInfo {
      * is still logged exactly as it is retrieved from the request.
      */
     public static final ClientInfo UNKNOWN_CLIENT = new ClientInfo.Builder().build();
-    
-    /**
-     * The osName that maps to an iOS client app.
-     */
-    public static final String IOS_OS_NAME = "iPhone OS";
-    
-    /**
-     * The osName that maps to an Android client app.
-     */
-    public static final String ANDROID_OS_NAME = "Android";
 
     /**
      * For example, "App Name/14".

--- a/app/org/sagebionetworks/bridge/models/ClientInfo.java
+++ b/app/org/sagebionetworks/bridge/models/ClientInfo.java
@@ -15,41 +15,45 @@ import com.google.common.cache.LoadingCache;
 
 /**
  * <p>
- * Parsed representation of the User-Agent header provided by the client, when
- * it is in our prescribed format:
+ * Parsed representation of the User-Agent header provided by the client, when it is in one of our prescribed formats:
  * </p>
  * 
  * <p>
+ * appName/appVersion<br>
+ * appName/appVersion sdkName/sdkVersion<br>
  * appName/appVersion (deviceName; osName/osVersion) sdkName/sdkVersion
  * </p>
  * 
  * <p>
- * OS name and version are optional, but filtering of server content by application version requires 
- * that the OS be specified. SDK name and version are optional, if clients are built against the REST 
- * API directly. Punctuation is removed as appropriate. Some examples:
+ * The full User-Agent header must be provided to enable the filtering of content based on the version of the application 
+ * making a request (because versioning information is specific to the name of the OS on which the app is running; we 
+ * currently expect either "iPhone OS" or "Android", but any value can be used and will work as long as it is also set 
+ * in the filtering criteria).
  * </p>
  * 
+ * <p>Some examples:</p>
+ * 
  * <ul>
- *     <li>Melanoma Challenge Application/1</li>
- *     <li>Unknown Client/14 BridgeJavaSDK/10</li>
- *     <li>Asthma/26 (Unknown iPhone; iPhone OS/9.1) BridgeSDK/4</li>
- *     <li>CardioHealth/1 (iPhone 6.0; iPhone OS/9.0.2) BridgeSDK/10</li>
+ * <li>Melanoma Challenge Application/1</li>
+ * <li>Unknown Client/14 BridgeJavaSDK/10</li>
+ * <li>Asthma/26 (Unknown iPhone; iPhone OS/9.1) BridgeSDK/4</li>
+ * <li>CardioHealth/1 (iPhone 6.0; iPhone OS/9.0.2) BridgeSDK/10</li>
  * </ul>
  * 
  * <p>
- * Other clients with more typical browser user agent strings will be represented by ClientInfo.UNKNOWN_CLIENT. This is a 
- * "null" object with all empty fields. Some examples of these headers, from our logs:
+ * Other clients with more typical browser user agent strings will be represented by ClientInfo.UNKNOWN_CLIENT. This is
+ * a "null" object with all empty fields. Some examples of these headers, from our logs:
  * </p>
  * 
  * <ul>
- *     <li>Amazon Route 53 Health Check Service; ref:c97cd53f-2272-49d6-a8cd-3cd658d9d020; report http://amzn.to/1vsZADi</li>
- *     <li>Integration Tests (Linux/3.13.0-36-generic) BridgeJavaSDK/3</li>
+ * <li>Amazon Route 53 Health Check Service; ref:c97cd53f-2272-49d6-a8cd-3cd658d9d020; report http://amzn.to/1vsZADi</li>
+ * <li>Integration Tests (Linux/3.13.0-36-generic) BridgeJavaSDK/3</li>
  * </ul>
  * 
  * <p>
- * ClientInfo is not the end result of a generic user agent string parser. Those are very complicated and we 
- * do not need all this information (we always log the user agent string as we receive it from the client, but only use 
- * these strings in our system when they are in format specified above).
+ * ClientInfo is not the end result of a generic user agent string parser. Those are very complicated and we do not need
+ * all this information (we always log the user agent string as we receive it from the client, but only use these
+ * strings in our system when they are in format specified above).
  * </p>
  *
  */
@@ -73,10 +77,9 @@ public final class ClientInfo {
        });
 
     /**
-     * A User-Agent string that does not follow our format is simply an unknown
-     * client, and no filtering will be done for such a client. It is represented with 
-     * a null object that is the ClientInfo object with all null fields. The User-Agent header 
-     * is still logged exactly as it is retrieved from the request.
+     * A User-Agent string that does not follow our format is simply an unknown client, and no filtering will be done
+     * for such a client. It is represented with a null object that is the ClientInfo object with all null fields. The
+     * User-Agent header is still logged exactly as it is retrieved from the request.
      */
     public static final ClientInfo UNKNOWN_CLIENT = new ClientInfo.Builder().build();
 

--- a/app/org/sagebionetworks/bridge/models/Criteria.java
+++ b/app/org/sagebionetworks/bridge/models/Criteria.java
@@ -24,22 +24,6 @@ public interface Criteria extends BridgeEntity {
     void setLanguage(String language);
     
     /**
-     * The object associated with these criteria should be matched only if the application version 
-     * supplied by the client is equal to or greater than the minAppVersion. If null, there is no 
-     * minimum required version.
-     */
-    Integer getMinAppVersion();
-    void setMinAppVersion(Integer minAppVersion);
-    
-    /**
-     * The object associated with these criteria should be matched only if the application version 
-     * supplied by the client is less that or equal to the maxAppVersion. If null, there is no 
-     * maximum required version.
-     */
-    Integer getMaxAppVersion();
-    void setMaxAppVersion(Integer maxAppVersion);
-    
-    /**
      * The object associated with these criteria should be matched only if the user has all of the 
      * groups contained in this set of data groups. If the set is empty, there are no required 
      * data groups. 
@@ -54,4 +38,30 @@ public interface Criteria extends BridgeEntity {
      */
     Set<String> getNoneOfGroups();
     void setNoneOfGroups(Set<String> noneOfGroups);
+    
+    /**
+     * Minimum required app version for this criteria to match, specified for an operating system. If 
+     * the operating system name is specified in the User-Agent string, then the app version must be 
+     * equal to or greater than this value.
+     */
+    Integer getMinAppVersion(String osName);
+    
+    /** @see #getMinAppVersions(); */
+    void setMinAppVersion(String osName, Integer minAppVersion);
+    
+    /**
+     * Maximum required app version for this criteria to match, specified for an operating system. If 
+     * the operating system name is specified in the User-Agent string, then the app version must be 
+     * equal to or less than this value.
+     */
+    Integer getMaxAppVersion(String osName);
+    
+    /** @see #getMaxAppVersions(); */
+    void setMaxAppVersion(String osName, Integer maxAppVersion);
+    
+    /**
+     * Get all the operating system names that are used to declare either minimum or maximum app 
+     * versions (or both).
+     */
+    Set<String> getAppVersionOperatingSystems();
 }

--- a/app/org/sagebionetworks/bridge/models/Criteria.java
+++ b/app/org/sagebionetworks/bridge/models/Criteria.java
@@ -14,12 +14,17 @@ public interface Criteria extends BridgeEntity {
     }
 
     /** 
-     * The foreign key to the object filtered with these criteria. It's the model and the model's
+     * The foreign key to the object filtered with these criteria. It's the model type and the model's
      * keys, e.g. "subpopulation:<guid>".
      */
     String getKey();
     void setKey(String key);
     
+    /**
+     * The object associated with these criteria should only be matched if the user has this language 
+     * in their list of desired languages. This should be a two-letter language code, e.g. fr, de, 
+     * es, or en.
+     */
     String getLanguage();
     void setLanguage(String language);
     
@@ -45,8 +50,6 @@ public interface Criteria extends BridgeEntity {
      * equal to or greater than this value.
      */
     Integer getMinAppVersion(String osName);
-    
-    /** @see #getMinAppVersions(); */
     void setMinAppVersion(String osName, Integer minAppVersion);
     
     /**
@@ -55,13 +58,11 @@ public interface Criteria extends BridgeEntity {
      * equal to or less than this value.
      */
     Integer getMaxAppVersion(String osName);
-    
-    /** @see #getMaxAppVersions(); */
     void setMaxAppVersion(String osName, Integer maxAppVersion);
     
     /**
      * Get all the operating system names that are used to declare either minimum or maximum app 
-     * versions (or both).
+     * versions (or both). Used to iterate through these collections.
      */
     Set<String> getAppVersionOperatingSystems();
 }

--- a/app/org/sagebionetworks/bridge/models/CriteriaUtils.java
+++ b/app/org/sagebionetworks/bridge/models/CriteriaUtils.java
@@ -65,15 +65,16 @@ public class CriteriaUtils {
         for (String osName : criteria.getAppVersionOperatingSystems()) {
             Integer minAppVersion = criteria.getMinAppVersion(osName);
             Integer maxAppVersion = criteria.getMaxAppVersion(osName);
+            String errorKey = BridgeUtils.textToErrorKey(osName);
             
             if (minAppVersion != null && maxAppVersion != null && maxAppVersion < minAppVersion) {
-                pushSubpathError(errors, "maxAppVersions", osName, "cannot be less than minAppVersion");
+                pushSubpathError(errors, "maxAppVersions", errorKey, "cannot be less than minAppVersions."+errorKey);
             }
             if (minAppVersion != null && minAppVersion < 0) {
-                pushSubpathError(errors, "minAppVersions", osName, "cannot be negative");
+                pushSubpathError(errors, "minAppVersions", errorKey, "cannot be negative");
             }
             if (maxAppVersion != null && maxAppVersion < 0) {
-                pushSubpathError(errors, "maxAppVersions", osName, "cannot be negative");
+                pushSubpathError(errors, "maxAppVersions", errorKey, "cannot be negative");
             }
         }
         validateDataGroups(errors, dataGroups, criteria.getAllOfGroups(), "allOfGroups");
@@ -81,9 +82,9 @@ public class CriteriaUtils {
         validateDataGroupNotRequiredAndProhibited(criteria, errors);
     }
     
-    private static void pushSubpathError(Errors errors, String subpath, String osName, String error) {
+    private static void pushSubpathError(Errors errors, String subpath, String errorKey, String error) {
         errors.pushNestedPath(subpath);
-        errors.rejectValue(BridgeUtils.textToErrorKey(osName), error);
+        errors.rejectValue(errorKey, error);
         errors.popNestedPath();
     }
 

--- a/app/org/sagebionetworks/bridge/models/CriteriaUtils.java
+++ b/app/org/sagebionetworks/bridge/models/CriteriaUtils.java
@@ -8,20 +8,21 @@ import java.util.Set;
 
 import org.springframework.validation.Errors;
 
+import org.sagebionetworks.bridge.BridgeUtils;
+
 import com.google.common.collect.Sets;
 
 /**
- * Utility classes for working with domain entities that should be matched by a growing list of 
- * criteria, such as the version of the app making a request or the data groups associated to 
- * a user. Matching is currently done through information passed in through the ScheduleContext, 
- * a parameter object of values against which matching occurs.
+ * Utility classes for working with domain entities that should be matched by a growing list of criteria, such as the
+ * version of the app making a request or the data groups associated to a user. Matching is currently done through
+ * information passed in through the ScheduleContext, a parameter object of values against which matching occurs.
  */
 public class CriteriaUtils {
     
     /**
-     * A matching method that matches our common set of matching criteria for consents, schedulses, and more. 
-     * We use the dataGroups and app version in the scheduling context and compare this to required and/or 
-     * prohibitied data groups, and an application version range, to determine if there is a match or not. 
+     * Match the context of a request (the user's language and data groups, the application making the request) against
+     * the criteria for including an object in the content that a user sees. Returns true if the object should be
+     * included, and false otherwise.
      */
     public static boolean matchCriteria(CriteriaContext context, Criteria criteria) {
         checkNotNull(context);
@@ -56,6 +57,10 @@ public class CriteriaUtils {
         return true;
     }
 
+    /**
+     * Validate that the criteria are correct (e.g. including the same data group in both required and prohibited sets,
+     * or having a min-max version range out of order, are obviously incorrect because they can never match).
+     */
     public static void validate(Criteria criteria, Set<String> dataGroups, Errors errors) {
         for (String osName : criteria.getAppVersionOperatingSystems()) {
             Integer minAppVersion = criteria.getMinAppVersion(osName);
@@ -78,7 +83,7 @@ public class CriteriaUtils {
     
     private static void pushSubpathError(Errors errors, String subpath, String osName, String error) {
         errors.pushNestedPath(subpath);
-        errors.rejectValue(osName.toLowerCase().replaceAll(" ", "_"), error);
+        errors.rejectValue(BridgeUtils.textToErrorKey(osName), error);
         errors.popNestedPath();
     }
 

--- a/app/org/sagebionetworks/bridge/models/OperatingSystem.java
+++ b/app/org/sagebionetworks/bridge/models/OperatingSystem.java
@@ -1,7 +1,8 @@
 package org.sagebionetworks.bridge.models;
 
 /**
- * Common operating system names.
+ * Common operating system names. There's nothing special about these, another operating system 
+ * could be provided through the API.
  */
 public class OperatingSystem {
     public static final String IOS = "iPhone OS";

--- a/app/org/sagebionetworks/bridge/models/OperatingSystem.java
+++ b/app/org/sagebionetworks/bridge/models/OperatingSystem.java
@@ -1,8 +1,8 @@
 package org.sagebionetworks.bridge.models;
 
 /**
- * Common operating system names. There's nothing special about these, another operating system 
- * could be provided through the API.
+ * Common operating system names. The operating system name is not constrained (any value could be used as long as the
+ * study supports it), so this is not an enumeration.
  */
 public class OperatingSystem {
     public static final String IOS = "iPhone OS";

--- a/app/org/sagebionetworks/bridge/models/OperatingSystem.java
+++ b/app/org/sagebionetworks/bridge/models/OperatingSystem.java
@@ -1,0 +1,9 @@
+package org.sagebionetworks.bridge.models;
+
+/**
+ * Common operating system names.
+ */
+public class OperatingSystem {
+    public static final String IOS = "iPhone OS";
+    public static final String ANDROID = "Android";
+}

--- a/test/org/sagebionetworks/bridge/BridgeUtilsTest.java
+++ b/test/org/sagebionetworks/bridge/BridgeUtilsTest.java
@@ -164,6 +164,23 @@ public class BridgeUtilsTest {
         BridgeUtils.getIdFromStormpathHref("https://enterprise.stormpath.io/v2/accounts/6278jk74xoPOXkruh9vJnh");
     }
     
+    @Test
+    public void textToErrorKey() {
+        assertEquals("iphone_os", BridgeUtils.textToErrorKey("iPhone OS"));
+        assertEquals("android", BridgeUtils.textToErrorKey("Android"));
+        assertEquals("testers_operating_system_v2", BridgeUtils.textToErrorKey("Tester's Operating System v2"));
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void textToErrorKeyRejectsNull() {
+        BridgeUtils.textToErrorKey(null);
+    }
+            
+    @Test(expected = IllegalArgumentException.class)
+    public void textToErrorKeyRejectsEmptyString() {
+        BridgeUtils.textToErrorKey(" ");
+    }
+    
     // assertEquals with two sets doesn't verify the order is the same... hence this test method.
     private <T> void orderedSetsEqual(Set<T> first, Set<T> second) {
         assertEquals(first.size(), second.size());

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -31,6 +31,7 @@ import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.models.Criteria;
+import org.sagebionetworks.bridge.models.OperatingSystem;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.schedules.ABTestScheduleStrategy;
@@ -368,8 +369,8 @@ public class TestUtils {
     
     public static Criteria createCriteria(Integer minAppVersion, Integer maxAppVersion, Set<String> allOfGroups, Set<String> noneOfGroups) {
         DynamoCriteria crit = new DynamoCriteria();
-        crit.setMinAppVersion(minAppVersion);
-        crit.setMaxAppVersion(maxAppVersion);
+        crit.setMinAppVersion(OperatingSystem.IOS, minAppVersion);
+        crit.setMaxAppVersion(OperatingSystem.IOS, maxAppVersion);
         crit.setAllOfGroups(allOfGroups);
         crit.setNoneOfGroups(noneOfGroups);
         return crit;
@@ -380,8 +381,10 @@ public class TestUtils {
         if (criteria != null) {
             crit.setKey(criteria.getKey());
             crit.setLanguage(criteria.getLanguage());
-            crit.setMinAppVersion(criteria.getMinAppVersion());
-            crit.setMaxAppVersion(criteria.getMaxAppVersion());
+            for (String osName : criteria.getAppVersionOperatingSystems()) {
+                crit.setMinAppVersion(osName, criteria.getMinAppVersion(osName));
+                crit.setMaxAppVersion(osName, criteria.getMaxAppVersion(osName));
+            }
             crit.setNoneOfGroups(criteria.getNoneOfGroups());
             crit.setAllOfGroups(criteria.getAllOfGroups());
         }

--- a/test/org/sagebionetworks/bridge/TestUtilsTest.java
+++ b/test/org/sagebionetworks/bridge/TestUtilsTest.java
@@ -3,6 +3,8 @@ package org.sagebionetworks.bridge;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.sagebionetworks.bridge.models.OperatingSystem.ANDROID;
+import static org.sagebionetworks.bridge.models.OperatingSystem.IOS;
 
 import java.util.HashSet;
 
@@ -22,8 +24,8 @@ public class TestUtilsTest {
     public void createCriteriaWithArguments() {
         Criteria criteria = TestUtils.createCriteria(5, 15, ALL_OF_GROUPS, NONE_OF_GROUPS);
 
-        assertEquals(new Integer(5), criteria.getMinAppVersion());
-        assertEquals(new Integer(15), criteria.getMaxAppVersion());
+        assertEquals(new Integer(5), criteria.getMinAppVersion(IOS));
+        assertEquals(new Integer(15), criteria.getMaxAppVersion(IOS));
         assertEquals(ALL_OF_GROUPS, criteria.getAllOfGroups());
         assertEquals(NONE_OF_GROUPS, criteria.getNoneOfGroups());
     }
@@ -39,19 +41,21 @@ public class TestUtilsTest {
         Criteria criteria = newCriteria();
         
         Criteria newCriteria = TestUtils.copyCriteria(criteria);
-        assertEquals(new Integer(5), newCriteria.getMinAppVersion());
-        assertEquals(new Integer(15), newCriteria.getMaxAppVersion());
+        assertEquals(new Integer(5), newCriteria.getMinAppVersion(IOS));
+        assertEquals(new Integer(15), newCriteria.getMaxAppVersion(IOS));
+        assertEquals(new Integer(12), newCriteria.getMaxAppVersion(ANDROID));
         assertEquals(ALL_OF_GROUPS, newCriteria.getAllOfGroups());
         assertEquals(NONE_OF_GROUPS, newCriteria.getNoneOfGroups());
-        
+        assertEquals(Sets.newHashSet(IOS, ANDROID), newCriteria.getAppVersionOperatingSystems());
         assertFalse( criteria == newCriteria);
     }
     
     private Criteria newCriteria() {
         // Don't use an interface method, that's what we're testing here.
         Criteria criteria = new DynamoCriteria();
-        criteria.setMinAppVersion(5);
-        criteria.setMaxAppVersion(15);
+        criteria.setMinAppVersion(IOS, 5);
+        criteria.setMaxAppVersion(IOS, 15);
+        criteria.setMaxAppVersion(ANDROID, 12);
         criteria.setAllOfGroups(ALL_OF_GROUPS);
         criteria.setNoneOfGroups(NONE_OF_GROUPS);
         return criteria;

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoCriteriaDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoCriteriaDaoTest.java
@@ -93,5 +93,18 @@ public class DynamoCriteriaDaoTest {
         assertEquals(new Integer(12), newCriteria.getMinAppVersion(IOS));
         assertEquals("fr", newCriteria.getLanguage());
     }
-
+    
+    @Test
+    public void originalMinMaxValuesAreMigratedToPlatformMap() {
+        DynamoCriteria dynoCriteria = new DynamoCriteria();
+        dynoCriteria.setKey("key1");
+        dynoCriteria.setMinAppVersion(1);
+        dynoCriteria.setMaxAppVersion(4);
+        
+        criteriaDao.createOrUpdateCriteria(dynoCriteria);
+        
+        Criteria criteria = criteriaDao.getCriteria("key1");
+        assertEquals(new Integer(1), criteria.getMinAppVersion(IOS));
+        assertEquals(new Integer(4), criteria.getMaxAppVersion(IOS));
+    }        
 }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoCriteriaDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoCriteriaDaoTest.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge.dynamodb;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.sagebionetworks.bridge.models.OperatingSystem.IOS;
 
 import java.util.HashSet;
 
@@ -42,35 +43,35 @@ public class DynamoCriteriaDaoTest {
         Criteria criteria = Criteria.create();
         criteria.setKey("key");
         criteria.setLanguage("de");
-        criteria.setMinAppVersion(2);
-        criteria.setMaxAppVersion(8);
+        criteria.setMinAppVersion(IOS, 2);
+        criteria.setMaxAppVersion(IOS, 8);
         criteria.setAllOfGroups(ALL_OF_GROUPS);
         criteria.setNoneOfGroups(NONE_OF_GROUPS);
         
         Criteria result = criteriaDao.createOrUpdateCriteria(criteria);
         assertEquals("key", result.getKey());
         assertEquals("de", result.getLanguage());
-        assertEquals(new Integer(2), result.getMinAppVersion());
-        assertEquals(new Integer(8), result.getMaxAppVersion());
+        assertEquals(new Integer(2), result.getMinAppVersion(IOS));
+        assertEquals(new Integer(8), result.getMaxAppVersion(IOS));
         assertEquals(ALL_OF_GROUPS, result.getAllOfGroups());
         assertEquals(NONE_OF_GROUPS, result.getNoneOfGroups());
         
         Criteria retrieved = criteriaDao.getCriteria("key");
         assertEquals("key", retrieved.getKey());
         assertEquals("de", retrieved.getLanguage());
-        assertEquals(new Integer(2), retrieved.getMinAppVersion());
-        assertEquals(new Integer(8), retrieved.getMaxAppVersion());
+        assertEquals(new Integer(2), retrieved.getMinAppVersion(IOS));
+        assertEquals(new Integer(8), retrieved.getMaxAppVersion(IOS));
         assertEquals(ALL_OF_GROUPS, retrieved.getAllOfGroups());
         assertEquals(NONE_OF_GROUPS, retrieved.getNoneOfGroups());
         
         // Try nullifying this, setting a property
         criteria.setAllOfGroups(null);
         criteria.setLanguage(null);
-        criteria.setMinAppVersion(4);
+        criteria.setMinAppVersion(IOS, 4);
         criteriaDao.createOrUpdateCriteria(criteria);
         
         retrieved = criteriaDao.getCriteria("key");
-        assertEquals(new Integer(4), retrieved.getMinAppVersion());
+        assertEquals(new Integer(4), retrieved.getMinAppVersion(IOS));
         assertNull(retrieved.getLanguage());
         assertTrue(retrieved.getAllOfGroups().isEmpty());
         
@@ -85,11 +86,11 @@ public class DynamoCriteriaDaoTest {
     public void canCopy() {
         Criteria criteria = Criteria.create();
         criteria.setKey("key1");
-        criteria.setMinAppVersion(12);
+        criteria.setMinAppVersion(IOS, 12);
         criteria.setLanguage("fr");
         
         Criteria newCriteria = TestUtils.copyCriteria(criteria);
-        assertEquals(new Integer(12), newCriteria.getMinAppVersion());
+        assertEquals(new Integer(12), newCriteria.getMinAppVersion(IOS));
         assertEquals("fr", newCriteria.getLanguage());
     }
 

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoCriteriaTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoCriteriaTest.java
@@ -2,6 +2,8 @@ package org.sagebionetworks.bridge.dynamodb;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.sagebionetworks.bridge.models.OperatingSystem.ANDROID;
+import static org.sagebionetworks.bridge.models.OperatingSystem.IOS;
 
 import java.util.HashSet;
 
@@ -11,6 +13,7 @@ import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.json.JsonUtils;
 import org.sagebionetworks.bridge.models.Criteria;
+import org.sagebionetworks.bridge.models.OperatingSystem;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Sets;
@@ -32,27 +35,54 @@ public class DynamoCriteriaTest {
     @Test
     public void canSerialize() throws Exception {
         Criteria criteria = TestUtils.createCriteria(2, 8, SET_A, SET_B);
+        criteria.setMinAppVersion(ANDROID, 10);
+        criteria.setMaxAppVersion(ANDROID, 15);
         criteria.setKey("subpopulation:AAA");
         criteria.setLanguage("fr");
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(criteria);
-        assertEquals(2, node.get("minAppVersion").asInt());
-        assertEquals(8, node.get("maxAppVersion").asInt());
         assertEquals("fr", node.get("language").asText());
         assertEquals(SET_A, JsonUtils.asStringSet(node, "allOfGroups"));
         assertEquals(SET_B, JsonUtils.asStringSet(node, "noneOfGroups"));
+        
+        JsonNode minValues = node.get("minAppVersions");
+        assertEquals(2, minValues.get(OperatingSystem.IOS).asInt());
+        assertEquals(10, minValues.get(OperatingSystem.ANDROID).asInt());
+        
+        JsonNode maxValues = node.get("maxAppVersions");
+        assertEquals(8, maxValues.get(OperatingSystem.IOS).asInt());
+        assertEquals(15, maxValues.get(OperatingSystem.ANDROID).asInt());
+        
         assertEquals("Criteria", node.get("type").asText());
         assertNull(node.get("key"));
+        assertEquals(6, node.size()); // Nothing else is serialized here. (That's important.)
         
+        // However, we will except the older variant of JSON for the time being
         String json = makeJson("{'minAppVersion':2,'maxAppVersion':8,'language':'de','allOfGroups':['a','b'],'noneOfGroups':['c','d']}");
         
         Criteria crit = BridgeObjectMapper.get().readValue(json, Criteria.class);
-        assertEquals(new Integer(2), crit.getMinAppVersion());
-        assertEquals(new Integer(8), crit.getMaxAppVersion());
+        assertEquals(new Integer(2), crit.getMinAppVersion(IOS));
+        assertEquals(new Integer(8), crit.getMaxAppVersion(IOS));
         assertEquals("de", crit.getLanguage());
         assertEquals(SET_A, crit.getAllOfGroups());
         assertEquals(SET_B, crit.getNoneOfGroups());
         assertNull(crit.getKey());
+    }
+    
+    @Test
+    public void canRemoveMinMaxAttributes() {
+        Criteria criteria = TestUtils.createCriteria(2, 8, SET_A, SET_B);
+        criteria.setMinAppVersion(ANDROID, 10);
+        criteria.setMaxAppVersion(ANDROID, 15);
+        criteria.setKey("subpopulation:AAA");
+        criteria.setLanguage("fr");
+
+        criteria.setMinAppVersion(IOS, null);
+        criteria.setMaxAppVersion(ANDROID, null);
+        
+        JsonNode node = BridgeObjectMapper.get().valueToTree(criteria);
+        assertNull(node.get("minAppVersions").get("ios"));
+        assertNull(node.get("maxAppVersions").get("android"));
     }
     
     private String makeJson(String string) {

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoCriteriaTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoCriteriaTest.java
@@ -85,6 +85,18 @@ public class DynamoCriteriaTest {
         assertNull(node.get("maxAppVersions").get("android"));
     }
     
+    @Test
+    public void newerPlatformVersionAttributesTakePrecedenceOverLegacyProperties() {
+        DynamoCriteria criteria = new DynamoCriteria();
+        
+        criteria.setMinAppVersion(OperatingSystem.IOS, 8);
+        criteria.setMinAppVersion(4); // this does not reset the value
+        assertEquals(new Integer(8), criteria.getMinAppVersion(OperatingSystem.IOS));
+        
+        criteria.setMinAppVersion(OperatingSystem.IOS, 10); // this does
+        assertEquals(new Integer(10), criteria.getMinAppVersion(OperatingSystem.IOS));
+    }
+    
     private String makeJson(String string) {
         return string.replaceAll("'", "\"");
     }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoCriteriaTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoCriteriaTest.java
@@ -1,11 +1,13 @@
 package org.sagebionetworks.bridge.dynamodb;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.sagebionetworks.bridge.models.OperatingSystem.ANDROID;
 import static org.sagebionetworks.bridge.models.OperatingSystem.IOS;
 
 import java.util.HashSet;
+import java.util.Map;
 
 import org.junit.Test;
 
@@ -15,6 +17,7 @@ import org.sagebionetworks.bridge.json.JsonUtils;
 import org.sagebionetworks.bridge.models.Criteria;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -94,6 +97,28 @@ public class DynamoCriteriaTest {
         // But of course you can update the value in the map
         criteria.setMinAppVersion(IOS, 10);
         assertEquals(new Integer(10), criteria.getMinAppVersion(IOS));
+    }
+    
+    @Test
+    public void cannotSetNullValuesInPlatformVersionMap() {
+        Map<String, Integer> map = Maps.newHashMap();
+        map.put(IOS, null);
+        
+        DynamoCriteria criteria = new DynamoCriteria();
+        criteria.setMinAppVersions(map);
+        criteria.setMaxAppVersions(map);
+        assertFalse(criteria.getMinAppVersions().containsKey(IOS));
+        assertFalse(criteria.getMaxAppVersions().containsKey(IOS));
+        
+        criteria.setMinAppVersion(IOS, null);
+        criteria.setMaxAppVersion(IOS, null);
+        assertFalse(criteria.getMinAppVersions().containsKey(IOS));
+        assertFalse(criteria.getMaxAppVersions().containsKey(IOS));
+        
+        criteria.setMinAppVersion(null);
+        criteria.setMaxAppVersion(null);
+        assertFalse(criteria.getMinAppVersions().containsKey(IOS));
+        assertFalse(criteria.getMaxAppVersions().containsKey(IOS));
     }
     
     private String makeJson(String string) {

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSchedulePlanDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSchedulePlanDaoMockTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
+import static org.sagebionetworks.bridge.models.OperatingSystem.IOS;
 
 import java.util.List;
 import java.util.Set;
@@ -97,16 +98,16 @@ public class DynamoSchedulePlanDaoMockTest {
         
         // now have criteriaDao return a different criteria object, that should update the plan
         Criteria persistedCriteria = Criteria.create();
-        persistedCriteria.setMinAppVersion(1);
-        persistedCriteria.setMaxAppVersion(65);
+        persistedCriteria.setMinAppVersion(IOS, 1);
+        persistedCriteria.setMaxAppVersion(IOS, 65);
         when(criteriaDao.getCriteria(key)).thenReturn(persistedCriteria);
         
         plans = dao.getSchedulePlans(ClientInfo.UNKNOWN_CLIENT, TEST_STUDY);
         plan = plans.get(0);
         strategy = (CriteriaScheduleStrategy)plan.getStrategy();
         criteria = strategy.getScheduleCriteria().get(0).getCriteria();
-        assertEquals(new Integer(1), criteria.getMinAppVersion());
-        assertEquals(new Integer(65), criteria.getMaxAppVersion());
+        assertEquals(new Integer(1), criteria.getMinAppVersion(IOS));
+        assertEquals(new Integer(65), criteria.getMaxAppVersion(IOS));
         assertTrue(criteria.getAllOfGroups().isEmpty());
         assertTrue(criteria.getNoneOfGroups().isEmpty());
     }
@@ -124,15 +125,15 @@ public class DynamoSchedulePlanDaoMockTest {
         
         // now have criteriaDao return a different criteria object, that should update the plan
         Criteria persistedCriteria = Criteria.create();
-        persistedCriteria.setMinAppVersion(1);
-        persistedCriteria.setMaxAppVersion(65);
+        persistedCriteria.setMinAppVersion(IOS, 1);
+        persistedCriteria.setMaxAppVersion(IOS, 65);
         when(criteriaDao.getCriteria(key)).thenReturn(persistedCriteria);
         
         plan = dao.getSchedulePlan(TEST_STUDY, plan.getGuid());
         strategy = (CriteriaScheduleStrategy)plan.getStrategy();
         criteria = strategy.getScheduleCriteria().get(0).getCriteria();
-        assertEquals(new Integer(1), criteria.getMinAppVersion());
-        assertEquals(new Integer(65), criteria.getMaxAppVersion());
+        assertEquals(new Integer(1), criteria.getMinAppVersion(IOS));
+        assertEquals(new Integer(65), criteria.getMaxAppVersion(IOS));
         assertTrue(criteria.getAllOfGroups().isEmpty());
         assertTrue(criteria.getNoneOfGroups().isEmpty());
     }
@@ -169,15 +170,15 @@ public class DynamoSchedulePlanDaoMockTest {
         
         Criteria newCriteria = Criteria.create();
         newCriteria.setKey(crit.getKey());
-        newCriteria.setMinAppVersion(100);
-        newCriteria.setMaxAppVersion(200);
+        newCriteria.setMinAppVersion(IOS, 100);
+        newCriteria.setMaxAppVersion(IOS, 200);
         strategy.getScheduleCriteria().set(0, new ScheduleCriteria(scheduleCriteria.getSchedule(), newCriteria));
         
         plan = dao.updateSchedulePlan(TEST_STUDY, plan);
         scheduleCriteria = strategy.getScheduleCriteria().get(0);
         criteria = scheduleCriteria.getCriteria();
-        assertEquals(new Integer(100), criteria.getMinAppVersion());
-        assertEquals(new Integer(200), criteria.getMaxAppVersion());
+        assertEquals(new Integer(100), criteria.getMinAppVersion(IOS));
+        assertEquals(new Integer(200), criteria.getMaxAppVersion(IOS));
         
         verify(criteriaDao).createOrUpdateCriteria(newCriteria);
     }
@@ -190,8 +191,8 @@ public class DynamoSchedulePlanDaoMockTest {
     }
 
     private void assertCriteria(Criteria criteria) {
-        assertEquals(new Integer(2), criteria.getMinAppVersion());
-        assertEquals(new Integer(10), criteria.getMaxAppVersion());
+        assertEquals(new Integer(2), criteria.getMinAppVersion(IOS));
+        assertEquals(new Integer(10), criteria.getMaxAppVersion(IOS));
         assertEquals(ALL_OF_GROUPS, criteria.getAllOfGroups());
         assertEquals(NONE_OF_GROUPS, criteria.getNoneOfGroups());
     }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSchedulePlanDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSchedulePlanDaoTest.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge.dynamodb;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
+import static org.sagebionetworks.bridge.models.OperatingSystem.IOS;
 
 import java.util.List;
 import java.util.Set;
@@ -211,12 +212,12 @@ public class DynamoSchedulePlanDaoTest {
         
         // Should be able to read the criteria objects for this.
         Criteria criteria1 = criteriaDao.getCriteria("scheduleCriteria:"+plan.getGuid()+":0");
-        assertEquals(new Integer(2), criteria1.getMinAppVersion());
-        assertEquals(new Integer(8), criteria1.getMaxAppVersion());
+        assertEquals(new Integer(2), criteria1.getMinAppVersion(IOS));
+        assertEquals(new Integer(8), criteria1.getMaxAppVersion(IOS));
         
         Criteria criteria2 = criteriaDao.getCriteria("scheduleCriteria:"+plan.getGuid()+":1");
-        assertEquals(new Integer(9), criteria2.getMinAppVersion());
-        assertEquals(new Integer(14), criteria2.getMaxAppVersion());
+        assertEquals(new Integer(9), criteria2.getMinAppVersion(IOS));
+        assertEquals(new Integer(14), criteria2.getMaxAppVersion(IOS));
         
         plansToDelete.add(new Keys(studyId.getIdentifier(), plan.getGuid()));
     }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.json.JsonUtils;
+import org.sagebionetworks.bridge.models.OperatingSystem;
 import org.sagebionetworks.bridge.models.studies.EmailTemplate;
 import org.sagebionetworks.bridge.models.studies.PasswordPolicy;
 import org.sagebionetworks.bridge.models.studies.Study;
@@ -37,7 +38,7 @@ public class DynamoStudyTest {
     public void studyFullySerializesForCaching() throws Exception {
         final DynamoStudy study = TestUtils.getValidStudy(DynamoStudyTest.class);
         study.setVersion(2L);
-        study.getMinSupportedAppVersions().put("iPhone OS", 2);
+        study.getMinSupportedAppVersions().put(OperatingSystem.IOS, 2);
         study.setStormpathHref("test");
         
         final String json = BridgeObjectMapper.get().writeValueAsString(study);
@@ -71,7 +72,9 @@ public class DynamoStudyTest {
         
         JsonNode supportedVersionsNode = JsonUtils.asJsonNode(node, "minSupportedAppVersions");
         assertNotNull(supportedVersionsNode);
-        assertEqualsAndNotNull(study.getMinSupportedAppVersions().get("iPhone OS"), (Integer)supportedVersionsNode.get("iPhone OS").asInt());
+        assertEqualsAndNotNull(
+                study.getMinSupportedAppVersions().get(OperatingSystem.IOS), 
+                (Integer)supportedVersionsNode.get(OperatingSystem.IOS).asInt());
         
         // Using the filtered view of a study, this should not include a couple of fields we don't expose to researchers.
         // Negates the need for a view wrapper object, is contextually adjustable, unlike @JsonIgnore.

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDaoMockTest.java
@@ -99,6 +99,7 @@ public class DynamoSubpopulationDaoMockTest {
         
         Criteria criteria = subpop.getCriteria();
         assertEquals(new Integer(0), criteria.getMinAppVersion(OperatingSystem.IOS));
+        assertEquals(new Integer(0), criteria.getMinAppVersion(OperatingSystem.ANDROID));
         
         verify(criteriaDao).createOrUpdateCriteria(criteria);
     }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDaoMockTest.java
@@ -31,6 +31,7 @@ import org.sagebionetworks.bridge.dao.StudyConsentDao;
 import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.Criteria;
 import org.sagebionetworks.bridge.models.CriteriaContext;
+import org.sagebionetworks.bridge.models.OperatingSystem;
 import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 
@@ -97,7 +98,7 @@ public class DynamoSubpopulationDaoMockTest {
         Subpopulation subpop = dao.createDefaultSubpopulation(TEST_STUDY);
         
         Criteria criteria = subpop.getCriteria();
-        assertEquals(new Integer(0), criteria.getMinAppVersion());
+        assertEquals(new Integer(0), criteria.getMinAppVersion(OperatingSystem.IOS));
         
         verify(criteriaDao).createOrUpdateCriteria(criteria);
     }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDaoTest.java
@@ -360,7 +360,7 @@ public class DynamoSubpopulationDaoTest {
     
     private CriteriaContext criteriaContext(int version, String tag) {
         CriteriaContext.Builder builder = new CriteriaContext.Builder()
-                .withClientInfo(ClientInfo.fromUserAgentCache("app/"+version+" (Unknown iPhone; iPhone OS 9.0.2) BridgeSDK/4"))
+                .withClientInfo(ClientInfo.fromUserAgentCache("app/"+version+" (Unknown iPhone; iPhone OS/9.0.2) BridgeSDK/4"))
                 .withStudyIdentifier(studyId);
         if (tag != null) {
             builder.withUserDataGroups(Sets.newHashSet(tag));    

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDaoTest.java
@@ -24,6 +24,7 @@ import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.Criteria;
 import org.sagebionetworks.bridge.models.CriteriaContext;
+import org.sagebionetworks.bridge.models.OperatingSystem;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.subpopulations.StudyConsent;
@@ -94,7 +95,7 @@ public class DynamoSubpopulationDaoTest {
         retrievedSubpop.setName("Name 2");
         retrievedSubpop.setDescription("Description 2");
         retrievedSubpop.setRequired(false);
-        retrievedSubpop.getCriteria().setMinAppVersion(3);
+        retrievedSubpop.getCriteria().setMinAppVersion(OperatingSystem.IOS, 3);
         Subpopulation finalSubpop = dao.updateSubpopulation(retrievedSubpop);
         
         // With this change, they should be equivalent using value equality
@@ -103,7 +104,7 @@ public class DynamoSubpopulationDaoTest {
         assertEquals("Description 2", retrievedSubpop.getDescription());
         assertFalse(retrievedSubpop.isRequired());
         assertEquals(retrievedSubpop, finalSubpop);
-        assertEquals(new Integer(3), finalSubpop.getCriteria().getMinAppVersion());
+        assertEquals(new Integer(3), finalSubpop.getCriteria().getMinAppVersion(OperatingSystem.IOS));
 
         // Some further things that should be true:
         // There's now only one subpopulation in the list
@@ -344,10 +345,10 @@ public class DynamoSubpopulationDaoTest {
         
         Criteria criteria = Criteria.create();
         if (min != null) {
-            criteria.setMinAppVersion(min);
+            criteria.setMinAppVersion(OperatingSystem.IOS, min);
         }
         if (max != null) {
-            criteria.setMaxAppVersion(max);
+            criteria.setMaxAppVersion(OperatingSystem.IOS, max);
         }
         if (group != null) {
             criteria.setAllOfGroups(Sets.newHashSet(group));
@@ -359,7 +360,7 @@ public class DynamoSubpopulationDaoTest {
     
     private CriteriaContext criteriaContext(int version, String tag) {
         CriteriaContext.Builder builder = new CriteriaContext.Builder()
-                .withClientInfo(ClientInfo.fromUserAgentCache("app/"+version))
+                .withClientInfo(ClientInfo.fromUserAgentCache("app/"+version+" (Unknown iPhone; iPhone OS 9.0.2) BridgeSDK/4"))
                 .withStudyIdentifier(studyId);
         if (tag != null) {
             builder.withUserDataGroups(Sets.newHashSet(tag));    

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.sagebionetworks.bridge.models.OperatingSystem.IOS;
 
 import java.util.Set;
 
@@ -15,6 +16,7 @@ import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.json.JsonUtils;
 import org.sagebionetworks.bridge.models.Criteria;
+import org.sagebionetworks.bridge.models.OperatingSystem;
 import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 
@@ -69,8 +71,8 @@ public class DynamoSubpopulationTest {
         JsonNode critNode = node.get("criteria");
         assertEquals(ALL_OF_GROUPS, JsonUtils.asStringSet(critNode, "allOfGroups"));
         assertEquals(NONE_OF_GROUPS, JsonUtils.asStringSet(critNode, "noneOfGroups"));
-        assertEquals(2, critNode.get("minAppVersion").asInt());
-        assertEquals(10, critNode.get("maxAppVersion").asInt());
+        assertEquals(2, critNode.get("minAppVersions").get(OperatingSystem.IOS).asInt());
+        assertEquals(10, critNode.get("maxAppVersions").get(OperatingSystem.IOS).asInt());
         
         Subpopulation newSubpop = BridgeObjectMapper.get().treeToValue(node, Subpopulation.class);
         // Not serialized, these values have to be added back to have equal objects 
@@ -90,8 +92,8 @@ public class DynamoSubpopulationTest {
         assertEquals(pdfURL, newSubpop.getConsentPDF());
         
         Criteria critObject = newSubpop.getCriteria();
-        assertEquals(new Integer(2), critObject.getMinAppVersion());
-        assertEquals(new Integer(10), critObject.getMaxAppVersion());
+        assertEquals(new Integer(2), critObject.getMinAppVersion(IOS));
+        assertEquals(new Integer(10), critObject.getMaxAppVersion(IOS));
         assertEquals(ALL_OF_GROUPS, critObject.getAllOfGroups());
         assertEquals(NONE_OF_GROUPS, critObject.getNoneOfGroups());
     }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationTest.java
@@ -16,7 +16,6 @@ import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.json.JsonUtils;
 import org.sagebionetworks.bridge.models.Criteria;
-import org.sagebionetworks.bridge.models.OperatingSystem;
 import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 
@@ -71,8 +70,8 @@ public class DynamoSubpopulationTest {
         JsonNode critNode = node.get("criteria");
         assertEquals(ALL_OF_GROUPS, JsonUtils.asStringSet(critNode, "allOfGroups"));
         assertEquals(NONE_OF_GROUPS, JsonUtils.asStringSet(critNode, "noneOfGroups"));
-        assertEquals(2, critNode.get("minAppVersions").get(OperatingSystem.IOS).asInt());
-        assertEquals(10, critNode.get("maxAppVersions").get(OperatingSystem.IOS).asInt());
+        assertEquals(2, critNode.get("minAppVersions").get(IOS).asInt());
+        assertEquals(10, critNode.get("maxAppVersions").get(IOS).asInt());
         
         Subpopulation newSubpop = BridgeObjectMapper.get().treeToValue(node, Subpopulation.class);
         // Not serialized, these values have to be added back to have equal objects 

--- a/test/org/sagebionetworks/bridge/models/ClientInfoTest.java
+++ b/test/org/sagebionetworks/bridge/models/ClientInfoTest.java
@@ -1,6 +1,13 @@
 package org.sagebionetworks.bridge.models;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.sagebionetworks.bridge.models.OperatingSystem.ANDROID;
+import static org.sagebionetworks.bridge.models.OperatingSystem.IOS;
 
 import org.junit.Test;
 
@@ -34,12 +41,12 @@ public class ClientInfoTest {
         ClientInfo info = new ClientInfo.Builder()
                 .withAppName("AppName")
                 .withAppVersion(1)
-                .withOsName(OperatingSystem.IOS)
+                .withOsName(IOS)
                 .withOsVersion("Version1")
                 .withSdkVersion(4).build();
         assertEquals("AppName", info.getAppName());
         assertEquals(1, info.getAppVersion().intValue());
-        assertEquals(OperatingSystem.IOS, info.getOsName());
+        assertEquals(IOS, info.getOsName());
         assertEquals("Version1", info.getOsVersion());
         assertEquals(4, info.getSdkVersion().intValue());
     }
@@ -111,7 +118,7 @@ public class ClientInfoTest {
         assertEquals("Asthma", info.getAppName());
         assertEquals(26, info.getAppVersion().intValue());
         assertEquals("Unknown iPhone", info.getDeviceName());
-        assertEquals(OperatingSystem.IOS, info.getOsName());
+        assertEquals(IOS, info.getOsName());
         assertEquals("9.1", info.getOsVersion());
         assertEquals("BridgeSDK", info.getSdkName());
         assertEquals(4, info.getSdkVersion().intValue());
@@ -120,7 +127,7 @@ public class ClientInfoTest {
         assertEquals("Cardio Health", info.getAppName());
         assertEquals(1, info.getAppVersion().intValue());
         assertEquals("Unknown iPhone", info.getDeviceName());
-        assertEquals(OperatingSystem.IOS, info.getOsName());
+        assertEquals(IOS, info.getOsName());
         assertEquals("9.0.2", info.getOsVersion());
         assertEquals("BridgeSDK", info.getSdkName());
         assertEquals(4, info.getSdkVersion().intValue());
@@ -129,7 +136,7 @@ public class ClientInfoTest {
         assertEquals("Belgium", info.getAppName());
         assertEquals(2, info.getAppVersion().intValue());
         assertEquals("Motorola Flip-Phone", info.getDeviceName());
-        assertEquals(OperatingSystem.ANDROID, info.getOsName());
+        assertEquals(ANDROID, info.getOsName());
         assertEquals("14", info.getOsVersion());
         assertEquals("BridgeJavaSDK", info.getSdkName());
         assertEquals(10, info.getSdkVersion().intValue());
@@ -140,7 +147,7 @@ public class ClientInfoTest {
         ClientInfo info = ClientInfo.parseUserAgentString(VALID_LONG_UA_1_DEPRECATED);
         assertEquals("Asthma", info.getAppName());
         assertEquals(26, info.getAppVersion().intValue());
-        assertEquals(OperatingSystem.IOS, info.getOsName());
+        assertEquals(IOS, info.getOsName());
         assertEquals("9.1", info.getOsVersion());
         assertEquals("BridgeSDK", info.getSdkName());
         assertEquals(4, info.getSdkVersion().intValue());
@@ -148,7 +155,7 @@ public class ClientInfoTest {
         info = ClientInfo.parseUserAgentString(VALID_LONG_UA_2_DEPRECATED);
         assertEquals("Cardio Health", info.getAppName());
         assertEquals(1, info.getAppVersion().intValue());
-        assertEquals(OperatingSystem.IOS, info.getOsName());
+        assertEquals(IOS, info.getOsName());
         assertEquals("9.0.2", info.getOsVersion());
         assertEquals("BridgeSDK", info.getSdkName());
         assertEquals(4, info.getSdkVersion().intValue());
@@ -156,7 +163,7 @@ public class ClientInfoTest {
         info = ClientInfo.parseUserAgentString(VALID_LONG_UA_3_DEPRECATED);
         assertEquals("Belgium", info.getAppName());
         assertEquals(2, info.getAppVersion().intValue());
-        assertEquals(OperatingSystem.ANDROID, info.getOsName());
+        assertEquals(ANDROID, info.getOsName());
         assertEquals("14", info.getOsVersion());
         assertEquals("BridgeJavaSDK", info.getSdkName());
         assertEquals(10, info.getSdkVersion().intValue());
@@ -240,12 +247,12 @@ public class ClientInfoTest {
     @Test
     public void operatingSystemParsed() {
         ClientInfo info = ClientInfo.parseUserAgentString(VALID_LONG_UA_3);
-        assertEquals(OperatingSystem.ANDROID, info.getOsName());
+        assertEquals(ANDROID, info.getOsName());
     }
     
     @Test
     public void deprecatedOperatingSystemParsed() {
         ClientInfo info = ClientInfo.parseUserAgentString(VALID_LONG_UA_3_DEPRECATED);
-        assertEquals(OperatingSystem.ANDROID, info.getOsName());
+        assertEquals(ANDROID, info.getOsName());
     }
  }

--- a/test/org/sagebionetworks/bridge/models/ClientInfoTest.java
+++ b/test/org/sagebionetworks/bridge/models/ClientInfoTest.java
@@ -34,12 +34,12 @@ public class ClientInfoTest {
         ClientInfo info = new ClientInfo.Builder()
                 .withAppName("AppName")
                 .withAppVersion(1)
-                .withOsName("OsName")
+                .withOsName(OperatingSystem.IOS)
                 .withOsVersion("Version1")
                 .withSdkVersion(4).build();
         assertEquals("AppName", info.getAppName());
         assertEquals(1, info.getAppVersion().intValue());
-        assertEquals("OsName", info.getOsName());
+        assertEquals(OperatingSystem.IOS, info.getOsName());
         assertEquals("Version1", info.getOsVersion());
         assertEquals(4, info.getSdkVersion().intValue());
     }
@@ -111,7 +111,7 @@ public class ClientInfoTest {
         assertEquals("Asthma", info.getAppName());
         assertEquals(26, info.getAppVersion().intValue());
         assertEquals("Unknown iPhone", info.getDeviceName());
-        assertEquals("iPhone OS", info.getOsName());
+        assertEquals(OperatingSystem.IOS, info.getOsName());
         assertEquals("9.1", info.getOsVersion());
         assertEquals("BridgeSDK", info.getSdkName());
         assertEquals(4, info.getSdkVersion().intValue());
@@ -120,7 +120,7 @@ public class ClientInfoTest {
         assertEquals("Cardio Health", info.getAppName());
         assertEquals(1, info.getAppVersion().intValue());
         assertEquals("Unknown iPhone", info.getDeviceName());
-        assertEquals("iPhone OS", info.getOsName());
+        assertEquals(OperatingSystem.IOS, info.getOsName());
         assertEquals("9.0.2", info.getOsVersion());
         assertEquals("BridgeSDK", info.getSdkName());
         assertEquals(4, info.getSdkVersion().intValue());
@@ -129,7 +129,7 @@ public class ClientInfoTest {
         assertEquals("Belgium", info.getAppName());
         assertEquals(2, info.getAppVersion().intValue());
         assertEquals("Motorola Flip-Phone", info.getDeviceName());
-        assertEquals("Android", info.getOsName());
+        assertEquals(OperatingSystem.ANDROID, info.getOsName());
         assertEquals("14", info.getOsVersion());
         assertEquals("BridgeJavaSDK", info.getSdkName());
         assertEquals(10, info.getSdkVersion().intValue());
@@ -140,7 +140,7 @@ public class ClientInfoTest {
         ClientInfo info = ClientInfo.parseUserAgentString(VALID_LONG_UA_1_DEPRECATED);
         assertEquals("Asthma", info.getAppName());
         assertEquals(26, info.getAppVersion().intValue());
-        assertEquals("iPhone OS", info.getOsName());
+        assertEquals(OperatingSystem.IOS, info.getOsName());
         assertEquals("9.1", info.getOsVersion());
         assertEquals("BridgeSDK", info.getSdkName());
         assertEquals(4, info.getSdkVersion().intValue());
@@ -148,7 +148,7 @@ public class ClientInfoTest {
         info = ClientInfo.parseUserAgentString(VALID_LONG_UA_2_DEPRECATED);
         assertEquals("Cardio Health", info.getAppName());
         assertEquals(1, info.getAppVersion().intValue());
-        assertEquals("iPhone OS", info.getOsName());
+        assertEquals(OperatingSystem.IOS, info.getOsName());
         assertEquals("9.0.2", info.getOsVersion());
         assertEquals("BridgeSDK", info.getSdkName());
         assertEquals(4, info.getSdkVersion().intValue());
@@ -156,7 +156,7 @@ public class ClientInfoTest {
         info = ClientInfo.parseUserAgentString(VALID_LONG_UA_3_DEPRECATED);
         assertEquals("Belgium", info.getAppName());
         assertEquals(2, info.getAppVersion().intValue());
-        assertEquals("Android", info.getOsName());
+        assertEquals(OperatingSystem.ANDROID, info.getOsName());
         assertEquals("14", info.getOsVersion());
         assertEquals("BridgeJavaSDK", info.getSdkName());
         assertEquals(10, info.getSdkVersion().intValue());
@@ -231,4 +231,21 @@ public class ClientInfoTest {
         assertFalse(info.isSupportedAppVersion(27));
     }
     
+    @Test
+    public void operatingSystemUnknown() {
+        ClientInfo info = ClientInfo.parseUserAgentString(VALID_SHORT_UA_1);
+        assertNull(info.getOsName());
+    }
+    
+    @Test
+    public void operatingSystemParsed() {
+        ClientInfo info = ClientInfo.parseUserAgentString(VALID_LONG_UA_3);
+        assertEquals(OperatingSystem.ANDROID, info.getOsName());
+    }
+    
+    @Test
+    public void deprecatedOperatingSystemParsed() {
+        ClientInfo info = ClientInfo.parseUserAgentString(VALID_LONG_UA_3_DEPRECATED);
+        assertEquals(OperatingSystem.ANDROID, info.getOsName());
+    }
  }

--- a/test/org/sagebionetworks/bridge/models/CriteriaUtilsTest.java
+++ b/test/org/sagebionetworks/bridge/models/CriteriaUtilsTest.java
@@ -156,7 +156,7 @@ public class CriteriaUtilsTest {
         
         Errors errors = Validate.getErrorsFor(criteria);
         CriteriaUtils.validate(criteria, EMPTY_SET, errors);
-        assertEquals("cannot be less than minAppVersion", errors.getFieldErrors("maxAppVersions.iphone_os").get(0).getCode());
+        assertEquals("cannot be less than minAppVersions.iphone_os", errors.getFieldErrors("maxAppVersions.iphone_os").get(0).getCode());
     }
     
     @Test
@@ -185,7 +185,7 @@ public class CriteriaUtilsTest {
         
         Errors errors = Validate.getErrorsFor(criteria);
         CriteriaUtils.validate(criteria, EMPTY_SET, errors);
-        assertEquals("cannot be less than minAppVersion", errors.getFieldErrors("maxAppVersions.android").get(0).getCode());
+        assertEquals("cannot be less than minAppVersions.android", errors.getFieldErrors("maxAppVersions.android").get(0).getCode());
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/models/CriteriaUtilsTest.java
+++ b/test/org/sagebionetworks/bridge/models/CriteriaUtilsTest.java
@@ -191,17 +191,16 @@ public class CriteriaUtilsTest {
             public String getKey() { return key; }
             public void setLanguage(String language) { this.language = language; }
             public String getLanguage() { return language; }
-            public void setMinAppVersion(String os, Integer minAppVersion) { this.minAppVersions.put(os, minAppVersion); }
-            public Integer getMinAppVersion(String os) { return minAppVersions.get(os); }
-            public void setMaxAppVersion(String os, Integer maxAppVersion) { this.maxAppVersions.put(os, maxAppVersion); }
-            public Integer getMaxAppVersion(String os) { return maxAppVersions.get(os); }
+            public void setMinAppVersion(String osName, Integer minAppVersion) { this.minAppVersions.put(osName, minAppVersion); }
+            public Integer getMinAppVersion(String osName) { return minAppVersions.get(osName); }
+            public void setMaxAppVersion(String osName, Integer maxAppVersion) { this.maxAppVersions.put(osName, maxAppVersion); }
+            public Integer getMaxAppVersion(String osName) { return maxAppVersions.get(osName); }
             public void setAllOfGroups(Set<String> allOfGroups) { this.allOfGroups = allOfGroups; }
             public Set<String> getAllOfGroups() { return allOfGroups; }
             public void setNoneOfGroups(Set<String> noneOfGroups) { this.noneOfGroups = noneOfGroups; }
             public Set<String> getNoneOfGroups() { return noneOfGroups; }
-            public Set<String> getAppVersionOperatingSystems() {
-                return new ImmutableSet.Builder<String>().addAll(minAppVersions.keySet()).addAll(maxAppVersions.keySet()).build();
-            }
+            public Set<String> getAppVersionOperatingSystems() { return new ImmutableSet.Builder<String>()
+                .addAll(minAppVersions.keySet()).addAll(maxAppVersions.keySet()).build(); }
         };
         
         Errors errors = Validate.getErrorsFor(criteria);

--- a/test/org/sagebionetworks/bridge/models/schedules/CriteriaScheduleStrategyTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/CriteriaScheduleStrategyTest.java
@@ -20,6 +20,7 @@ import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.Criteria;
+import org.sagebionetworks.bridge.models.OperatingSystem;
 import org.sagebionetworks.bridge.validators.SchedulePlanValidator;
 import org.sagebionetworks.bridge.validators.Validate;
 
@@ -30,6 +31,9 @@ import com.google.common.collect.Sets;
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class CriteriaScheduleStrategyTest {
+    
+    private static final ClientInfo CLIENT_INFO = ClientInfo.fromUserAgentCache(
+            "Cardio Health/1 (Unknown iPhone; iPhone OS/9.0.2) BridgeSDK/4");
     
     private static final Schedule SCHEDULE_FOR_STRATEGY_WITH_APP_VERSIONS = makeValidSchedule(
             "Strategy With App Versions");
@@ -84,8 +88,13 @@ public class CriteriaScheduleStrategyTest {
         assertEquals("ScheduleCriteria", schCriteria1.get("type").asText());
         
         JsonNode criteriaNode = schCriteria1.get("criteria");
-        assertEquals(4, criteriaNode.get("minAppVersion").asInt());
-        assertEquals(12, criteriaNode.get("maxAppVersion").asInt());
+        System.out.println(criteriaNode);
+        
+        JsonNode minVersionsNode = criteriaNode.get("minAppVersions");
+        assertEquals(4, minVersionsNode.get(OperatingSystem.IOS).asInt());
+        JsonNode maxVersionsNode = criteriaNode.get("maxAppVersions");
+        assertEquals(12, maxVersionsNode.get(OperatingSystem.IOS).asInt());
+        
         assertNotNull(criteriaNode.get("allOfGroups"));
         assertNotNull(criteriaNode.get("noneOfGroups"));
         assertNotNull(schCriteria1.get("schedule"));
@@ -114,7 +123,7 @@ public class CriteriaScheduleStrategyTest {
         assertEquals(SCHEDULE_FOR_STRATEGY_WITH_APP_VERSIONS, schedule);
         
         // Context version info outside minimum range of first criteria, last one returned
-        schedule = getScheduleFromStrategy(ClientInfo.fromUserAgentCache("app/2"));
+        schedule = getScheduleFromStrategy(CLIENT_INFO);
         assertEquals(SCHEDULE_FOR_STRATEGY_NO_CRITERIA, schedule);
     }
     
@@ -128,7 +137,7 @@ public class CriteriaScheduleStrategyTest {
         assertEquals(SCHEDULE_FOR_STRATEGY_WITH_APP_VERSIONS, schedule);
         
         // Context version info outside maximum range of first criteria, last one returned
-        schedule = getScheduleFromStrategy(ClientInfo.fromUserAgentCache("app/44"));
+        schedule = getScheduleFromStrategy(CLIENT_INFO);
         assertEquals(SCHEDULE_FOR_STRATEGY_NO_CRITERIA, schedule);
     }
     
@@ -203,7 +212,7 @@ public class CriteriaScheduleStrategyTest {
         
         ScheduleContext context = new ScheduleContext.Builder()
                 .withStudyIdentifier(TestConstants.TEST_STUDY)
-                .withClientInfo(ClientInfo.fromUserAgentCache("app/44"))
+                .withClientInfo(CLIENT_INFO)
                 .withUserDataGroups(Sets.newHashSet("group1"))
                 .withHealthCode("BBB").build();
 
@@ -219,7 +228,7 @@ public class CriteriaScheduleStrategyTest {
         
         ScheduleContext context = new ScheduleContext.Builder()
                 .withStudyIdentifier(TestConstants.TEST_STUDY)
-                .withClientInfo(ClientInfo.fromUserAgentCache("app/44"))
+                .withClientInfo(CLIENT_INFO)
                 .withHealthCode("AAA").build();
         
         // First two ScheduleCriteria don't match; the first because the app version is wrong 
@@ -281,12 +290,12 @@ public class CriteriaScheduleStrategyTest {
             assertError(e, "strategy.scheduleCriteria[1].criteria.allOfGroups", 0, " 'group1' is not in enumeration: <no data groups declared>");
             assertError(e, "strategy.scheduleCriteria[2].criteria.noneOfGroups", 0, " 'group2' is not in enumeration: <no data groups declared>");
             assertError(e, "strategy.scheduleCriteria[2].criteria.noneOfGroups", 1, " 'group1' is not in enumeration: <no data groups declared>");
-            assertError(e, "strategy.scheduleCriteria[4].criteria.maxAppVersion", 0, " cannot be less than minAppVersion");
-            assertError(e, "strategy.scheduleCriteria[4].criteria.maxAppVersion", 1, " cannot be negative");
-            assertError(e, "strategy.scheduleCriteria[4].criteria.minAppVersion", 0, " cannot be negative");
-            assertError(e, "strategy.scheduleCriteria[5].criteria.maxAppVersion", 0, " cannot be less than minAppVersion");
-            assertError(e, "strategy.scheduleCriteria[5].criteria.maxAppVersion", 1, " cannot be negative");
-            assertError(e, "strategy.scheduleCriteria[5].criteria.minAppVersion", 0, " cannot be negative");
+            assertError(e, "strategy.scheduleCriteria[4].criteria.maxAppVersions.iphone_os", 0, " cannot be less than minAppVersion");
+            assertError(e, "strategy.scheduleCriteria[4].criteria.maxAppVersions.iphone_os", 1, " cannot be negative");
+            assertError(e, "strategy.scheduleCriteria[4].criteria.minAppVersions.iphone_os", 0, " cannot be negative");
+            assertError(e, "strategy.scheduleCriteria[5].criteria.maxAppVersions.iphone_os", 0, " cannot be less than minAppVersion");
+            assertError(e, "strategy.scheduleCriteria[5].criteria.maxAppVersions.iphone_os", 1, " cannot be negative");
+            assertError(e, "strategy.scheduleCriteria[5].criteria.minAppVersions.iphone_os", 0, " cannot be negative");
             assertError(e, "strategy.scheduleCriteria[5].schedule.activities", 0, " are required");
             assertError(e, "strategy.scheduleCriteria[5].schedule.scheduleType", 0, " is required");
          }

--- a/test/org/sagebionetworks/bridge/models/schedules/CriteriaScheduleStrategyTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/CriteriaScheduleStrategyTest.java
@@ -88,7 +88,6 @@ public class CriteriaScheduleStrategyTest {
         assertEquals("ScheduleCriteria", schCriteria1.get("type").asText());
         
         JsonNode criteriaNode = schCriteria1.get("criteria");
-        System.out.println(criteriaNode);
         
         JsonNode minVersionsNode = criteriaNode.get("minAppVersions");
         assertEquals(4, minVersionsNode.get(OperatingSystem.IOS).asInt());

--- a/test/org/sagebionetworks/bridge/models/schedules/CriteriaScheduleStrategyTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/CriteriaScheduleStrategyTest.java
@@ -289,10 +289,10 @@ public class CriteriaScheduleStrategyTest {
             assertError(e, "strategy.scheduleCriteria[1].criteria.allOfGroups", 0, " 'group1' is not in enumeration: <no data groups declared>");
             assertError(e, "strategy.scheduleCriteria[2].criteria.noneOfGroups", 0, " 'group2' is not in enumeration: <no data groups declared>");
             assertError(e, "strategy.scheduleCriteria[2].criteria.noneOfGroups", 1, " 'group1' is not in enumeration: <no data groups declared>");
-            assertError(e, "strategy.scheduleCriteria[4].criteria.maxAppVersions.iphone_os", 0, " cannot be less than minAppVersion");
+            assertError(e, "strategy.scheduleCriteria[4].criteria.maxAppVersions.iphone_os", 0, " cannot be less than minAppVersions.iphone_os");
             assertError(e, "strategy.scheduleCriteria[4].criteria.maxAppVersions.iphone_os", 1, " cannot be negative");
             assertError(e, "strategy.scheduleCriteria[4].criteria.minAppVersions.iphone_os", 0, " cannot be negative");
-            assertError(e, "strategy.scheduleCriteria[5].criteria.maxAppVersions.iphone_os", 0, " cannot be less than minAppVersion");
+            assertError(e, "strategy.scheduleCriteria[5].criteria.maxAppVersions.iphone_os", 0, " cannot be less than minAppVersions.iphone_os");
             assertError(e, "strategy.scheduleCriteria[5].criteria.maxAppVersions.iphone_os", 1, " cannot be negative");
             assertError(e, "strategy.scheduleCriteria[5].criteria.minAppVersions.iphone_os", 0, " cannot be negative");
             assertError(e, "strategy.scheduleCriteria[5].schedule.activities", 0, " are required");

--- a/test/org/sagebionetworks/bridge/models/schedules/ScheduleCriteriaTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/ScheduleCriteriaTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.models.Criteria;
+import org.sagebionetworks.bridge.models.OperatingSystem;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
@@ -20,8 +21,8 @@ public class ScheduleCriteriaTest {
         Schedule schedule = TestUtils.getSchedule("A schedule");
         
         Criteria criteria = Criteria.create();
-        criteria.setMinAppVersion(2);
-        criteria.setMaxAppVersion(10);
+        criteria.setMinAppVersion(OperatingSystem.IOS, 2);
+        criteria.setMaxAppVersion(OperatingSystem.IOS, 10);
         
         ScheduleCriteria scheduleCriteria = new ScheduleCriteria(schedule, criteria);
         

--- a/test/org/sagebionetworks/bridge/play/controllers/BaseControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/BaseControllerTest.java
@@ -36,6 +36,7 @@ import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.exceptions.UnsupportedVersionException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.ClientInfo;
+import org.sagebionetworks.bridge.models.OperatingSystem;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.studies.Study;
@@ -110,7 +111,7 @@ public class BaseControllerTest {
         ClientInfo info = new SchedulePlanController().getClientInfoFromUserAgentHeader();
         assertEquals("Asthma", info.getAppName());
         assertEquals(26, info.getAppVersion().intValue());
-        assertEquals("iPhone OS", info.getOsName());
+        assertEquals(OperatingSystem.IOS, info.getOsName());
         assertEquals("9.0.2", info.getOsVersion());
         assertEquals("BridgeSDK", info.getSdkName());
         assertEquals(4, info.getSdkVersion().intValue());
@@ -135,7 +136,7 @@ public class BaseControllerTest {
         mockHeader(USER_AGENT, "Asthma/26 (Unknown iPhone; iPhone OS 9.0.2) BridgeSDK/4");
         
         HashMap<String, Integer> map =new HashMap<>();
-        map.put("iPhone OS", 28);
+        map.put(OperatingSystem.IOS, 28);
         
         Study study = mock(Study.class);
         when(study.getMinSupportedAppVersions()).thenReturn(map);
@@ -150,7 +151,7 @@ public class BaseControllerTest {
         mockHeader(USER_AGENT, "Asthma/26 (Unknown iPhone; iPhone OS 9.0.2) BridgeSDK/4");
         
         HashMap<String, Integer> map =new HashMap<>();
-        map.put("iPhone OS", 25);
+        map.put(OperatingSystem.IOS, 25);
         
         Study study = mock(Study.class);
         when(study.getMinSupportedAppVersions()).thenReturn(map);
@@ -177,7 +178,7 @@ public class BaseControllerTest {
         mockHeader(USER_AGENT, "Asthma/26 BridgeSDK/4");
         
         HashMap<String, Integer> map =new HashMap<>();
-        map.put("iPhone OS", 25);
+        map.put(OperatingSystem.IOS, 25);
         
         Study study = mock(Study.class);
         when(study.getMinSupportedAppVersions()).thenReturn(map);

--- a/test/org/sagebionetworks/bridge/play/controllers/SubpopulationControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SubpopulationControllerTest.java
@@ -26,6 +26,7 @@ import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.Criteria;
+import org.sagebionetworks.bridge.models.OperatingSystem;
 import org.sagebionetworks.bridge.models.ResourceList;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
@@ -128,8 +129,8 @@ public class SubpopulationControllerTest {
         assertEquals("Description", created.getDescription());
         assertTrue(created.isDefaultGroup());
         Criteria criteria = created.getCriteria();
-        assertEquals((Integer)2, criteria.getMinAppVersion());
-        assertEquals((Integer)10, criteria.getMaxAppVersion());
+        assertEquals((Integer)2, criteria.getMinAppVersion(OperatingSystem.IOS));
+        assertEquals((Integer)10, criteria.getMaxAppVersion(OperatingSystem.IOS));
         assertEquals(Sets.newHashSet("requiredGroup"), criteria.getAllOfGroups());
         assertEquals(Sets.newHashSet("prohibitedGroup"), criteria.getNoneOfGroups());
     }
@@ -158,8 +159,8 @@ public class SubpopulationControllerTest {
         assertEquals("Description", created.getDescription());
         assertTrue(created.isDefaultGroup());
         Criteria criteria = created.getCriteria();
-        assertEquals((Integer)2, criteria.getMinAppVersion());
-        assertEquals((Integer)10, criteria.getMaxAppVersion());
+        assertEquals((Integer)2, criteria.getMinAppVersion(OperatingSystem.IOS));
+        assertEquals((Integer)10, criteria.getMaxAppVersion(OperatingSystem.IOS));
         assertEquals(Sets.newHashSet("requiredGroup"), criteria.getAllOfGroups());
         assertEquals(Sets.newHashSet("prohibitedGroup"), criteria.getNoneOfGroups());
     }

--- a/test/org/sagebionetworks/bridge/validators/SubpopulationValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/SubpopulationValidatorTest.java
@@ -52,8 +52,8 @@ public class SubpopulationValidatorTest {
             Validate.entityThrowingException(validator, subpop);
             fail("Should have thrown an exception");
         } catch(InvalidEntityException e) {
-            assertMessage(e, "minAppVersion", " cannot be negative");
-            assertMessage(e, "maxAppVersion", " cannot be negative");
+            assertMessage(e, "minAppVersions.iphone_os", " cannot be negative");
+            assertMessage(e, "maxAppVersions.iphone_os", " cannot be negative");
             assertMessage(e, "studyIdentifier", " is required");
             assertMessage(e, "name", " is required");
             assertMessage(e, "guid", " is required");


### PR DESCRIPTION
Subpopulations (aka consent groups) and criteria-based schedule plans contain a "criteria" object that is data about how these objects should be filtered based on a request. We do language, data group and app version filtering of these objects, now the app version filtering can be declared for any arbitray operating system name:

```
CardioHealth/1 (iPhone 6.0; iPhone OS/9.0.2) BridgeSDK/10
```

If the User-Agent string doesn't contain that "iPhone OS" information, then no filtering is done. This is opt-in.

Note that while the server will accept any string for the OS name, I wrote the SDK to have a more typesafe enumeration of the values ("Android" and "iPhone OS" only). That's because in the BSM UI, those are the only OS names I allow you to set versions for, so I wanted to help implementers align these (seems really easy to get this wrong).
- criteria object now has a map of operating system names to integer min/max app versions (two we specifically expect are "Android" and "iPhone OS");
- Find the os name in the ClientInfo object and use it to filter by app version (if no os name is specified... don't filter. This is our default behavior currently)
- the existing min/max app versions are still retrieved from DDB but transferred and saved in the map as the values for IOS (which they are by default). Eventually this code can be removed when the relevant objects are re-saved (which essentially migrates them). I plan to do this manually, confirm, and then remove this code from DynamoCriteria as part of migration.
