### PR TITLE
This endpoint seems like a mistake, removing

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/ReportController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ReportController.java
@@ -310,26 +310,6 @@ public class ReportController extends BaseController {
         return okResult("Report index updated.");
     }
     
-    /**
-     * Update a single participant report index. 
-     */
-    public Result updateParticipantReportIndex(String identifier) {
-        UserSession session = getAuthenticatedSession(DEVELOPER);
-        
-        ReportIndex index = parseJson(request(), ReportIndex.class);
-        ReportDataKey key = new ReportDataKey.Builder()
-                .withHealthCode(session.getHealthCode())
-                .withReportType(ReportType.PARTICIPANT)
-                .withIdentifier(identifier)
-                .withStudyIdentifier(session.getStudyIdentifier()).build();
-        index.setKey(key.getIndexKeyString());
-        index.setIdentifier(identifier);
-        
-        reportService.updateReportIndex(ReportType.PARTICIPANT, index);
-        
-        return okResult("Report index updated.");
-    }
-    
     private void verifyIndex(final StudyIdentifier studyId, final String identifier) {
         ReportDataKey key = new ReportDataKey.Builder()
                 .withIdentifier(identifier)

--- a/conf/routes
+++ b/conf/routes
@@ -85,7 +85,6 @@ POST   /v3/reports/:identifier/index                      @org.sagebionetworks.b
 DELETE /v3/reports/:identifier                            @org.sagebionetworks.bridge.play.controllers.ReportController.deleteStudyReport(identifier: String)
 DELETE /v3/reports/:identifier/:date                      @org.sagebionetworks.bridge.play.controllers.ReportController.deleteStudyReportRecord(identifier: String, date: String)
 POST   /v3/participants/reports/:identifier               @org.sagebionetworks.bridge.play.controllers.ReportController.saveParticipantReportForWorker(identifier: String)
-POST   /v3/participants/reports/:identifier/index         @org.sagebionetworks.bridge.play.controllers.ReportController.updateParticipantReportIndex(identifier: String)
 DELETE /v3/participants/reports/:identifier               @org.sagebionetworks.bridge.play.controllers.ReportController.deleteParticipantReportIndex(identifier: String)
 GET    /v3/participants/:userId/reports/:identifier       @org.sagebionetworks.bridge.play.controllers.ReportController.getParticipantReportForResearcher(userId: String, identifier: String, startDate: String ?= null, endDate: String ?= null)
 POST   /v3/participants/:userId/reports/:identifier       @org.sagebionetworks.bridge.play.controllers.ReportController.saveParticipantReport(userId: String, identifier: String)

--- a/test/org/sagebionetworks/bridge/play/controllers/ReportControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ReportControllerTest.java
@@ -479,21 +479,6 @@ public class ReportControllerTest {
         TestUtils.assertResult(result, 200, "Report index updated.");
     }
     
-    @Test
-    public void canUpdateParticipantReportIndex() throws Exception {
-        TestUtils.mockPlayContextWithJson("{\"public\":true}");
-        
-        Result result = controller.updateParticipantReportIndex(REPORT_ID);
-        
-        verify(mockReportService).updateReportIndex(eq(ReportType.PARTICIPANT), reportDataIndex.capture());
-        ReportIndex index = reportDataIndex.getValue();
-        assertTrue(index.isPublic());
-        assertEquals(REPORT_ID, index.getIdentifier());
-        assertEquals("api:PARTICIPANT", index.getKey());
-        
-        TestUtils.assertResult(result, 200, "Report index updated.");
-    }
-    
     private static final TypeReference<DateRangeResourceList<? extends ReportData>> REPORT_REF = new TypeReference<DateRangeResourceList<? extends ReportData>>() {
     };
     


### PR DESCRIPTION
Given the logic of the controller, you couldn't really use it except for a developer to edit their own study index, and isn't needed for public study reports.