### PR TITLE
This works, going to look at setting events to always use UTC.

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivity.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivity.java
@@ -12,6 +12,7 @@ import org.sagebionetworks.bridge.json.DateTimeToLongSerializer;
 import org.sagebionetworks.bridge.json.JsonUtils;
 import org.sagebionetworks.bridge.models.BridgeEntity;
 import org.sagebionetworks.bridge.models.schedules.Activity;
+import org.sagebionetworks.bridge.models.schedules.Schedule;
 import org.sagebionetworks.bridge.models.schedules.ScheduledActivity;
 import org.sagebionetworks.bridge.models.schedules.ScheduledActivityStatus;
 
@@ -47,6 +48,7 @@ public final class DynamoScheduledActivity implements ScheduledActivity, BridgeE
     private Activity activity;
     private boolean persistent;
     private DateTimeZone timeZone;
+    private Schedule schedule;
 
     @Override
     @DynamoDBIgnore
@@ -93,6 +95,17 @@ public final class DynamoScheduledActivity implements ScheduledActivity, BridgeE
     @Override
     public void setScheduledOn(DateTime scheduledOn) {
         this.localScheduledOn = (scheduledOn == null) ? null : scheduledOn.toLocalDateTime();
+    }
+    
+    @Override
+    @DynamoDBIgnore
+    @JsonIgnore
+    public Schedule getSchedule() {
+        return schedule;
+    }
+    
+    public void setSchedule(Schedule schedule) {
+        this.schedule = schedule;
     }
 
     @Override

