### PR TITLE
Adding study configuration for platform ARNs needed to register devices for notifications.

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/StudyDao.java
+++ b/app/org/sagebionetworks/bridge/dao/StudyDao.java
@@ -3,7 +3,6 @@ package org.sagebionetworks.bridge.dao;
 import java.util.List;
 
 import org.sagebionetworks.bridge.models.studies.Study;
-import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 
 public interface StudyDao {
 

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
@@ -50,12 +50,14 @@ public final class DynamoStudy implements Study {
     private boolean emailVerificationEnabled;
     private boolean externalIdValidationEnabled;
     private Map<String, Integer> minSupportedAppVersions;
+    private Map<String, String> pushNotificationARNs;
 
     public DynamoStudy() {
         profileAttributes = new HashSet<>();
         taskIdentifiers = new HashSet<>();
         dataGroups = new HashSet<>();
         minSupportedAppVersions = new HashMap<>();
+        pushNotificationARNs = new HashMap<>();
     }
 
     /** {@inheritDoc} */
@@ -343,6 +345,19 @@ public final class DynamoStudy implements Study {
     public void setMinSupportedAppVersions(Map<String,Integer> map) {
         this.minSupportedAppVersions = (map == null) ? new HashMap<>() : map;
     }
+    
+    /** {@inheritDoc} */
+    @Override
+    public Map<String,String> getPushNotificationARNs() {
+        return pushNotificationARNs;
+    }
+
+    @Override
+    public void setPushNotificationARNs(Map<String,String> map) {
+        this.pushNotificationARNs = (map == null) ? new HashMap<>() : map;
+    }
+    
+    
 
     @Override
     public int hashCode() {
@@ -351,7 +366,7 @@ public final class DynamoStudy implements Study {
                 dataGroups, passwordPolicy, verifyEmailTemplate, resetPasswordTemplate, active,
                 strictUploadValidationEnabled, healthCodeExportEnabled, emailVerificationEnabled,
                 externalIdValidationEnabled, minSupportedAppVersions, synapseDataAccessTeamId, synapseProjectId,
-                usesCustomExportSchedule);
+                usesCustomExportSchedule, pushNotificationARNs);
     }
 
     @Override
@@ -382,7 +397,8 @@ public final class DynamoStudy implements Study {
                 && Objects.equals(healthCodeExportEnabled, other.healthCodeExportEnabled)
                 && Objects.equals(externalIdValidationEnabled, other.externalIdValidationEnabled)
                 && Objects.equals(emailVerificationEnabled, other.emailVerificationEnabled)
-                && Objects.equals(minSupportedAppVersions, other.minSupportedAppVersions);
+                && Objects.equals(minSupportedAppVersions, other.minSupportedAppVersions)
+                && Objects.equals(pushNotificationARNs, other.pushNotificationARNs);
     }
 
     @Override
@@ -393,11 +409,12 @@ public final class DynamoStudy implements Study {
                             + "consentNotificationEmail=%s, version=%s, userProfileAttributes=%s, taskIdentifiers=%s, "
                             + "dataGroups=%s, passwordPolicy=%s, verifyEmailTemplate=%s, resetPasswordTemplate=%s, "
                             + "strictUploadValidationEnabled=%s, healthCodeExportEnabled=%s, emailVerificationEnabled=%s, "
-                            + "externalIdValidationEnabled=%s, minSupportedAppVersions=%s, usesCustomExportSchedule=%s]",
+                            + "externalIdValidationEnabled=%s, minSupportedAppVersions=%s, usesCustomExportSchedule=%s, "
+                            + "pushNotificationARNs=%s]",
                 name, active, sponsorName, identifier, stormpathHref, minAgeOfConsent, supportEmail, synapseDataAccessTeamId, 
                 synapseProjectId, technicalEmail, consentNotificationEmail, version, profileAttributes, taskIdentifiers, 
                 dataGroups, passwordPolicy, verifyEmailTemplate, resetPasswordTemplate, strictUploadValidationEnabled, 
                 healthCodeExportEnabled, emailVerificationEnabled, externalIdValidationEnabled, minSupportedAppVersions, 
-                usesCustomExportSchedule);
+                usesCustomExportSchedule, pushNotificationARNs);
     }
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoStudyDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoStudyDao.java
@@ -7,7 +7,6 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
@@ -24,7 +23,6 @@ import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.models.studies.Study;
-import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.validators.Validate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;

