### PR TITLE
Adding get study report index, and changing to a more useful default date range.

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/ReportController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ReportController.java
@@ -277,6 +277,20 @@ public class ReportController extends BaseController {
     }
     
     /**
+     * Get a single study report index
+     */
+    public Result getStudyReportIndex(String identifier) {
+        UserSession session = getAuthenticatedSession(DEVELOPER, RESEARCHER);
+        ReportDataKey key = new ReportDataKey.Builder()
+                .withIdentifier(identifier)
+                .withReportType(ReportType.STUDY)
+                .withStudyIdentifier(session.getStudyIdentifier()).build();
+        
+        ReportIndex index = reportService.getReportIndex(key);
+        return okResult(index);
+    }
+    
+    /**
      * Update a single study report index. 
      */
     public Result updateStudyReportIndex(String identifier) {

--- a/app/org/sagebionetworks/bridge/services/ReportService.java
+++ b/app/org/sagebionetworks/bridge/services/ReportService.java
@@ -60,8 +60,8 @@ public class ReportService {
             LocalDate startDate, LocalDate endDate) {
         // ReportDataKey validates all parameters to this method
         
-        startDate = defaultValueToYesterday(startDate);
-        endDate = defaultValueToYesterday(endDate);
+        startDate = defaultValueToMinusDays(startDate, 1);
+        endDate = defaultValueToMinusDays(endDate, 0);
         validateDateRange(startDate, endDate);
 
         ReportDataKey key = new ReportDataKey.Builder()
@@ -75,8 +75,8 @@ public class ReportService {
     public DateRangeResourceList<? extends ReportData> getParticipantReport(StudyIdentifier studyId, String identifier, String healthCode, LocalDate startDate, LocalDate endDate) {
         // ReportDataKey validates all parameters to this method
         
-        startDate = defaultValueToYesterday(startDate);
-        endDate = defaultValueToYesterday(endDate);
+        startDate = defaultValueToMinusDays(startDate, 1);
+        endDate = defaultValueToMinusDays(endDate, 0);
         validateDateRange(startDate, endDate);
 
         ReportDataKey key = new ReportDataKey.Builder()
@@ -210,9 +210,9 @@ public class ReportService {
         }
     }
     
-    private LocalDate defaultValueToYesterday(LocalDate submittedValue) {
+    private LocalDate defaultValueToMinusDays(LocalDate submittedValue, int minusDays) {
         if (submittedValue == null) {
-            return DateUtils.getCurrentCalendarDateInLocalTime().minusDays(1);
+            return DateUtils.getCurrentCalendarDateInLocalTime().minusDays(minusDays);
         }
         return submittedValue;
     }

--- a/conf/routes
+++ b/conf/routes
@@ -80,6 +80,7 @@ GET    /v3/users/self/reports/:identifier @org.sagebionetworks.bridge.play.contr
 GET    /v3/reports                                        @org.sagebionetworks.bridge.play.controllers.ReportController.getReportIndices(type: String)
 GET    /v3/reports/:identifier                            @org.sagebionetworks.bridge.play.controllers.ReportController.getStudyReport(identifier: String, startDate: String ?= null, endDate: String ?= null)
 POST   /v3/reports/:identifier                            @org.sagebionetworks.bridge.play.controllers.ReportController.saveStudyReport(identifier: String)
+GET    /v3/reports/:identifier/index                      @org.sagebionetworks.bridge.play.controllers.ReportController.getStudyReportIndex(identifier: String)
 POST   /v3/reports/:identifier/index                      @org.sagebionetworks.bridge.play.controllers.ReportController.updateStudyReportIndex(identifier: String)
 DELETE /v3/reports/:identifier                            @org.sagebionetworks.bridge.play.controllers.ReportController.deleteStudyReport(identifier: String)
 DELETE /v3/reports/:identifier/:date                      @org.sagebionetworks.bridge.play.controllers.ReportController.deleteStudyReportRecord(identifier: String, date: String)

--- a/test/org/sagebionetworks/bridge/services/ReportServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ReportServiceTest.java
@@ -144,8 +144,9 @@ public class ReportServiceTest {
         DateTimeUtils.setCurrentMillisFixed(DateTime.parse("2015-05-05T12:00:00.000Z").getMillis());
         try {
             LocalDate yesterday = LocalDate.parse("2015-05-04");
+            LocalDate today = LocalDate.parse("2015-05-05");
             
-            doReturn(results).when(mockReportDataDao).getReportData(STUDY_REPORT_DATA_KEY, yesterday, yesterday);
+            doReturn(results).when(mockReportDataDao).getReportData(STUDY_REPORT_DATA_KEY, yesterday, today);
             
             DateRangeResourceList<? extends ReportData> retrieved = service.getStudyReport(
                     TEST_STUDY, IDENTIFIER, null, null);
@@ -153,7 +154,7 @@ public class ReportServiceTest {
             verify(mockReportDataDao).getReportData(eq(STUDY_REPORT_DATA_KEY), localDateCaptor.capture(),
                     localDateCaptor.capture());
             assertEquals(yesterday, localDateCaptor.getAllValues().get(0));
-            assertEquals(yesterday, localDateCaptor.getAllValues().get(1));
+            assertEquals(today, localDateCaptor.getAllValues().get(1));
             assertEquals(results, retrieved);
         } finally {
             DateTimeUtils.setCurrentMillisSystem();
@@ -176,8 +177,9 @@ public class ReportServiceTest {
         DateTimeUtils.setCurrentMillisFixed(DateTime.parse("2015-05-05T12:00:00.000Z").getMillis());
         try {
             LocalDate yesterday = LocalDate.parse("2015-05-04");
+            LocalDate today = LocalDate.parse("2015-05-05");
             
-            doReturn(results).when(mockReportDataDao).getReportData(PARTICIPANT_REPORT_DATA_KEY, yesterday, yesterday);
+            doReturn(results).when(mockReportDataDao).getReportData(PARTICIPANT_REPORT_DATA_KEY, yesterday, today);
             
             DateRangeResourceList<? extends ReportData> retrieved = service.getParticipantReport(
                     TEST_STUDY, IDENTIFIER, HEALTH_CODE, null, null);
@@ -185,7 +187,7 @@ public class ReportServiceTest {
             verify(mockReportDataDao).getReportData(eq(PARTICIPANT_REPORT_DATA_KEY), localDateCaptor.capture(),
                     localDateCaptor.capture());
             assertEquals(yesterday, localDateCaptor.getAllValues().get(0));
-            assertEquals(yesterday, localDateCaptor.getAllValues().get(1));
+            assertEquals(today, localDateCaptor.getAllValues().get(1));
             assertEquals(results, retrieved);
         } finally {
             DateTimeUtils.setCurrentMillisSystem();
@@ -331,7 +333,7 @@ public class ReportServiceTest {
         try {
             service.getParticipantReport(TEST_STUDY, IDENTIFIER, HEALTH_CODE, null, null);
             
-            verify(mockReportDataDao).getReportData(PARTICIPANT_REPORT_DATA_KEY, LocalDate.parse("2016-02-07"), LocalDate.parse("2016-02-07"));
+            verify(mockReportDataDao).getReportData(PARTICIPANT_REPORT_DATA_KEY, LocalDate.parse("2016-02-07"), LocalDate.parse("2016-02-08"));
         } finally {
             DateTimeUtils.setCurrentMillisSystem();
         }


### PR DESCRIPTION
Some tweaks to the public reporting stuff based on implementing it in the researcher UI:

- get the study index to get publication state, for both developers and researchers
- getting date range from yesterday to yesterday doesn't return anything obvious, get from yesterday until today.