### PR TITLE
delete schema API is now an Admin API (only to be used by integ tests for test cleanup)

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/UploadSchemaController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/UploadSchemaController.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.play.controllers;
 
+import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.WORKER;
 
@@ -61,37 +62,18 @@ public class UploadSchemaController extends BaseController {
     }
 
     /**
-     * Play controller for DELETE /researcher/v1/uploadSchema/byIdAndRev/:schemaId/:rev. This API deletes an upload
-     * schema with the specified schema ID and revision. If the schema doesn't exist, this API throws a 404 exception.
+     * Admin API to delete all revisions of a schema with the given schema ID in the given study. If the schema doesn't
+     * exist, this API throws a 404 exception.
      *
+     * @param studyId
+     *         study ID that the schema lives in
      * @param schemaId
-     *         schema ID of the upload schema to delete
-     * @param rev
-     *         revision number of the upload schema to delete, must be positive
+     *         schema to delete
      * @return Play result with the OK message
      */
-    public Result deleteUploadSchemaByIdAndRev(String schemaId, int rev) {
-        UserSession session = getAuthenticatedSession(DEVELOPER);
-        StudyIdentifier studyIdentifier = session.getStudyIdentifier();
-
-        uploadSchemaService.deleteUploadSchemaByIdAndRev(studyIdentifier, schemaId, rev);
-        return okResult("Schema has been deleted.");
-    }
-
-    /**
-     * Play controller for DELETE /researcher/v1/uploadSchema/byId/:schemaId. This API deletes all revisions of the
-     * upload schema with the specified schema ID. If there are no schemas with this schema ID, this API throws a 404
-     * exception.
-     *
-     * @param schemaId
-     *         schema ID of the upload schemas to delete, must be non-null and non-empty
-     * @return Play result with the OK message
-     */
-    public Result deleteUploadSchemaById(String schemaId) {
-        UserSession session = getAuthenticatedSession(DEVELOPER);
-        StudyIdentifier studyIdentifier = session.getStudyIdentifier();
-
-        uploadSchemaService.deleteUploadSchemaById(studyIdentifier, schemaId);
+    public Result deleteAllRevisionsOfUploadSchema(String studyId, String schemaId) {
+        getAuthenticatedSession(ADMIN);
+        uploadSchemaService.deleteUploadSchemaById(new StudyIdentifierImpl(studyId), schemaId);
         return okResult("Schemas have been deleted.");
     }
 

--- a/conf/routes
+++ b/conf/routes
@@ -126,8 +126,6 @@ POST   /v4/uploadschemas/:schemaId/revisions/:revision @org.sagebionetworks.brid
 GET    /v3/uploadschemas/:schemaId                 @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getUploadSchemaAllRevisions(schemaId: String)
 GET    /v3/uploadschemas/:schemaId/recent          @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getUploadSchema(schemaId: String)
 GET    /v3/uploadschemas/:schemaId/revisions/:rev  @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getUploadSchemaByIdAndRev(schemaId: String, rev: Int)
-DELETE /v3/uploadschemas/:schemaId                 @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.deleteUploadSchemaById(schemaId: String)
-DELETE /v3/uploadschemas/:schemaId/revisions/:rev  @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.deleteUploadSchemaByIdAndRev(schemaId: String, rev: Int)
 
 # Schedule Plans
 GET    /v3/scheduleplans           @org.sagebionetworks.bridge.play.controllers.SchedulePlanController.getSchedulePlans
@@ -161,6 +159,7 @@ DELETE /v3/externalIds    @org.sagebionetworks.bridge.play.controllers.ExternalI
 # APIs for getting entities across studies
 GET    /v3/studies/:studyId/surveys/published @org.sagebionetworks.bridge.play.controllers.SurveyController.getAllSurveysMostRecentlyPublishedVersionForStudy(studyId: String)
 GET    /v3/studies/:studyId/uploadschemas/:schemaId/revisions/:revision @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getUploadSchemaByStudyAndSchemaAndRev(studyId: String, schemaId: String, revision: Int)
+DELETE /v3/studies/:studyId/uploadschemas/:schemaId @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.deleteAllRevisionsOfUploadSchema(studyId: String, schemaId: String)
 POST   /v3/studies/:studyId/reports/:identifier           @org.sagebionetworks.bridge.play.controllers.ReportController.saveStudyReportForSpecifiedStudy(studyId: String, identifier: String)
 GET    /v3/studies/:studyId/uploads @org.sagebionetworks.bridge.play.controllers.StudyController.getUploadsForStudy(studyId: String, startTime: String ?= null, endTime: String ?= null)
 

--- a/test/org/sagebionetworks/bridge/play/controllers/UploadSchemaControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/UploadSchemaControllerTest.java
@@ -81,25 +81,14 @@ public class UploadSchemaControllerTest {
     }
 
     @Test
-    public void deleteSchemaByIdAndRevSuccess() throws Exception {
-        // mock UploadSchemaService
-        UploadSchemaService mockSvc = mock(UploadSchemaService.class);
-
-        // setup, execute, and validate
-        UploadSchemaController controller = setupControllerWithService(mockSvc);
-        Result result = controller.deleteUploadSchemaByIdAndRev("delete-schema", 1);
-        assertEquals(200, result.status());
-        verify(mockSvc).deleteUploadSchemaByIdAndRev(TestConstants.TEST_STUDY, "delete-schema", 1);
-    }
-
-    @Test
     public void deleteSchemaById() throws Exception {
         // mock UploadSchemaService
         UploadSchemaService mockSvc = mock(UploadSchemaService.class);
 
         // setup, execute, and validate
         UploadSchemaController controller = setupControllerWithService(mockSvc);
-        Result result = controller.deleteUploadSchemaById("delete-schema");
+        Result result = controller.deleteAllRevisionsOfUploadSchema(TestConstants.TEST_STUDY_IDENTIFIER,
+                "delete-schema");
         assertEquals(200, result.status());
         verify(mockSvc).deleteUploadSchemaById(TestConstants.TEST_STUDY, "delete-schema");
     }


### PR DESCRIPTION
In response to the recent incident where a production schema was accidentally deleted, we're now changing delete schema APIs to be admin-only. This is technically a breaking change, but the only place we're using this API is in Integ Tests, and possibly in the Researcher UI.

Note that integ tests will fail until the integ tests are updated:

Testing done:
* updated unit tests
* manually tested
* updated JavaSDK and Integ Tests

See also:
* https://github.com/Sage-Bionetworks/BridgeJavaSDK/pull/357
* https://github.com/Sage-Bionetworks/BridgeIntegrationTests/pull/109