### PR TITLE
limit dupe upload logging to 10 dupes

### DIFF
--- a/app/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/app/org/sagebionetworks/bridge/BridgeConstants.java
@@ -42,7 +42,10 @@ public class BridgeConstants {
     public static final String CUSTOM_DATA_CONSENT_SIGNATURE_SUFFIX = "_consent_signature";
 
     public static final String CUSTOM_DATA_VERSION = "version";
-    
+
+    /** Used to cap the number of dupe records we fetch from DDB and the number of log messages we write. */
+    public static final int DUPE_RECORDS_MAX_COUNT = 10;
+
     public static final String STUDY_PROPERTY = "study";
 
     public static final DateTimeZone LOCAL_TIME_ZONE = DateTimeZone.forID("America/Los_Angeles");

--- a/app/org/sagebionetworks/bridge/dao/HealthDataDao.java
+++ b/app/org/sagebionetworks/bridge/dao/HealthDataDao.java
@@ -54,7 +54,9 @@ public interface HealthDataDao {
     HealthDataRecordBuilder getRecordBuilder();
 
     /**
-     * Get a list of records by healthCode, creatdOn and SchemaId
+     * Get a list of records with the same healthCode and schemaId that are within an hour of the createdOn. For
+     * performance reasons, this caps the number of results returned to 10.
+     *
      * @param healthCode
      *      healthCode in String format
      * @param createdOn

--- a/app/org/sagebionetworks/bridge/upload/UploadValidationTask.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadValidationTask.java
@@ -1,10 +1,14 @@
 package org.sagebionetworks.bridge.upload;
 
 import javax.annotation.Nonnull;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import com.google.common.base.Stopwatch;
+
+import org.sagebionetworks.bridge.BridgeConstants;
+import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.models.healthdata.HealthDataRecord;
 import org.sagebionetworks.bridge.services.HealthDataService;
@@ -141,7 +145,6 @@ public class UploadValidationTask implements Runnable {
     /**
      * helper method: query healthdatarecord by healthcode, schema and createdOn from the upload just finished above,
      * if there are more than 1 such records in ddb, there are duplicates. log that information but not stop or delete anything right now
-     * @param healthRecordId
      */
     private void dedupeHelper(String healthRecordId) throws BadRequestException {
         if (healthRecordId == null) {
@@ -160,27 +163,34 @@ public class UploadValidationTask implements Runnable {
         String schemaId = record.getSchemaId();
 
         List<HealthDataRecord> retList = healthDataService.getRecordsByHealthcodeCreatedOnSchemaId(healthCode, createdOn, schemaId);
+        List<String> dupeRecordIdList = new ArrayList<>();
+        int numDupes = 0;
+        for (HealthDataRecord oneDupeRecord : retList) {
+            String dupeRecordId = oneDupeRecord.getId();
+            if (!dupeRecordId.equals(healthRecordId)) {
+                dupeRecordIdList.add(dupeRecordId);
+                numDupes++;
 
-        if (retList.size() > 1) {
-            logger.info(String.format("Duplicate health data records for record id: %s, created on:  %s, schema id: %s, duplicate size: %s",
-                    healthRecordId, createdOn, schemaId, retList.size()));
+                if (numDupes >= BridgeConstants.DUPE_RECORDS_MAX_COUNT) {
+                    // HealthDataService shouldn't return more than MAX_COUNT, but in case it does, have an extra check
+                    // here to prevent quadratic logging.
+                    break;
+                }
+            }
+        }
 
-            logDuplicateUploadRecords(record, retList);
+        if (numDupes > 0) {
+            logDuplicateUploadRecords(record, dupeRecordIdList);
         }
         // else there is only one such record exists in ddb or no record exists yet, means no duplicate -- do nothing
     }
 
-    void logDuplicateUploadRecords(HealthDataRecord originRecord, List<HealthDataRecord> dupeRecords) {
-        for (HealthDataRecord dupeRecord: dupeRecords) {
-            if (!dupeRecord.getId().equals(originRecord.getId())) {
-                logger.info("Origin Record: " + "record id: " + originRecord.getId()
-                        + ", Duplicate HealthDataRecord: " + "record id: " + dupeRecord.getId()
-                        + ", createdOn: " + dupeRecord.getCreatedOn().toString()
-                        + ", schemaId: " + dupeRecord.getSchemaId()
-                        + ", studyId: " + dupeRecord.getStudyId() + ", uploadDate: " + dupeRecord.getUploadDate().toString()
-                        + ", uploadId: " + dupeRecord.getUploadId());
-            }
-        }
+    // Package-scoped so we can spy this and verify this is being called.
+    void logDuplicateUploadRecords(HealthDataRecord originRecord, List<String> dupeRecordIdList) {
+        logger.info("Duplicate health data records for record id: " + originRecord.getId() + ", created on: "
+                + originRecord.getCreatedOn() + ", schema id: " + originRecord.getSchemaId() + ", study: "
+                + originRecord.getStudyId() + ", duplicate size: " + dupeRecordIdList.size()
+                + ", duplicate record IDs: " + BridgeUtils.COMMA_SPACE_JOINER.join(dupeRecordIdList));
     }
 
     // Log helper. Unit tests will mock (spy) this, so we verify that we're catching and logging the exception.


### PR DESCRIPTION
Right now, we log every duplicate if an upload is a duplicate this is bad because (a) it consumes a lot of DDB capacity (b) it logs a quadratic amount of logs.

This change caps the max dupes to 10, in both of those places.

Testing done:
* updated unit tests
* ran UploadTest integ tests
* manual test: Set max dupes to 2, then tested with 3 dupes and verified logs.