### PR TITLE
validation for schema field names, survey question names, and multi-choice answers

### DIFF
--- a/app/org/sagebionetworks/bridge/upload/UploadUtil.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadUtil.java
@@ -1,6 +1,8 @@
 package org.sagebionetworks.bridge.upload;
 
 import java.math.BigDecimal;
+import java.util.Set;
+import java.util.regex.Pattern;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -8,6 +10,7 @@ import com.fasterxml.jackson.databind.node.BigIntegerNode;
 import com.fasterxml.jackson.databind.node.BooleanNode;
 import com.fasterxml.jackson.databind.node.DecimalNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+import com.google.common.collect.ImmutableSet;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
@@ -24,6 +27,27 @@ import org.sagebionetworks.bridge.schema.SchemaUtils;
 /** Utility class that contains static utility methods for handling uploads. */
 public class UploadUtil {
     private static final Logger logger = LoggerFactory.getLogger(UploadUtil.class);
+
+    private static final Pattern FIELD_NAME_MULTIPLE_SPECIAL_CHARS_PATTERN = Pattern.compile("[\\-\\._ ]{2,}");
+    private static final Pattern FIELD_NAME_SPECIAL_CHARS_PATTERN = Pattern.compile("[\\-\\._ ]");
+    private static final Pattern FIELD_NAME_VALID_CHARS_PATTERN = Pattern.compile("[a-zA-Z0-9\\-\\._ ]+");
+    public static final String INVALID_FIELD_NAME_ERROR_MESSAGE = "must start and end with an alphanumeric character, "
+            + "can only contain alphanumeric characters, spaces, dashes, underscores, and periods, can't contain two "
+            + "or more non-alphanumeric characters in a row, and can't be a reserved keyword";
+
+    // List of reserved SQL keywords and Synapse keywords that can't be used as field names.
+    private static final Set<String> RESERVED_FIELD_NAME_LIST = ImmutableSet.<String>builder().add("access", "add",
+            "all", "alter", "and", "any", "as", "asc", "audit", "between", "by", "char", "check", "cluster", "column",
+            "column_value", "comment", "compress", "connect", "create", "current", "date", "decimal", "default",
+            "delete", "desc", "distinct", "drop", "else", "exclusive", "exists", "file", "float", "for", "from",
+            "grant", "group", "having", "identified", "immediate", "in", "increment", "index", "initial", "insert",
+            "integer", "intersect", "into", "is", "level", "like", "lock", "long", "maxextents", "minus", "mlslabel",
+            "mode", "modify", "nested_table_id", "noaudit", "nocompress", "not", "nowait", "null", "number", "of",
+            "offline", "on", "online", "option", "or", "order", "pctfree", "prior", "public", "raw", "rename",
+            "resource", "revoke", "row", "row_id", "row_version", "rowid", "rownum", "rows", "select", "session", "set",
+            "share", "size", "smallint", "start", "successful", "synonym", "sysdate", "table", "then", "time", "to",
+            "trigger", "uid", "union", "unique", "update", "user", "validate", "values", "varchar", "varchar2", "view",
+            "whenever", "where", "with").build();
 
     /** Utility method for canonicalizing an upload JSON value given the schema's field type. */
     public static CanonicalizationResult canonicalize(final JsonNode valueNode, UploadFieldType type) {
@@ -265,6 +289,60 @@ public class UploadUtil {
         } else {
             return node.toString();
         }
+    }
+
+    /**
+     * <p>
+     * Validates a schema field name or multi-choice answer. Since these become Synapse table fields, we need to
+     * validate them.
+     * </p>
+     * <p>
+     * Rules:
+     * 1. must start and end with an alphanumeric character
+     * 2. can only contain alphanumeric characters, spaces, dashes, underscores, and periods
+     * 3. can't contain two or more non-alphanumeric characters in a row
+     * 4. can't be a reserved keyword
+     * </p>
+     *
+     * @param name
+     *         name to validate
+     * @return true if valid, false otherwise
+     */
+    public static boolean isValidSchemaFieldName(String name) {
+        // Blank names are invalid.
+        if (StringUtils.isBlank(name)) {
+            return false;
+        }
+
+        // Can't be a reserved keyword
+        if (RESERVED_FIELD_NAME_LIST.contains(name)) {
+            return false;
+        }
+
+        // Can only contain alphanumeric, space, dash, underscore, and period.
+        if (!FIELD_NAME_VALID_CHARS_PATTERN.matcher(name).matches()) {
+            return false;
+        }
+
+        // Must start and end with an alphanumeric char
+        String firstChar = name.substring(0, 1);
+        if (FIELD_NAME_SPECIAL_CHARS_PATTERN.matcher(firstChar).matches()) {
+            return false;
+        }
+
+        int nameLength = name.length();
+        String lastChar = name.substring(nameLength - 1, nameLength);
+        if (FIELD_NAME_SPECIAL_CHARS_PATTERN.matcher(lastChar).matches()) {
+            return false;
+        }
+
+        // Can't contain multiple special chars in a row.
+        if (FIELD_NAME_MULTIPLE_SPECIAL_CHARS_PATTERN.matcher(name).find()) {
+            return false;
+        }
+
+        // Exhausted all our rules, so it must be valid.
+        return true;
     }
 
     /**

--- a/app/org/sagebionetworks/bridge/validators/SurveyValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/SurveyValidator.java
@@ -29,6 +29,8 @@ import org.sagebionetworks.bridge.models.surveys.SurveyQuestion;
 import org.sagebionetworks.bridge.models.surveys.SurveyQuestionOption;
 import org.sagebionetworks.bridge.models.surveys.SurveyRule;
 import org.sagebionetworks.bridge.models.surveys.UIHint;
+import org.sagebionetworks.bridge.upload.UploadUtil;
+
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
@@ -84,9 +86,13 @@ public class SurveyValidator implements Validator {
         }
     }
     private void doValidateQuestion(SurveyQuestion question, Errors errors) {
-        if (isBlank(question.getIdentifier())) {
+        String questionId = question.getIdentifier();
+        if (isBlank(questionId)) {
             errors.rejectValue("identifier", "is required");
+        } else if (!UploadUtil.isValidSchemaFieldName(questionId)) {
+            errors.rejectValue("identifier", UploadUtil.INVALID_FIELD_NAME_ERROR_MESSAGE);
         }
+
         if (question.getUiHint() == null) {
             errors.rejectValue("uiHint", "is required");
         }
@@ -227,8 +233,12 @@ public class SurveyValidator implements Validator {
                     rejectField(errors, "label", "must be specified");
                 }
 
-                // record values seen so far
                 String optionValue = oneOption.getValue();
+                if (!UploadUtil.isValidSchemaFieldName(optionValue)) {
+                    rejectField(errors, "value", UploadUtil.INVALID_FIELD_NAME_ERROR_MESSAGE);
+                }
+
+                // record values seen so far
                 if (!valueSet.contains(optionValue)) {
                     valueSet.add(optionValue);
                 } else {

--- a/app/org/sagebionetworks/bridge/validators/UploadSchemaValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/UploadSchemaValidator.java
@@ -15,6 +15,7 @@ import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
 import org.sagebionetworks.bridge.models.upload.UploadFieldType;
 import org.sagebionetworks.bridge.models.upload.UploadSchema;
+import org.sagebionetworks.bridge.upload.UploadUtil;
 
 /** Validator for {@link org.sagebionetworks.bridge.models.upload.UploadSchema} */
 public class UploadSchemaValidator implements Validator {
@@ -99,6 +100,11 @@ public class UploadSchemaValidator implements Validator {
                             errors.rejectValue("name", "is required");
                         } else {
                             fieldNameList.add(fieldName);
+
+                            // Validate field name.
+                            if (!UploadUtil.isValidSchemaFieldName(fieldName)) {
+                                errors.rejectValue("name", UploadUtil.INVALID_FIELD_NAME_ERROR_MESSAGE);
+                            }
                         }
 
                         UploadFieldType fieldType = fieldDef.getType();
@@ -115,9 +121,17 @@ public class UploadSchemaValidator implements Validator {
                             } else {
                                 // Multi-Choice fields create extra "sub-field" columns, and we need to check for
                                 // potential name collisions.
-                                //noinspection Convert2streamapi
-                                for (String oneAnswer : multiChoiceAnswerList) {
+
+                                int numAnswers = multiChoiceAnswerList.size();
+                                for (int j = 0; j < numAnswers; j++) {
+                                    String oneAnswer = multiChoiceAnswerList.get(j);
                                     fieldNameList.add(fieldName + MULTI_CHOICE_FIELD_SEPARATOR + oneAnswer);
+
+                                    // Validate choice answer name.
+                                    if (!UploadUtil.isValidSchemaFieldName(oneAnswer)) {
+                                        errors.rejectValue("multiChoice[" + j + "]",
+                                                UploadUtil.INVALID_FIELD_NAME_ERROR_MESSAGE);
+                                    }
                                 }
                             }
 

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDaoMockTest.java
@@ -237,7 +237,7 @@ public class DynamoUploadSchemaDaoMockTest {
         // decimal
         {
             SurveyQuestion q = new DynamoSurveyQuestion();
-            q.setIdentifier("decimal");
+            q.setIdentifier("decimal-q");
             q.setConstraints(new DecimalConstraints());
             surveyElementList.add(q);
         }
@@ -353,10 +353,10 @@ public class DynamoUploadSchemaDaoMockTest {
         assertEquals(UploadFieldType.STRING, fieldDefList.get(9).getType());
         assertEquals(Unit.MAX_STRING_LENGTH, fieldDefList.get(9).getMaxLength().intValue());
 
-        assertEquals("decimal", fieldDefList.get(10).getName());
+        assertEquals("decimal-q", fieldDefList.get(10).getName());
         assertEquals(UploadFieldType.FLOAT, fieldDefList.get(10).getType());
 
-        assertEquals("decimal" + UploadUtil.UNIT_FIELD_SUFFIX, fieldDefList.get(11).getName());
+        assertEquals("decimal-q" + UploadUtil.UNIT_FIELD_SUFFIX, fieldDefList.get(11).getName());
         assertEquals(UploadFieldType.STRING, fieldDefList.get(11).getType());
         assertEquals(Unit.MAX_STRING_LENGTH, fieldDefList.get(11).getMaxLength().intValue());
 

--- a/test/org/sagebionetworks/bridge/upload/UploadUtilTest.java
+++ b/test/org/sagebionetworks/bridge/upload/UploadUtilTest.java
@@ -278,6 +278,52 @@ public class UploadUtilTest {
     }
 
     @Test
+    public void isValidFieldNameInvalid() {
+        String[] testCases = {
+                null,
+                "",
+                "   ",
+                "_foo",
+                "foo_",
+                "-foo",
+                "foo-",
+                ".foo",
+                "foo.",
+                ".foo",
+                "foo.",
+                "foo*bar",
+                "foo__bar",
+                "foo--bar",
+                "foo..bar",
+                "foo  bar",
+                "foo-_-bar",
+                "select",
+                "where",
+                "time",
+        };
+
+        for (String oneTestCase : testCases) {
+            assertFalse(oneTestCase + " should be invalid", UploadUtil.isValidSchemaFieldName(oneTestCase));
+        }
+    }
+
+    @Test
+    public void isValidFieldNameValid() {
+        String[] testCases = {
+                "foo",
+                "foo_bar",
+                "foo-bar",
+                "foo.bar",
+                "foo bar",
+                "foo-bar_baz.qwerty asdf",
+        };
+
+        for (String oneTestCase : testCases) {
+            assertTrue(oneTestCase + " should be valid", UploadUtil.isValidSchemaFieldName(oneTestCase));
+        }
+    }
+
+    @Test
     public void nullCalendarDate() {
         assertNull(UploadUtil.parseIosCalendarDate(null));
     }

--- a/test/org/sagebionetworks/bridge/validators/SurveyValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/SurveyValidatorTest.java
@@ -35,6 +35,7 @@ import org.sagebionetworks.bridge.models.surveys.SurveyRule;
 import org.sagebionetworks.bridge.models.surveys.SurveyRule.Operator;
 import org.sagebionetworks.bridge.models.surveys.TestSurvey;
 import org.sagebionetworks.bridge.models.surveys.UIHint;
+import org.sagebionetworks.bridge.upload.UploadUtil;
 
 import com.google.common.collect.Lists;
 
@@ -211,6 +212,20 @@ public class SurveyValidatorTest {
     }
 
     @Test
+    public void questionIdentifierInvalid() {
+        try {
+            survey = new TestSurvey(SurveyValidatorTest.class, false);
+            survey.getElements().get(0).setIdentifier("**invalid!q##");
+
+            Validate.entityThrowingException(validator, survey);
+            fail("Should have thrown exception");
+        } catch (InvalidEntityException e) {
+            assertEquals("elements[0].identifier " + UploadUtil.INVALID_FIELD_NAME_ERROR_MESSAGE,
+                    errorFor(e, "elements[0].identifier"));
+        }
+    }
+
+    @Test
     public void questionUiHintRequired() {
         try {
             survey = new TestSurvey(SurveyValidatorTest.class, false);
@@ -379,6 +394,23 @@ public class SurveyValidatorTest {
     }
 
     @Test
+    public void multiValueWithOptionWithInvalidValue() {
+        try {
+            List<SurveyQuestionOption> optionList = ImmutableList.of(new SurveyQuestionOption("My Question", null,
+                    "@invalid#answer$", null));
+
+            SurveyQuestion question = ((TestSurvey) survey).getMultiValueQuestion();
+            ((MultiValueConstraints) question.getConstraints()).setEnumeration(optionList);
+
+            Validate.entityThrowingException(validator, survey);
+            fail("Should have thrown exception");
+        } catch (InvalidEntityException e) {
+            assertEquals("value " + UploadUtil.INVALID_FIELD_NAME_ERROR_MESSAGE,
+                    errorFor(e, "elements[7].constraints.enumeration[0].value"));
+        }
+    }
+
+    @Test
     public void multiValueWithDupeOptions() {
         try {
             List<SurveyQuestionOption> optionList = ImmutableList.of(
@@ -429,7 +461,7 @@ public class SurveyValidatorTest {
                 new SurveyRule.Builder().withOperator(Operator.EQ).withValue("No").withSkipToTarget("theend").build());
         
         SurveyQuestion question = new DynamoSurveyQuestion();
-        question.setIdentifier("start");
+        question.setIdentifier("start-q");
         question.setUiHint(UIHint.TEXTFIELD);
         question.setPrompt("Prompt");
         question.setConstraints(constraints);
@@ -464,7 +496,7 @@ public class SurveyValidatorTest {
         constraints.getRules().add(rule);
         
         SurveyQuestion question = new DynamoSurveyQuestion();
-        question.setIdentifier("start");
+        question.setIdentifier("start-q");
         question.setUiHint(UIHint.TEXTFIELD);
         question.setPrompt("Prompt");
         question.setConstraints(constraints);
@@ -500,7 +532,7 @@ public class SurveyValidatorTest {
         constraints.getRules().add(rule);
         
         SurveyQuestion question = new DynamoSurveyQuestion();
-        question.setIdentifier("start");
+        question.setIdentifier("start-q");
         question.setUiHint(UIHint.TEXTFIELD);
         question.setPrompt("Prompt");
         question.setConstraints(constraints);

--- a/test/org/sagebionetworks/bridge/validators/UploadSchemaValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/UploadSchemaValidatorTest.java
@@ -260,6 +260,45 @@ public class UploadSchemaValidatorTest {
         Validate.entityThrowingException(UploadSchemaValidator.INSTANCE, schema);
     }
 
+    @Test(expected = InvalidEntityException.class)
+    public void invalidFieldName() {
+        // The specifics of what is an invalid field name is covered in UploadUtilTest. This tests that the validator
+        // validates invalid field names.
+        DynamoUploadSchema schema = new DynamoUploadSchema();
+        schema.setName("Test Schema");
+        schema.setSchemaId("test-schema");
+        schema.setStudyId("test-study");
+        schema.setSchemaType(UploadSchemaType.IOS_DATA);
+
+        // test field def list
+        List<UploadFieldDefinition> fieldDefList = new ArrayList<>();
+        fieldDefList.add(new DynamoUploadFieldDefinition.Builder().withName("**invalid$field^name##")
+                .withType(UploadFieldType.BOOLEAN).build());
+        schema.setFieldDefinitions(fieldDefList);
+
+        // validate
+        Validate.entityThrowingException(UploadSchemaValidator.INSTANCE, schema);
+    }
+
+    @Test(expected = InvalidEntityException.class)
+    public void invalidMultiChoiceAnswer() {
+        // Similarly
+        DynamoUploadSchema schema = new DynamoUploadSchema();
+        schema.setName("Test Schema");
+        schema.setSchemaId("test-schema");
+        schema.setStudyId("test-study");
+        schema.setSchemaType(UploadSchemaType.IOS_DATA);
+
+        // test field def list
+        List<UploadFieldDefinition> fieldDefList = new ArrayList<>();
+        fieldDefList.add(new DynamoUploadFieldDefinition.Builder().withName("multi-choice-q")
+                .withType(UploadFieldType.MULTI_CHOICE).withMultiChoiceAnswerList("!invalid@choice%").build());
+        schema.setFieldDefinitions(fieldDefList);
+
+        // validate
+        Validate.entityThrowingException(UploadSchemaValidator.INSTANCE, schema);
+    }
+
     // These tests are redundant, but I wrote them specifically to test the messages that are sent
     // back, and some use JSON to test what happens when properties are missing
     


### PR DESCRIPTION
Schema field names, survey question names, and multi-choice answers become part of Synapse table column names. As such, there are certain restrictions on these names. (Specifically, they must start and end with an alphanumeric character, can only contain alphanumeric characters, spaces, dashes, underscores, and periods, can't contain two or more non-alphanumeric characters in a row, and can't be a reserved keyword.)

Given that we haven't had any broken Synapse tables yet, we can confirm that there are currently no schema fields or survey questions with invalid names. Someone somewhere might be using an invalid multi-choice answer. This change will force them to update the answer list next time they save their survey.

I've also confirmed that no existing integration test creates an invalid survey or schema, and I've updated unit tests to be valid.

Closes the following JIRAs:
- https://sagebionetworks.jira.com/browse/BRIDGE-1392 - sanitize schema field names and multi-choice values
- https://sagebionetworks.jira.com/browse/BRIDGE-1444 - Filter schema column names from using SQL keywords like "time"

Testing done:
- updated unit tests
- integ tests that create surveys or schemas
- manually tested validation through create survey and create schema APIs
