### PR TITLE
Survey Answer Choice Validation Improvements, and other minor changes

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadFieldDefinition.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadFieldDefinition.java
@@ -12,7 +12,6 @@ import com.google.common.collect.ImmutableList;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
 import org.sagebionetworks.bridge.models.upload.UploadFieldType;
-import org.sagebionetworks.bridge.schema.SchemaUtils;
 
 /**
  * Dynamo DB implementation of UploadFieldDefinition. While there is nothing specific to Dynamo DB in this class, this
@@ -228,23 +227,14 @@ public final class DynamoUploadFieldDefinition implements UploadFieldDefinition 
                 required = true;
             }
 
-            // Sanitize the field name.
-            String sanitizedName = SchemaUtils.sanitizeFieldName(name);
-
             // If the answer list was specified, make an immutable copy.
             List<String> multiChoiceAnswerListCopy = null;
             if (multiChoiceAnswerList != null) {
-                ImmutableList.Builder<String> answerListBuilder = ImmutableList.builder();
-                for (String oneAnswer : multiChoiceAnswerList) {
-                    // Since multi-choice answers become part of Synapse column names, we should sanitize those too.
-                    answerListBuilder.add(SchemaUtils.sanitizeFieldName(oneAnswer));
-                }
-
-                multiChoiceAnswerListCopy = answerListBuilder.build();
+                multiChoiceAnswerListCopy = ImmutableList.copyOf(multiChoiceAnswerList);
             }
 
             return new DynamoUploadFieldDefinition(allowOtherChoices, fileExtension, mimeType, maxLength,
-                    multiChoiceAnswerListCopy, sanitizedName, required, type, unboundedText);
+                    multiChoiceAnswerListCopy, name, required, type, unboundedText);
         }
     }
 }

--- a/app/org/sagebionetworks/bridge/validators/SurveyValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/SurveyValidator.java
@@ -90,7 +90,7 @@ public class SurveyValidator implements Validator {
         if (isBlank(questionId)) {
             errors.rejectValue("identifier", "is required");
         } else if (!UploadUtil.isValidSchemaFieldName(questionId)) {
-            errors.rejectValue("identifier", UploadUtil.INVALID_FIELD_NAME_ERROR_MESSAGE);
+            errors.rejectValue("identifier", String.format(UploadUtil.INVALID_FIELD_NAME_ERROR_MESSAGE, questionId));
         }
 
         if (question.getUiHint() == null) {
@@ -234,8 +234,9 @@ public class SurveyValidator implements Validator {
                 }
 
                 String optionValue = oneOption.getValue();
-                if (!UploadUtil.isValidSchemaFieldName(optionValue)) {
-                    rejectField(errors, "value", UploadUtil.INVALID_FIELD_NAME_ERROR_MESSAGE);
+                if (!UploadUtil.isValidAnswerChoice(optionValue)) {
+                    errors.rejectValue("value", String.format(UploadUtil.INVALID_ANSWER_CHOICE_ERROR_MESSAGE,
+                            optionValue));
                 }
 
                 // record values seen so far

--- a/app/org/sagebionetworks/bridge/validators/UploadSchemaValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/UploadSchemaValidator.java
@@ -103,7 +103,8 @@ public class UploadSchemaValidator implements Validator {
 
                             // Validate field name.
                             if (!UploadUtil.isValidSchemaFieldName(fieldName)) {
-                                errors.rejectValue("name", UploadUtil.INVALID_FIELD_NAME_ERROR_MESSAGE);
+                                errors.rejectValue("name", String.format(UploadUtil.INVALID_FIELD_NAME_ERROR_MESSAGE,
+                                        fieldName));
                             }
                         }
 
@@ -128,9 +129,9 @@ public class UploadSchemaValidator implements Validator {
                                     fieldNameList.add(fieldName + MULTI_CHOICE_FIELD_SEPARATOR + oneAnswer);
 
                                     // Validate choice answer name.
-                                    if (!UploadUtil.isValidSchemaFieldName(oneAnswer)) {
-                                        errors.rejectValue("multiChoice[" + j + "]",
-                                                UploadUtil.INVALID_FIELD_NAME_ERROR_MESSAGE);
+                                    if (!UploadUtil.isValidAnswerChoice(oneAnswer)) {
+                                        errors.rejectValue("multiChoice[" + j + "]", String.format(
+                                                UploadUtil.INVALID_ANSWER_CHOICE_ERROR_MESSAGE, oneAnswer));
                                     }
                                 }
                             }

--- a/test/org/sagebionetworks/bridge/models/upload/UploadFieldDefinitionTest.java
+++ b/test/org/sagebionetworks/bridge/models/upload/UploadFieldDefinitionTest.java
@@ -94,22 +94,6 @@ public class UploadFieldDefinitionTest {
     }
 
     @Test
-    public void fieldNameSanitization() {
-        // Don't need to exhaustively test all sanitizations, just that sanitization happens.
-        UploadFieldDefinition fieldDef = new DynamoUploadFieldDefinition.Builder().withName(".foo..bar")
-                .withType(UploadFieldType.STRING).build();
-        assertEquals("_foo.bar", fieldDef.getName());
-    }
-
-    @Test
-    public void choiceNameSanitization() {
-        // Similarly
-        UploadFieldDefinition fieldDef = new DynamoUploadFieldDefinition.Builder().withName("saniTest")
-                .withType(UploadFieldType.MULTI_CHOICE).withMultiChoiceAnswerList("-bar", "!@baz#$").build();
-        assertEquals(ImmutableList.of("_bar", "__baz__"), fieldDef.getMultiChoiceAnswerList());
-    }
-
-    @Test
     public void testSerialization() throws Exception {
         // start with JSON
         String jsonText = "{\n" +

--- a/test/org/sagebionetworks/bridge/upload/UploadUtilTest.java
+++ b/test/org/sagebionetworks/bridge/upload/UploadUtilTest.java
@@ -282,7 +282,7 @@ public class UploadUtilTest {
     }
 
     @Test
-    public void isValidFieldNameInvalid() {
+    public void invalidFieldNameAndAnswerChoice() {
         String[] testCases = {
                 null,
                 "",
@@ -301,18 +301,32 @@ public class UploadUtilTest {
                 "foo..bar",
                 "foo  bar",
                 "foo-_-bar",
-                "select",
-                "where",
-                "time",
         };
 
         for (String oneTestCase : testCases) {
-            assertFalse(oneTestCase + " should be invalid", UploadUtil.isValidSchemaFieldName(oneTestCase));
+            assertFalse(oneTestCase + " should be invalid answer choice", UploadUtil.isValidAnswerChoice(oneTestCase));
+            assertFalse(oneTestCase + " should be invalid field name", UploadUtil.isValidSchemaFieldName(oneTestCase));
         }
     }
 
     @Test
-    public void isValidFieldNameValid() {
+    public void invalidFieldNameValidAnswerChoice() {
+        String[] testCases = {
+                "select",
+                "where",
+                "time",
+                "true",
+                "false",
+        };
+
+        for (String oneTestCase : testCases) {
+            assertTrue(oneTestCase + " should be valid answer choice", UploadUtil.isValidAnswerChoice(oneTestCase));
+            assertFalse(oneTestCase + " should be invalid field name", UploadUtil.isValidSchemaFieldName(oneTestCase));
+        }
+    }
+
+    @Test
+    public void validFieldNameAndAnswerChoice() {
         String[] testCases = {
                 "foo",
                 "foo_bar",
@@ -323,7 +337,8 @@ public class UploadUtilTest {
         };
 
         for (String oneTestCase : testCases) {
-            assertTrue(oneTestCase + " should be valid", UploadUtil.isValidSchemaFieldName(oneTestCase));
+            assertTrue(oneTestCase + " should be valid answer choice", UploadUtil.isValidAnswerChoice(oneTestCase));
+            assertTrue(oneTestCase + " should be valid field name", UploadUtil.isValidSchemaFieldName(oneTestCase));
         }
     }
 

--- a/test/org/sagebionetworks/bridge/validators/SurveyValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/SurveyValidatorTest.java
@@ -213,14 +213,15 @@ public class SurveyValidatorTest {
 
     @Test
     public void questionIdentifierInvalid() {
+        String fieldName = "**invalid!q##";
         try {
             survey = new TestSurvey(SurveyValidatorTest.class, false);
-            survey.getElements().get(0).setIdentifier("**invalid!q##");
+            survey.getElements().get(0).setIdentifier(fieldName);
 
             Validate.entityThrowingException(validator, survey);
             fail("Should have thrown exception");
         } catch (InvalidEntityException e) {
-            assertEquals("elements[0].identifier " + UploadUtil.INVALID_FIELD_NAME_ERROR_MESSAGE,
+            assertEquals("elements[0].identifier " + String.format(UploadUtil.INVALID_FIELD_NAME_ERROR_MESSAGE, fieldName),
                     errorFor(e, "elements[0].identifier"));
         }
     }
@@ -394,10 +395,23 @@ public class SurveyValidatorTest {
     }
 
     @Test
+    public void keywordsAreValidChoiceValues() {
+        List<SurveyQuestionOption> optionList = ImmutableList.of(new SurveyQuestionOption("true"),
+                new SurveyQuestionOption("false"), new SurveyQuestionOption("select"),
+                new SurveyQuestionOption("where"));
+
+        SurveyQuestion question = ((TestSurvey) survey).getMultiValueQuestion();
+        ((MultiValueConstraints) question.getConstraints()).setEnumeration(optionList);
+
+        Validate.entityThrowingException(validator, survey);
+    }
+
+    @Test
     public void multiValueWithOptionWithInvalidValue() {
+        String answerChoice = "@invalid#answer$";
         try {
             List<SurveyQuestionOption> optionList = ImmutableList.of(new SurveyQuestionOption("My Question", null,
-                    "@invalid#answer$", null));
+                    answerChoice, null));
 
             SurveyQuestion question = ((TestSurvey) survey).getMultiValueQuestion();
             ((MultiValueConstraints) question.getConstraints()).setEnumeration(optionList);
@@ -405,7 +419,8 @@ public class SurveyValidatorTest {
             Validate.entityThrowingException(validator, survey);
             fail("Should have thrown exception");
         } catch (InvalidEntityException e) {
-            assertEquals("value " + UploadUtil.INVALID_FIELD_NAME_ERROR_MESSAGE,
+            assertEquals("elements[7].constraints.enumeration[0].value " +
+                            String.format(UploadUtil.INVALID_ANSWER_CHOICE_ERROR_MESSAGE, answerChoice),
                     errorFor(e, "elements[7].constraints.enumeration[0].value"));
         }
     }

--- a/test/org/sagebionetworks/bridge/validators/UploadSchemaValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/UploadSchemaValidatorTest.java
@@ -281,6 +281,26 @@ public class UploadSchemaValidatorTest {
         Validate.entityThrowingException(UploadSchemaValidator.INSTANCE, schema);
     }
 
+    @Test
+    public void keywordsAreValidChoiceValues() {
+        // Similarly
+        DynamoUploadSchema schema = new DynamoUploadSchema();
+        schema.setName("Test Schema");
+        schema.setSchemaId("test-schema");
+        schema.setStudyId("test-study");
+        schema.setSchemaType(UploadSchemaType.IOS_DATA);
+
+        // test field def list
+        List<UploadFieldDefinition> fieldDefList = new ArrayList<>();
+        fieldDefList.add(new DynamoUploadFieldDefinition.Builder().withName("multi-choice-q")
+                .withType(UploadFieldType.MULTI_CHOICE)
+                .withMultiChoiceAnswerList("true", "false", "select", "where").build());
+        schema.setFieldDefinitions(fieldDefList);
+
+        // validate
+        Validate.entityThrowingException(UploadSchemaValidator.INSTANCE, schema);
+    }
+
     @Test(expected = InvalidEntityException.class)
     public void invalidMultiChoiceAnswer() {
         // Similarly
@@ -437,10 +457,6 @@ public class UploadSchemaValidatorTest {
                 .build());
         fieldDefList.add(new DynamoUploadFieldDefinition.Builder().withName("baz.timezone")
                 .withType(UploadFieldType.STRING).build());
-        fieldDefList.add(new DynamoUploadFieldDefinition.Builder().withName("#underscore")
-                .withType(UploadFieldType.STRING).build());
-        fieldDefList.add(new DynamoUploadFieldDefinition.Builder().withName("!underscore")
-                .withType(UploadFieldType.STRING).build());
         schema.setFieldDefinitions(fieldDefList);
 
         // validate
@@ -451,7 +467,7 @@ public class UploadSchemaValidatorTest {
         } catch (InvalidEntityException ex) {
             thrownEx = ex;
         }
-        assertTrue(thrownEx.getMessage().contains("conflict in field names or sub-field names: _underscore, bar.bar, "
+        assertTrue(thrownEx.getMessage().contains("conflict in field names or sub-field names: bar.bar, "
                 + "bar.other, baz.timezone, foo-field"));
     }
 


### PR DESCRIPTION
Main JIRA: https://sagebionetworks.jira.com/browse/BRIDGE-1482

Changes:
- survey answer choices can now be keywords, since they get the question name pre-pended to them
- improving the error messages for survey and schema validation, to include the path and the offending string
- since we're validating field names instead of sanitizing, sanitizing logic has been removed from schema field def builder
- single-choice fields now default to length 100, to prevent cases where a minor update to a single-choice question triggers a full schema refresh (longer single-choice fields will use unbounded strings)
- "true" and "false" have been added to reserved keywords

Testing done:
- updated and ran relevant unit tests
- ran integ tests for surveys, schemas, and survey schemas

Manual Tests
- survey question name and answer choice validation
- schema field name and answer choice validation
- survey with single-choice fields (short and unbounded)
- schema with keywords as choice
- true/false illegal schema field name
