### PR TITLE
Add time to summary accounts query

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/AccountDao.java
+++ b/app/org/sagebionetworks/bridge/dao/AccountDao.java
@@ -2,6 +2,8 @@ package org.sagebionetworks.bridge.dao;
 
 import java.util.Iterator;
 
+import org.joda.time.DateTime;
+
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountSummary;
@@ -101,12 +103,16 @@ public interface AccountDao {
      *      number of records to return (or the number of remaining records if less than the pageSize).
      * @param emailFilter
      *      a substring that will be matched (ignoring case) against the email addresses of the accounts.
+     * @param startDate
+     *      a date and time on or after which the account should have been created in order to match the query.
+     * @param endDate
+     *      a date and time on or before which the account should have been created in order to match the query.
      * @return
      *      a paged resource list that includes the page of account summaries, as well as other information 
      *      about the request and the total number of records.
      */
     PagedResourceList<AccountSummary> getPagedAccountSummaries(Study study, int offsetBy, int pageSize,
-            String emailFilter);
+            String emailFilter, DateTime startDate, DateTime endDate);
     
     /**
      * For MailChimp, and other external systems, we need a way to get a healthCode for a given email.

--- a/app/org/sagebionetworks/bridge/models/PagedResourceList.java
+++ b/app/org/sagebionetworks/bridge/models/PagedResourceList.java
@@ -7,6 +7,8 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
+import org.joda.time.DateTime;
+
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -54,6 +56,15 @@ public class PagedResourceList<T> {
     public PagedResourceList<T> withFilter(String key, String value) {
         if (isNotBlank(key) && isNotBlank(value)) {
             filters.put(key, value);
+        }
+        return this;
+    }
+    /**
+     * A convenience method for adding a date filter.
+     */
+    public PagedResourceList<T> withFilter(String key, DateTime value) {
+        if (isNotBlank(key) && value != null) {
+            filters.put(key, value.toString());
         }
         return this;
     }

--- a/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
@@ -84,14 +84,18 @@ public class ParticipantController extends BaseController {
         return okResult(UserSessionInfo.toJSON(session));
     }
     
