### PR TITLE
Remove request info for a user you are deleting.

### DIFF
--- a/app/org/sagebionetworks/bridge/cache/CacheProvider.java
+++ b/app/org/sagebionetworks/bridge/cache/CacheProvider.java
@@ -69,6 +69,17 @@ public class CacheProvider {
         }
     }
     
+    public void removeRequestInfo(String userId) {
+        checkNotNull(userId);
+        try {
+            final String requestInfoKey = RedisKey.REQUEST_INFO.getRedisKey(userId);
+            jedisOps.del(requestInfoKey);
+        } catch(Throwable e) {
+            promptToStartRedisIfLocal(e);
+            throw new BridgeServiceException(e);
+        }
+    }
+    
     private void setRequestInfo(RequestInfo requestInfo) {
         try {
             String ser = bridgeObjectMapper.writeValueAsString(requestInfo);

--- a/app/org/sagebionetworks/bridge/services/UserAdminService.java
+++ b/app/org/sagebionetworks/bridge/services/UserAdminService.java
@@ -179,6 +179,7 @@ public class UserAdminService {
             // remove this first so if account is partially deleted, re-authenticating will pick
             // up accurate information about the state of the account (as we can recover it)
             cacheProvider.removeSessionByUserId(account.getId());
+            cacheProvider.removeRequestInfo(account.getId());
             
             String healthCode = account.getHealthCode();
             healthDataService.deleteRecordsForHealthCode(healthCode);

--- a/test/org/sagebionetworks/bridge/cache/CacheProviderTest.java
+++ b/test/org/sagebionetworks/bridge/cache/CacheProviderTest.java
@@ -173,7 +173,7 @@ public class CacheProviderTest {
         
         // Data is combined in cache.
         RequestInfo combinedRequestInfo = cacheProvider.getRequestInfo(USER_ID);
-        assertEquals("userId", combinedRequestInfo.getUserId());
+        assertEquals(USER_ID, combinedRequestInfo.getUserId());
         assertEquals(USER_AGENT_STRING, combinedRequestInfo.getUserAgent());
         assertEquals(STUDY_ID, combinedRequestInfo.getStudyIdentifier());
         assertEquals(TestConstants.USER_DATA_GROUPS, combinedRequestInfo.getUserDataGroups());
@@ -181,6 +181,9 @@ public class CacheProviderTest {
         assertEquals(MST, combinedRequestInfo.getTimeZone());
         assertEquals(ACTIVITIES_REQUESTED_ON.withZone(MST), combinedRequestInfo.getActivitiesAccessedOn());
         assertEquals(SIGNED_IN_ON.withZone(MST), combinedRequestInfo.getSignedInOn());
+        
+        cacheProvider.removeRequestInfo(USER_ID);
+        assertNull(cacheProvider.getRequestInfo(USER_ID));
     }
     
 }

--- a/test/org/sagebionetworks/bridge/services/UserAdminServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/UserAdminServiceMockTest.java
@@ -188,6 +188,7 @@ public class UserAdminServiceMockTest {
         
         // Verify a lot of stuff is deleted or removed
         verify(cacheProvider).removeSessionByUserId("userId");
+        verify(cacheProvider).removeRequestInfo("userId");
         verify(healthDataService).deleteRecordsForHealthCode("healthCode");
         verify(uploadService).deleteUploadsForHealthCode("healthCode");
         verify(scheduledActivityService).deleteActivitiesForUser("healthCode");


### PR DESCRIPTION
We don't want test users to starve memory over a long period of time.
