### PR TITLE
fix unit tests (schema field sanitization vs validation)

### DIFF
--- a/test/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2Test.java
+++ b/test/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2Test.java
@@ -82,8 +82,6 @@ public class IosSchemaValidationHandler2Test {
                         .build(),
                 new DynamoUploadFieldDefinition.Builder().withName("baz")
                         .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build(),
-                new DynamoUploadFieldDefinition.Builder().withName("$sanitize..me").withType(UploadFieldType.STRING)
-                        .build(),
                 new DynamoUploadFieldDefinition.Builder().withName("optional").withRequired(false)
                         .withType(UploadFieldType.STRING).build(),
                 new DynamoUploadFieldDefinition.Builder().withName("optional_attachment").withRequired(false)
@@ -99,8 +97,6 @@ public class IosSchemaValidationHandler2Test {
                 new DynamoUploadFieldDefinition.Builder().withName("string.json.string")
                         .withType(UploadFieldType.STRING).build(),
                 new DynamoUploadFieldDefinition.Builder().withName("string.json.intAsString")
-                        .withType(UploadFieldType.STRING).build(),
-                new DynamoUploadFieldDefinition.Builder().withName("string.json.$sanitize..this..field")
                         .withType(UploadFieldType.STRING).build(),
                 new DynamoUploadFieldDefinition.Builder().withName("blob.json.blob")
                         .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build(),
@@ -123,10 +119,6 @@ public class IosSchemaValidationHandler2Test {
                 new DynamoUploadFieldDefinition.Builder().withName("nonJsonFile.txt")
                         .withType(UploadFieldType.ATTACHMENT_BLOB).build(),
                 new DynamoUploadFieldDefinition.Builder().withName("jsonFile.json")
-                        .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build(),
-                new DynamoUploadFieldDefinition.Builder().withName("$sanitize..blob..file")
-                        .withType(UploadFieldType.ATTACHMENT_BLOB).build(),
-                new DynamoUploadFieldDefinition.Builder().withName("$sanitize..json..file.json")
                         .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build(),
                 new DynamoUploadFieldDefinition.Builder().withName("optional").withRequired(false)
                         .withType(UploadFieldType.STRING).build(),
@@ -211,9 +203,6 @@ public class IosSchemaValidationHandler2Test {
                 "   },{\n" +
                 "       \"filename\":\"baz.json\",\n" +
                 "       \"timestamp\":\"2015-04-02T03:24:01-07:00\"\n" +
-                "   },{\n" +
-                "       \"filename\":\"$sanitize..me.json\",\n" +
-                "       \"timestamp\":\"2015-04-02T03:24:01-07:00\"\n" +
                 "   }],\n" +
                 "   \"item\":\"test-survey\"\n" +
                 "}";
@@ -250,22 +239,11 @@ public class IosSchemaValidationHandler2Test {
                 "}";
         JsonNode bazAnswerJsonNode = BridgeObjectMapper.get().readTree(bazAnswerJsonText);
 
-        String sanitizeMeAnswerJsonText = "{\n" +
-                "   \"questionType\":0,\n" +
-                "   \"textAnswer\":\"value doesn't matter\",\n" +
-                "   \"startDate\":\"2015-04-02T03:23:59-07:00\",\n" +
-                "   \"questionTypeName\":\"Text\",\n" +
-                "   \"item\":\"$sanitize..me\",\n" +
-                "   \"endDate\":\"2015-04-02T03:24:01-07:00\"\n" +
-                "}";
-        JsonNode sanitizeMeAnswerJsonNode = BridgeObjectMapper.get().readTree(sanitizeMeAnswerJsonText);
-
         context.setJsonDataMap(ImmutableMap.of(
                 "info.json", infoJsonNode,
                 "foo.json", fooAnswerJsonNode,
                 "bar.json", barAnswerJsonNode,
-                "baz.json", bazAnswerJsonNode,
-                "$sanitize..me.json", sanitizeMeAnswerJsonNode));
+                "baz.json", bazAnswerJsonNode));
         context.setUnzippedDataMap(ImmutableMap.<String, byte[]>of());
 
         // execute
@@ -281,11 +259,10 @@ public class IosSchemaValidationHandler2Test {
         assertEquals(1, recordBuilder.getSchemaRevision());
 
         JsonNode dataNode = recordBuilder.getData();
-        assertEquals(4, dataNode.size());
+        assertEquals(3, dataNode.size());
         assertEquals("foo answer", dataNode.get("foo").textValue());
         assertEquals(42, dataNode.get("bar").intValue());
         assertEquals("lb", dataNode.get("bar_unit").textValue());
-        assertEquals("value doesn't matter", dataNode.get("_sanitize.me").textValue());
 
         Map<String, byte[]> attachmentMap = context.getAttachmentsByFieldName();
         assertEquals(1, attachmentMap.size());
@@ -417,8 +394,7 @@ public class IosSchemaValidationHandler2Test {
 
         String stringJsonText = "{\n" +
                 "   \"string\":\"This is a string\",\n" +
-                "   \"intAsString\":42,\n" +
-                "   \"$sanitize..this..field\":\"sanitize key, not value\"\n" +
+                "   \"intAsString\":42\n" +
                 "}";
         JsonNode stringJsonNode = BridgeObjectMapper.get().readTree(stringJsonText);
 
@@ -453,11 +429,10 @@ public class IosSchemaValidationHandler2Test {
         assertEquals(1, recordBuilder.getSchemaRevision());
 
         JsonNode dataNode = recordBuilder.getData();
-        assertEquals(5, dataNode.size());
+        assertEquals(4, dataNode.size());
         assertEquals("This is a string", dataNode.get("string.json.string").textValue());
         assertTrue(dataNode.get("string.json.intAsString").isTextual());
         assertEquals("42", dataNode.get("string.json.intAsString").textValue());
-        assertEquals("sanitize key, not value", dataNode.get("string.json._sanitize.this.field").textValue());
         assertEquals("2015-12-25", dataNode.get("date.json.date").textValue());
         assertEquals("2015-12-25", dataNode.get("date.json.timestampAsDate").textValue());
 
@@ -484,12 +459,6 @@ public class IosSchemaValidationHandler2Test {
                 "   },{\n" +
                 "       \"filename\":\"nonJsonFile.txt\",\n" +
                 "       \"timestamp\":\"2015-04-13T18:58:21-07:00\"\n" +
-                "   },{\n" +
-                "       \"filename\":\"$sanitize..blob..file\",\n" +
-                "       \"timestamp\":\"2015-04-13T18:58:21-07:00\"\n" +
-                "   },{\n" +
-                "       \"filename\":\"$sanitize..json..file.json\",\n" +
-                "       \"timestamp\":\"2015-04-13T18:58:21-07:00\"\n" +
                 "   }],\n" +
                 "   \"item\":\"non-json-data\"\n" +
                 "}";
@@ -500,15 +469,11 @@ public class IosSchemaValidationHandler2Test {
                 "}";
         JsonNode jsonJsonNode = BridgeObjectMapper.get().readTree(jsonJsonText);
 
-        JsonNode sanitizeJsonNode = BridgeObjectMapper.get().readTree("[\"content doesn't matter here\"]");
-
         context.setJsonDataMap(ImmutableMap.of(
                 "info.json", infoJsonNode,
-                "jsonFile.json", jsonJsonNode,
-                "$sanitize..json..file.json", sanitizeJsonNode));
+                "jsonFile.json", jsonJsonNode));
         context.setUnzippedDataMap(ImmutableMap.<String, byte[]>builder()
                 .put("nonJsonFile.txt", "This is non-JSON data".getBytes(Charsets.UTF_8))
-                .put("$sanitize..blob..file", "Nor here".getBytes(Charsets.UTF_8))
                 .build());
 
         // execute
@@ -527,20 +492,13 @@ public class IosSchemaValidationHandler2Test {
         assertEquals(0, dataNode.size());
 
         Map<String, byte[]> attachmentMap = context.getAttachmentsByFieldName();
-        assertEquals(4, attachmentMap.size());
+        assertEquals(2, attachmentMap.size());
 
         JsonNode jsonJsonAttachmentNode = BridgeObjectMapper.get().readTree(attachmentMap.get("jsonFile.json"));
         assertEquals(1, jsonJsonAttachmentNode.size());
         assertEquals("This is JSON data", jsonJsonAttachmentNode.get("field").textValue());
 
-        JsonNode sanitizeJsonAttachmentNode = BridgeObjectMapper.get().readTree(attachmentMap.get(
-                "_sanitize.json.file.json"));
-        assertEquals(1, sanitizeJsonAttachmentNode.size());
-        assertEquals("content doesn't matter here", sanitizeJsonAttachmentNode.get(0).textValue());
-
         assertEquals("This is non-JSON data", new String(attachmentMap.get("nonJsonFile.txt"), Charsets.UTF_8));
-
-        assertEquals("Nor here", new String(attachmentMap.get("_sanitize.blob.file"), Charsets.UTF_8));
 
         // We should have no messages.
         assertTrue(context.getMessageList().isEmpty());

--- a/test/org/sagebionetworks/bridge/upload/UploadHandlersEndToEndTest.java
+++ b/test/org/sagebionetworks/bridge/upload/UploadHandlersEndToEndTest.java
@@ -257,10 +257,7 @@ public class UploadHandlersEndToEndTest {
                 new DynamoUploadFieldDefinition.Builder().withName("BBB").withType(UploadFieldType.MULTI_CHOICE)
                         .withMultiChoiceAnswerList("fencing", "football", "running", "swimming", "3").build(),
                 new DynamoUploadFieldDefinition.Builder().withName("delicious").withType(UploadFieldType.MULTI_CHOICE)
-                        .withMultiChoiceAnswerList("Yes", "No").withAllowOtherChoices(true).build(),
-                new DynamoUploadFieldDefinition.Builder().withName("$sanitize..me")
-                        .withType(UploadFieldType.MULTI_CHOICE).withMultiChoiceAnswerList("$dollar", "-dash", " space")
-                        .build());
+                        .withMultiChoiceAnswerList("Yes", "No").withAllowOtherChoices(true).build());
 
         DynamoUploadSchema schema = new DynamoUploadSchema();
         schema.setFieldDefinitions(fieldDefList);
@@ -289,9 +286,6 @@ public class UploadHandlersEndToEndTest {
                 "       \"timestamp\":\"" + CREATED_ON_STRING + "\"\n" +
                 "   },{\n" +
                 "       \"filename\":\"delicious.json\",\n" +
-                "       \"timestamp\":\"" + CREATED_ON_STRING + "\"\n" +
-                "   },{\n" +
-                "       \"filename\":\"$sanitize..me.json\",\n" +
                 "       \"timestamp\":\"" + CREATED_ON_STRING + "\"\n" +
                 "   }],\n" +
                 "   \"surveyGuid\":\"survey-guid\",\n" +
@@ -327,18 +321,9 @@ public class UploadHandlersEndToEndTest {
                 "   \"endDate\":\"2015-04-02T03:27:09-07:00\"\n" +
                 "}";
 
-        String sanitizeMeJsonText = "{\n" +
-                "   \"questionType\":0,\n" +
-                "   \"choiceAnswers\":[\"$dollar\", \"-dash\", \" space\"],\n" +
-                "   \"startDate\":\"2015-04-02T03:27:05-07:00\",\n" +
-                "   \"questionTypeName\":\"MultipleChoice\",\n" +
-                "   \"item\":\"$sanitize..me\",\n" +
-                "   \"endDate\":\"2015-04-02T03:27:09-07:00\"\n" +
-                "}";
-
         Map<String, String> fileMap = ImmutableMap.<String, String>builder().put("info.json", infoJsonText)
                 .put("AAA.json", aaaJsonText).put("BBB.json", bbbJsonText).put("delicious.json", deliciousJsonText)
-                .put("$sanitize..me.json", sanitizeMeJsonText).build();
+                .build();
 
         // execute
         test(schema, survey, fileMap);
@@ -353,7 +338,7 @@ public class UploadHandlersEndToEndTest {
         assertEquals(2, record.getSchemaRevision());
 
         JsonNode dataNode = record.getData();
-        assertEquals(4, dataNode.size());
+        assertEquals(3, dataNode.size());
         assertEquals("Yes", dataNode.get("AAA").textValue());
 
         JsonNode bbbChoiceAnswersNode = dataNode.get("BBB");
@@ -366,12 +351,6 @@ public class UploadHandlersEndToEndTest {
         assertEquals(2, deliciousNode.size());
         assertEquals("Yes", deliciousNode.get(0).textValue());
         assertEquals("Maybe", deliciousNode.get(1).textValue());
-
-        JsonNode sanitizeMeChoiceAnswersNode = dataNode.get("_sanitize.me");
-        assertEquals(3, sanitizeMeChoiceAnswersNode.size());
-        assertEquals("_dollar", sanitizeMeChoiceAnswersNode.get(0).textValue());
-        assertEquals("_dash", sanitizeMeChoiceAnswersNode.get(1).textValue());
-        assertEquals("_space", sanitizeMeChoiceAnswersNode.get(2).textValue());
 
         // validate no uploads to S3
         verifyZeroInteractions(mockS3UploadHelper);
@@ -416,13 +395,7 @@ public class UploadHandlersEndToEndTest {
                 new DynamoUploadFieldDefinition.Builder().withName("record.json.QQQ").withType(UploadFieldType.TIME_V2)
                         .build(),
                 new DynamoUploadFieldDefinition.Builder().withName("record.json.arrr")
-                        .withType(UploadFieldType.TIMESTAMP).build(),
-                new DynamoUploadFieldDefinition.Builder().withName("record.json.$sanitize..this..field")
-                    .withType(UploadFieldType.STRING).build(),
-                new DynamoUploadFieldDefinition.Builder().withName("$sanitize..blob..file")
-                        .withType(UploadFieldType.ATTACHMENT_V2).build(),
-                new DynamoUploadFieldDefinition.Builder().withName("$sanitize..json..file.json")
-                        .withType(UploadFieldType.ATTACHMENT_V2).build());
+                        .withType(UploadFieldType.TIMESTAMP).build());
 
         DynamoUploadSchema schema = new DynamoUploadSchema();
         schema.setFieldDefinitions(fieldDefList);
@@ -452,12 +425,6 @@ public class UploadHandlersEndToEndTest {
                 "   },{\n" +
                 "       \"filename\":\"record.json\",\n" +
                 "       \"timestamp\":\"" + CREATED_ON_STRING + "\"\n" +
-                "   },{\n" +
-                "       \"filename\":\"$sanitize..blob..file\",\n" +
-                "       \"timestamp\":\"" + CREATED_ON_STRING + "\"\n" +
-                "   },{\n" +
-                "       \"filename\":\"$sanitize..json..file.json\",\n" +
-                "       \"timestamp\":\"" + CREATED_ON_STRING + "\"\n" +
                 "   }],\n" +
                 "   \"item\":\"non-survey-schema\",\n" +
                 "   \"schemaRevision\":2,\n" +
@@ -485,19 +452,12 @@ public class UploadHandlersEndToEndTest {
                 "   \"OOO\":\"2.718\",\n" +
                 "   \"PPP\":1337,\n" +
                 "   \"QQQ\":\"2016-06-03T19:21:35.378-0700\",\n" +
-                "   \"arrr\":\"2016-06-03T18:12:34.567+0900\",\n" +
-                "   \"$sanitize..this..field\":\"$text..values..don't..sanitize\"\n" +
+                "   \"arrr\":\"2016-06-03T18:12:34.567+0900\"\n" +
                 "}";
-
-        String sanitizeBlobFileContent = "#blob#file#not#sanitized..";
-
-        String sanitizeJsonFileContent = "[\"  json!@not#$sanitized  \"]";
 
         Map<String, String> fileMap = ImmutableMap.<String, String>builder().put("info.json", infoJsonText)
                 .put("CCC.txt", cccTxtContent).put("DDD.csv", dddCsvContent).put("EEE.json", eeeJsonContent)
                 .put("FFF.json", fffJsonContent).put("GGG.txt", gggTxtContent).put("record.json", recordJsonContent)
-                .put("$sanitize..blob..file", sanitizeBlobFileContent)
-                .put("$sanitize..json..file.json", sanitizeJsonFileContent)
                 .build();
 
         // execute
@@ -513,7 +473,7 @@ public class UploadHandlersEndToEndTest {
         assertEquals(2, record.getSchemaRevision());
 
         JsonNode dataNode = record.getData();
-        assertEquals(18, dataNode.size());
+        assertEquals(15, dataNode.size());
         assertTrue(dataNode.get("record.json.III").booleanValue());
         assertEquals("2016-06-03", dataNode.get("record.json.JJJ").textValue());
         assertEquals("PT1H", dataNode.get("record.json.LLL").textValue());
@@ -523,7 +483,6 @@ public class UploadHandlersEndToEndTest {
         assertEquals("19:21:35.378", dataNode.get("record.json.QQQ").textValue());
         assertEquals(DateTime.parse("2016-06-03T18:12:34.567+0900"),
                 DateTime.parse(dataNode.get("record.json.arrr").textValue()));
-        assertEquals("$text..values..don't..sanitize", dataNode.get("record.json._sanitize.this.field").textValue());
 
         JsonNode nnnNode = dataNode.get("record.json.NNN");
         assertEquals(2, nnnNode.size());
@@ -562,18 +521,10 @@ public class UploadHandlersEndToEndTest {
         assertEquals("inside", hhhNode.get(1).textValue());
         assertEquals("file", hhhNode.get(2).textValue());
 
-        String sanitizeBlobFileAttachmentId = dataNode.get("_sanitize.blob.file").textValue();
-        validateTextAttachment(sanitizeBlobFileContent, sanitizeBlobFileAttachmentId);
-
-        String sanitizeJsonFileAttachmentId = dataNode.get("_sanitize.json.file.json").textValue();
-        JsonNode sanitizeJsonNode = getAttachmentAsJson(sanitizeJsonFileAttachmentId);
-        assertEquals(1, sanitizeJsonNode.size());
-        assertEquals("  json!@not#$sanitized  ", sanitizeJsonNode.get(0).textValue());
-
         // verify attachments in HealthDataAttachments - Of all the attributes, the only one that actually matters is
         // the record ID
         ArgumentCaptor<HealthDataAttachment> attachmentCaptor = ArgumentCaptor.forClass(HealthDataAttachment.class);
-        verify(mockHealthDataService, times(8)).createOrUpdateAttachment(attachmentCaptor.capture());
+        verify(mockHealthDataService, times(6)).createOrUpdateAttachment(attachmentCaptor.capture());
         for (HealthDataAttachment oneAttachment : attachmentCaptor.getAllValues()) {
             assertEquals(RECORD_ID, oneAttachment.getRecordId());
         }


### PR DESCRIPTION
Fixed unit tests. We switched schema fields from a sanitization strategy to a validation strategy, but I neglected to fix a few unit tests.
