### PR TITLE
Revert task fix

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivity.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivity.java
@@ -12,7 +12,6 @@ import org.sagebionetworks.bridge.json.DateTimeToLongSerializer;
 import org.sagebionetworks.bridge.json.JsonUtils;
 import org.sagebionetworks.bridge.models.BridgeEntity;
 import org.sagebionetworks.bridge.models.schedules.Activity;
-import org.sagebionetworks.bridge.models.schedules.Schedule;
 import org.sagebionetworks.bridge.models.schedules.ScheduledActivity;
 import org.sagebionetworks.bridge.models.schedules.ScheduledActivityStatus;
 
@@ -48,7 +47,6 @@ public final class DynamoScheduledActivity implements ScheduledActivity, BridgeE
     private Activity activity;
     private boolean persistent;
     private DateTimeZone timeZone;
-    private Schedule schedule;
 
     @Override
     @DynamoDBIgnore
@@ -90,17 +88,6 @@ public final class DynamoScheduledActivity implements ScheduledActivity, BridgeE
     @JsonSerialize(using = DateTimeSerializer.class)
     public DateTime getScheduledOn() {
         return getInstant(getLocalScheduledOn());
-    }
-
-    @Override
-    @DynamoDBIgnore
-    @JsonIgnore
-    public Schedule getSchedule() {
-        return schedule;
-    }
-
-    public void setSchedule(Schedule schedule) {
-        this.schedule = schedule;
     }
 
     @Override

--- a/app/org/sagebionetworks/bridge/models/schedules/ActivityScheduler.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/ActivityScheduler.java
@@ -9,12 +9,8 @@ import org.joda.time.LocalDate;
 import org.joda.time.LocalDateTime;
 import org.joda.time.LocalTime;
 
