### PR TITLE
Remove scheduleplan filtering

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSchedulePlan.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSchedulePlan.java
@@ -37,8 +37,6 @@ public final class DynamoSchedulePlan implements SchedulePlan {
     private static final String MODIFIED_ON_PROPERTY = "modifiedOn";
     private static final String STRATEGY_PROPERTY = "strategy";
     private static final String VERSION_PROPERTY = "version";
-    private static final String MIN_APP_VERSION_PROPERTY = "minAppVersion";
-    private static final String MAX_APP_VERSION_PROPERTY = "maxAppVersion";
 
     private String guid;
     private String label;
@@ -46,8 +44,6 @@ public final class DynamoSchedulePlan implements SchedulePlan {
     private Long version;
     private long modifiedOn;
     private ScheduleStrategy strategy;
-    private Integer minAppVersion;
-    private Integer maxAppVersion;
 
     public static DynamoSchedulePlan fromJson(JsonNode node) {
         DynamoSchedulePlan plan = new DynamoSchedulePlan();
@@ -56,8 +52,6 @@ public final class DynamoSchedulePlan implements SchedulePlan {
         plan.setModifiedOn(JsonUtils.asMillisSinceEpoch(node, MODIFIED_ON_PROPERTY));
         plan.setData(JsonUtils.asObjectNode(node, STRATEGY_PROPERTY));
         plan.setVersion(JsonUtils.asLong(node, VERSION_PROPERTY));
-        plan.setMinAppVersion(JsonUtils.asInt(node, MIN_APP_VERSION_PROPERTY));
-        plan.setMaxAppVersion(JsonUtils.asInt(node, MAX_APP_VERSION_PROPERTY));
         return plan;
     }
 
@@ -130,26 +124,6 @@ public final class DynamoSchedulePlan implements SchedulePlan {
         this.label = label;
     }
 
-    @Override
-    public Integer getMinAppVersion() {
-        return minAppVersion;
-    }
-
-    @Override
-    public void setMinAppVersion(Integer minAppVersion) {
-        this.minAppVersion = minAppVersion;
-    }
-
-    @Override
-    public Integer getMaxAppVersion() {
-        return maxAppVersion;
-    }
-
-    @Override
-    public void setMaxAppVersion(Integer maxAppVersion) {
-        this.maxAppVersion = maxAppVersion;
-    }
-
     @DynamoDBAttribute(attributeName = "strategy")
     @DynamoDBMarshalling(marshallerClass = JsonNodeMarshaller.class)
     @JsonIgnore
@@ -181,8 +155,6 @@ public final class DynamoSchedulePlan implements SchedulePlan {
         result = prime * result + Objects.hashCode(modifiedOn);
         result = prime * result + Objects.hashCode(strategy);
         result = prime * result + Objects.hashCode(studyKey);
-        result = prime * result + Objects.hashCode(minAppVersion);
-        result = prime * result + Objects.hashCode(maxAppVersion);
         result = prime * result + Objects.hashCode(version);
         return result;
     }
@@ -199,15 +171,13 @@ public final class DynamoSchedulePlan implements SchedulePlan {
         return (Objects.equals(guid, other.guid) && Objects.equals(label, other.label)
                 && Objects.equals(modifiedOn, other.modifiedOn) && Objects.equals(strategy, other.strategy)
                 && Objects.equals(label, other.label) && Objects.equals(studyKey, other.studyKey)
-                && Objects.equals(version,  other.version) && Objects.equals(minAppVersion, other.minAppVersion)
-                && Objects.equals(maxAppVersion, other.maxAppVersion));
+                && Objects.equals(version,  other.version));
     }
 
     @Override
     public String toString() {
-        return String.format(
-                "DynamoSchedulePlan [guid=%s, label=%s, studyKey=%s, modifiedOn=%s, strategy=%s, minAppVersin=%s, maxAppVersion=%s]",
-                guid, label, studyKey, modifiedOn, strategy, minAppVersion, maxAppVersion);
+        return String.format("DynamoSchedulePlan [guid=%s, label=%s, studyKey=%s, modifiedOn=%s, strategy=%s]",
+            guid, label, studyKey, modifiedOn, strategy);
     }
 
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSchedulePlanDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSchedulePlanDao.java
@@ -64,11 +64,7 @@ public class DynamoSchedulePlanDao implements SchedulePlanDao {
         
         ArrayList<SchedulePlan> plans = Lists.newArrayListWithCapacity(dynamoPlans.size());
         for(DynamoSchedulePlan dynamoPlan : dynamoPlans) {
-            // We will continue to filter app version based min/max values for a plan. This is in use in prod. 
-            // But future filtering will be moved to the ContextScheduleStrategy encapsulated in a schedule plan.  
-            if (clientInfo.isTargetedAppVersion(dynamoPlan.getMinAppVersion(), dynamoPlan.getMaxAppVersion())) {
-                plans.add(dynamoPlan);
-            }
+            plans.add(dynamoPlan);
             forEachCriteria(dynamoPlan, scheduleCriteria -> loadCriteria(scheduleCriteria));
         }
         return plans;

--- a/app/org/sagebionetworks/bridge/models/ClientInfo.java
+++ b/app/org/sagebionetworks/bridge/models/ClientInfo.java
@@ -156,18 +156,6 @@ public final class ClientInfo {
     	// greater than or equal to the minSupportedVersion
     	return (appVersion == null || minSupportedVersion == null || appVersion >= minSupportedVersion);
     }
-    
-    public boolean isTargetedAppVersion(Integer minValue, Integer maxValue) {
-        // If there's no declared client version, it matches anything.
-        if (appVersion != null) {
-            // Otherwise we can't be outside of either range boundary if the boundary is declared.
-            if ((minValue != null && appVersion < minValue) || 
-                (maxValue != null && appVersion > maxValue)) {
-                return false;
-            }
-        }
-        return true;
-    }
 
     @Override
     public int hashCode() {

--- a/app/org/sagebionetworks/bridge/models/schedules/SchedulePlan.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/SchedulePlan.java
@@ -27,10 +27,4 @@ public interface SchedulePlan extends BridgeEntity {
     
     public ScheduleStrategy getStrategy();
     public void setStrategy(ScheduleStrategy strategy);
-    
-    public Integer getMinAppVersion();
-    public void setMinAppVersion(Integer minAppVersion);
-    
-    public Integer getMaxAppVersion();
-    public void setMaxAppVersion(Integer maxAppVersion);
 }

--- a/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
@@ -191,7 +191,10 @@ public abstract class BaseController extends Controller {
     
     void verifySupportedVersionOrThrowException(Study study) throws UnsupportedVersionException {
         ClientInfo clientInfo = getClientInfoFromUserAgentHeader();
-        if (!clientInfo.isSupportedAppVersion(study.getMinSupportedAppVersions().get(clientInfo.getOsName()))) {
+        String osName = clientInfo.getOsName();
+        Integer minVersionForOs = study.getMinSupportedAppVersions().get(osName);
+        
+        if (!clientInfo.isSupportedAppVersion(minVersionForOs)) {
         	throw new UnsupportedVersionException(clientInfo);
         }
     }

--- a/app/org/sagebionetworks/bridge/validators/SchedulePlanValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/SchedulePlanValidator.java
@@ -32,16 +32,6 @@ public class SchedulePlanValidator implements Validator {
         if (isBlank(plan.getLabel())) {
             errors.rejectValue("label", "cannot be missing, null, or blank");
         }
-        if ((plan.getMinAppVersion() != null && plan.getMaxAppVersion() != null) && 
-            (plan.getMaxAppVersion() < plan.getMinAppVersion())) {
-            errors.rejectValue("maxAppVersion", "cannot be less than minAppVersion");
-        }
-        if (plan.getMinAppVersion() != null && plan.getMinAppVersion() < 0) {
-            errors.rejectValue("minAppVersion", "cannot be negative");
-        }
-        if (plan.getMaxAppVersion() != null && plan.getMaxAppVersion() < 0) {
-            errors.rejectValue("maxAppVersion", "cannot be negative");
-        }
         if (plan.getStrategy() == null) {
             errors.rejectValue("strategy", "is required");
         } else {

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -198,12 +198,10 @@ public class TestUtils {
     public static List<ScheduledActivity> runSchedulerForActivities(List<SchedulePlan> plans, ScheduleContext context) {
         List<ScheduledActivity> scheduledActivities = Lists.newArrayList();
         for (SchedulePlan plan : plans) {
-            if (context.getCriteriaContext().getClientInfo().isTargetedAppVersion(plan.getMinAppVersion(), plan.getMaxAppVersion())) {
-                Schedule schedule = plan.getStrategy().getScheduleForUser(plan, context);
-                // It's become possible for a user to match no schedule
-                if (schedule != null) {
-                    scheduledActivities.addAll(schedule.getScheduler().getScheduledActivities(plan, context));    
-                }
+            Schedule schedule = plan.getStrategy().getScheduleForUser(plan, context);
+            // It's become possible for a user to match no schedule
+            if (schedule != null) {
+                scheduledActivities.addAll(schedule.getScheduler().getScheduledActivities(plan, context));    
             }
         }
         Collections.sort(scheduledActivities, ScheduledActivity.SCHEDULED_ACTIVITY_COMPARATOR);
@@ -221,23 +219,18 @@ public class TestUtils {
         plan.setGuid("DDD");
         plan.setStrategy(getStrategy("P3D", TestConstants.TEST_1_ACTIVITY));
         plan.setStudyKey(studyId.getIdentifier());
-        plan.setMinAppVersion(2);
-        plan.setMaxAppVersion(5);
         plans.add(plan);
         
         plan = new DynamoSchedulePlan();
         plan.setGuid("BBB");
         plan.setStrategy(getStrategy("P1D", TestConstants.TEST_2_ACTIVITY));
         plan.setStudyKey(studyId.getIdentifier());
-        plan.setMinAppVersion(9);
         plans.add(plan);
         
         plan = new DynamoSchedulePlan();
         plan.setGuid("CCC");
         plan.setStrategy(getStrategy("P2D", TestConstants.TEST_3_ACTIVITY));
         plan.setStudyKey(studyId.getIdentifier());
-        plan.setMinAppVersion(5);
-        plan.setMaxAppVersion(8);
         plans.add(plan);
 
         return plans;

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSchedulePlanDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSchedulePlanDaoTest.java
@@ -142,34 +142,6 @@ public class DynamoSchedulePlanDaoTest {
         List<SchedulePlan> plans = schedulePlanDao.getSchedulePlans(ClientInfo.UNKNOWN_CLIENT, studyIdentifier);
         assertEquals(getSchedulePlanGuids(plan1, plan2), getSchedulePlanGuids(plans));
     }
-    
-    @Test
-    public void filtersSchedulePlans() {
-        Set<String> guids = Sets.newHashSet();
-        Set<String> oneGuid = Sets.newHashSet();
-        
-        List<SchedulePlan> plans = TestUtils.getSchedulePlans(studyIdentifier);
-        SchedulePlan plan = schedulePlanDao.createSchedulePlan(studyIdentifier, plans.get(0));
-        guids.add(plan.getGuid());
-        plansToDelete.add(new Keys(plan.getStudyKey(), plan.getGuid()));
-        
-        SchedulePlan plan2 = schedulePlanDao.createSchedulePlan(studyIdentifier, plans.get(1));
-        guids.add(plan2.getGuid());
-        oneGuid.add(plan2.getGuid());
-        plansToDelete.add(new Keys(plan2.getStudyKey(), plan2.getGuid()));
-
-        SchedulePlan plan3 = schedulePlanDao.createSchedulePlan(studyIdentifier, plans.get(2));
-        guids.add(plan3.getGuid());
-        plansToDelete.add(new Keys(plan3.getStudyKey(), plan3.getGuid()));
-        
-        // No known client, all the guids are returned
-        plans = schedulePlanDao.getSchedulePlans(ClientInfo.UNKNOWN_CLIENT, studyIdentifier);
-        assertEquals(guids, getSchedulePlanGuids(plans));
-        
-        // Only one schedule plan matches v9
-        plans = schedulePlanDao.getSchedulePlans(ClientInfo.fromUserAgentCache("app/9"), studyIdentifier);
-        assertEquals(oneGuid, getSchedulePlanGuids(plans));
-    }
 
     @Test
     public void scheduleCriteriaStrategyWork() {

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSchedulePlanTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSchedulePlanTest.java
@@ -35,8 +35,6 @@ public class DynamoSchedulePlanTest {
         DynamoSchedulePlan plan = new DynamoSchedulePlan();
         plan.setLabel("Label");
         plan.setGuid("guid");
-        plan.setMinAppVersion(2);
-        plan.setMaxAppVersion(10);
         plan.setModifiedOn(datetime.getMillis());
         plan.setStudyKey("test-study");
         plan.setVersion(2L);
@@ -46,8 +44,6 @@ public class DynamoSchedulePlanTest {
         JsonNode node = BridgeObjectMapper.get().readTree(json);
         
         assertEquals("SchedulePlan", node.get("type").asText());
-        assertEquals(2, node.get("minAppVersion").asInt());
-        assertEquals(10, node.get("maxAppVersion").asInt());
         assertEquals(2, node.get("version").asInt());
         assertEquals("guid", node.get("guid").asText());
         assertEquals("Label", node.get("label").asText());
@@ -56,8 +52,6 @@ public class DynamoSchedulePlanTest {
         assertEquals(datetime, DateTime.parse(node.get("modifiedOn").asText()));
 
         DynamoSchedulePlan plan2 = DynamoSchedulePlan.fromJson(node);
-        assertEquals(plan.getMinAppVersion(), plan2.getMinAppVersion());
-        assertEquals(plan.getMaxAppVersion(), plan2.getMaxAppVersion());
         assertEquals(plan.getVersion(), plan2.getVersion());
         assertEquals(plan.getGuid(), plan2.getGuid());
         assertEquals(plan.getLabel(), plan2.getLabel());

--- a/test/org/sagebionetworks/bridge/models/ClientInfoTest.java
+++ b/test/org/sagebionetworks/bridge/models/ClientInfoTest.java
@@ -177,37 +177,6 @@ public class ClientInfoTest {
     }
     
     @Test
-    public void clientWithoutVersionMatchesAnyRange() {
-        ClientInfo info = ClientInfo.parseUserAgentString(INVALID_UA_1);
-        assertTrue(info.isTargetedAppVersion(3, 3));
-    }
-    
-    @Test
-    public void clientWithVersionInRangeSucceeds() {
-        ClientInfo info = ClientInfo.parseUserAgentString(VALID_LONG_UA_1);
-        assertTrue(info.isTargetedAppVersion(24, 26));
-        assertTrue(info.isTargetedAppVersion(26, 27));
-    }
-    
-    @Test
-    public void clientWithVersionFilteredOnLowEnd() {
-        ClientInfo info = ClientInfo.parseUserAgentString(VALID_LONG_UA_1);
-        assertFalse(info.isTargetedAppVersion(27, null));
-    }
-    
-    @Test
-    public void clientWithVersionFilteredOnHighEnd() {
-        ClientInfo info = ClientInfo.parseUserAgentString(VALID_LONG_UA_1);
-        assertFalse(info.isTargetedAppVersion(null, 13));
-    }
-    
-    @Test
-    public void clientWithVersionFilteredWithZeroes() {
-        ClientInfo info = ClientInfo.parseUserAgentString(VALID_LONG_UA_1);
-        assertTrue(info.isTargetedAppVersion(0, 100));
-    }
-    
-    @Test
     public void testIsSupportedAppVersion_GreaterThanSucceeds() {
         ClientInfo info = ClientInfo.parseUserAgentString(VALID_LONG_UA_1);
         assertTrue(info.isSupportedAppVersion(25));

--- a/test/org/sagebionetworks/bridge/models/schedules/ActivitySchedulerTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/ActivitySchedulerTest.java
@@ -47,8 +47,6 @@ public class ActivitySchedulerTest {
     @Before
     public void before() {
         plan.setGuid("BBB");
-        plan.setMinAppVersion(0);
-        plan.setMaxAppVersion(1000);
         
         // Day of tests is 2015-04-06T10:10:10.000-07:00 for purpose of calculating expiration
         DateTimeUtils.setCurrentMillisFixed(1428340210000L);

--- a/test/org/sagebionetworks/bridge/play/controllers/ScheduleControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ScheduleControllerTest.java
@@ -51,14 +51,9 @@ public class ScheduleControllerTest {
         studyId = new StudyIdentifierImpl(TestUtils.randomName(ScheduleControllerTest.class));
         ClientInfo clientInfo = ClientInfo.fromUserAgentCache("app name/9");
         
-        // This filter is done in the bowels of the DAO; tested elsewhere
-        List<SchedulePlan> plans = Lists.newArrayList();
-        for (SchedulePlan plan : TestUtils.getSchedulePlans(studyId)) {
-            if (clientInfo.isTargetedAppVersion(plan.getMinAppVersion(), plan.getMaxAppVersion())) {
-                plans.add(plan);
-            }
-        }
-        // add a plan that will returns null for a schedule, this is not included in the final list.
+        List<SchedulePlan> plans = TestUtils.getSchedulePlans(studyId);
+        
+        // Add a plan that will returns null for a schedule, this is not included in the final list.
         // This is now possible and should not cause an error or a gap in the returned array.
         SchedulePlan plan = new DynamoSchedulePlan();
         plan.setStrategy(new ScheduleStrategy() {
@@ -98,7 +93,7 @@ public class ScheduleControllerTest {
         
         JsonNode node = BridgeObjectMapper.get().readTree(content);
         
-        assertEquals(1, node.get("total").asInt());
+        assertEquals(3, node.get("total").asInt());
     }
     
     @SuppressWarnings("deprecation")

--- a/test/org/sagebionetworks/bridge/services/SchedulePlanServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SchedulePlanServiceTest.java
@@ -41,44 +41,7 @@ public class SchedulePlanServiceTest {
         study.setIdentifier("test-study");
         study.setTaskIdentifiers(Sets.newHashSet("AAA", "BBB", "CCC"));
     }
-    
-    @Test
-    public void schedulePlansAreFilteredByAppVersion() {
-        SchedulePlan savedPlan = null;
-        try {
-            SchedulePlan plan = TestUtils.getABTestSchedulePlan(TEST_STUDY);
-            plan.setGuid(null);
-            plan.setVersion(null);
-            plan.setMinAppVersion(14);
-            plan.setMaxAppVersion(15);
-            plan.setStudyKey(study.getIdentifier());
-            savedPlan = schedulePlanService.createSchedulePlan(study, plan);
-            
-            int baseCount = schedulePlanService.getSchedulePlans(ClientInfo.UNKNOWN_CLIENT, study).size();
-            
-            // This is not high enough for the app version, nothing returned.
-            ClientInfo clientInfo = ClientInfo.fromUserAgentCache("TestApp/13 TestSDK/8");
-            List<SchedulePlan> plans = schedulePlanService.getSchedulePlans(clientInfo, study);
-            assertEquals(baseCount-1, plans.size());
-            
-            // Right in the range, the plan is returned
-            clientInfo = ClientInfo.fromUserAgentCache("TestApp/14 TestSDK/8");
-            plans = schedulePlanService.getSchedulePlans(clientInfo, study);
-            assertEquals(baseCount, plans.size());
-            
-            clientInfo = ClientInfo.fromUserAgentCache("TestApp/15 TestSDK/8");
-            plans = schedulePlanService.getSchedulePlans(clientInfo, study);
-            assertEquals(baseCount, plans.size());
-            
-            // Finally, this is outside the upper-bound, so the plan will not be returned
-            clientInfo = ClientInfo.fromUserAgentCache("TestApp/16 TestSDK/40");
-            plans = schedulePlanService.getSchedulePlans(clientInfo, study);
-            assertEquals(baseCount-1, plans.size());
-        } finally {
-            schedulePlanService.deleteSchedulePlan(new StudyIdentifierImpl(savedPlan.getStudyKey()), savedPlan.getGuid());
-        }
-    }
-    
+        
     @Test
     public void canSaveSchedulePlan() throws Exception {
         SchedulePlan savedPlan = null;

--- a/test/org/sagebionetworks/bridge/services/SchedulePlanServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SchedulePlanServiceTest.java
@@ -4,8 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 
-import java.util.List;
-
 import javax.annotation.Resource;
 
 import org.junit.Before;
@@ -14,7 +12,6 @@ import org.junit.runner.RunWith;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
-import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.schedules.ABTestScheduleStrategy;
 import org.sagebionetworks.bridge.models.schedules.Activity;
 import org.sagebionetworks.bridge.models.schedules.ABTestGroup;

--- a/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceTest.java
@@ -78,7 +78,6 @@ public class ScheduledActivityServiceTest {
         schedulePlan = new DynamoSchedulePlan();
         schedulePlan.setLabel("Label");
         schedulePlan.setStudyKey(TEST_STUDY.getIdentifier());
-        schedulePlan.setMinAppVersion(10);
         schedulePlan.setStrategy(strategy);
         schedulePlan = schedulePlanService.createSchedulePlan(study, schedulePlan);
     }
@@ -162,24 +161,6 @@ public class ScheduledActivityServiceTest {
         assertEquals(2, activities.size());
         assertEquals(msk3+"T10:00:00.000+03:00", activities.get(0).getScheduledOn().toString());
         assertEquals(msk4+"T10:00:00.000+03:00", activities.get(1).getScheduledOn().toString());
-    }
-    
-    @Test
-    public void activitiesAreFilteredBasedOnAppVersion() throws Exception {
-        ScheduleContext context = new ScheduleContext.Builder()
-                .withContext(getContextWith2DayWindow(DateTimeZone.UTC))
-                .withClientInfo(ClientInfo.fromUserAgentCache("app/5")).build();
-        
-        // Ask for version 5, nothing is created
-        List<ScheduledActivity> activities = service.getScheduledActivities(context);
-        assertEquals(0, activities.size());
-        
-        // Ask for version 11, normal activities are created.
-        context = new ScheduleContext.Builder()
-                .withContext(context)
-                .withClientInfo(ClientInfo.fromUserAgentCache("app/11")).build();
-        activities = service.getScheduledActivities(context);
-        assertEquals(3, activities.size());
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/validators/SchedulePlanValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/SchedulePlanValidatorTest.java
@@ -57,31 +57,6 @@ public class SchedulePlanValidatorTest {
     }
     
     @Test
-    public void itIsValidToSetMinMaxToSameVersion() {
-        SchedulePlan plan = getValidSimpleStrategy();
-        plan.setMinAppVersion(1);
-        plan.setMaxAppVersion(1);
-        Validate.entityThrowingException(validator, plan);
-    }
-
-    @Test
-    public void cannotSetMaxUnderMinAppVersion() {
-        SchedulePlan plan = getValidSimpleStrategy();
-        plan.setMinAppVersion(0);
-        plan.setMaxAppVersion(-1);
-        assertMessage(plan, "maxAppVersion cannot be less than minAppVersion", "maxAppVersion");
-    }
-    
-    @Test
-    public void cannotSetMinLessThanZero() {
-        SchedulePlan plan = getValidSimpleStrategy();
-        plan.setMinAppVersion(-2);
-        plan.setMaxAppVersion(-1);
-        assertMessage(plan, "minAppVersion cannot be negative", "minAppVersion");
-        assertMessage(plan, "maxAppVersion cannot be negative", "maxAppVersion");
-    }
-    
-    @Test
     public void studyKeyRequired() {
         SchedulePlan plan = getValidSimpleStrategy();
         plan.setStudyKey(null);


### PR DESCRIPTION
This needs to be merged after the change to filtering criteria by platform. It completes the switch over to this new model.