-    public Result getParticipants(String offsetByString, String pageSizeString, String emailFilter) {
+    public Result getParticipants(String offsetByString, String pageSizeString, String emailFilter,
+            String startDateString, String endDateString) {
         UserSession session = getAuthenticatedSession(RESEARCHER);
         
         Study study = studyService.getStudy(session.getStudyIdentifier());
         int offsetBy = getIntOrDefault(offsetByString, 0);
         int pageSize = getIntOrDefault(pageSizeString, API_DEFAULT_PAGE_SIZE);
+        DateTime startDate = DateUtils.getDateTimeOrDefault(startDateString, null);
+        DateTime endDate = DateUtils.getDateTimeOrDefault(endDateString, null);
         
-        PagedResourceList<AccountSummary> page = participantService.getPagedAccountSummaries(study, offsetBy, pageSize, emailFilter);
+        PagedResourceList<AccountSummary> page = participantService.getPagedAccountSummaries(study, offsetBy, pageSize,
+                emailFilter, startDate, endDate);
         return okResult(page);
     }
     

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -61,6 +61,7 @@ public class ParticipantService {
     private static Logger LOG = LoggerFactory.getLogger(ParticipantService.class);
 
     private static final String PAGE_SIZE_ERROR = "pageSize must be from "+API_MINIMUM_PAGE_SIZE+"-"+API_MAXIMUM_PAGE_SIZE+" records";
+    private static final String DATE_RANGE_ERROR = "startDate should be before endDate";
     
     private AccountDao accountDao;
     
@@ -175,7 +176,8 @@ public class ParticipantService {
         return builder.build();
     }
     
-    public PagedResourceList<AccountSummary> getPagedAccountSummaries(Study study, int offsetBy, int pageSize, String emailFilter) {
+    public PagedResourceList<AccountSummary> getPagedAccountSummaries(Study study, int offsetBy, int pageSize,
+            String emailFilter, DateTime startDate, DateTime endDate) {
         checkNotNull(study);
         if (offsetBy < 0) {
             throw new BadRequestException("offsetBy cannot be less than 0");
@@ -184,7 +186,10 @@ public class ParticipantService {
         if (pageSize < API_MINIMUM_PAGE_SIZE || pageSize > API_MAXIMUM_PAGE_SIZE) {
             throw new BadRequestException(PAGE_SIZE_ERROR);
         }
-        return accountDao.getPagedAccountSummaries(study, offsetBy, pageSize, emailFilter);
+        if (startDate != null && endDate != null && startDate.getMillis() >= endDate.getMillis()) {
+            throw new BadRequestException(DATE_RANGE_ERROR);
+        }
+        return accountDao.getPagedAccountSummaries(study, offsetBy, pageSize, emailFilter, startDate, endDate);
     }
     
     public void signUserOut(Study study, String email) {

--- a/app/org/sagebionetworks/bridge/stormpath/StormpathAccountDao.java
+++ b/app/org/sagebionetworks/bridge/stormpath/StormpathAccountDao.java
@@ -49,6 +49,8 @@ import org.sagebionetworks.bridge.services.SubpopulationService;
 import org.sagebionetworks.bridge.util.BridgeCollectors;
 
 import com.stormpath.sdk.directory.CustomData;
+
+import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -148,7 +150,8 @@ public class StormpathAccountDao implements AccountDao {
     }
 
     @Override
-    public PagedResourceList<AccountSummary> getPagedAccountSummaries(Study study, int offsetBy, int pageSize, String emailFilter) {
+    public PagedResourceList<AccountSummary> getPagedAccountSummaries(Study study, int offsetBy, int pageSize,
+            String emailFilter, DateTime startDate, DateTime endDate) {
         checkNotNull(study);
         checkArgument(offsetBy >= 0);
         checkArgument(pageSize >= API_MINIMUM_PAGE_SIZE && pageSize <= API_MAXIMUM_PAGE_SIZE);
@@ -164,7 +167,12 @@ public class StormpathAccountDao implements AccountDao {
         if (isNotBlank(emailFilter)) {
             criteria = criteria.add(Accounts.email().containsIgnoreCase(emailFilter));
         }
-        
+        if (startDate != null) {
+            criteria.add(Accounts.createdAt().gte(startDate.toDate()));    
+        }
+        if (endDate != null) {
+            criteria.add(Accounts.createdAt().lte(endDate.toDate()));    
+        }
         Directory directory = client.getResource(study.getStormpathHref(), Directory.class);
         AccountList accts = directory.getAccounts(criteria);
         

--- a/app/org/sagebionetworks/bridge/stormpath/StormpathAccountDao.java
+++ b/app/org/sagebionetworks/bridge/stormpath/StormpathAccountDao.java
@@ -186,7 +186,9 @@ public class StormpathAccountDao implements AccountDao {
             }
         }
         return new PagedResourceList<AccountSummary>(results, offsetBy, pageSize, accts.getSize())
-                .withFilter("emailFilter", emailFilter);
+                .withFilter("emailFilter", emailFilter)
+                .withFilter("startDate", startDate)
+                .withFilter("endDate", endDate);
     }
     
     @Override

--- a/conf/routes
+++ b/conf/routes
@@ -14,7 +14,7 @@ POST   /v3/auth/verifyEmail             @org.sagebionetworks.bridge.play.control
 POST   /v3/auth/resendEmailVerification @org.sagebionetworks.bridge.play.controllers.AuthenticationController.resendEmailVerification
 
 # Participants Researcher APIs
-GET    /v3/participants                                      @org.sagebionetworks.bridge.play.controllers.ParticipantController.getParticipants(offsetBy: String ?= null, pageSize: String ?= null, emailFilter: String ?= null)
+GET    /v3/participants                                      @org.sagebionetworks.bridge.play.controllers.ParticipantController.getParticipants(offsetBy: String ?= null, pageSize: String ?= null, emailFilter: String ?= null, createdBefore: String ?= null, createdAfter: String ?= null)
 POST   /v3/participants                                      @org.sagebionetworks.bridge.play.controllers.ParticipantController.createParticipant(verifyEmail: String ?= "true")
 GET    /v3/participants/self                                 @org.sagebionetworks.bridge.play.controllers.ParticipantController.getSelfParticipant
 POST   /v3/participants/self                                 @org.sagebionetworks.bridge.play.controllers.ParticipantController.updateSelfParticipant

--- a/conf/routes
+++ b/conf/routes
@@ -14,7 +14,7 @@ POST   /v3/auth/verifyEmail             @org.sagebionetworks.bridge.play.control
 POST   /v3/auth/resendEmailVerification @org.sagebionetworks.bridge.play.controllers.AuthenticationController.resendEmailVerification
 
 # Participants Researcher APIs
-GET    /v3/participants                                      @org.sagebionetworks.bridge.play.controllers.ParticipantController.getParticipants(offsetBy: String ?= null, pageSize: String ?= null, emailFilter: String ?= null, createdBefore: String ?= null, createdAfter: String ?= null)
+GET    /v3/participants                                      @org.sagebionetworks.bridge.play.controllers.ParticipantController.getParticipants(offsetBy: String ?= null, pageSize: String ?= null, emailFilter: String ?= null, startDate: String ?= null, endDate: String ?= null)
 POST   /v3/participants                                      @org.sagebionetworks.bridge.play.controllers.ParticipantController.createParticipant(verifyEmail: String ?= "true")
 GET    /v3/participants/self                                 @org.sagebionetworks.bridge.play.controllers.ParticipantController.getSelfParticipant
 POST   /v3/participants/self                                 @org.sagebionetworks.bridge.play.controllers.ParticipantController.updateSelfParticipant

--- a/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
@@ -146,7 +146,7 @@ public class ParticipantControllerTest {
         
         when(authService.getSession(eq(study), any())).thenReturn(session);
         
-        when(participantService.getPagedAccountSummaries(eq(study), anyInt(), anyInt(), any())).thenReturn(page);
+        when(participantService.getPagedAccountSummaries(eq(study), anyInt(), anyInt(), any(), any(), any())).thenReturn(page);
         
         controller.setParticipantService(participantService);
         controller.setStudyService(studyService);
@@ -158,7 +158,9 @@ public class ParticipantControllerTest {
     
     @Test
     public void getParticipants() throws Exception {
-        Result result = controller.getParticipants("10", "20", "foo");
+        DateTime start = DateTime.now();
+        DateTime end = DateTime.now();
+        Result result = controller.getParticipants("10", "20", "foo", start.toString(), end.toString());
         PagedResourceList<AccountSummary> page = resultToPage(result);
         
         // verify the result contains items
@@ -170,15 +172,15 @@ public class ParticipantControllerTest {
         assertEquals(new Integer(10), page.getOffsetBy());
         assertEquals(20, page.getPageSize());
         assertEquals("foo", page.getFilters().get("emailFilter"));
-        verify(participantService).getPagedAccountSummaries(study, 10, 20, "foo");
+        verify(participantService).getPagedAccountSummaries(study, 10, 20, "foo", start, end);
     }
     
     @Test(expected = BadRequestException.class)
     public void oddParametersUseDefaults() throws Exception {
-        controller.getParticipants("asdf", "qwer", null);
+        controller.getParticipants("asdf", "qwer", null, null, null);
         
         // paging with defaults
-        verify(participantService).getPagedAccountSummaries(study, 0, API_DEFAULT_PAGE_SIZE, null);
+        verify(participantService).getPagedAccountSummaries(study, 0, API_DEFAULT_PAGE_SIZE, null, null, null);
     }
 
     @Test
@@ -257,10 +259,10 @@ public class ParticipantControllerTest {
     
     @Test
     public void nullParametersUseDefaults() throws Exception {
-        controller.getParticipants(null, null, null);
+        controller.getParticipants(null, null, null, null, null);
 
         // paging with defaults
-        verify(participantService).getPagedAccountSummaries(study, 0, API_DEFAULT_PAGE_SIZE, null);
+        verify(participantService).getPagedAccountSummaries(study, 0, API_DEFAULT_PAGE_SIZE, null, null, null);
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -118,6 +118,9 @@ public class ParticipantServiceTest {
             .copyOf(PARTICIPANT)
             .withExternalId(null).build();
     
+    private static final DateTime START_DATE = DateTime.now();
+    private static final DateTime END_DATE = START_DATE.plusDays(1);
+    
     private ParticipantService participantService;
     
     @Mock
@@ -297,36 +300,41 @@ public class ParticipantServiceTest {
     
     @Test
     public void getPagedAccountSummaries() {
-        participantService.getPagedAccountSummaries(STUDY, 1100, 50, "foo");
+        participantService.getPagedAccountSummaries(STUDY, 1100, 50, "foo", START_DATE, END_DATE);
         
-        verify(accountDao).getPagedAccountSummaries(STUDY, 1100, 50, "foo"); 
+        verify(accountDao).getPagedAccountSummaries(STUDY, 1100, 50, "foo", START_DATE, END_DATE); 
     }
     
     @Test(expected = NullPointerException.class)
     public void getPagedAccountSummariesWithBadStudy() {
-        participantService.getPagedAccountSummaries(null, 0, 100, null);
+        participantService.getPagedAccountSummaries(null, 0, 100, null, null, null);
     }
     
     @Test(expected = BadRequestException.class)
     public void getPagedAccountSummariesWithNegativeOffsetBy() {
-        participantService.getPagedAccountSummaries(STUDY, -1, 100, null);
+        participantService.getPagedAccountSummaries(STUDY, -1, 100, null, null, null);
     }
 
     @Test(expected = BadRequestException.class)
     public void getPagedAccountSummariesWithNegativePageSize() {
-        participantService.getPagedAccountSummaries(STUDY, 0, -100, null);
+        participantService.getPagedAccountSummaries(STUDY, 0, -100, null, null, null);
+    }
+    
+    @Test(expected = BadRequestException.class)
+    public void getPagedAccountSummariesWithBadDateRange() {
+        participantService.getPagedAccountSummaries(STUDY, 0, -100, null, END_DATE, START_DATE);
     }
     
     @Test
     public void getPagedAccountSummariesWithoutEmailFilterOK() {
-        participantService.getPagedAccountSummaries(STUDY, 1100, 50, null);
+        participantService.getPagedAccountSummaries(STUDY, 1100, 50, null, null, null);
         
-        verify(accountDao).getPagedAccountSummaries(STUDY, 1100, 50, null); 
+        verify(accountDao).getPagedAccountSummaries(STUDY, 1100, 50, null, null, null); 
     }
     
     @Test(expected = BadRequestException.class)
     public void getPagedAccountSummariesWithTooLargePageSize() {
-        participantService.getPagedAccountSummaries(STUDY, 0, 251, null);
+        participantService.getPagedAccountSummaries(STUDY, 0, 251, null, null, null);
     }
     
     @Test(expected = EntityNotFoundException.class)

--- a/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoMockTest.java
@@ -354,17 +354,17 @@ public class StormpathAccountDaoMockTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void getStudyPagedAccountsRejectsPageSizeTooSmall() {
-        dao.getPagedAccountSummaries(study, 0, BridgeConstants.API_MINIMUM_PAGE_SIZE-1, null);
+        dao.getPagedAccountSummaries(study, 0, BridgeConstants.API_MINIMUM_PAGE_SIZE-1, null, null, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void getStudyPagedAccountsRejectsPageSizeTooLarge() {
-        dao.getPagedAccountSummaries(study, 0, BridgeConstants.API_MAXIMUM_PAGE_SIZE+1, null);
+        dao.getPagedAccountSummaries(study, 0, BridgeConstants.API_MAXIMUM_PAGE_SIZE+1, null, null, null);
     }
     
     @Test(expected = IllegalArgumentException.class)
     public void getStudyPagedAccountsRejectsNonsenseOffsetBy() {
-        dao.getPagedAccountSummaries(study, -10, BridgeConstants.API_DEFAULT_PAGE_SIZE, null);
+        dao.getPagedAccountSummaries(study, -10, BridgeConstants.API_DEFAULT_PAGE_SIZE, null, null, null);
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoTest.java
+++ b/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoTest.java
@@ -165,9 +165,11 @@ public class StormpathAccountDaoTest {
             // This should filter to half the accounts
             accounts = accountDao.getPagedAccountSummaries(study, 0, 20, null, middleCreatedOn, null);
             assertEquals(half+1, accounts.getItems().size());
+            assertEquals(middleCreatedOn.toString(), accounts.getFilters().get("startDate"));
             
             accounts = accountDao.getPagedAccountSummaries(study, 0, 20, null, null, middleCreatedOn);
             assertEquals(half+1, accounts.getItems().size());
+            assertEquals(middleCreatedOn.toString(), accounts.getFilters().get("endDate"));
         } finally {
             for (String id : newAccounts) {
                 accountDao.deleteAccount(study, id);

--- a/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoTest.java
+++ b/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoTest.java
@@ -158,18 +158,25 @@ public class StormpathAccountDaoTest {
             int half = accounts.getItems().size()/2;
             DateTime middleCreatedOn = accounts.getItems().get(half).getCreatedOn();
             
-            // Late timestamp, nothing is returned
+            // This returns no accounts 
             accounts = accountDao.getPagedAccountSummaries(study, 0, 20, null, DateTime.now(), null);
             assertEquals(0, accounts.getItems().size());
 
-            // This should filter to half the accounts
+            // This returns the last half of the accounts
             accounts = accountDao.getPagedAccountSummaries(study, 0, 20, null, middleCreatedOn, null);
             assertEquals(half+1, accounts.getItems().size());
             assertEquals(middleCreatedOn.toString(), accounts.getFilters().get("startDate"));
+            for (AccountSummary summary : accounts.getItems()) {
+                assertTrue(summary.getCreatedOn().getMillis() >= middleCreatedOn.getMillis());
+            }
             
+            // This returns the first half of the accounts
             accounts = accountDao.getPagedAccountSummaries(study, 0, 20, null, null, middleCreatedOn);
             assertEquals(half+1, accounts.getItems().size());
             assertEquals(middleCreatedOn.toString(), accounts.getFilters().get("endDate"));
+            for (AccountSummary summary : accounts.getItems()) {
+                assertTrue(summary.getCreatedOn().getMillis() <= middleCreatedOn.getMillis());
+            }
         } finally {
             for (String id : newAccounts) {
                 accountDao.deleteAccount(study, id);

--- a/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoTest.java
+++ b/test/org/sagebionetworks/bridge/stormpath/StormpathAccountDaoTest.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.stormpath;
 
+import static java.util.Comparator.comparing;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -10,6 +11,8 @@ import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.TEST_USERS;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 
+import java.util.Collections;
+
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
@@ -17,6 +20,7 @@ import java.util.List;
 import javax.annotation.Resource;
 
 import org.apache.commons.lang3.RandomStringUtils;
+import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -92,10 +96,10 @@ public class StormpathAccountDaoTest {
     }
     
     @Test
-    public void getStudyPagedAccounts() {
+    public void getStudyPagedAccounts() throws Exception {
         List<String> newAccounts = Lists.newArrayList();
         try {
-            PagedResourceList<AccountSummary> accounts = accountDao.getPagedAccountSummaries(study, 0, 10, null);
+            PagedResourceList<AccountSummary> accounts = accountDao.getPagedAccountSummaries(study, 0, 10, null, null, null);
             
             // Make sure you add 2 records with the "SADT" infix so searching will work and be tested, 
             // and at least 6 records in total so that paging can be tested.
@@ -113,38 +117,57 @@ public class StormpathAccountDaoTest {
                 newAccounts.add(account.getId());
             }
             // Fetch only 5 accounts. Empty search string ignored
-            accounts = accountDao.getPagedAccountSummaries(study, 0, 5, "");
+            accounts = accountDao.getPagedAccountSummaries(study, 0, 5, "", null, null);
             
             // pageSize is respected
             assertEquals(5, accounts.getItems().size());
             
             // offsetBy is advanced
-            AccountSummary account1 = accountDao.getPagedAccountSummaries(study, 1, 5, null).getItems().get(0);
-            AccountSummary account2 = accountDao.getPagedAccountSummaries(study, 2, 5, null).getItems().get(0);
+            AccountSummary account1 = accountDao.getPagedAccountSummaries(study, 1, 5, null, null, null).getItems().get(0);
+            AccountSummary account2 = accountDao.getPagedAccountSummaries(study, 2, 5, null, null, null).getItems().get(0);
             assertNotNull(account1.getCreatedOn());
             assertNotNull(account2.getCreatedOn());
             assertEquals(accounts.getItems().get(1), account1);
             assertEquals(accounts.getItems().get(2), account2);
             
             // Next page = offset + pageSize
-            AccountSummary nextPageAccount = accountDao.getPagedAccountSummaries(study, 5, 5, null).getItems().get(0);
+            AccountSummary nextPageAccount = accountDao.getPagedAccountSummaries(study, 5, 5, null, null, null).getItems().get(0);
             assertFalse(accounts.getItems().contains(nextPageAccount));
             
             // This should be beyond the number of users in any API study. Should be empty
-            accounts = accountDao.getPagedAccountSummaries(study, 100000, 100, null);
+            accounts = accountDao.getPagedAccountSummaries(study, 100000, 100, null, null, null);
             assertEquals(0, accounts.getItems().size());
             
             // This should filter down to one of the accounts
-            accounts = accountDao.getPagedAccountSummaries(study, 0, 20, "bridgeit@");
+            accounts = accountDao.getPagedAccountSummaries(study, 0, 20, "bridgeit@", null, null);
             assertEquals(1, accounts.getItems().size());
             assertEquals("bridgeit@sagebase.org", accounts.getItems().get(0).getEmail());
             
-            accounts = accountDao.getPagedAccountSummaries(study, 0, 20, "bridge-testing+SADT");
+            accounts = accountDao.getPagedAccountSummaries(study, 0, 20, "bridge-testing+SADT", null, null);
             assertTrue(accounts.getItems().size() > 0);
             for (AccountSummary summary : accounts.getItems()) {
                 assertNull(summary.getFirstName());
                 assertNull(summary.getLastName());
-            }            
+            }
+            
+            // Now work with up to 20 accounts (there are at least 6), sort them by createdOn
+            accounts = accountDao.getPagedAccountSummaries(study, 0, 20, null, null, null);
+            Collections.sort(accounts.getItems(), comparing(AccountSummary::getCreatedOn));
+
+            totalAccounts = accounts.getItems().size();
+            int half = accounts.getItems().size()/2;
+            DateTime middleCreatedOn = accounts.getItems().get(half).getCreatedOn();
+            
+            // Late timestamp, nothing is returned
+            accounts = accountDao.getPagedAccountSummaries(study, 0, 20, null, DateTime.now(), null);
+            assertEquals(0, accounts.getItems().size());
+
+            // This should filter to half the accounts
+            accounts = accountDao.getPagedAccountSummaries(study, 0, 20, null, middleCreatedOn, null);
+            assertEquals(half+1, accounts.getItems().size());
+            
+            accounts = accountDao.getPagedAccountSummaries(study, 0, 20, null, null, middleCreatedOn);
+            assertEquals(half+1, accounts.getItems().size());
         } finally {
             for (String id : newAccounts) {
                 accountDao.deleteAccount(study, id);


### PR DESCRIPTION
Start date and end date. Makes it more efficient to export subsets of the participants, rather than all of them every time.