### PR TITLE
optimize Stormpath delete directory code

### DIFF
--- a/app/org/sagebionetworks/bridge/stormpath/StormpathDirectoryDao.java
+++ b/app/org/sagebionetworks/bridge/stormpath/StormpathDirectoryDao.java
@@ -131,23 +131,13 @@ public class StormpathDirectoryDao implements DirectoryDao {
         checkNotNull(study, Validate.CANNOT_BE_NULL, "study");
         Application app = getApplication();
         checkNotNull(app);
-        
-        Directory existing = getDirectoryForStudy(study);
-        
-        // delete the mapping
-        ApplicationAccountStoreMapping mapping = getApplicationMapping(existing.getHref(), app);
-        if (mapping != null) {
-            mapping.delete();
-        } else {
-            logger.warn("ApplicationAccountStoreMapping not found: " + app.getName() + ", " + existing.getHref());
-        }
 
         // delete the directory
-        Directory directory = client.getResource(existing.getHref(), Directory.class);
+        Directory directory = getDirectoryForStudy(study);
         if (directory != null) {
             directory.delete();
         } else {
-            logger.warn("Directory not found: " + existing.getHref());
+            logger.warn("Directory not found: " + study.getStormpathHref());
         }
     }
 

--- a/test/org/sagebionetworks/bridge/stormpath/StormpathDirectoryDaoTest.java
+++ b/test/org/sagebionetworks/bridge/stormpath/StormpathDirectoryDaoTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.stormpath;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
@@ -97,6 +98,7 @@ public class StormpathDirectoryDaoTest {
         directoryDao.deleteDirectoryForStudy(study);
         newDirectory = directoryDao.getDirectoryForStudy(study);
         assertNull("Directory has been deleted", newDirectory);
+        assertFalse("Mapping no longer exists", containsMapping(stormpathHref));
         
         study = null;
     }


### PR DESCRIPTION
See https://sagebionetworks.jira.com/browse/BRIDGE-1254

As per Stormpath support, it is not necessary to delete account store mappings before deleting a directory, as deleting a directory automatically deletes account store mappings.

Testing done:
- added a check to the unit tests to verify the mapping no longer exists after deleting
- ran StudyTest in integ tests to verify crudding studies still works
- manually checked Stormpath account mappings API to make sure there are no stray mappings attached to the application
