### PR TITLE
add null check to getUploadsForStudy APIs

### DIFF
--- a/app/org/sagebionetworks/bridge/services/UploadService.java
+++ b/app/org/sagebionetworks/bridge/services/UploadService.java
@@ -281,9 +281,11 @@ public class UploadService {
             builder.withUpload(upload);
             if (upload.getRecordId() != null) {
                 HealthDataRecord record = healthDataService.getRecordById(upload.getRecordId());
-                builder.withSchemaId(record.getSchemaId());
-                builder.withSchemaRevision(record.getSchemaRevision());
-                builder.withHealthRecordExporterStatus(record.getSynapseExporterStatus());
+                if (record != null) {
+                    builder.withSchemaId(record.getSchemaId());
+                    builder.withSchemaRevision(record.getSchemaRevision());
+                    builder.withHealthRecordExporterStatus(record.getSynapseExporterStatus());
+                }
             }
             return builder.build();
         }).collect(Collectors.toList());


### PR DESCRIPTION
For whatever reason, some uploads have record IDs, but no records. Under normal conditions, this shouldn't be possible, but it comes up occasionally in test environments. Either way, we shouldn't be throwing NullPointerExceptions for data integrity issues.

Testing done:
* manual tests with a test set that includes (a) failed uploads (b) successful uploads (c) successful uploads with no record
* updated unit tests