### PR TITLE
notifyByEmail not being set to default value of true under some use cases

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/ParticipantOption.java
+++ b/app/org/sagebionetworks/bridge/dao/ParticipantOption.java
@@ -32,7 +32,8 @@ public enum ParticipantOption {
     },
     EMAIL_NOTIFICATIONS(Boolean.TRUE.toString(), "notifyByEmail") {
         public String fromParticipant(StudyParticipant participant) {
-            return Boolean.toString(participant.isNotifyByEmail());
+            Boolean bool = participant.isNotifyByEmail();
+            return (bool == null) ? getDefaultValue() : Boolean.toString(bool);
         }
         public String deserialize(JsonNode node) {
             checkNotNull(node);

--- a/app/org/sagebionetworks/bridge/models/accounts/StudyParticipant.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/StudyParticipant.java
@@ -55,7 +55,7 @@ public final class StudyParticipant implements BridgeEntity {
     private final String externalId;
     private final String password;
     private final SharingScope sharingScope;
-    private final boolean notifyByEmail;
+    private final Boolean notifyByEmail;
     private final Set<String> dataGroups;
     private final String healthCode;
     private final Map<String,String> attributes;
@@ -67,7 +67,7 @@ public final class StudyParticipant implements BridgeEntity {
     private final String id;
     
     private StudyParticipant(String firstName, String lastName, String email, String externalId, String password,
-            SharingScope sharingScope, boolean notifyByEmail, Set<String> dataGroups, String healthCode,
+            SharingScope sharingScope, Boolean notifyByEmail, Set<String> dataGroups, String healthCode,
             Map<String, String> attributes, Map<String, List<UserConsentHistory>> consentHistories, Set<Roles> roles,
             LinkedHashSet<String> languages, AccountStatus status, DateTime createdOn, String id) {
         
@@ -117,7 +117,7 @@ public final class StudyParticipant implements BridgeEntity {
     public SharingScope getSharingScope() {
         return sharingScope;
     }
-    public boolean isNotifyByEmail() {
+    public Boolean isNotifyByEmail() {
         return notifyByEmail;
     }
     public Set<String> getDataGroups() {
@@ -182,7 +182,7 @@ public final class StudyParticipant implements BridgeEntity {
         private String externalId;
         private String password;
         private SharingScope sharingScope;
-        private boolean notifyByEmail;
+        private Boolean notifyByEmail;
         private Set<String> dataGroups;
         private String healthCode;
         private Map<String,String> attributes;
@@ -287,7 +287,7 @@ public final class StudyParticipant implements BridgeEntity {
             this.sharingScope = sharingScope;
             return this;
         }
-        public Builder withNotifyByEmail(boolean notifyByEmail) {
+        public Builder withNotifyByEmail(Boolean notifyByEmail) {
             this.notifyByEmail = notifyByEmail;
             return this;
         }

--- a/test/org/sagebionetworks/bridge/dao/ParticipantOptionTest.java
+++ b/test/org/sagebionetworks/bridge/dao/ParticipantOptionTest.java
@@ -72,7 +72,7 @@ public class ParticipantOptionTest {
     public void canRetrieveEmptyValuesFromStudyParticipant() {
         StudyParticipant emptyParticipant = new StudyParticipant.Builder().build();
         assertNull(ParticipantOption.DATA_GROUPS.fromParticipant(emptyParticipant));
-        assertEquals("false",ParticipantOption.EMAIL_NOTIFICATIONS.fromParticipant(emptyParticipant));
+        assertEquals("true",ParticipantOption.EMAIL_NOTIFICATIONS.fromParticipant(emptyParticipant));
         assertNull(ParticipantOption.EXTERNAL_IDENTIFIER.fromParticipant(emptyParticipant));
         assertNull(ParticipantOption.LANGUAGES.fromParticipant(emptyParticipant));
         assertNull(ParticipantOption.SHARING_SCOPE.fromParticipant(emptyParticipant));

--- a/test/org/sagebionetworks/bridge/models/accounts/UserSessionInfoTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/UserSessionInfoTest.java
@@ -25,6 +25,7 @@ public class UserSessionInfoTest {
                 .withEmail("test@test.com")
                 .withFirstName("first name")
                 .withLastName("last name")
+                .withNotifyByEmail(false)
                 .withEncryptedHealthCode(TestConstants.ENCRYPTED_HEALTH_CODE)
                 .withId("user-identifier")
                 .withRoles(Sets.newHashSet(RESEARCHER))
@@ -56,6 +57,7 @@ public class UserSessionInfoTest {
         assertEquals("foo", node.get("dataGroups").get(0).asText());
         assertEquals("staging", node.get("environment").asText());
         assertEquals(participant.getId(), node.get("id").asText());
+        assertFalse(node.get("notifyByEmail").asBoolean());
         assertNull(node.get("healthCode"));
         assertNull(node.get("encryptedHealthCode"));
         assertEquals("UserSessionInfo", node.get("type").asText());

--- a/test/org/sagebionetworks/bridge/play/interceptors/ExceptionInterceptorTest.java
+++ b/test/org/sagebionetworks/bridge/play/interceptors/ExceptionInterceptorTest.java
@@ -65,6 +65,7 @@ public class ExceptionInterceptorTest {
                 .withFirstName("firstName")
                 .withLastName("lastName")
                 .withHealthCode("healthCode")
+                .withNotifyByEmail(true)
                 .withId("userId")
                 .withSharingScope(SharingScope.ALL_QUALIFIED_RESEARCHERS)
                 .withDataGroups(Sets.newHashSet("group1")).build();
@@ -95,6 +96,7 @@ public class ExceptionInterceptorTest {
         assertEquals("email@email.com", node.get("email").asText());
         assertEquals("userId", node.get("id").asText());
         assertTrue(node.get("dataSharing").asBoolean());
+        assertTrue(node.get("notifyByEmail").asBoolean());
         assertEquals("UserSessionInfo", node.get("type").asText());
         ArrayNode array = (ArrayNode)node.get("roles");
         assertEquals(0, array.size());


### PR DESCRIPTION
Change this value to a Boolean object so that it can be left null, rather than the default value of false, if it is not set through calls that update all fields of StudyParticipant. This will allow it to preserve its default value.