--- a/app/org/sagebionetworks/bridge/models/studies/Study.java
+++ b/app/org/sagebionetworks/bridge/models/studies/Study.java
@@ -212,4 +212,13 @@ public interface Study extends BridgeEntity, StudyIdentifier {
 	
 	/** @see #getMinSupportedVersion(); */
     void setMinSupportedAppVersions(Map<String, Integer> map);
+    
+    /**
+     * A map between operating system names, and the platform ARN necessary to register a device to 
+     * receive mobile push notifications for this study, on that platform.
+     */
+    Map<String, String> getPushNotificationARNs();
+
+    /** @see #getPushNotificationARNs(); */
+    void setPushNotificationARNs(Map<String, String> pushNotificationARNs);
 }

--- a/app/org/sagebionetworks/bridge/services/StudyService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyService.java
@@ -33,7 +33,6 @@ import org.sagebionetworks.bridge.models.studies.MimeType;
 import org.sagebionetworks.bridge.models.studies.PasswordPolicy;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
-import org.sagebionetworks.bridge.models.surveys.Survey;
 import org.sagebionetworks.bridge.validators.StudyValidator;
 import org.sagebionetworks.bridge.validators.Validate;
 

--- a/app/org/sagebionetworks/bridge/services/UserDataDownloadViaSqsService.java
+++ b/app/org/sagebionetworks/bridge/services/UserDataDownloadViaSqsService.java
@@ -1,7 +1,5 @@
 package org.sagebionetworks.bridge.services;
 
-import java.util.HashMap;
-import java.util.Map;
 import javax.annotation.Nonnull;
 
 import com.amazonaws.services.sqs.AmazonSQSClient;
