### PR TITLE
DynamoDBMapper.query() ignores LIMIT; move to queryPage()

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataDao.java
@@ -7,6 +7,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
+import com.amazonaws.services.dynamodbv2.datamodeling.QueryResultPage;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
 import com.amazonaws.services.dynamodbv2.model.Condition;
@@ -119,7 +120,8 @@ public class DynamoHealthDataDao implements HealthDataDao {
                 .withRangeKeyCondition("createdOn", rangeKeyCondition)
                 .withLimit(BridgeConstants.DUPE_RECORDS_MAX_COUNT);
 
-        List<DynamoHealthDataRecord> recordList = mapper.query(DynamoHealthDataRecord.class, expression);
+        QueryResultPage<DynamoHealthDataRecord> resultPage = mapper.queryPage(DynamoHealthDataRecord.class, expression);
+        List<DynamoHealthDataRecord> recordList = resultPage.getResults();
 
         // Filter out schemas that don't match and convert it to a list of the parent type.
         return recordList.stream().filter(record -> schemaId.equals(record.getSchemaId())).collect(

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoStudyConsentDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoStudyConsentDao.java
@@ -10,6 +10,7 @@ import org.sagebionetworks.bridge.dao.StudyConsentDao;
 import org.sagebionetworks.bridge.models.subpopulations.StudyConsent;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 
+import com.amazonaws.services.dynamodbv2.datamodeling.QueryResultPage;
 import org.springframework.stereotype.Component;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
@@ -46,7 +47,8 @@ public class DynamoStudyConsentDao implements StudyConsentDao {
                 .withHashKeyValues(hashKey)
                 .withScanIndexForward(false)
                 .withLimit(1);
-        PaginatedQueryList<DynamoStudyConsent1> page = mapper.query(DynamoStudyConsent1.class, queryExpression);
+        QueryResultPage<DynamoStudyConsent1> resultPage = mapper.queryPage(DynamoStudyConsent1.class, queryExpression);
+        List<DynamoStudyConsent1> page = resultPage.getResults();
         if (page.isEmpty()) {
             return null;
         }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDao.java
@@ -16,6 +16,7 @@ import java.util.TreeSet;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBSaveExpression;
+import com.amazonaws.services.dynamodbv2.datamodeling.QueryResultPage;
 import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException;
 import com.amazonaws.services.dynamodbv2.model.ExpectedAttributeValue;
 import com.google.common.base.Preconditions;
@@ -576,7 +577,8 @@ public class DynamoUploadSchemaDao implements UploadSchemaDao {
         // Get the latest revision. This is accomplished by scanning the range key backwards.
         DynamoDBQueryExpression<DynamoUploadSchema> ddbQuery = new DynamoDBQueryExpression<DynamoUploadSchema>()
                 .withHashKeyValues(key).withScanIndexForward(false).withLimit(1);
-        List<DynamoUploadSchema> schemaList = mapper.query(DynamoUploadSchema.class, ddbQuery);
+        QueryResultPage<DynamoUploadSchema> resultPage = mapper.queryPage(DynamoUploadSchema.class, ddbQuery);
+        List<DynamoUploadSchema> schemaList = resultPage.getResults();
         if (schemaList.isEmpty()) {
             return null;
         } else {

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataDaoDdbTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataDaoDdbTest.java
@@ -13,6 +13,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.models.healthdata.HealthDataRecord;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +26,7 @@ import org.sagebionetworks.bridge.dao.ParticipantOption;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -146,6 +149,37 @@ public class DynamoHealthDataDaoDdbTest {
         assertEquals(1, metadataNode.size());
         assertEquals("dummy meta value", metadataNode.get("metadata").textValue());
 
+    }
+
+    @Test
+    public void getRecordsByHealthCodeCreatedOnSchemaIdWithLimit() {
+        List<DynamoHealthDataRecord> recordsToDelete = new ArrayList<>();
+        try {
+            // Create DUPE_RECORD_MAX_COUNT+2 additional records, so that there will be MAX_COUNT+3 records. We have a
+            // bunch of extra records just to make sure we have more than enough and aren't hitting any weird
+            // off-by-one errors in our test.
+            for (int i = 0; i < BridgeConstants.DUPE_RECORDS_MAX_COUNT+2; i++) {
+                // Should have the same healthCode, same schemaId, and similar createdOn, but different recordId.
+                DynamoHealthDataRecord record = new DynamoHealthDataRecord();
+                record.setId(recordId + i);
+                record.setHealthCode(healthCode);
+                record.setSchemaId(SCHEMA_ID);
+                record.setCreatedOn(CREATED_ON + i);
+                mapper.save(record);
+                recordsToDelete.add(record);
+            }
+
+            // query
+            List<HealthDataRecord> retList = dao.getRecordsByHealthCodeCreatedOnSchemaId(healthCode, CREATED_ON,
+                    SCHEMA_ID);
+
+            // Verify just the number of records. Everything else is tested elsewhere.
+            assertEquals(BridgeConstants.DUPE_RECORDS_MAX_COUNT, retList.size());
+        } finally {
+            for (DynamoHealthDataRecord oneRecord : recordsToDelete) {
+                mapper.delete(oneRecord);
+            }
+        }
     }
 
     @Test

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataDaoTest.java
@@ -10,18 +10,16 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
-import com.amazonaws.services.dynamodbv2.datamodeling.PaginatedQueryList;
+import com.amazonaws.services.dynamodbv2.datamodeling.QueryResultPage;
 import com.amazonaws.services.dynamodbv2.model.WriteRequest;
 import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
-import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.models.healthdata.HealthDataRecord;
 
@@ -154,11 +152,11 @@ public class DynamoHealthDataDaoTest {
         DynamoHealthDataDao dao = new DynamoHealthDataDao();
 
         // mock mapper
-        PaginatedQueryList<DynamoHealthDataRecord> mockGetResult = mock(PaginatedQueryList.class);
-        when(mockGetResult.stream()).thenReturn(mockResult.stream());
+        QueryResultPage<DynamoHealthDataRecord> resultPage = new QueryResultPage<>();
+        resultPage.setResults(mockResult);
 
         DynamoDBMapper mockMapper = mock(DynamoDBMapper.class);
-        when(mockMapper.query(eq(DynamoHealthDataRecord.class), any())).thenReturn(mockGetResult);
+        when(mockMapper.queryPage(eq(DynamoHealthDataRecord.class), any())).thenReturn(resultPage);
 
         dao.setMapper(mockMapper);
 

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDaoMockTest.java
@@ -26,6 +26,7 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBSaveExpression;
 import com.amazonaws.services.dynamodbv2.datamodeling.PaginatedQueryList;
+import com.amazonaws.services.dynamodbv2.datamodeling.QueryResultPage;
 import com.amazonaws.services.dynamodbv2.model.WriteRequest;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -1321,22 +1322,19 @@ public class DynamoUploadSchemaDaoMockTest {
 
     private static DynamoDBMapper setupMockMapperWithSchema(DynamoUploadSchema schema) {
         // mock get result
-        PaginatedQueryList<DynamoUploadSchema> mockGetResult = mock(PaginatedQueryList.class);
+        List<DynamoUploadSchema> schemaList = new ArrayList<>();
         if (schema != null) {
-            // mock result should contain the old rev
-            when(mockGetResult.isEmpty()).thenReturn(false);
-            when(mockGetResult.get(0)).thenReturn(schema);
-        } else {
-            // no old rev means no old result
-            when(mockGetResult.isEmpty()).thenReturn(true);
+            schemaList.add(schema);
         }
+        QueryResultPage<DynamoUploadSchema> resultPage = new QueryResultPage<>();
+        resultPage.setResults(schemaList);
 
         // mock DDB mapper
         DynamoDBMapper mockMapper = mock(DynamoDBMapper.class);
-        when(mockMapper.query(
+        when(mockMapper.queryPage(
             (Class<DynamoUploadSchema>)eq(DynamoUploadSchema.class), 
             (DynamoDBQueryExpression<DynamoUploadSchema>)notNull(DynamoDBQueryExpression.class)
-        )).thenReturn(mockGetResult);
+        )).thenReturn(resultPage);
         return mockMapper;
     }
     


### PR DESCRIPTION
See https://github.com/aws/aws-sdk-java/issues/736

This is causing throttling errors for us, since our paginated APIs and other uses of query() are consuming a lot more DDB capacity than expected, in some cases unbounded capacity. This change moves most usages of query() with LIMIT to queryPage(), which does respect LIMIT. (Note that some cases can't be fixed, like ExternalId. Since LIMIT and filters interact in weird ways, assignmentFilter doesn't work anymore. See https://sagebionetworks.jira.com/browse/BRIDGE-1652)

I also removed the redundant dupe max records from UploadValidationTask. Because we were enforcing the limit in two places, this masked the bug in DynamoHealthDataDao that was browning out DDB.

Testing done:
* manually tested upload dedupe detection - This is the case where we discovered the issue.
* integ tests and unit tests