### PR TITLE
restore URL to fix Bridge-Exporter

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -138,6 +138,7 @@ DELETE /v3/scheduleplans/:guid     @org.sagebionetworks.bridge.play.controllers.
 
 # Bridge Exporter
 POST /v3/recordexportstatuses      @org.sagebionetworks.bridge.play.controllers.HealthDataController.updateRecordsStatus
+POST /v3/recordExportStatuses      @org.sagebionetworks.bridge.play.controllers.HealthDataController.updateRecordsStatus
 
 # Studies
 GET    /v3/studies                  @org.sagebionetworks.bridge.play.controllers.StudyController.getAllStudies(format: String ?= null, summary: String ?= null)


### PR DESCRIPTION
A URL was changed, which broke Bridge-Exporter. This change restores the original URL side-by-side with the new URL.

Testing done:
* Ran local server. Verified both URLs can be hit with a basic request.