### PR TITLE
move dupe record max count as part of DDB query

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataDao.java
@@ -2,9 +2,9 @@ package org.sagebionetworks.bridge.dynamodb;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Resource;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
@@ -116,24 +116,13 @@ public class DynamoHealthDataDao implements HealthDataDao {
         DynamoDBQueryExpression<DynamoHealthDataRecord> expression = new DynamoDBQueryExpression<DynamoHealthDataRecord>()
                 .withConsistentRead(false)
                 .withHashKeyValues(queryRecord)
-                .withRangeKeyCondition("createdOn", rangeKeyCondition);
+                .withRangeKeyCondition("createdOn", rangeKeyCondition)
+                .withLimit(BridgeConstants.DUPE_RECORDS_MAX_COUNT);
 
         List<DynamoHealthDataRecord> recordList = mapper.query(DynamoHealthDataRecord.class, expression);
 
-        List<HealthDataRecord> finalRecords = new ArrayList<>();
-        int numDupes = 0;
-        for (DynamoHealthDataRecord oneResult : recordList) {
-            if (oneResult.getSchemaId().equals(schemaId)) {
-                finalRecords.add(oneResult);
-                numDupes++;
-
-                if (numDupes >= BridgeConstants.DUPE_RECORDS_MAX_COUNT) {
-                    // Limit the number of dupes we get to prevent browning out DDB.
-                    break;
-                }
-            }
-        }
-
-        return finalRecords;
+        // Filter out schemas that don't match and convert it to a list of the parent type.
+        return recordList.stream().filter(record -> schemaId.equals(record.getSchemaId())).collect(
+                Collectors.toList());
     }
 }


### PR DESCRIPTION
Currently, we query DDB, then keep looping until we find DUPE_RECORD_MAX_COUNT queries. Unfortunately, this can consume a lot of capacity if the participant submits a bunch of uploads in a short time (which is common MyHeartCounts).

This moves the DUPE_RECORD_MAX_COUNT to be used as a limit in the DDB query. This means we miss some duplicates, but we cap our DDB usage. (Long-term, we need to re-implement this query to use a compound hash key on healthCode and schemaID. See https://sagebionetworks.jira.com/browse/BRIDGE-468)

Testing done: There is no functional change, and testing DDB capacity consumption is not that easy to test. However, I did manual tests to verify that the DUPE_RECORD_MAX_COUNT is still be enforced.