### PR TITLE
Upload Validation ignore empty uploads

### DIFF
--- a/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2.java
+++ b/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2.java
@@ -451,7 +451,7 @@ public class IosSchemaValidationHandler2 implements UploadValidationHandler {
             String fieldName = oneFieldDef.getName();
 
             if (sanitizedUnzippedDataMap.containsKey(fieldName)) {
-                attachmentMap.put(fieldName, sanitizedUnzippedDataMap.get(fieldName));
+                addAttachment(attachmentMap, fieldName, sanitizedUnzippedDataMap.get(fieldName));
             } else if (sanitizedFlattenedJsonDataMap.containsKey(fieldName)) {
                 copyJsonField(context, uploadId, sanitizedFlattenedJsonDataMap.get(fieldName), oneFieldDef, dataMap,
                         attachmentMap);
@@ -506,7 +506,7 @@ public class IosSchemaValidationHandler2 implements UploadValidationHandler {
 
         if (UploadFieldType.ATTACHMENT_TYPE_SET.contains(fieldDef.getType())) {
             try {
-                attachmentMap.put(fieldName, BridgeObjectMapper.get().writeValueAsBytes(fieldValue));
+                addAttachment(attachmentMap, fieldName, BridgeObjectMapper.get().writeValueAsBytes(fieldValue));
             } catch (JsonProcessingException ex) {
                 context.addMessage(String.format(
                         "Upload ID %s field %s could not be converted from JSON: %s", uploadId, fieldName,
@@ -532,6 +532,14 @@ public class IosSchemaValidationHandler2 implements UploadValidationHandler {
             dataMap.put(fieldName, fieldValue.toString());
         } else {
             dataMap.set(fieldName, fieldValue);
+        }
+    }
+
+    // Helper method which encapsulates validating an upload before adding it to the attachment map. Right now, all it
+    // does is filter out empty attachments.
+    private static void addAttachment(Map<String, byte[]> attachmentMap, String fieldName, byte[] data) {
+        if (data.length != 0) {
+            attachmentMap.put(fieldName, data);
         }
     }
 }

--- a/test/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2Test.java
+++ b/test/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2Test.java
@@ -122,6 +122,8 @@ public class IosSchemaValidationHandler2Test {
                         .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build(),
                 new DynamoUploadFieldDefinition.Builder().withName("optional").withRequired(false)
                         .withType(UploadFieldType.STRING).build(),
+                new DynamoUploadFieldDefinition.Builder().withName("empty_attachment").withRequired(false)
+                        .withType(UploadFieldType.ATTACHMENT_V2).build(),
                 new DynamoUploadFieldDefinition.Builder().withName("optional_attachment").withRequired(false)
                         .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build()));
 
@@ -459,6 +461,9 @@ public class IosSchemaValidationHandler2Test {
                 "   },{\n" +
                 "       \"filename\":\"nonJsonFile.txt\",\n" +
                 "       \"timestamp\":\"2015-04-13T18:58:21-07:00\"\n" +
+                "   },{\n" +
+                "       \"filename\":\"empty_attachment\",\n" +
+                "       \"timestamp\":\"2015-04-13T18:58:18-07:00\"\n" +
                 "   }],\n" +
                 "   \"item\":\"non-json-data\"\n" +
                 "}";
@@ -474,6 +479,7 @@ public class IosSchemaValidationHandler2Test {
                 "jsonFile.json", jsonJsonNode));
         context.setUnzippedDataMap(ImmutableMap.<String, byte[]>builder()
                 .put("nonJsonFile.txt", "This is non-JSON data".getBytes(Charsets.UTF_8))
+                .put("empty_attachment", new byte[0])
                 .build());
 
         // execute


### PR DESCRIPTION
Right now, it's possible to submit an upload with an empty attachment. This leads to wonky things down the line. This change adds logic to ignore empty uploads, treating them as if they didn't exist.

Also fixed a non-failing NullPointerException in the unit tests.

Testing done:
* updated unit tests
* ran upload integ tests
* manual tested by uploading an upload with an empty attachment