--- a/app/org/sagebionetworks/bridge/models/schedules/ActivityScheduler.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/ActivityScheduler.java
@@ -6,6 +6,7 @@ import static org.sagebionetworks.bridge.models.schedules.ScheduleType.ONCE;
 import java.util.List;
 
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.joda.time.LocalTime;
 
 public abstract class ActivityScheduler {
@@ -61,9 +62,11 @@ public abstract class ActivityScheduler {
      * the rare event someone tries it.
      */
     protected DateTime adjustOnceIntervalActivityWithNoTimes(ScheduleContext context, DateTime scheduledTime) {
-        // We already know there are no times... but in case this is ever called in another sequence, do check it
-        if (schedule.getTimes().isEmpty() && schedule.getScheduleType() == ScheduleType.ONCE && schedule.getCronTrigger() == null) {
-            return new DateTime(scheduledTime, context.getZone()).withTime(LocalTime.MIDNIGHT);
+        // We already know there are no times... but in case this is ever called in another sequence, do check it.
+        // Normalize to UTC minus one day from enrollment, to ensure no matter where user is at the time of request,
+        // the one-time activity is available.
+        if (ScheduledActivity.isOnceTaskWithoutTimes(schedule)) {
+            return ScheduledActivity.eventToPriorUTCMidnight(scheduledTime);
         }
         return scheduledTime;
     }

--- a/app/org/sagebionetworks/bridge/models/schedules/Schedule.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/Schedule.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Objects;
 
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.joda.time.LocalTime;
 import org.joda.time.Period;
 import org.sagebionetworks.bridge.models.BridgeEntity;

--- a/app/org/sagebionetworks/bridge/models/schedules/ScheduledActivity.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/ScheduledActivity.java
@@ -36,7 +36,7 @@ public interface ScheduledActivity extends BridgeEntity {
         return new DynamoScheduledActivity();
     }
 
-    // Sorts in reverse order.
+    // Sorts in temporal order, oldest to newest activity, labels alphabetically if at the same moment in time.
     Comparator<ScheduledActivity> SCHEDULED_ACTIVITY_COMPARATOR = new Comparator<ScheduledActivity>() {
         @Override
         public int compare(ScheduledActivity scheduledActivity1, ScheduledActivity scheduledActivity2) {
@@ -61,6 +61,15 @@ public interface ScheduledActivity extends BridgeEntity {
 
     ScheduledActivityStatus getStatus();
 
+    /**
+     * BRIDGE-1589. Carry over the schedule used to generate a ScheduledActivity in order to infer one-time tasks 
+     * that may have been duplicated as a result of scheduling from enrollment in a particular time zone. This 
+     * schedule is not persisted or returned to the user.
+     */
+    Schedule getSchedule();
+    
+    void setSchedule(Schedule schedule);
+    
     /**
      * Get the time zone for this request. Currently this is a field on the activity and must be set to get DateTime values
      * from other fields in the class. This forces one method of converting schedule times to local times in order to

--- a/app/org/sagebionetworks/bridge/models/schedules/ScheduledActivity.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/ScheduledActivity.java
@@ -4,6 +4,8 @@ import java.util.Comparator;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.joda.time.LocalTime;
+
 import org.sagebionetworks.bridge.dynamodb.DynamoScheduledActivity;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.BridgeEntity;
@@ -15,7 +17,17 @@ import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
 @JsonDeserialize(as = DynamoScheduledActivity.class)
 public interface ScheduledActivity extends BridgeEntity {
-
+    
+    public static boolean isOnceTaskWithoutTimes(Schedule schedule) {
+        return (schedule.getTimes().isEmpty() && 
+                schedule.getScheduleType() == ScheduleType.ONCE && 
+                schedule.getCronTrigger() == null);
+    }
+    
+    public static DateTime eventToPriorUTCMidnight(DateTime dateTime) {
+        return new DateTime(dateTime, DateTimeZone.UTC).minusDays(1).withTime(LocalTime.MIDNIGHT);
+    }
+    
     /**
      * Due to the use of the DynamoIndexHelper, which uses JSON deserialization to recover object
      * structure, we do not use @JsonIgnore annotation on DynamoScheduledActivity. Instead, we 

--- a/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
+++ b/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
@@ -103,10 +103,7 @@ public class ScheduledActivityService {
             return Collections.emptySet();
         }
         return scheduledActivities.stream().filter(act -> {
-            Schedule schedule = act.getSchedule();
-            return schedule.getScheduleType() == ScheduleType.ONCE && 
-                   schedule.getTimes().isEmpty() && 
-                   schedule.getCronTrigger() == null;
+            return ScheduledActivity.isOnceTaskWithoutTimes(act.getSchedule());
         }).map(ScheduledActivity::getSchedulePlanGuid).collect(toSet());
     }
     
@@ -122,7 +119,7 @@ public class ScheduledActivityService {
         for (int i=0; i < dbActivities.size(); i++) {
             ScheduledActivity activity = dbActivities.get(i);
             if (oneTimeSchedulePlans.contains(activity.getSchedulePlanGuid())) {
-                DateTime dateTime = activity.getScheduledOn().withTime(LocalTime.MIDNIGHT);
+                DateTime dateTime = ScheduledActivity.eventToPriorUTCMidnight(activity.getScheduledOn());
                 String guid = activity.getActivity().getGuid() + ":" + dateTime.toLocalDateTime().toString();
                 activity.setScheduledOn(dateTime);
                 activity.setGuid(guid);

--- a/test/org/sagebionetworks/bridge/DateTimeTest.java
+++ b/test/org/sagebionetworks/bridge/DateTimeTest.java
@@ -1,0 +1,21 @@
+package org.sagebionetworks.bridge;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Test;
+
+public class DateTimeTest {
+
+    @Test
+    public void test() {
+        DateTime now = DateTime.now();
+        System.out.println("now: "+ now);
+        
+        DateTime second = now.withZone(DateTimeZone.UTC);
+        System.out.println("second: " + second);
+        
+        DateTime third = second.minusDays(2);
+        System.out.println("third: " + third);
+    }
+    
+}

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityTest.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge.dynamodb;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Collections;
@@ -29,7 +30,8 @@ public class DynamoScheduledActivityTest {
 
     @Test
     public void equalsHashCode() {
-        EqualsVerifier.forClass(DynamoScheduledActivity.class).suppress(Warning.NONFINAL_FIELDS).allFieldsShouldBeUsed().verify();
+        EqualsVerifier.forClass(DynamoScheduledActivity.class).suppress(Warning.NONFINAL_FIELDS)
+                .allFieldsShouldBeUsedExcept("schedule").verify();
     }
 
     @Test
@@ -106,7 +108,7 @@ public class DynamoScheduledActivityTest {
         
         BridgeObjectMapper mapper = BridgeObjectMapper.get();
         String output = ScheduledActivity.SCHEDULED_ACTIVITY_WRITER.writeValueAsString(schActivity);
-        
+
         JsonNode node = mapper.readTree(output);
         assertEquals("AAA-BBB-CCC", node.get("guid").asText());
         assertEquals(scheduledOnString, node.get("scheduledOn").asText());
@@ -114,6 +116,7 @@ public class DynamoScheduledActivityTest {
         assertEquals("scheduled", node.get("status").asText());
         assertEquals("ScheduledActivity", node.get("type").asText());
         assertTrue(node.get("persistent").asBoolean());
+        assertNull(node.get("schedule"));
         
         JsonNode activityNode = node.get("activity");
         assertEquals("Activity3", activityNode.get("label").asText());

--- a/test/org/sagebionetworks/bridge/models/schedules/IntervalActivitySchedulerTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/IntervalActivitySchedulerTest.java
@@ -277,7 +277,8 @@ public class IntervalActivitySchedulerTest {
         
         events.put("survey:AAA:completedOn", asDT("2015-04-02 09:22"));
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(6)));
-        assertDates(scheduledActivities, "2015-04-02 00:00");
+        // Pulled back to yesterday midnight to avoid TZ changes causing activity to be unavailable
+        assertDates(scheduledActivities, "2015-04-01 00:00");
     }
     @Test
     public void onceEventDelayExpiresStartEndsOnScheduleWorks() {
@@ -298,7 +299,11 @@ public class IntervalActivitySchedulerTest {
         
         events.put("survey:AAA:completedOn", asDT("2015-04-06 09:22"));
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(6)));
-        assertEquals(asLong("2015-04-06 00:00"), scheduledActivities.get(0).getScheduledOn().getMillis());
+        
+        System.out.println(scheduledActivities.get(0).getScheduledOn());
+        System.out.println(scheduledActivities.get(0).getExpiresOn());
+        
+        assertEquals(asLong("2015-04-04 00:00"), scheduledActivities.get(0).getScheduledOn().getMillis());
         assertEquals(asLong("2015-04-09 00:00"), scheduledActivities.get(0).getExpiresOn().getMillis());
     }
     @Test

--- a/test/org/sagebionetworks/bridge/models/schedules/IntervalActivitySchedulerTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/IntervalActivitySchedulerTest.java
@@ -180,7 +180,7 @@ public class IntervalActivitySchedulerTest {
         
         schedule.getTimes().clear();
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(1)));
-        assertDates(scheduledActivities, "2015-04-10 11:40");
+        assertDates(scheduledActivities, "2015-04-10 00:00");
     }
     @Test
     public void onceEventStartsOnScheduleWorks() {
@@ -237,7 +237,7 @@ public class IntervalActivitySchedulerTest {
         // If we delete the times, it delays exactly 50 hours. (2 days, 2 hours)
         schedule.getTimes().clear();
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(1)));
-        assertDates(scheduledActivities, "2015-04-04 11:22");
+        assertDates(scheduledActivities, "2015-04-04 00:00");
     }
     @Test
     public void onceEventDelayStartsOnScheduleWorks() {
@@ -277,7 +277,7 @@ public class IntervalActivitySchedulerTest {
         
         events.put("survey:AAA:completedOn", asDT("2015-04-02 09:22"));
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(6)));
-        assertDates(scheduledActivities, "2015-04-02 12:22");
+        assertDates(scheduledActivities, "2015-04-02 00:00");
     }
     @Test
     public void onceEventDelayExpiresStartEndsOnScheduleWorks() {
@@ -298,8 +298,8 @@ public class IntervalActivitySchedulerTest {
         
         events.put("survey:AAA:completedOn", asDT("2015-04-06 09:22"));
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(6)));
-        assertEquals(asLong("2015-04-06 12:22"), scheduledActivities.get(0).getScheduledOn().getMillis());
-        assertEquals(asLong("2015-04-09 12:22"), scheduledActivities.get(0).getExpiresOn().getMillis());
+        assertEquals(asLong("2015-04-06 00:00"), scheduledActivities.get(0).getScheduledOn().getMillis());
+        assertEquals(asLong("2015-04-09 00:00"), scheduledActivities.get(0).getExpiresOn().getMillis());
     }
     @Test
     public void recurringScheduleWorks() {

--- a/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceDuplicateTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceDuplicateTest.java
@@ -1,0 +1,181 @@
+package org.sagebionetworks.bridge.services;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import org.sagebionetworks.bridge.dao.ScheduledActivityDao;
+import org.sagebionetworks.bridge.models.schedules.Activity;
+import org.sagebionetworks.bridge.models.schedules.Schedule;
+import org.sagebionetworks.bridge.models.schedules.ScheduleContext;
+import org.sagebionetworks.bridge.models.schedules.ScheduleType;
+import org.sagebionetworks.bridge.models.schedules.ScheduledActivity;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ScheduledActivityServiceDuplicateTest {
+    
+    private static final String TEST_STUDY_ID = "test-study";
+    private static final String HEALTH_CODE = "healthCode";
+    private static final String USER_ID = "userId";
+    private static final DateTime ENROLLMENT = DateTime.now();
+    private static final String SCHEDULE_PLAN_GUID = "ABC";
+    
+    @Mock
+    ScheduledActivityDao activityDao;
+    
+    @Mock
+    ActivityEventService activityEventService;
+    
+    @Spy
+    ScheduledActivityService service;
+    
+    ScheduleContext context;
+    
+    @Before
+    public void before() {
+        service.setScheduledActivityDao(activityDao);
+        service.setActivityEventService(activityEventService);
+        
+        // Mock activityEventService
+        Map<String,DateTime> events = new ImmutableMap.Builder<String, DateTime>().put("enrollment",ENROLLMENT).build();
+        doReturn(events).when(activityEventService).getActivityEventMap(HEALTH_CODE);
+        
+        context = new ScheduleContext.Builder()
+                .withStudyIdentifier(TEST_STUDY_ID)
+                .withEndsOn(DateTime.now().plusDays(2).withTimeAtStartOfDay())
+                .withTimeZone(DateTimeZone.UTC)
+                .withHealthCode(HEALTH_CODE)
+                .withUserId(USER_ID)
+                .withAccountCreatedOn(ENROLLMENT.minusHours(2))
+                .build();
+    }
+    
+    // BRIDGE-1589, using duplicates generated for Erin Mount's Lily account (user 1232)
+    @Test
+    public void testExistingDuplicationScenario() {
+        Schedule schedule = new Schedule();
+        schedule.setScheduleType(ScheduleType.ONCE);
+        
+        // Duplicated persisted activities.
+        ScheduledActivity background = activity(schedule, "actGuid1", DateTime.parse("2016-06-30T11:43:07.951"), false);
+        ScheduledActivity backgroundDup = activity(schedule, "actGuid1", DateTime.parse("2016-06-30T12:43:07.951"), false);
+        ScheduledActivity train1 = activity(schedule, "actGuid2", DateTime.parse("2016-06-30T11:43:07.951"), false);
+        ScheduledActivity train1Dup = activity(schedule, "actGuid2", DateTime.parse("2016-06-30T12:43:07.951"), false);
+        ScheduledActivity train2 = activity(schedule, "actGuid3", DateTime.parse("2016-06-30T11:43:07.951"), false);
+        // this one will have been started... we should de-duplicate to include this activity
+        ScheduledActivity train2Dup = activity(schedule, "actGuid3", DateTime.parse("2016-06-30T12:43:07.951"), true);
+        List<ScheduledActivity> dbActivities = Lists.newArrayList(background, backgroundDup, train1, train1Dup, train2,
+                train2Dup);
+        doReturn(dbActivities).when(activityDao).getActivities(any(), any());
+        
+        // Correctly scheduled one-time tasks coming from scheduler
+        ScheduledActivity act1 = activity(schedule, "actGuid1", DateTime.parse("2016-06-30T00:00:00.000"), false);
+        ScheduledActivity act2 = activity(schedule, "actGuid2", DateTime.parse("2016-06-30T00:00:00.000"), false);
+        ScheduledActivity act3 = activity(schedule, "actGuid3", DateTime.parse("2016-06-30T00:00:00.000"), false);
+        List<ScheduledActivity> schedulerActivities = Lists.newArrayList(act1, act2, act3);
+        doReturn(schedulerActivities).when(service).scheduleActivitiesForPlans(any());
+
+        List<ScheduledActivity> activities = service.getScheduledActivities(context);
+        
+        // There should only be 3 activities, and the actGuid3 activity should have selected the db version with state
+        assertEquals(3, activities.size());
+        assertEquals(1, filterByGuid(activities, "actGuid1").size());
+        assertEquals(1, filterByGuid(activities, "actGuid2").size());
+        assertEquals(1, filterByGuid(activities, "actGuid3").size());
+        assertTrue(filterByGuid(activities, "actGuid3").get(0).getStartedOn() != null);
+    }
+    
+    @Test
+    public void testExistingCorrectScenario() {
+        Schedule schedule = new Schedule();
+        schedule.setScheduleType(ScheduleType.ONCE);
+        
+        // Duplicated persisted activities.
+        ScheduledActivity background = activity(schedule, "actGuid1", DateTime.parse("2016-06-30T00:00:00.000"), false);
+        ScheduledActivity train1 = activity(schedule, "actGuid2", DateTime.parse("2016-06-30T00:00:00.000"), false);
+        ScheduledActivity train2 = activity(schedule, "actGuid3", DateTime.parse("2016-06-30T00:00:00.000"), true);
+        List<ScheduledActivity> dbActivities = Lists.newArrayList(background, train1, train2);
+        doReturn(dbActivities).when(activityDao).getActivities(any(), any());
+        
+        // Correctly scheduled one-time tasks coming from scheduler
+        ScheduledActivity act1 = activity(schedule, "actGuid1", DateTime.parse("2016-06-30T00:00:00.000"), false);
+        ScheduledActivity act2 = activity(schedule, "actGuid2", DateTime.parse("2016-06-30T00:00:00.000"), false);
+        ScheduledActivity act3 = activity(schedule, "actGuid3", DateTime.parse("2016-06-30T00:00:00.000"), false);
+        List<ScheduledActivity> schedulerActivities = Lists.newArrayList(act1, act2, act3);
+        doReturn(schedulerActivities).when(service).scheduleActivitiesForPlans(any());
+
+        List<ScheduledActivity> activities = service.getScheduledActivities(context);
+        
+        // There should only be 3 activities, and the actGuid3 activity should have selected the db version with state
+        assertEquals(3, activities.size());
+        assertEquals(1, filterByGuid(activities, "actGuid1").size());
+        assertEquals(1, filterByGuid(activities, "actGuid2").size());
+        assertEquals(1, filterByGuid(activities, "actGuid3").size());
+        assertTrue(filterByGuid(activities, "actGuid3").get(0).getStartedOn() != null);
+    }
+
+    @Test
+    public void testNothingPersistedScenario() {
+        Schedule schedule = new Schedule();
+        schedule.setScheduleType(ScheduleType.ONCE);
+        
+        // Duplicated persisted activities.
+        List<ScheduledActivity> dbActivities = Lists.newArrayList();
+        doReturn(dbActivities).when(activityDao).getActivities(any(), any());
+        
+        // Correctly scheduled one-time tasks coming from scheduler
+        ScheduledActivity act1 = activity(schedule, "actGuid1", DateTime.parse("2016-06-30T00:00:00.000"), false);
+        ScheduledActivity act2 = activity(schedule, "actGuid2", DateTime.parse("2016-06-30T00:00:00.000"), false);
+        ScheduledActivity act3 = activity(schedule, "actGuid3", DateTime.parse("2016-06-30T00:00:00.000"), false);
+        List<ScheduledActivity> schedulerActivities = Lists.newArrayList(act1, act2, act3);
+        doReturn(schedulerActivities).when(service).scheduleActivitiesForPlans(any());
+
+        List<ScheduledActivity> activities = service.getScheduledActivities(context);
+        
+        // There should only be 3 activities, and the actGuid3 activity should have selected the db version with state
+        assertEquals(3, activities.size());
+        assertEquals(1, filterByGuid(activities, "actGuid1").size());
+        assertEquals(1, filterByGuid(activities, "actGuid2").size());
+        assertEquals(1, filterByGuid(activities, "actGuid3").size());
+    }
+
+    
+    private List<ScheduledActivity> filterByGuid(List<ScheduledActivity> activities, String guid) {
+        return activities.stream().filter(act -> {
+            return act.getGuid().startsWith(guid);
+        }).collect(Collectors.toList());
+    }
+    
+    private ScheduledActivity activity(Schedule schedule, String actGuid, DateTime scheduledTime, boolean isFinished) {
+        ScheduledActivity act = ScheduledActivity.create();
+        act.setSchedule(schedule);
+        act.setTimeZone(DateTimeZone.UTC);
+        act.setSchedulePlanGuid(SCHEDULE_PLAN_GUID);
+        act.setGuid(actGuid + ":" + scheduledTime.toLocalDateTime().toString());
+        act.setHealthCode(HEALTH_CODE);
+        act.setActivity(new Activity.Builder().withLabel("Activity " + actGuid).withTask("task"+actGuid).withGuid(actGuid).build());
+        if (isFinished) {
+            act.setStartedOn(ENROLLMENT.getMillis());
+        }
+        act.setScheduledOn(scheduledTime);
+        return act;
+    }
+       
+}

--- a/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceOnceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceOnceTest.java
@@ -1,0 +1,137 @@
+package org.sagebionetworks.bridge.services;
+
+import static org.junit.Assert.assertEquals;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
+
+import java.util.List;
+
+import javax.annotation.Resource;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeUtils;
+import org.joda.time.DateTimeZone;
+import org.joda.time.LocalTime;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import org.sagebionetworks.bridge.TestUserAdminHelper;
+import org.sagebionetworks.bridge.TestUserAdminHelper.TestUser;
+import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
+import org.sagebionetworks.bridge.dynamodb.DynamoScheduledActivity;
+import org.sagebionetworks.bridge.models.ClientInfo;
+import org.sagebionetworks.bridge.models.schedules.Activity;
+import org.sagebionetworks.bridge.models.schedules.Schedule;
+import org.sagebionetworks.bridge.models.schedules.ScheduleContext;
+import org.sagebionetworks.bridge.models.schedules.SchedulePlan;
+import org.sagebionetworks.bridge.models.schedules.ScheduleType;
+import org.sagebionetworks.bridge.models.schedules.ScheduledActivity;
+import org.sagebionetworks.bridge.models.schedules.SimpleScheduleStrategy;
+import org.sagebionetworks.bridge.models.studies.Study;
+
+import com.google.common.collect.Sets;
+
+@ContextConfiguration("classpath:test-context.xml")
+@RunWith(SpringJUnit4ClassRunner.class)
+public class ScheduledActivityServiceOnceTest {
+    private static DateTimeZone MSK = DateTimeZone.forOffsetHours(3);
+    private static DateTimeZone PST = DateTimeZone.forOffsetHours(-7);
+
+    @Resource
+    private ScheduledActivityService service;
+    
+    @Resource
+    private StudyService studyService;
+    
+    @Resource
+    private TestUserAdminHelper helper;
+    
+    @Resource
+    private SchedulePlanService schedulePlanService;
+    
+    private Schedule schedule;
+    
+    private SchedulePlan schedulePlan;
+    
+    private Study study;
+    
+    private TestUser testUser;
+    
+    @Before
+    public void before() {
+        study = studyService.getStudy(TEST_STUDY.getIdentifier());
+        study.setTaskIdentifiers(Sets.newHashSet("taskId"));
+        testUser = helper.getBuilder(ScheduledActivityServiceRecurringTest.class).build();
+        
+        schedule = new Schedule();
+        schedule.setLabel("Schedule Label");
+        schedule.setScheduleType(ScheduleType.ONCE);
+        schedule.addActivity(new Activity.Builder().withLabel("label").withTask("taskId").build());
+        
+        SimpleScheduleStrategy strategy = new SimpleScheduleStrategy(); 
+        strategy.setSchedule(schedule);
+        
+        schedulePlan = new DynamoSchedulePlan();
+        schedulePlan.setLabel("Label");
+        schedulePlan.setStudyKey(TEST_STUDY.getIdentifier());
+        schedulePlan.setStrategy(strategy);
+        schedulePlan = schedulePlanService.createSchedulePlan(study, schedulePlan);
+    }
+
+    @After
+    public void after() {
+        DateTimeUtils.setCurrentMillisSystem();
+        schedulePlanService.deleteSchedulePlan(TEST_STUDY, schedulePlan.getGuid());
+        if (testUser != null) {
+            helper.deleteUser(study, testUser.getId());
+        }
+    }
+
+
+    @Test // BRIDGE-1589
+    public void onetimeTasksScheduleCorrectlyThroughTimezoneChange() {
+        List<ScheduledActivity> first = service.getScheduledActivities(getContextWith2DayAdvance(PST));
+        List<ScheduledActivity> second = service.getScheduledActivities(getContextWith2DayAdvance(MSK));
+        assertEquals(1, first.size());
+        assertEquals(1, second.size());
+        
+        DynamoScheduledActivity dynAct1 = (DynamoScheduledActivity)first.get(0);
+        DynamoScheduledActivity dynAct2 = (DynamoScheduledActivity)second.get(0);
+        
+        // The time portion should be midnight, regardless of time zone
+        assertEquals(dynAct1.getLocalScheduledOn().toLocalTime(), dynAct2.getLocalScheduledOn().toLocalTime());
+    }
+    
+    @Test
+    public void onetimeTasksScheduledCorrectlyWithTimePortionThroughTimezoneChange() {
+        schedule.addTimes(LocalTime.parse("13:11"));
+        schedulePlanService.updateSchedulePlan(study, schedulePlan);
+        
+        List<ScheduledActivity> first = service.getScheduledActivities(getContextWith2DayAdvance(PST));
+        List<ScheduledActivity> second = service.getScheduledActivities(getContextWith2DayAdvance(MSK));
+        assertEquals(1, first.size());
+        assertEquals(1, second.size());
+        
+        DynamoScheduledActivity dynAct1 = (DynamoScheduledActivity)first.get(0);
+        DynamoScheduledActivity dynAct2 = (DynamoScheduledActivity)second.get(0);
+        
+        // The time portion should 13:11 because that's what we set, regardless of time zone.
+        assertEquals("13:11:00.000", dynAct1.getLocalScheduledOn().toLocalTime().toString());
+        assertEquals("13:11:00.000", dynAct2.getLocalScheduledOn().toLocalTime().toString());
+    }
+    
+    private ScheduleContext getContextWith2DayAdvance(DateTimeZone zone) {
+        return new ScheduleContext.Builder()
+            .withStudyIdentifier(TEST_STUDY)
+            .withClientInfo(ClientInfo.UNKNOWN_CLIENT)
+            .withTimeZone(zone)
+            .withAccountCreatedOn(DateTime.now())
+            // Setting the endsOn value to the end of the day, as we do in the controller.
+            .withEndsOn(DateTime.now(zone).plusDays(2).withHourOfDay(23).withMinuteOfHour(59).withSecondOfMinute(59))
+            .withHealthCode(testUser.getHealthCode())
+            .withUserId(testUser.getId()).build();
+    }
+}

--- a/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceRecurringTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceRecurringTest.java
@@ -38,7 +38,7 @@ import com.google.common.collect.Sets;
  */
 @ContextConfiguration("classpath:test-context.xml")
 @RunWith(SpringJUnit4ClassRunner.class)
-public class ScheduledActivityServiceTest {
+public class ScheduledActivityServiceRecurringTest {
 
     @Resource
     private ScheduledActivityService service;
@@ -62,7 +62,7 @@ public class ScheduledActivityServiceTest {
     public void before() {
         study = studyService.getStudy(TEST_STUDY.getIdentifier());
         study.setTaskIdentifiers(Sets.newHashSet("taskId"));
-        testUser = helper.getBuilder(ScheduledActivityServiceTest.class).build();
+        testUser = helper.getBuilder(ScheduledActivityServiceRecurringTest.class).build();
         
         Schedule schedule = new Schedule();
         schedule.setLabel("Schedule Label");

--- a/test/org/sagebionetworks/bridge/validators/ScheduleValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/ScheduleValidatorTest.java
@@ -31,6 +31,21 @@ public class ScheduleValidatorTest {
     }
     
     @Test
+    public void oneTimeScheduleWithExpirationNotUnderOneDay() {
+        schedule.setScheduleType(ScheduleType.ONCE);
+        schedule.setExpires(Period.parse("PT23H"));
+        schedule.addActivity(TestConstants.TEST_3_ACTIVITY);
+        try {
+            Validate.entityThrowingException(validator, schedule);
+            fail("Should have thrown InvalidEntityException");
+        } catch(InvalidEntityException e) {
+            assertEquals(
+                    "scheduleType set to once with no time of day start, but expires in under a day (this can cause confusing behavior)",
+                    e.getErrors().get("scheduleType").get(0));
+        }
+    }
+    
+    @Test
     public void persistentScheduleDoesNotHaveDelay() {
         schedule.setScheduleType(ScheduleType.PERSISTENT);
         schedule.setDelay(Period.parse("P2D"));


### PR DESCRIPTION
This might originally have been prevented by putting all event timestamps in UTC, however, it turns out to be very challenging to keep DateTime in UTC as every time you transform it, you have to reset it (at least in testing). In any event, now that there are duplicate one-time tasks in the database, this alone will not fix the issue.

So the strategy here is to do the following:

1) From now on, when creating one-time tasks, set their scheduledOn time portion to midnight of the day of the event, not whatever the time portion is of the event timestamp;

2) During scheduling, fix these persisted one-time tasks to use the same midnight time value, which fixes the GUIDs of the scheduled activities as well, and then makes it possible to identify and remove duplicates.

3) People rarely (never?) set an expiration for one-time tasks but if they do, enforce it being at least 24 hours in the future because otherwise, the expiration will be confusing.