### PR TITLE
replace mysterious null pointer exception with comment and log error

### DIFF
--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -720,7 +720,14 @@ public class ParticipantServiceTest {
         assertEquals(EMAIL, participant.getEmail());
         assertEquals(ID, participant.getId());
     }
-    
+
+    // Contrived test case for a case that never happens, but somehow does.
+    // See https://sagebionetworks.jira.com/browse/BRIDGE-1463
+    @Test(expected = EntityNotFoundException.class)
+    public void getStudyParticipantWithoutAccountThrows404() {
+        participantService.getParticipant(STUDY, (Account) null, false);
+    }
+
     @Test
     public void requestResetPassword() {
         mockHealthCodeAndAccountRetrieval();


### PR DESCRIPTION
See https://sagebionetworks.jira.com/browse/BRIDGE-1463

Basically, race condition causes this code path to suddenly have a null account and fail with a null pointer exception. It now has a comment and a log error and throws a 404. Functionally the same, but slightly less mysterious.

I manually tested this by first adding a 15 second wait to the consentToResearch() call between the consent call and the getSession() call, then by adding a 5 second timeout to the the consentToResearch() call in the JavaSDK. Before the null-check, I got a NullPointerException and a 500. After the null-check, I got the log message and 404 as expected.

Other testing done:
- contrived unit test to exercise this null check
- AuthenticationTest, ConsentTest, and ParticipantsTest from integ test, to verify general functionality still works
