### PR TITLE
Upload dedupe logic for completed uploads

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/UploadDao.java
+++ b/app/org/sagebionetworks/bridge/dao/UploadDao.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.dao;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.List;
 
 import org.joda.time.DateTime;
@@ -21,9 +22,12 @@ public interface UploadDao {
      *         the study of the user
      * @param healthCode
      *         user's health code
+     * @param originalUploadId
+     *         upload ID this upload is a duplicate of, or null if it's not a dupe
      * @return upload metadata of created upload
      */
-    Upload createUpload(@Nonnull UploadRequest uploadRequest, @Nonnull StudyIdentifier studyId, @Nonnull String healthCode);
+    Upload createUpload(@Nonnull UploadRequest uploadRequest, @Nonnull StudyIdentifier studyId,
+            @Nonnull String healthCode, @Nullable String originalUploadId);
 
     /**
      * Gets the upload metadata associated with this upload.
@@ -43,16 +47,20 @@ public interface UploadDao {
      * Get the uploads for an entire study in the indicated time range.
      */
     List<? extends Upload> getStudyUploads(@Nonnull StudyIdentifier studyId, @Nonnull DateTime startTime, @Nonnull DateTime endTime);
-    
+
     /**
      * Signals to the Bridge server that the file has been uploaded. This also kicks off upload validation.
      *
      * @param completedBy
      *         a string description of the client that is completing this upload (client, s3 listener, etc.)
+     * @param status
+     *         upload status of the completed status; is generally either VALIDATION_IN_PROGRESS if
+     *         we're kicking off validation or DUPLICATE if it's a duplicate
      * @param upload
      *         upload to mark as completed
      */
-    void uploadComplete(@Nonnull UploadCompletionClient completedBy, @Nonnull Upload upload);
+    void uploadComplete(@Nonnull UploadCompletionClient completedBy, @Nonnull UploadStatus status,
+            @Nonnull Upload upload);
 
     /**
      * Persists the validation status, message list, and health data record ID (if it exists) to the Upload metadata

--- a/app/org/sagebionetworks/bridge/dao/UploadDao.java
+++ b/app/org/sagebionetworks/bridge/dao/UploadDao.java
@@ -53,14 +53,10 @@ public interface UploadDao {
      *
      * @param completedBy
      *         a string description of the client that is completing this upload (client, s3 listener, etc.)
-     * @param status
-     *         upload status of the completed status; is generally either VALIDATION_IN_PROGRESS if
-     *         we're kicking off validation or DUPLICATE if it's a duplicate
      * @param upload
      *         upload to mark as completed
      */
-    void uploadComplete(@Nonnull UploadCompletionClient completedBy, @Nonnull UploadStatus status,
-            @Nonnull Upload upload);
+    void uploadComplete(@Nonnull UploadCompletionClient completedBy, @Nonnull Upload upload);
 
     /**
      * Persists the validation status, message list, and health data record ID (if it exists) to the Upload metadata

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUpload2.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUpload2.java
@@ -37,6 +37,7 @@ public class DynamoUpload2 implements Upload {
     private long contentLength;
     private String contentMd5;
     private String contentType;
+    private String duplicateUploadId;
     private String filename;
     private String healthCode;
     private String recordId;
@@ -103,6 +104,17 @@ public class DynamoUpload2 implements Upload {
     /** @see #getContentType */
     public void setContentType(String contentType) {
         this.contentType = contentType;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getDuplicateUploadId() {
+        return duplicateUploadId;
+    }
+
+    /** @see #getDuplicateUploadId */
+    public void setDuplicateUploadId(String duplicateUploadId) {
+        this.duplicateUploadId = duplicateUploadId;
     }
 
     /** {@inheritDoc} */

--- a/app/org/sagebionetworks/bridge/models/upload/Upload.java
+++ b/app/org/sagebionetworks/bridge/models/upload/Upload.java
@@ -12,6 +12,9 @@ public interface Upload {
      */
     boolean canBeValidated();
 
+    /** The original ID that this upload is a duplicate of, or null if this upload is not a duplicate. */
+    String getDuplicateUploadId();
+
     /** Name of the file to upload. */
     String getFilename();
 

--- a/app/org/sagebionetworks/bridge/models/upload/UploadStatus.java
+++ b/app/org/sagebionetworks/bridge/models/upload/UploadStatus.java
@@ -17,6 +17,9 @@ public enum UploadStatus {
     /** Upload validation has failed. */
     VALIDATION_FAILED,
 
+    /** Upload is a duplicate of an existing upload and was ignored. */
+    DUPLICATE,
+
     /** Upload has succeeded, including validation. */
     SUCCEEDED,
 }

--- a/conf/bridge-server.conf
+++ b/conf/bridge-server.conf
@@ -90,6 +90,9 @@ uat.upload.cms.priv.bucket = org-sagebridge-upload-cms-priv-uat
 prod.upload.cms.cert.bucket = org-sagebridge-upload-cms-cert-prod
 prod.upload.cms.priv.bucket = org-sagebridge-upload-cms-priv-prod
 
+# Studies in this comma-separated list ignore upload dedupe logic
+upload.dupe.study.whitelist = api
+
 // Maximum 25 MB per zip entry
 max.zip.entry.size = 25000000
 // Maximum 100 zip entries per archive

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoUpload2Test.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoUpload2Test.java
@@ -40,6 +40,7 @@ public class DynamoUpload2Test {
         upload.setContentLength(10000L);
         upload.setContentMd5("abc");
         upload.setContentType("application/json");
+        upload.setDuplicateUploadId("original-upload-id");
         upload.setFilename("filename.zip");
         upload.setHealthCode("healthCode");
         upload.setRecordId("ABC");
@@ -55,6 +56,7 @@ public class DynamoUpload2Test {
         assertEquals(requestedOn.toString(), node.get("requestedOn").asText());
         assertEquals(completedOn.toString(), node.get("completedOn").asText());
         assertEquals(10000L, node.get("contentLength").asLong());
+        assertEquals("original-upload-id", node.get("duplicateUploadId").textValue());
         assertEquals("succeeded", node.get("status").asText());
         assertEquals("2016-10-10", node.get("uploadDate").asText());
         assertEquals("DEF", node.get("uploadId").asText());

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoUploadDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoUploadDaoMockTest.java
@@ -42,7 +42,7 @@ public class DynamoUploadDaoMockTest {
         DynamoUploadDao dao = new DynamoUploadDao();
         dao.setDdbMapper(mockMapper);
         UploadRequest req = createUploadRequest();
-        Upload upload = dao.createUpload(req, TEST_STUDY, "fakeHealthCode");
+        Upload upload = dao.createUpload(req, TEST_STUDY, "fakeHealthCode", "original-upload-id");
 
         // Validate that our mock DDB mapper was called.
         ArgumentCaptor<DynamoUpload2> arg = ArgumentCaptor.forClass(DynamoUpload2.class);
@@ -50,6 +50,7 @@ public class DynamoUploadDaoMockTest {
 
         // Validate that our DDB upload object matches our upload request, and that the upload ID matches.
         assertEquals(upload.getUploadId(), arg.getValue().getUploadId());
+        assertEquals("original-upload-id", arg.getValue().getDuplicateUploadId());
         assertEquals(TEST_STUDY.getIdentifier(), arg.getValue().getStudyId());
         assertTrue(arg.getValue().getRequestedOn() > 0);
         assertEquals(req.getContentLength(), arg.getValue().getContentLength());
@@ -108,13 +109,13 @@ public class DynamoUploadDaoMockTest {
         // execute
         DynamoUploadDao dao = new DynamoUploadDao();
         dao.setDdbMapper(mockMapper);
-        dao.uploadComplete(UploadCompletionClient.APP, new DynamoUpload2());
+        dao.uploadComplete(UploadCompletionClient.APP, UploadStatus.DUPLICATE, new DynamoUpload2());
 
-        // Verify our mock. We add status=VALIDATION_IN_PROGRESS and uploadDate on save, so only check for those
+        // Verify our mock. We add upload status and uploadDate on save, so only check for those
         // properties.
         ArgumentCaptor<DynamoUpload2> argSave = ArgumentCaptor.forClass(DynamoUpload2.class);
         verify(mockMapper).save(argSave.capture());
-        assertEquals(UploadStatus.VALIDATION_IN_PROGRESS, argSave.getValue().getStatus());
+        assertEquals(UploadStatus.DUPLICATE, argSave.getValue().getStatus());
         assertEquals(UploadCompletionClient.APP, argSave.getValue().getCompletedBy());
         assertTrue(argSave.getValue().getCompletedOn() > 0);
 

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoUploadDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoUploadDaoTest.java
@@ -40,6 +40,7 @@ import org.sagebionetworks.bridge.models.upload.UploadStatus;
 @RunWith(SpringJUnit4ClassRunner.class)
 public class DynamoUploadDaoTest {
     private static final DateTime MOCK_NOW = DateTime.parse("2016-04-12T15:00:00-0700");
+    private static final String ORIGINAL_UPLOAD_ID = "original-upload-id";
     private static final String TEST_HEALTH_CODE = "test-health-code";
     private static final int UPLOAD_CONTENT_LENGTH = 1213;
     private static final String UPLOAD_CONTENT_MD5 = "fFROLXJeXfzQvXYhJRKNfg==";
@@ -92,7 +93,7 @@ public class DynamoUploadDaoTest {
         UploadRequest uploadRequest = createRequest();
 
         // create upload
-        DynamoUpload2 upload = (DynamoUpload2) dao.createUpload(uploadRequest, TEST_STUDY, TEST_HEALTH_CODE);
+        DynamoUpload2 upload = (DynamoUpload2) dao.createUpload(uploadRequest, TEST_STUDY, TEST_HEALTH_CODE, null);
         assertUpload(upload);
         assertEquals(UploadStatus.REQUESTED, upload.getStatus());
         assertEquals(TEST_STUDY_IDENTIFIER, upload.getStudyId());
@@ -107,11 +108,11 @@ public class DynamoUploadDaoTest {
         DynamoUpload2 fetchedUpload2 = (DynamoUpload2) dao.getUpload(upload.getUploadId());
 
         // upload complete
-        dao.uploadComplete(UploadCompletionClient.S3_WORKER, fetchedUpload);
+        dao.uploadComplete(UploadCompletionClient.S3_WORKER, UploadStatus.VALIDATION_IN_PROGRESS, fetchedUpload);
 
         // second call to upload complete throws ConcurrentModificationException
         try {
-            dao.uploadComplete(UploadCompletionClient.APP, fetchedUpload2);
+            dao.uploadComplete(UploadCompletionClient.APP, UploadStatus.VALIDATION_IN_PROGRESS, fetchedUpload2);
             fail("expected exception");
         } catch (ConcurrentModificationException ex) {
             // expected exception
@@ -123,7 +124,32 @@ public class DynamoUploadDaoTest {
         assertEquals(UploadStatus.VALIDATION_IN_PROGRESS, completedUpload.getStatus());
         assertEquals(MOCK_NOW.toLocalDate(), completedUpload.getUploadDate());
     }
-    
+
+    @Test
+    public void testDuplicate() throws Exception {
+        // Most of the stuff in this code path has already been tested in test(). So this simplified test tests the new
+        // parameters for dedupe logic.
+
+        UploadRequest uploadRequest = createRequest();
+
+        // create upload - We still care about requestedOn for reporting.
+        DynamoUpload2 upload = (DynamoUpload2) dao.createUpload(uploadRequest, TEST_STUDY, TEST_HEALTH_CODE,
+                ORIGINAL_UPLOAD_ID);
+        uploadIds.add(upload.getUploadId());
+        assertEquals(ORIGINAL_UPLOAD_ID, upload.getDuplicateUploadId());
+        assertEquals(MOCK_NOW.getMillis(), upload.getRequestedOn());
+
+        // upload complete
+        dao.uploadComplete(UploadCompletionClient.S3_WORKER, UploadStatus.DUPLICATE, upload);
+
+        // fetch completed upload - Similarly, We still care about uploadDate and createdOn.
+        DynamoUpload2 completedUpload = (DynamoUpload2) dao.getUpload(upload.getUploadId());
+        assertEquals(UploadStatus.DUPLICATE, completedUpload.getStatus());
+        assertEquals(MOCK_NOW.toLocalDate(), completedUpload.getUploadDate());
+        assertEquals(MOCK_NOW.getMillis(), completedUpload.getCompletedOn());
+        assertEquals(UploadCompletionClient.S3_WORKER, completedUpload.getCompletedBy());
+    }
+
     @Test
     public void canRetrieveUploadRecords() throws Exception {
         int numUploads = 2;
@@ -131,7 +157,7 @@ public class DynamoUploadDaoTest {
         for (int i = 0; i < numUploads; i++) {
             String healthcode = "code" + i;
             UploadRequest uploadRequest = createRequest();
-            Upload upload = dao.createUpload(uploadRequest, TEST_STUDY, healthcode);
+            Upload upload = dao.createUpload(uploadRequest, TEST_STUDY, healthcode, null);
             String uploadId = upload.getUploadId();
 
             uploadIds.add(uploadId);

--- a/test/org/sagebionetworks/bridge/services/UploadServiceCreateUploadMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/UploadServiceCreateUploadMockTest.java
@@ -119,7 +119,7 @@ public class UploadServiceCreateUploadMockTest {
     @Test
     public void isNotDupe() {
         // mock upload DAO
-        when(mockUploadDao.createUpload(uploadRequest, TEST_STUDY, TEST_HEALTH_CODE)).thenReturn(TEST_UPLOAD);
+        when(mockUploadDao.createUpload(uploadRequest, TEST_STUDY, TEST_HEALTH_CODE, null)).thenReturn(TEST_UPLOAD);
 
         // mock upload dedupe DAO
         when(mockUploadDedupeDao.getDuplicate(TEST_HEALTH_CODE, TEST_UPLOAD_MD5, TEST_UPLOAD_REQUESTED_ON)).thenReturn(
@@ -128,7 +128,7 @@ public class UploadServiceCreateUploadMockTest {
         testUpload(TEST_UPLOAD_ID);
 
         // verify we created and registered the dupe
-        verify(mockUploadDao).createUpload(uploadRequest, TEST_STUDY, TEST_HEALTH_CODE);
+        verify(mockUploadDao).createUpload(uploadRequest, TEST_STUDY, TEST_HEALTH_CODE, null);
         verify(mockUploadDedupeDao).registerUpload(TEST_HEALTH_CODE, TEST_UPLOAD_MD5, TEST_UPLOAD_REQUESTED_ON,
                 TEST_UPLOAD_ID);
     }
@@ -148,14 +148,15 @@ public class UploadServiceCreateUploadMockTest {
         testUpload(TEST_ORIGINAL_UPLOAD_ID);
 
         // verify we never create or register a dupe
-        verify(mockUploadDao, never()).createUpload(any(), eq(TEST_STUDY), any());
+        verify(mockUploadDao, never()).createUpload(any(), eq(TEST_STUDY), any(), any());
         verify(mockUploadDedupeDao, never()).registerUpload(any(), any(), any(), any());
     }
 
     @Test
     public void isDupeOfCompleteUpload() {
         // mock upload DAO
-        when(mockUploadDao.createUpload(uploadRequest, TEST_STUDY, TEST_HEALTH_CODE)).thenReturn(TEST_UPLOAD);
+        when(mockUploadDao.createUpload(uploadRequest, TEST_STUDY, TEST_HEALTH_CODE, TEST_ORIGINAL_UPLOAD_ID))
+                .thenReturn(TEST_UPLOAD);
 
         DynamoUpload2 originalUpload = new DynamoUpload2();
         originalUpload.setUploadId(TEST_ORIGINAL_UPLOAD_ID);
@@ -169,7 +170,7 @@ public class UploadServiceCreateUploadMockTest {
         testUpload(TEST_UPLOAD_ID);
 
         // verify we create the upload, but we don't register a dupe
-        verify(mockUploadDao).createUpload(uploadRequest, TEST_STUDY, TEST_HEALTH_CODE);
+        verify(mockUploadDao).createUpload(uploadRequest, TEST_STUDY, TEST_HEALTH_CODE, TEST_ORIGINAL_UPLOAD_ID);
         verify(mockUploadDedupeDao, never()).registerUpload(any(), any(), any(), any());
     }
 
@@ -178,7 +179,7 @@ public class UploadServiceCreateUploadMockTest {
         // Throwing on dedupe logic shouldn't fail the upload.
 
         // mock upload DAO
-        when(mockUploadDao.createUpload(uploadRequest, TEST_STUDY, TEST_HEALTH_CODE)).thenReturn(TEST_UPLOAD);
+        when(mockUploadDao.createUpload(uploadRequest, TEST_STUDY, TEST_HEALTH_CODE, null)).thenReturn(TEST_UPLOAD);
 
         // mock upload dedupe DAO
         when(mockUploadDedupeDao.getDuplicate(TEST_HEALTH_CODE, TEST_UPLOAD_MD5, TEST_UPLOAD_REQUESTED_ON)).thenThrow(
@@ -187,7 +188,7 @@ public class UploadServiceCreateUploadMockTest {
         testUpload(TEST_UPLOAD_ID);
 
         // verify we created and registered the dupe
-        verify(mockUploadDao).createUpload(uploadRequest, TEST_STUDY, TEST_HEALTH_CODE);
+        verify(mockUploadDao).createUpload(uploadRequest, TEST_STUDY, TEST_HEALTH_CODE, null);
         verify(mockUploadDedupeDao).registerUpload(TEST_HEALTH_CODE, TEST_UPLOAD_MD5, TEST_UPLOAD_REQUESTED_ON,
                 TEST_UPLOAD_ID);
     }
@@ -197,7 +198,7 @@ public class UploadServiceCreateUploadMockTest {
         // Throwing on dedupe logic shouldn't fail the upload.
 
         // mock upload DAO
-        when(mockUploadDao.createUpload(uploadRequest, TEST_STUDY, TEST_HEALTH_CODE)).thenReturn(TEST_UPLOAD);
+        when(mockUploadDao.createUpload(uploadRequest, TEST_STUDY, TEST_HEALTH_CODE, null)).thenReturn(TEST_UPLOAD);
 
         // mock upload dedupe DAO
         when(mockUploadDedupeDao.getDuplicate(TEST_HEALTH_CODE, TEST_UPLOAD_MD5, TEST_UPLOAD_REQUESTED_ON)).thenReturn(
@@ -208,7 +209,7 @@ public class UploadServiceCreateUploadMockTest {
         testUpload(TEST_UPLOAD_ID);
 
         // verify we created and registered the dupe (even if we threw immediately after registration)
-        verify(mockUploadDao).createUpload(uploadRequest, TEST_STUDY, TEST_HEALTH_CODE);
+        verify(mockUploadDao).createUpload(uploadRequest, TEST_STUDY, TEST_HEALTH_CODE, null);
         verify(mockUploadDedupeDao).registerUpload(TEST_HEALTH_CODE, TEST_UPLOAD_MD5, TEST_UPLOAD_REQUESTED_ON,
                 TEST_UPLOAD_ID);
     }


### PR DESCRIPTION
Part of https://sagebionetworks.jira.com/browse/BRIDGE-468

Dedupe logic currently only applies to requested incomplete uploads. In some cases, we have duplicate uploads for uploads that are already complete. This change allows us to dedupe uploads that have already been completed.

This works by, when we create an upload, if we detect it as a dupe (based on healthCode and MD5 hash within the last 7 days), we'll tag the upload with the dupe upload ID. Then when the upload is completed, if it's a dupe, we ignore it. This allows apps to continue their existing workflow of request-upload-complete, but we don't end up with duplicate uploads.

Testing done:
- ran updated Upload unit tests
- upload integ test
- manual tests

Manual test cases:
- not a dupe
- dupe of requested incomplete upload
- dupe of completed upload
- dupe of completed upload, but passes study whitelist
