### PR TITLE
Changes to improve client libraries/documentation

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
@@ -24,6 +24,7 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.springframework.stereotype.Controller;
 
+import play.mvc.BodyParser;
 import play.mvc.Result;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -35,6 +36,7 @@ public class AuthenticationController extends BaseController {
         return signInWithRetry(5);
     }
 
+    @BodyParser.Of(BodyParser.Empty.class)
     public Result signOut() throws Exception {
         final UserSession session = getSessionIfItExists();
         if (session != null) {

--- a/app/org/sagebionetworks/bridge/play/controllers/ConsentController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ConsentController.java
@@ -20,6 +20,7 @@ import org.sagebionetworks.bridge.services.ParticipantOptionsService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 
+import play.mvc.BodyParser;
 import play.mvc.Result;
 
 @Controller
@@ -131,6 +132,7 @@ public class ConsentController extends BaseController {
         return okResult("User has been withdrawn from the study.");
     }
     
+    @BodyParser.Of(BodyParser.Empty.class)
     public Result emailCopyV2(String guid) {
         final UserSession session = getAuthenticatedAndConsentedSession();
         final Study study = studyService.getStudy(session.getStudyIdentifier());

--- a/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.common.collect.Sets;
 
+import play.mvc.BodyParser;
 import play.mvc.Result;
 
 @Controller
@@ -148,6 +149,7 @@ public class ParticipantController extends BaseController {
         return okResult("Participant updated.");
     }
     
+    @BodyParser.Of(BodyParser.Empty.class)
     public Result signOut(String userId) throws Exception {
         UserSession session = getAuthenticatedSession(RESEARCHER);
         Study study = studyService.getStudy(session.getStudyIdentifier());

--- a/app/org/sagebionetworks/bridge/play/controllers/StudyConsentController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/StudyConsentController.java
@@ -19,6 +19,7 @@ import org.sagebionetworks.bridge.services.SubpopulationService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 
+import play.mvc.BodyParser;
 import play.mvc.Result;
 
 @Controller
@@ -140,6 +141,7 @@ public class StudyConsentController extends BaseController {
         return createdResult(studyConsent);
     }
 
+    @BodyParser.Of(BodyParser.Empty.class)
     public Result publishConsentV2(String guid, String createdOn) throws Exception {
         UserSession session = getAuthenticatedSession(DEVELOPER);
         Study study = studyService.getStudy(session.getStudyIdentifier());

--- a/app/org/sagebionetworks/bridge/play/controllers/StudyController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/StudyController.java
@@ -28,6 +28,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 
 import play.libs.Json;
+import play.mvc.BodyParser;
 import play.mvc.Result;
 
 import static org.sagebionetworks.bridge.Roles.*;
@@ -105,9 +106,11 @@ public class StudyController extends BaseController {
         return ok(Study.STUDY_WRITER.writeValueAsString(study));
     }
 
-    public Result getAllStudies(String format) throws Exception {
+    // You can get a truncated view of studies with either format=summary or summary=true; 
+    // the latter allows us to make this a boolean flag in the Java client libraries.
+    public Result getAllStudies(String format, String summary) throws Exception {
         List<Study> studies = studyService.getStudies();
-        if ("summary".equals(format)) {
+        if ("summary".equals(format) || "true".equals(summary)) {
             Collections.sort(studies, STUDY_COMPARATOR);
             return ok(Study.STUDY_LIST_WRITER.writeValueAsString(new ResourceList<Study>(studies)));
         }
@@ -149,6 +152,7 @@ public class StudyController extends BaseController {
         return okResult(new EmailVerificationStatusHolder(status));
     }
     
+    @BodyParser.Of(BodyParser.Empty.class)
     public Result verifyEmail() throws Exception {
         UserSession session = getAuthenticatedSession(DEVELOPER);
         Study study = studyService.getStudy(session.getStudyIdentifier());

--- a/app/org/sagebionetworks/bridge/play/controllers/SurveyController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/SurveyController.java
@@ -26,6 +26,7 @@ import org.sagebionetworks.bridge.services.SurveyService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 
+import play.mvc.BodyParser;
 import play.mvc.Result;
 
 import com.google.common.base.Supplier;
@@ -207,6 +208,7 @@ public class SurveyController extends BaseController {
         return createdResult(new GuidCreatedOnVersionHolderImpl(survey));
     }
     
+    @BodyParser.Of(BodyParser.Empty.class)
     public Result versionSurvey(String surveyGuid, String createdOnString) throws Exception {
         UserSession session = getAuthenticatedSession(DEVELOPER);
         StudyIdentifier studyId = session.getStudyIdentifier();
@@ -239,6 +241,7 @@ public class SurveyController extends BaseController {
         return okResult(new GuidCreatedOnVersionHolderImpl(survey));
     }
     
+    @BodyParser.Of(BodyParser.Empty.class)
     public Result publishSurvey(String surveyGuid, String createdOnString, String newSchemaRev) throws Exception {
         UserSession session = getAuthenticatedSession(DEVELOPER);
         StudyIdentifier studyId = session.getStudyIdentifier();

--- a/app/org/sagebionetworks/bridge/play/controllers/UploadController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/UploadController.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 
+import play.mvc.BodyParser;
 import play.mvc.Result;
 
 @Controller
@@ -72,8 +73,8 @@ public class UploadController extends BaseController {
      * Signals to the Bridge server that the upload is complete. This kicks off the asynchronous validation process
      * through the Upload Validation Service.
      */
+    @BodyParser.Of(BodyParser.Empty.class)
     public Result uploadComplete(String uploadId) throws Exception {
-
         final Metrics metrics = getMetrics();
         if (metrics != null) {
             metrics.setUploadId(uploadId);

--- a/app/org/sagebionetworks/bridge/play/controllers/UserDataDownloadController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/UserDataDownloadController.java
@@ -1,6 +1,10 @@
 package org.sagebionetworks.bridge.play.controllers;
 
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.joda.time.LocalDate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import play.mvc.Result;
@@ -25,12 +29,16 @@ public class UserDataDownloadController extends BaseController {
      * Play handler for requesting user data. User must be authenticated and consented. (Otherwise, they couldn't have
      * any data to download to begin with.)
      */
-    public Result requestUserData() throws JsonProcessingException {
+    public Result requestUserData(String startDate, String endDate) throws JsonProcessingException {
         UserSession session = getAuthenticatedAndConsentedSession();
-
         StudyIdentifier studyIdentifier = session.getStudyIdentifier();
-        DateRange dateRange = parseJson(request(), DateRange.class);
-
+        
+        DateRange dateRange = null;
+        if (isNotBlank(startDate) && isNotBlank(endDate)) {
+            dateRange = new DateRange(LocalDate.parse(startDate), LocalDate.parse(endDate));
+        } else {
+            dateRange = parseJson(request(), DateRange.class);    
+        }
         userDataDownloadService.requestUserData(studyIdentifier, session.getParticipant().getEmail(), dateRange);
         return acceptedResult("Request submitted.");
     }

--- a/conf/routes
+++ b/conf/routes
@@ -68,7 +68,7 @@ DELETE /v3/users/:userId                  @org.sagebionetworks.bridge.play.contr
 GET    /v3/users/self                     @org.sagebionetworks.bridge.play.controllers.UserProfileController.getUserProfile
 POST   /v3/users/self                     @org.sagebionetworks.bridge.play.controllers.UserProfileController.updateUserProfile
 POST   /v3/users/self/externalId          @org.sagebionetworks.bridge.play.controllers.UserProfileController.createExternalIdentifier
-POST   /v3/users/self/emailData           @org.sagebionetworks.bridge.play.controllers.UserDataDownloadController.requestUserData
+POST   /v3/users/self/emailData           @org.sagebionetworks.bridge.play.controllers.UserDataDownloadController.requestUserData(startDate: String ?= null, endDate: String ?= null)
 GET    /v3/users/self/unsubscribeEmail    @org.sagebionetworks.bridge.play.controllers.EmailController.unsubscribeFromEmail
 POST   /v3/users/self/unsubscribeEmail    @org.sagebionetworks.bridge.play.controllers.EmailController.unsubscribeFromEmail
 POST   /v3/users/self/dataSharing         @org.sagebionetworks.bridge.play.controllers.ConsentController.changeSharingScope
@@ -140,7 +140,7 @@ DELETE /v3/scheduleplans/:guid     @org.sagebionetworks.bridge.play.controllers.
 POST /v3/recordexportstatuses      @org.sagebionetworks.bridge.play.controllers.HealthDataController.updateRecordsStatus
 
 # Studies
-GET    /v3/studies                  @org.sagebionetworks.bridge.play.controllers.StudyController.getAllStudies(format: String ?= null)
+GET    /v3/studies                  @org.sagebionetworks.bridge.play.controllers.StudyController.getAllStudies(format: String ?= null, summary: String ?= null)
 POST   /v3/studies                  @org.sagebionetworks.bridge.play.controllers.StudyController.createStudy 
 GET    /v3/studies/self             @org.sagebionetworks.bridge.play.controllers.StudyController.getCurrentStudy
 GET    /v3/studies/self/publicKey   @org.sagebionetworks.bridge.play.controllers.StudyController.getStudyPublicKeyAsPem

--- a/test/org/sagebionetworks/bridge/play/controllers/ConsentControllerMockedTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ConsentControllerMockedTest.java
@@ -386,7 +386,7 @@ public class ConsentControllerMockedTest {
                 new Withdrawal(null), 20000);
         DateTimeUtils.setCurrentMillisSystem();
     }
-
+    
     private void validateSignature(ConsentSignature signature) {
         assertEquals(UNIX_TIMESTAMP, signature.getSignedOn());
         assertEquals("Jack Aubrey", signature.getName());

--- a/test/org/sagebionetworks/bridge/play/controllers/UserDataDownloadControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/UserDataDownloadControllerTest.java
@@ -3,12 +3,17 @@ package org.sagebionetworks.bridge.play.controllers;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
 import play.mvc.Result;
 
 import org.sagebionetworks.bridge.TestUtils;
@@ -19,18 +24,35 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.services.UserDataDownloadService;
 
+@RunWith(MockitoJUnitRunner.class)
 public class UserDataDownloadControllerTest {
+    
+    private StudyIdentifier studyIdentifier = new StudyIdentifierImpl("test-study");
+    
+    @Mock
+    UserSession mockSession;
+    
+    @Mock
+    UserDataDownloadService mockService;
+    
+    @Spy
+    UserDataDownloadController controller;
+    
+    @Captor
+    ArgumentCaptor<DateRange> dateRangeCaptor;
+    
+    @Before
+    public void before() throws Exception {
+        doReturn(studyIdentifier).when(mockSession).getStudyIdentifier();
+        doReturn(new StudyParticipant.Builder().withEmail("email@email.com").build()).when(mockSession).getParticipant();
+
+        controller.setUserDataDownloadService(mockService);
+        doReturn(mockSession).when(controller).getAuthenticatedAndConsentedSession();
+    }
+    
     @Test
     public void test() throws Exception {
         // test strategy is to make sure args get pulled from the controller context and passed into the inner service
-
-        // mock session
-        StudyIdentifier studyIdentifier = new StudyIdentifierImpl("test-study");
-
-        UserSession mockSession = new UserSession();
-        mockSession.setStudyIdentifier(studyIdentifier);
-        mockSession.setParticipant(new StudyParticipant.Builder().withEmail("email@email.com").build());
-
         // mock request JSON
         String dateRangeJsonText = "{\n" +
                 "   \"startDate\":\"2015-08-15\",\n" +
@@ -38,25 +60,29 @@ public class UserDataDownloadControllerTest {
                 "}";
         TestUtils.mockPlayContextWithJson(dateRangeJsonText);
 
-        // mock service
-        UserDataDownloadService mockService = mock(UserDataDownloadService.class);
-
-        // spy controller
-        UserDataDownloadController controller = spy(new UserDataDownloadController());
-        controller.setUserDataDownloadService(mockService);
-        doReturn(mockSession).when(controller).getAuthenticatedAndConsentedSession();
-
         // execute and validate
-        Result result = controller.requestUserData();
+        Result result = controller.requestUserData(null, null);
         assertEquals(202, result.status());
 
+        verify(mockService).requestUserData(eq(studyIdentifier), eq("email@email.com"), dateRangeCaptor.capture());
+        
         // validate args sent to mock service
-        ArgumentCaptor<DateRange> dateRangeCaptor = ArgumentCaptor.forClass(DateRange.class);
-        verify(mockService).requestUserData(eq(studyIdentifier), eq(mockSession.getParticipant().getEmail()),
-                dateRangeCaptor.capture());
-
         DateRange dateRange = dateRangeCaptor.getValue();
         assertEquals("2015-08-15", dateRange.getStartDate().toString());
         assertEquals("2015-08-19", dateRange.getEndDate().toString());
     }
+    
+    @Test
+    public void testQueryParameters() throws Exception {
+        Result result = controller.requestUserData("2015-08-15", "2015-08-19");
+        assertEquals(202, result.status());
+
+        verify(mockService).requestUserData(eq(studyIdentifier), eq("email@email.com"), dateRangeCaptor.capture());
+        
+        // validate args sent to mock service
+        DateRange dateRange = dateRangeCaptor.getValue();
+        assertEquals("2015-08-15", dateRange.getStartDate().toString());
+        assertEquals("2015-08-19", dateRange.getEndDate().toString());
+    }
+    
 }

--- a/test/org/sagebionetworks/bridge/services/UserAdminServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/UserAdminServiceTest.java
@@ -20,7 +20,6 @@ import org.junit.runner.RunWith;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.config.BridgeConfig;
 import org.sagebionetworks.bridge.dynamodb.DynamoExternalIdentifier;
-import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;


### PR DESCRIPTION
- Annotated POST calls that have no BODY JSON so this no longer throws an exception (and can be removed from the client libraries/documentation);
- Added query string parameters to the download user data request
- Made call to get study summaries also take a boolean parameter