@@ -15,7 +13,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import org.sagebionetworks.bridge.config.BridgeConfig;
-import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.DateRange;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -270,13 +270,19 @@ public class TestUtils {
     }
     
     public static DynamoStudy getValidStudy(Class<?> clazz) {
+        String id = TestUtils.randomName(clazz);
+        
+        Map<String,String> pushNotificationARNs = Maps.newHashMap();
+        pushNotificationARNs.put(OperatingSystem.IOS, "arn:ios:"+id);
+        pushNotificationARNs.put(OperatingSystem.ANDROID, "arn:android:"+id);
+        
         // This study will save without further modification.
         DynamoStudy study = new DynamoStudy();
         study.setName("Test Study ["+clazz.getSimpleName()+"]");
         study.setPasswordPolicy(PasswordPolicy.DEFAULT_PASSWORD_POLICY);
         study.setVerifyEmailTemplate(new EmailTemplate("subject", "body with ${url}", MimeType.TEXT));
         study.setResetPasswordTemplate(new EmailTemplate("subject", "body with ${url}", MimeType.TEXT));
-        study.setIdentifier(TestUtils.randomName(clazz));
+        study.setIdentifier(id);
         study.setMinAgeOfConsent(18);
         study.setSponsorName("The Council on Test Studies");
         study.setConsentNotificationEmail("bridge-testing+consent@sagebase.org");
@@ -293,6 +299,7 @@ public class TestUtils {
         study.setEmailVerificationEnabled(true);
         study.setExternalIdValidationEnabled(true);
         study.setActive(true);
+        study.setPushNotificationARNs(pushNotificationARNs);
         return study;
     }
     

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyDaoTest.java
@@ -19,6 +19,7 @@ import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
+import org.sagebionetworks.bridge.models.OperatingSystem;
 import org.sagebionetworks.bridge.models.studies.Study;
 
 import org.slf4j.Logger;
@@ -63,6 +64,13 @@ public class DynamoStudyDaoTest {
     @Test
     public void crudOneStudy() {
         Study study = TestUtils.getValidStudy(DynamoStudyDaoTest.class);
+        
+        // Verify these values are persisted in a map
+        String androidARN = study.getPushNotificationARNs().get(OperatingSystem.ANDROID);
+        String iosARN = study.getPushNotificationARNs().get(OperatingSystem.IOS);
+        assertNotNull(androidARN);
+        assertNotNull(iosARN);
+        
         study.setStormpathHref("http://url.com/");
         study.setUserProfileAttributes(USER_PROFILE_ATTRIBUTES);
         study.setTaskIdentifiers(TASK_IDENTIFIERS);
@@ -83,6 +91,8 @@ public class DynamoStudyDaoTest {
         assertTrue(study.getUsesCustomExportSchedule());
         assertEquals(TASK_IDENTIFIERS, study.getTaskIdentifiers());
         assertEquals(DATA_GROUPS, study.getDataGroups());
+        assertEquals(androidARN, study.getPushNotificationARNs().get(OperatingSystem.ANDROID));
+        assertEquals(iosARN, study.getPushNotificationARNs().get(OperatingSystem.IOS));
 
         String identifier = study.getIdentifier();
         studyDao.deleteStudy(study);

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
@@ -43,7 +43,7 @@ public class DynamoStudyTest {
         
         final String json = BridgeObjectMapper.get().writeValueAsString(study);
         final JsonNode node = BridgeObjectMapper.get().readTree(json);
-        
+
         assertEqualsAndNotNull(study.getConsentNotificationEmail(), node.get("consentNotificationEmail").asText());
         assertEqualsAndNotNull(study.getSupportEmail(), node.get("supportEmail").asText());
         assertEqualsAndNotNull(study.getSynapseDataAccessTeamId(), node.get("synapseDataAccessTeamId").longValue());
@@ -69,6 +69,10 @@ public class DynamoStudyTest {
         assertTrue(node.get("emailVerificationEnabled").asBoolean());
         assertTrue(node.get("externalIdValidationEnabled").asBoolean());
         assertEqualsAndNotNull("Study", node.get("type").asText());
+        assertEqualsAndNotNull(study.getPushNotificationARNs().get(OperatingSystem.IOS),
+                node.get("pushNotificationARNs").get(OperatingSystem.IOS).asText());
+        assertEqualsAndNotNull(study.getPushNotificationARNs().get(OperatingSystem.ANDROID),
+                node.get("pushNotificationARNs").get(OperatingSystem.ANDROID).asText());
         
         JsonNode supportedVersionsNode = JsonUtils.asJsonNode(node, "minSupportedAppVersions");
         assertNotNull(supportedVersionsNode);

--- a/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
@@ -9,7 +9,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.services.StudyService.EXPORTER_SYNAPSE_USER_ID;
 

--- a/test/org/sagebionetworks/bridge/services/UserDataDownloadViaSqsServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/UserDataDownloadViaSqsServiceTest.java
@@ -7,19 +7,14 @@ import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 import static org.sagebionetworks.bridge.services.UserDataDownloadViaSqsService.*;
 
-import java.util.Map;
-
 import com.amazonaws.services.sqs.AmazonSQSClient;
 import com.amazonaws.services.sqs.model.SendMessageResult;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.sagebionetworks.bridge.config.BridgeConfig;
-import org.sagebionetworks.bridge.json.BridgeObjectMapper;
-import org.sagebionetworks.bridge.json.JsonUtils;
 import org.sagebionetworks.bridge.models.DateRange;
 
 public class UserDataDownloadViaSqsServiceTest {


### PR DESCRIPTION
It's just a place to hold the metadata. We are not going to try and configure this when we create a study (not clear to me we'll even have notifications in each study). It must be done manually because you need a lot of stuff from the external notification systems like certificates, and this is more easily done through SNS.