### PR TITLE
tweak New Relic configs

### DIFF
--- a/newrelic.yml
+++ b/newrelic.yml
@@ -11,8 +11,10 @@ common: &default_settings
 
   app_name: BridgePF
   enable_auto_app_naming: true
-  enable_auto_transaction_naming: false
-  log_file_name: newrelic_agent.log
+  enable_auto_transaction_naming: true
+
+  # Log to stdout because Heroku doesn't support writing logs to disk.
+  log_file_name: STDOUT
 
   # The levels in increasing order of verboseness are:
   #   off, severe, warning, info, fine, finer, finest


### PR DESCRIPTION
There are a few New Relic configs that must be done through config change, not through New Relic UI.

The two changes here:
1. enable_auto_transaction_naming: true - This allows New Relic to track requests using Play Controller and method names (UploadController.createUpload) instead of URLs. This should hopefully be friendlier to use and less error prone.
2. Log to stdout instead of log file. Heroku doesn't support logging to a file. Not sure if New Relic logs are being blackholed right now or if they're already being forwarded to stdout. Either way, explicitly sending them to stdout is an improvement.

Testing done: Unfortunately, this can't be tested locally. Fortunately, this is the New Relic config we were using before we upgraded to an unsupported version of Play, so they _should_ still be working.
