### PR TITLE
Change rules for HTML sanitization of consents and email templates.

### DIFF
--- a/app/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/app/org/sagebionetworks/bridge/BridgeConstants.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge;
 import java.util.Set;
 
 import org.joda.time.DateTimeZone;
+import org.jsoup.safety.Whitelist;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -73,5 +74,16 @@ public class BridgeConstants {
     
     public static final String STORMPATH_NAME_PLACEHOLDER_STRING = "<EMPTY>";
     
-    public static final Set<Roles> NO_CALLER_ROLES = ImmutableSet.of();    
+    public static final Set<Roles> NO_CALLER_ROLES = ImmutableSet.of();
+    
+    /**
+     * This whitelist adds a few additional tags and attributes that are used by the CKEDITOR options we have 
+     * displayed in the UI.
+     */
+    public static final Whitelist CKEDITOR_WHITELIST = Whitelist.relaxed()
+            .addTags("hr", "s", "caption")
+            .addAttributes(":all", "style", "scope")
+            .addAttributes("a", "target")
+            .addAttributes("table", "align", "border", "cellpadding", "cellspacing", "summary");
+    
 }

--- a/app/org/sagebionetworks/bridge/services/StudyConsentService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyConsentService.java
@@ -61,9 +61,7 @@ public class StudyConsentService {
 
     private static Logger logger = LoggerFactory.getLogger(StudyConsentService.class);
     
-    /**
-     * I'm assuming this is thread-safe because it's exposed as a static constant.
-     */
+    // Documented to be threat-safe
     private static final CharSequenceTranslator XML_ESCAPER = StringEscapeUtils.ESCAPE_XML11;
     
     private Validator validator;

--- a/app/org/sagebionetworks/bridge/services/StudyConsentService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyConsentService.java
@@ -19,6 +19,8 @@ import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.lang3.text.translate.CharSequenceTranslator;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Document.OutputSettings.Syntax;
@@ -48,6 +50,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Validator;
 import org.xhtmlrenderer.pdf.ITextRenderer;
+import org.xhtmlrenderer.util.XRRuntimeException;
 
 import com.fasterxml.jackson.core.util.ByteArrayBuilder;
 import com.google.common.collect.Maps;
@@ -57,6 +60,11 @@ import com.lowagie.text.DocumentException;
 public class StudyConsentService {
 
     private static Logger logger = LoggerFactory.getLogger(StudyConsentService.class);
+    
+    /**
+     * I'm assuming this is thread-safe because it's exposed as a static constant.
+     */
+    private static final CharSequenceTranslator XML_ESCAPER = StringEscapeUtils.ESCAPE_XML11;
     
     private Validator validator;
     private StudyConsentDao studyConsentDao;
@@ -220,7 +228,7 @@ public class StudyConsentService {
             subpop.setPublishedConsentCreatedOn(timestamp);
             subpopService.updateSubpopulation(study, subpop);
 
-        } catch(IOException | DocumentException e) {
+        } catch(IOException | DocumentException | XRRuntimeException e) {
             throw new BridgeServiceException(e.getMessage());
         }
         return new StudyConsentView(consent, documentContent);
@@ -245,14 +253,16 @@ public class StudyConsentService {
     
     private void publishFormatsToS3(Study study, SubpopulationGuid subpopGuid, String bodyTemplate) throws DocumentException, IOException {
         Map<String,String> map = Maps.newHashMap();
-        map.put("studyName", study.getName());
-        map.put("supportEmail", study.getSupportEmail());
-        map.put("technicalEmail", study.getTechnicalEmail());
-        map.put("sponsorName", study.getSponsorName());
+        String escapedStudyName = XML_ESCAPER.translate(study.getName());
+        
+        map.put("studyName", escapedStudyName);
+        map.put("supportEmail", XML_ESCAPER.translate(study.getSupportEmail()));
+        map.put("technicalEmail", XML_ESCAPER.translate(study.getTechnicalEmail()));
+        map.put("sponsorName", XML_ESCAPER.translate(study.getSponsorName()));
         String resolvedHTML = BridgeUtils.resolveTemplate(bodyTemplate, map);
 
         map = Maps.newHashMap();
-        map.put("studyName", study.getName());
+        map.put("studyName", escapedStudyName);
         map.put("consent.body", resolvedHTML);
         resolvedHTML = BridgeUtils.resolveTemplate(fullPageTemplate, map);
         

--- a/app/org/sagebionetworks/bridge/services/StudyConsentService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyConsentService.java
@@ -23,7 +23,8 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Document.OutputSettings.Syntax;
 import org.jsoup.nodes.Entities.EscapeMode;
-import org.jsoup.safety.Whitelist;
+
+import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 import org.sagebionetworks.bridge.dao.StudyConsentDao;
@@ -235,7 +236,7 @@ public class StudyConsentService {
     }
     
     private String sanitizeHTML(String documentContent) {
-        documentContent = Jsoup.clean(documentContent, Whitelist.relaxed());
+        documentContent = Jsoup.clean(documentContent, BridgeConstants.CKEDITOR_WHITELIST);
         Document document = Jsoup.parseBodyFragment(documentContent);
         document.outputSettings().escapeMode(EscapeMode.xhtml)
             .prettyPrint(false).syntax(Syntax.xml).charset("UTF-8");

--- a/app/org/sagebionetworks/bridge/services/StudyService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyService.java
@@ -18,6 +18,8 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jsoup.Jsoup;
 import org.jsoup.safety.Whitelist;
+
+import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 import org.sagebionetworks.bridge.dao.DirectoryDao;
@@ -292,7 +294,7 @@ public class StudyService {
             if (template.getMimeType() == MimeType.TEXT) {
                 body = Jsoup.clean(body, Whitelist.none());
             } else {
-                body = Jsoup.clean(body, Whitelist.relaxed());
+                body = Jsoup.clean(body, BridgeConstants.CKEDITOR_WHITELIST);
             }
         }
         return new EmailTemplate(subject, body, template.getMimeType());

--- a/test/org/sagebionetworks/bridge/services/StudyConsentServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyConsentServiceTest.java
@@ -14,7 +14,6 @@ import javax.annotation.Resource;
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.sagebionetworks.bridge.BridgeUtils;
@@ -80,7 +79,6 @@ public class StudyConsentServiceTest {
     }
 
     @Test
-    @Ignore
     public void crudStudyConsent() {
         String documentContent = "<p>This is a consent document.</p><p>This is the second paragraph of same.</p>";
         StudyConsentForm form = new StudyConsentForm(documentContent);
@@ -105,7 +103,6 @@ public class StudyConsentServiceTest {
     }
     
     @Test
-    @Ignore
     public void studyConsentWithFileAndS3ContentTakesS3Content() throws Exception {
         long createdOn = DateUtils.getCurrentMillisFromEpoch();
         String key = subpopulation.getGuidString() + "." + createdOn;
@@ -119,7 +116,6 @@ public class StudyConsentServiceTest {
     }
     
     @Test
-    @Ignore
     public void invalidMarkupIsFixed() {
         StudyConsentForm form = new StudyConsentForm("<cml><p>This is not valid XML.</cml>");
         StudyConsentView view = studyConsentService.addConsent(subpopulation.getGuid(), form);
@@ -127,7 +123,6 @@ public class StudyConsentServiceTest {
     }
     
     @Test
-    @Ignore
     public void fullDocumentsAreConvertedToFragments() {
         String doc = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\"><html xmlns=\"http://www.w3.org/1999/xhtml\"><head><title></title></head><body><p>This is all the content that should be kept.</p><br><p>And this makes it a fragment.</p></body></html>";
         
@@ -137,7 +132,6 @@ public class StudyConsentServiceTest {
     }
     
     @Test
-    @Ignore
     public void ckeditorMarkupIsPreserved() {
         String doc = "<s>This is a test</s><p style=\"color:red\">of new attributes ${url}.</p><hr />";
         
@@ -174,7 +168,6 @@ public class StudyConsentServiceTest {
      * just isn't throwing an exception when testing through the service.
      */
     @Test
-    @Ignore
     public void evenVeryBrokenContentIsFixed() {
         StudyConsentForm form = new StudyConsentForm("</script><div ankle='foo'>This just isn't a SGML-based document no matter how you slice it.</p><h4><img>");
         StudyConsentView view = studyConsentService.addConsent(subpopulation.getGuid(), form);
@@ -182,7 +175,6 @@ public class StudyConsentServiceTest {
     }
     
     @Test
-    @Ignore
     public void publishingConsentCreatesPublicBucketDocuments() throws IOException {
         String content = "<p>"+BridgeUtils.generateGuid()+"</p>";
 
@@ -199,7 +191,6 @@ public class StudyConsentServiceTest {
     }
     
     @Test
-    @Ignore
     public void getActiveConsentUsesSubpopulation() {
         String documentContent = "<p>This is a consent document.</p>";
         StudyConsentForm form = new StudyConsentForm(documentContent);
@@ -211,7 +202,6 @@ public class StudyConsentServiceTest {
     }
     
     @Test
-    @Ignore
     public void getActiveConsentWorksWithoutSubpopulation() {
         StudyConsentForm form = new StudyConsentForm("<p>This is a consent document.</p>");
         StudyConsentView view = studyConsentService.addConsent(subpopulation.getGuid(), form);        
@@ -223,7 +213,6 @@ public class StudyConsentServiceTest {
     }
     
     @Test
-    @Ignore
     public void publishConsentUpdatesSubpopulation() {
         String documentContent = "<p>This is a consent document.</p>";
         StudyConsentForm form = new StudyConsentForm(documentContent);

--- a/test/org/sagebionetworks/bridge/services/StudyConsentServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyConsentServiceTest.java
@@ -130,6 +130,16 @@ public class StudyConsentServiceTest {
         assertEquals("<p>This is all the content that should be kept.</p>\n<br />\n<p>And this makes it a fragment.</p>", view.getDocumentContent());
     }
     
+    @Test
+    public void ckeditorMarkupIsPreserved() {
+        String doc = "<s>This is a test</s><p style=\"color:red\">of new attributes ${url}.</p><hr />";
+        
+        StudyConsentForm form = new StudyConsentForm(doc);
+        StudyConsentView view = studyConsentService.addConsent(subpopulation.getGuid(), form);
+        // Text is pretty printed so remove that before comparing 
+        assertEquals(doc, view.getDocumentContent().replaceAll("[\n\t\r]", ""));
+    }
+    
     /**
      * There used to be a test that an InvalidEntityException would be thrown if the content was not valid XML. But
      * Jsoup is very dogged in fixing even the worst documents, as this test demonstrates. Consenquently the validator 

--- a/test/org/sagebionetworks/bridge/services/StudyServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceTest.java
@@ -288,4 +288,26 @@ public class StudyServiceTest {
     public void cantDeleteApiStudy() {
         studyService.deleteStudy("api");
     }
+    
+    @Test
+    public void ckeditorHTMLIsPreserved() {
+        study = TestUtils.getValidStudy(StudyServiceTest.class);
+        
+        String body = "<s>This is a test</s><p style=\"color:red\">of new attributes ${url}.</p><hr>";
+        
+        EmailTemplate template = new EmailTemplate("Subject", body, MimeType.HTML);
+        
+        study.setVerifyEmailTemplate(template);
+        study.setResetPasswordTemplate(template);
+        study = studyService.createStudy(study);
+        
+        // The templates are pretty-print formatted, so remove that. Otherwise, everything should be
+        // preserved.
+        
+        template = study.getVerifyEmailTemplate();
+        assertEquals(body, template.getBody().replaceAll("[\n\t\r]", ""));
+        
+        template = study.getResetPasswordTemplate();
+        assertEquals(body, template.getBody().replaceAll("[\n\t\r]", ""));
+    }
 }


### PR DESCRIPTION
Added some HTML tags and attributes to sanitization that are used by the WYSIWYG editor to implement things like text coloring. (Also removed some advanced tabs in the WYSIWYG editor that weren't needed, so the two things now seem to align and anything you can do in the editor, is persisted in either the consent or the email templates).

Added entity escaping to the study fields that are interpolated into the templates. Without this escaping, you could break PDF generation with an ampersand or tick mark in something like the study name (e.g. Parkinson's Study).