-import com.google.common.collect.Lists;
-
 public abstract class ActivityScheduler {
     
-    private static final List<LocalTime> MIDNIGHT_IN_LIST = Lists.newArrayList(LocalTime.MIDNIGHT);
-
     protected final Schedule schedule;
     
     ActivityScheduler(Schedule schedule) {
@@ -45,11 +41,14 @@ public abstract class ActivityScheduler {
     }
     
     protected void addScheduledActivityForAllTimes(List<ScheduledActivity> scheduledActivities, SchedulePlan plan,
-            ScheduleContext context, LocalDate localDate) {
-        
-        List<LocalTime> localTimes = (schedule.getTimes().isEmpty()) ? MIDNIGHT_IN_LIST : schedule.getTimes();
-        for (LocalTime localTime : localTimes) {
-            addScheduledActivityAtTime(scheduledActivities, plan, context, localDate, localTime);
+            ScheduleContext context, DateTime dateTime) {
+
+        if (schedule.getTimes().isEmpty()) {
+            addScheduledActivityAtTime(scheduledActivities, plan, context, dateTime.toLocalDate(), dateTime.toLocalTime());
+        } else {
+            for (LocalTime localTime : schedule.getTimes()) {
+                addScheduledActivityAtTime(scheduledActivities, plan, context, dateTime.toLocalDate(), localTime);
+            }
         }
     }
     
@@ -70,7 +69,6 @@ public abstract class ActivityScheduler {
                     schActivity.setLocalScheduledOn(localDate.toLocalDateTime(localTime));
                     schActivity.setGuid(activity.getGuid() + ":" + localDate.toLocalDateTime(localTime));
                     schActivity.setPersistent(activity.isPersistentlyRescheduledBy(schedule));
-                    schActivity.setSchedule(schedule);
                     if (expiresOn != null) {
                         schActivity.setLocalExpiresOn(expiresOn);
                     }

--- a/app/org/sagebionetworks/bridge/models/schedules/IntervalActivityScheduler.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/IntervalActivityScheduler.java
@@ -23,11 +23,8 @@ class IntervalActivityScheduler extends ActivityScheduler {
         DateTime datetime = getScheduledTimeBasedOnEvent(context);
 
         if (datetime != null) {
-            // Remove the time component at this point because we're going to be adding the times in the array
-            // of times, and then we'll test again. If this moves past the day where smoe times are in and some 
-            // times are out, then the loop will break.
             while(shouldContinueScheduling(context, datetime, scheduledActivities)) {
-                addScheduledActivityForAllTimes(scheduledActivities, plan, context, datetime.toLocalDate());
+                addScheduledActivityForAllTimes(scheduledActivities, plan, context, datetime);
                 // A one-time activity with no interval (for example); don't loop
                 if (schedule.getInterval() == null) {
                     return trimScheduledActivities(scheduledActivities);

--- a/app/org/sagebionetworks/bridge/models/schedules/Schedule.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/Schedule.java
@@ -18,11 +18,6 @@ import com.google.common.collect.Lists;
 
 public final class Schedule implements BridgeEntity {
     
-    public static final boolean isScheduleWithoutTimes(Schedule schedule) {
-        return (schedule.getTimes().isEmpty() && 
-                schedule.getCronTrigger() == null);
-    }
-
     public static final String SCHEDULE_TYPE_NAME = "Schedule";
     
     public static final String LABEL_PROPERTY = "label";

--- a/app/org/sagebionetworks/bridge/models/schedules/ScheduledActivity.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/ScheduledActivity.java
@@ -64,15 +64,6 @@ public interface ScheduledActivity extends BridgeEntity {
     ScheduledActivityStatus getStatus();
 
     /**
-     * BRIDGE-1589. Carry over the schedule used to generate a ScheduledActivity in order to infer one-time tasks 
-     * that may have been duplicated as a result of scheduling from enrollment in a particular time zone. This 
-     * schedule is not persisted or returned to the user.
-     */
-    Schedule getSchedule();
-    
-    void setSchedule(Schedule schedule);
-    
-    /**
      * Get the time zone for this request. Currently this is a field on the activity and must be set to get DateTime values
      * from other fields in the class. This forces one method of converting schedule times to local times in order to
      * satisfy the API's delivery of times in the user's time zone, and may change when we convert closer to the service

--- a/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
+++ b/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
@@ -120,9 +120,9 @@ public class ScheduledActivityService {
     protected List<ScheduledActivity> updateActivitiesAndCollectSaves(List<ScheduledActivity> scheduledActivities, List<ScheduledActivity> dbActivities) {
         Map<String, ScheduledActivity> dbMap = Maps.uniqueIndex(dbActivities, ScheduledActivity::getGuid);
         
-        // At this point all one-time interval tasks without times whether schedules or already persisted, have a 
-        // time of midnight, and the db activities have been processed so there is only one and we can determine 
-        // if we're adding to an existing activity record or creating a new one.
+        // Find activities that have been scheduled, but not saved. If they have been scheduled and saved,
+        // replace the scheduled activity with the database activity so the existing state is returned to 
+        // user (startedOn/finishedOn). Don't save expired tasks though.
         List<ScheduledActivity> saves = Lists.newArrayList();
         for (int i=0; i < scheduledActivities.size(); i++) {
             ScheduledActivity activity = scheduledActivities.get(i);

--- a/test/org/sagebionetworks/bridge/SchedulingTestSuite.java
+++ b/test/org/sagebionetworks/bridge/SchedulingTestSuite.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge;
 
+import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
@@ -16,6 +17,7 @@ import org.sagebionetworks.bridge.services.ScheduledActivityServiceRecurringTest
  * These are run as part of the entire test suite, but when working on the scheduling, it is useful
  * to be able to run these tests separately. 
  */
+@Ignore
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
     ScheduledActivityServiceDuplicateTest.class,

--- a/test/org/sagebionetworks/bridge/SchedulingTestSuite.java
+++ b/test/org/sagebionetworks/bridge/SchedulingTestSuite.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.bridge;
 
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
@@ -17,7 +16,6 @@ import org.sagebionetworks.bridge.services.ScheduledActivityServiceRecurringTest
  * These are run as part of the entire test suite, but when working on the scheduling, it is useful
  * to be able to run these tests separately. 
  */
-@Ignore
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
     ScheduledActivityServiceDuplicateTest.class,

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityTest.java
@@ -30,8 +30,8 @@ public class DynamoScheduledActivityTest {
 
     @Test
     public void equalsHashCode() {
-        EqualsVerifier.forClass(DynamoScheduledActivity.class).suppress(Warning.NONFINAL_FIELDS)
-                .allFieldsShouldBeUsedExcept("schedule").verify();
+        EqualsVerifier.forClass(DynamoScheduledActivity.class).suppress(Warning.NONFINAL_FIELDS).allFieldsShouldBeUsed()
+                .verify();
     }
 
     @Test

--- a/test/org/sagebionetworks/bridge/models/schedules/ActivitySchedulerTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/ActivitySchedulerTest.java
@@ -129,7 +129,7 @@ public class ActivitySchedulerTest {
         schedule2.setEventId("task:task1");
 
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(NOW.plusMonths(2)));
-        assertEquals(asLong("2015-04-23 00:00"), scheduledActivities.get(0).getScheduledOn().getMillis());
+        assertEquals(asLong("2015-04-23 10:00"), scheduledActivities.get(0).getScheduledOn().getMillis());
 
         scheduledActivities = schedule2.getScheduler().getScheduledActivities(plan, getContext(NOW.plusMonths(2)));
         assertEquals(0, scheduledActivities.size());
@@ -141,7 +141,7 @@ public class ActivitySchedulerTest {
         
         // One-time tasks without times specified continue to schedule at midnight.
         scheduledActivities = schedule2.getScheduler().getScheduledActivities(plan, getContext(NOW.plusMonths(2)));
-        assertEquals(activity1Event.withTime(LocalTime.MIDNIGHT), scheduledActivities.get(0).getScheduledOn());
+        assertEquals(activity1Event, scheduledActivities.get(0).getScheduledOn());
     }
     
     @Test
@@ -229,11 +229,11 @@ public class ActivitySchedulerTest {
         
         events.put("scheduledOn:task:foo", NOW.minusHours(3));
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(NOW.plusDays(1)));
-        assertEquals(NOW.minusHours(3).withTime(LocalTime.MIDNIGHT), scheduledActivities.get(0).getScheduledOn());
+        assertEquals(NOW.minusHours(3), scheduledActivities.get(0).getScheduledOn());
 
         events.put("scheduledOn:task:foo", NOW.plusHours(8));
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(NOW.plusDays(1)));
-        assertEquals(NOW.plusHours(8).withTime(LocalTime.MIDNIGHT), scheduledActivities.get(0).getScheduledOn());
+        assertEquals(NOW.plusHours(8), scheduledActivities.get(0).getScheduledOn());
     }
     
     @Test
@@ -244,11 +244,11 @@ public class ActivitySchedulerTest {
         schedule.setScheduleType(ONCE);
         
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(NOW.plusDays(1)));
-        assertEquals(ENROLLMENT.withTime(LocalTime.MIDNIGHT).plusDays(2), scheduledActivities.get(0).getScheduledOn());
+        assertEquals(ENROLLMENT.plusDays(2), scheduledActivities.get(0).getScheduledOn());
         
         events.remove("survey:event");
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(NOW.plusDays(1)));
-        assertEquals(ENROLLMENT.withTime(LocalTime.MIDNIGHT), scheduledActivities.get(0).getScheduledOn());
+        assertEquals(ENROLLMENT, scheduledActivities.get(0).getScheduledOn());
         
         // BUT this produces nothing because the system doesn't fallback to enrollment if an event has been set
         schedule.setEventId("survey:event");

--- a/test/org/sagebionetworks/bridge/models/schedules/IntervalActivitySchedulerTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/IntervalActivitySchedulerTest.java
@@ -180,7 +180,7 @@ public class IntervalActivitySchedulerTest {
         
         schedule.getTimes().clear();
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(1)));
-        assertDates(scheduledActivities, "2015-04-10 00:00");
+        assertDates(scheduledActivities, "2015-04-10 11:40");
     }
     @Test
     public void onceEventStartsOnScheduleWorks() {
@@ -237,7 +237,7 @@ public class IntervalActivitySchedulerTest {
         // If we delete the times, it delays exactly 50 hours. (2 days, 2 hours)
         schedule.getTimes().clear();
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(1)));
-        assertDates(scheduledActivities, "2015-04-04 00:00");
+        assertDates(scheduledActivities, "2015-04-04 11:22");
     }
     @Test
     public void onceEventDelayStartsOnScheduleWorks() {
@@ -278,7 +278,7 @@ public class IntervalActivitySchedulerTest {
         events.put("survey:AAA:completedOn", asDT("2015-04-02 09:22"));
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(6)));
         // Pulled back to yesterday midnight to avoid TZ changes causing activity to be unavailable
-        assertDates(scheduledActivities, "2015-04-02 00:00");
+        assertDates(scheduledActivities, "2015-04-02 12:22");
     }
     @Test
     public void onceEventDelayExpiresStartEndsOnScheduleWorks() {
@@ -300,8 +300,8 @@ public class IntervalActivitySchedulerTest {
         events.put("survey:AAA:completedOn", asDT("2015-04-06 09:22"));
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(6)));
         
-        assertEquals(asLong("2015-04-06 00:00"), scheduledActivities.get(0).getScheduledOn().getMillis());
-        assertEquals(asLong("2015-04-09 00:00"), scheduledActivities.get(0).getExpiresOn().getMillis());
+        assertEquals(asLong("2015-04-06 12:22"), scheduledActivities.get(0).getScheduledOn().getMillis());
+        assertEquals(asLong("2015-04-09 12:22"), scheduledActivities.get(0).getExpiresOn().getMillis());
     }
     @Test
     public void recurringScheduleWorks() {

--- a/test/org/sagebionetworks/bridge/models/schedules/ScheduleTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/ScheduleTest.java
@@ -159,22 +159,4 @@ public class ScheduleTest {
         schedule.setDelay((Period)null);
         assertTrue(schedule.getPersistent());
     }
-    
-    @Test
-    public void isOnceTaskWithoutTimes() {
-        Schedule schedule = new Schedule();
-        schedule.setScheduleType(ScheduleType.ONCE);
-        assertTrue(Schedule.isScheduleWithoutTimes(schedule));
-        
-        schedule.addTimes(LocalTime.parse("10:00"));
-        assertFalse(Schedule.isScheduleWithoutTimes(schedule));
-        
-        schedule.getTimes().clear();
-        schedule.setCronTrigger("some nonsense here");
-        assertFalse(Schedule.isScheduleWithoutTimes(schedule));
-        
-        schedule.setCronTrigger(null);
-        schedule.setScheduleType(ScheduleType.PERSISTENT);
-        assertTrue(Schedule.isScheduleWithoutTimes(schedule));
-    }
 }

--- a/test/org/sagebionetworks/bridge/play/controllers/BaseControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/BaseControllerTest.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import org.junit.Test;
 
 import org.sagebionetworks.bridge.BridgeConstants;
-import org.sagebionetworks.bridge.BridgeUtils;
 import play.mvc.Http;
 
 import org.sagebionetworks.bridge.Roles;
@@ -166,7 +165,6 @@ public class BaseControllerTest {
         mockPlayContext();
         mockHeader(USER_AGENT, "Asthma/26 (Unknown iPhone; iPhone OS 9.0.2) BridgeSDK/4");
 
-        ClientInfo info = new SchedulePlanController().getClientInfoFromUserAgentHeader();
         Http.Response mockResponse = BaseController.response();
         verify(mockResponse, times(0)).setHeader(BRIDGE_API_STATUS_HEADER, WARN_NO_USER_AGENT);
     }
@@ -438,11 +436,8 @@ public class BaseControllerTest {
 
     @Test
     public void doesNotSetWarnHeaderWhenHasAcceptLanguage() throws Exception {
-        BaseController controller = new SchedulePlanController();
         mockPlayContext();
         mockHeader(ACCEPT_LANGUAGE, "de-de;q=0.4,de;q=0.2,en-ca,en;q=0.8,en-us;q=0.6");
-
-        LinkedHashSet<String> langs = controller.getLanguagesFromAcceptLanguageHeader();
 
         // verify if it does not set warning header
         Http.Response mockResponse = BaseController.response();

--- a/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceDuplicateTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceDuplicateTest.java
@@ -1,8 +1,8 @@
 package org.sagebionetworks.bridge.services;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
@@ -17,7 +17,6 @@ import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDateTime;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -45,7 +44,6 @@ import com.google.common.collect.Lists;
  * a standard time and midnight seems to work regardless of when the timestamp is).
  */
 @RunWith(MockitoJUnitRunner.class)
-@Ignore
 public class ScheduledActivityServiceDuplicateTest {
     //"studyKey (S)","guid (S)","label (S)","modifiedOn (N)","strategy (S)","version (N)"
     private static final String[][] SCHEDULE_PLAN_RECORDS = new String[][] {
@@ -269,11 +267,24 @@ public class ScheduledActivityServiceDuplicateTest {
         verify(activityDao).getActivities(any(), any());
         verify(schedulePlanService).getSchedulePlans(any(), any());
         
-        assertEquals(16, activities.size());
-        assertEquals(0, filterByGuid(activities, "bea8fd5d-7622-451f-a727-f9e37f00e1be:2016-06-30T00:00:00.000").size());
-        assertEquals(1, filterByGuid(activities, "6966c3d7-0949-43a8-804e-efc25d0f83e2:2016-06-30T00:00:00.000").size());
-        assertEquals(1, filterByGuid(activities, "79cf1788-a087-4fa3-92e4-92e43d9699a7:2016-06-30T00:00:00.000").size());
-        assertNotNull(filterByLabel(activities, "Training Session 1").get(0).getStartedOn());
+        log(activities, context);
+        allWithinQueryWindow(activities, context);
+        //assertEquals(16, activities.size());
+        assertEquals(1, filterByGuid(activities, "bea8fd5d-7622-451f-a727-f9e37f00e1be:2016-06-30T19:43:07.951").size());
+        assertEquals(1, filterByGuid(activities, "6966c3d7-0949-43a8-804e-efc25d0f83e2:2016-06-30T19:43:07.951").size());
+        assertEquals(1, filterByGuid(activities, "79cf1788-a087-4fa3-92e4-92e43d9699a7:2016-06-30T19:43:07.951").size());
+        // NOTE: this task has reset because the timestamp is different
+        // assertNotNull(filterByLabel(activities, "Training Session 1").get(0).getStartedOn());
+    }
+    
+    private void allWithinQueryWindow(List<ScheduledActivity> activities, ScheduleContext context) {
+        for (ScheduledActivity act : activities) {
+            DateTime windowStart = context.getNow();
+            DateTime windowEnd = context.getEndsOn();
+            
+            assertTrue(act.getExpiresOn() == null || act.getExpiresOn().isAfter(windowStart));
+            assertTrue(act.getScheduledOn().isBefore(windowEnd));
+        }
     }
     
     @Test
@@ -297,11 +308,12 @@ public class ScheduledActivityServiceDuplicateTest {
         verify(activityDao).getActivities(any(), any());
         verify(schedulePlanService).getSchedulePlans(any(), any());
         
-        assertEquals(15, activities.size());
-        assertEquals(0, filterByGuid(activities, "bea8fd5d-7622-451f-a727-f9e37f00e1be:2016-06-30T00:00:00.000").size());
-        assertEquals(1, filterByGuid(activities, "6966c3d7-0949-43a8-804e-efc25d0f83e2:2016-06-30T00:00:00.000").size());
-        assertEquals(1, filterByGuid(activities, "79cf1788-a087-4fa3-92e4-92e43d9699a7:2016-06-30T00:00:00.000").size());
-        assertNotNull(filterByLabel(activities, "Training Session 1").get(0).getStartedOn());
+        allWithinQueryWindow(activities, context);
+        assertEquals(1, filterByGuid(activities, "bea8fd5d-7622-451f-a727-f9e37f00e1be:2016-06-30T19:43:07.951").size());
+        assertEquals(1, filterByGuid(activities, "6966c3d7-0949-43a8-804e-efc25d0f83e2:2016-06-30T19:43:07.951").size());
+        assertEquals(1, filterByGuid(activities, "79cf1788-a087-4fa3-92e4-92e43d9699a7:2016-06-30T19:43:07.951").size());
+        // NOTE: this task has reset because the timestamp is different
+        //assertNotNull(filterByLabel(activities, "Training Session 1").get(0).getStartedOn());
     }
 
     @Test
@@ -321,11 +333,19 @@ public class ScheduledActivityServiceDuplicateTest {
         verify(activityDao).getActivities(any(), any());
         verify(schedulePlanService).getSchedulePlans(any(), any());
         // This one is there...
-        assertEquals(1, filterByGuid(activities, "bea8fd5d-7622-451f-a727-f9e37f00e1be:2016-06-30T00:00:00.000").size());
-        assertEquals(1, filterByGuid(activities, "6966c3d7-0949-43a8-804e-efc25d0f83e2:2016-06-30T00:00:00.000").size());
-        assertEquals(1, filterByGuid(activities, "79cf1788-a087-4fa3-92e4-92e43d9699a7:2016-06-30T00:00:00.000").size());
+        assertEquals(1, filterByGuid(activities, "bea8fd5d-7622-451f-a727-f9e37f00e1be:2016-06-30T19:43:07.951").size());
+        assertEquals(1, filterByGuid(activities, "6966c3d7-0949-43a8-804e-efc25d0f83e2:2016-06-30T19:43:07.951").size());
+        assertEquals(1, filterByGuid(activities, "79cf1788-a087-4fa3-92e4-92e43d9699a7:2016-06-30T19:43:07.951").size());
         // This one hasn't been started, obviously
         assertNull(filterByLabel(activities, "Training Session 1").get(0).getStartedOn());
+    }
+    
+    private void log(List<ScheduledActivity> activities, ScheduleContext context) {
+        System.out.println("activities: " + activities.size());
+        System.out.println("context.getNow(): " + context.getNow() + ", endsOn: " + context.getEndsOn());
+        for (ScheduledActivity act : activities) {
+            System.out.println(act.getExpiresOn() + ": " + act.getActivity().getLabel());
+        }
     }
     
     @Test
@@ -344,9 +364,9 @@ public class ScheduledActivityServiceDuplicateTest {
         // There's only one of these and they are set to midnight UTC.
         verify(activityDao).getActivities(any(), any());
         verify(schedulePlanService).getSchedulePlans(any(), any());
-        assertEquals(1, filterByGuid(activities, "bea8fd5d-7622-451f-a727-f9e37f00e1be:2016-06-30T00:00:00.000").size());
-        assertEquals(1, filterByGuid(activities, "6966c3d7-0949-43a8-804e-efc25d0f83e2:2016-06-30T00:00:00.000").size());
-        assertEquals(1, filterByGuid(activities, "79cf1788-a087-4fa3-92e4-92e43d9699a7:2016-06-30T00:00:00.000").size());
+        assertEquals(1, filterByGuid(activities, "bea8fd5d-7622-451f-a727-f9e37f00e1be:2016-06-30T19:43:07.951").size());
+        assertEquals(1, filterByGuid(activities, "6966c3d7-0949-43a8-804e-efc25d0f83e2:2016-06-30T19:43:07.951").size());
+        assertEquals(1, filterByGuid(activities, "79cf1788-a087-4fa3-92e4-92e43d9699a7:2016-06-30T19:43:07.951").size());
         
         // It's adjusted, magically it's still 6/30 I haven't figured out why yet.
         List<ScheduledActivity> list = filterByLabel(activities, "Do Persistent Activity");

--- a/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceDuplicateTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceDuplicateTest.java
@@ -267,7 +267,6 @@ public class ScheduledActivityServiceDuplicateTest {
         verify(activityDao).getActivities(any(), any());
         verify(schedulePlanService).getSchedulePlans(any(), any());
         
-        log(activities, context);
         allWithinQueryWindow(activities, context);
         //assertEquals(16, activities.size());
         assertEquals(1, filterByGuid(activities, "bea8fd5d-7622-451f-a727-f9e37f00e1be:2016-06-30T19:43:07.951").size());
@@ -275,16 +274,6 @@ public class ScheduledActivityServiceDuplicateTest {
         assertEquals(1, filterByGuid(activities, "79cf1788-a087-4fa3-92e4-92e43d9699a7:2016-06-30T19:43:07.951").size());
         // NOTE: this task has reset because the timestamp is different
         // assertNotNull(filterByLabel(activities, "Training Session 1").get(0).getStartedOn());
-    }
-    
-    private void allWithinQueryWindow(List<ScheduledActivity> activities, ScheduleContext context) {
-        for (ScheduledActivity act : activities) {
-            DateTime windowStart = context.getNow();
-            DateTime windowEnd = context.getEndsOn();
-            
-            assertTrue(act.getExpiresOn() == null || act.getExpiresOn().isAfter(windowStart));
-            assertTrue(act.getScheduledOn().isBefore(windowEnd));
-        }
     }
     
     @Test
@@ -340,14 +329,6 @@ public class ScheduledActivityServiceDuplicateTest {
         assertNull(filterByLabel(activities, "Training Session 1").get(0).getStartedOn());
     }
     
-    private void log(List<ScheduledActivity> activities, ScheduleContext context) {
-        System.out.println("activities: " + activities.size());
-        System.out.println("context.getNow(): " + context.getNow() + ", endsOn: " + context.getEndsOn());
-        for (ScheduledActivity act : activities) {
-            System.out.println(act.getExpiresOn() + ": " + act.getActivity().getLabel());
-        }
-    }
-    
     @Test
     public void withNoPersistedTasksItWorksEvenOnNextDayUTC() throws Exception {
         // Mock activityEventService
@@ -374,6 +355,16 @@ public class ScheduledActivityServiceDuplicateTest {
         assertEquals("21e97935-6d64-4cd5-ae70-653caad7b2f9:2016-06-30T00:00:00.000", list.get(0).getGuid());
         // This one hasn't been started, obviously
         assertNull(filterByLabel(activities, "Training Session 1").get(0).getStartedOn());
+    }
+    
+    private void allWithinQueryWindow(List<ScheduledActivity> activities, ScheduleContext context) {
+        for (ScheduledActivity act : activities) {
+            DateTime windowStart = context.getNow();
+            DateTime windowEnd = context.getEndsOn();
+            
+            assertTrue(act.getExpiresOn() == null || act.getExpiresOn().isAfter(windowStart));
+            assertTrue(act.getScheduledOn().isBefore(windowEnd));
+        }
     }
     
     private List<ScheduledActivity> filterByGuid(List<ScheduledActivity> activities, String guid) {

--- a/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceDuplicateTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceDuplicateTest.java
@@ -17,6 +17,7 @@ import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDateTime;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -44,6 +45,7 @@ import com.google.common.collect.Lists;
  * a standard time and midnight seems to work regardless of when the timestamp is).
  */
 @RunWith(MockitoJUnitRunner.class)
+@Ignore
 public class ScheduledActivityServiceDuplicateTest {
     //"studyKey (S)","guid (S)","label (S)","modifiedOn (N)","strategy (S)","version (N)"
     private static final String[][] SCHEDULE_PLAN_RECORDS = new String[][] {


### PR DESCRIPTION
Times are now based off the timestamp once again.

The plan instead is to record the time zone in the event table, in order to derive a local time of day that will work regardless of time zone changes. We'll backfill where we're able or probably use a central time zone (like central) instead.