### PR TITLE
add extra logging to AsyncBackfillTemplateTest

### DIFF
--- a/test/org/sagebionetworks/bridge/services/backfill/AsyncBackfillTemplateTest.java
+++ b/test/org/sagebionetworks/bridge/services/backfill/AsyncBackfillTemplateTest.java
@@ -153,7 +153,7 @@ public class AsyncBackfillTemplateTest {
                 // goes back for the duration of lock expiration
                 long lower = beforeBackfill - expireInMillis;
                 long upper = afterBackfill - expireInMillis;
-                if (lower < since && since < upper) {
+                if (lower <= since && since <= upper) {
                     return true;
                 } else {
                     LOG.error("getTasks() expected to be called with a time between " + lower + " and " + upper +


### PR DESCRIPTION
This test seems to fail a lot, often enough to be noticeable and force retries in Travis.

This change adds extra logging so that when it does fail, we'll have some idea of what went wrong.
