### PR TITLE
Remove request-info keys from the cache keys that are returned.

### DIFF
--- a/app/org/sagebionetworks/bridge/services/CacheAdminService.java
+++ b/app/org/sagebionetworks/bridge/services/CacheAdminService.java
@@ -20,6 +20,8 @@ public class CacheAdminService {
 
     private final String SESSION_SUFFIX = RedisKey.SEPARATOR + RedisKey.SESSION.getSuffix();
     private final String USER_SESSION_SUFFIX = RedisKey.SEPARATOR + RedisKey.SESSION.getSuffix() + RedisKey.SEPARATOR + RedisKey.USER.getSuffix();
+    private final String REQUEST_INFO_SUFFIX = RedisKey.SEPARATOR + RedisKey.REQUEST_INFO.getSuffix();
+    
     private JedisPool jedisPool;
     
     @Autowired
@@ -63,6 +65,6 @@ public class CacheAdminService {
     }
     
     private boolean notASessionKey(String key) {
-        return !(key.endsWith(SESSION_SUFFIX) || key.endsWith(USER_SESSION_SUFFIX));
+        return !(key.endsWith(SESSION_SUFFIX) || key.endsWith(USER_SESSION_SUFFIX) || key.endsWith(REQUEST_INFO_SUFFIX));
     }
 }

--- a/test/org/sagebionetworks/bridge/services/CacheAdminServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/CacheAdminServiceTest.java
@@ -18,6 +18,11 @@ import redis.clients.jedis.JedisPool;
 
 public class CacheAdminServiceTest {
 
+    private static final String REQUEST_INFO_KEY = "10E9SFUz9BYrqCrTzfiaNW:request-info";
+    
+    private final static Set<String> KEYS = Sets.newHashSet("foo:study", "bar:session", "baz:Survey:view",
+            "xh7YDmjGQuTKnfdv9iJb0:session:user", REQUEST_INFO_KEY);
+    
     private CacheAdminService adminService;
     
     @Before
@@ -71,18 +76,20 @@ public class CacheAdminServiceTest {
         adminService.removeItem(null);
     }
     
+    @Test(expected = BridgeServiceException.class)
+    public void cannotRemoveRequestInfo() {
+        adminService.removeItem(REQUEST_INFO_KEY);
+    }
+    
     private Jedis createStubJedis() {
         return new Jedis("") {
-            // xh7YDmjGQuTKnfdv9iJb0:session:user is an actual key we're suppressing
-            private Set<String> set = Sets.newHashSet("foo:study", "bar:session", "baz:Survey:view", "xh7YDmjGQuTKnfdv9iJb0:session:user");
-
             @Override
             public Set<String> keys(String pattern) {
-                return set;
+                return KEYS;
             }
             @Override
             public Long del(String key) {
-                return (set.remove(key)) ? 1L : 0L;
+                return (KEYS.remove(key)) ? 1L : 0L;
             }
         };
     }


### PR DESCRIPTION
There can be a lot of these and like sessions, there's no reason to delete them and no reason to see them in the list of cache keys.