### PR TITLE
Compound Activity Definitions

### DIFF
--- a/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
+++ b/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
@@ -31,6 +31,7 @@ import com.stormpath.sdk.client.Clients;
 import com.stormpath.sdk.impl.client.DefaultClientBuilder;
 
 import org.sagebionetworks.bridge.dynamodb.AnnotationBasedTableCreator;
+import org.sagebionetworks.bridge.dynamodb.DynamoCompoundActivityDefinition;
 import org.sagebionetworks.bridge.dynamodb.DynamoNamingHelper;
 import org.sagebionetworks.client.SynapseAdminClientImpl;
 import org.sagebionetworks.client.SynapseClient;
@@ -250,6 +251,12 @@ public class BridgeSpringConfig {
     @Autowired
     public DynamoNamingHelper dynamoNamingHelper(BridgeConfig bridgeConfig) {
         return new DynamoNamingHelper(bridgeConfig);
+    }
+
+    @Bean(name = "compoundActivityDefinitionDdbMapper")
+    @Autowired
+    public DynamoDBMapper compoundActivityDefinitionDdbMapper(DynamoUtils dynamoUtils) {
+        return dynamoUtils.getMapper(DynamoCompoundActivityDefinition.class);
     }
 
     @Bean(name = "healthDataAttachmentDdbMapper")

--- a/app/org/sagebionetworks/bridge/dao/CompoundActivityDefinitionDao.java
+++ b/app/org/sagebionetworks/bridge/dao/CompoundActivityDefinitionDao.java
@@ -8,14 +8,13 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 /** DAO for basic CRUD and list operations for compound activity definitions. */
 public interface CompoundActivityDefinitionDao {
     /** Creates a compound activity definition. */
-    CompoundActivityDefinition createCompoundActivityDefinition(StudyIdentifier studyId,
-            CompoundActivityDefinition compoundActivityDefinition);
+    CompoundActivityDefinition createCompoundActivityDefinition(CompoundActivityDefinition compoundActivityDefinition);
 
-    /**
-     * Deletes a compound activity definition. This is intended to be used by admin accounts to clean up after tests or
-     * other administrative tasks.
-     */
+    /** Deletes a compound activity definition. */
     void deleteCompoundActivityDefinition(StudyIdentifier studyId, String taskId);
+
+    /** Deletes all compound activity definitions in the specified study. Used when we physically delete a study. */
+    void deleteAllCompoundActivityDefinitionsInStudy(StudyIdentifier studyId);
 
     /** List all compound activity definitions in a study. */
     List<CompoundActivityDefinition> getAllCompoundActivityDefinitionsInStudy(StudyIdentifier studyId);
@@ -24,6 +23,5 @@ public interface CompoundActivityDefinitionDao {
     CompoundActivityDefinition getCompoundActivityDefinition(StudyIdentifier studyId, String taskId);
 
     /** Update a compound activity definition. */
-    CompoundActivityDefinition updateCompoundActivityDefinition(StudyIdentifier studyId, String taskId,
-            CompoundActivityDefinition compoundActivityDefinition);
+    CompoundActivityDefinition updateCompoundActivityDefinition(CompoundActivityDefinition compoundActivityDefinition);
 }

--- a/app/org/sagebionetworks/bridge/dao/CompoundActivityDefinitionDao.java
+++ b/app/org/sagebionetworks/bridge/dao/CompoundActivityDefinitionDao.java
@@ -1,0 +1,29 @@
+package org.sagebionetworks.bridge.dao;
+
+import java.util.List;
+
+import org.sagebionetworks.bridge.models.schedules.CompoundActivityDefinition;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
+
+/** DAO for basic CRUD and list operations for compound activity definitions. */
+public interface CompoundActivityDefinitionDao {
+    /** Creates a compound activity definition. */
+    CompoundActivityDefinition createCompoundActivityDefinition(StudyIdentifier studyId,
+            CompoundActivityDefinition compoundActivityDefinition);
+
+    /**
+     * Deletes a compound activity definition. This is intended to be used by admin accounts to clean up after tests or
+     * other administrative tasks.
+     */
+    void deleteCompoundActivityDefinition(StudyIdentifier studyId, String taskId);
+
+    /** List all compound activity definitions in a study. */
+    List<CompoundActivityDefinition> getAllCompoundActivityDefinitionsInStudy(StudyIdentifier studyId);
+
+    /** Get a compound activity definition by ID. */
+    CompoundActivityDefinition getCompoundActivityDefinition(StudyIdentifier studyId, String taskId);
+
+    /** Update a compound activity definition. */
+    CompoundActivityDefinition updateCompoundActivityDefinition(StudyIdentifier studyId, String taskId,
+            CompoundActivityDefinition compoundActivityDefinition);
+}

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoCompoundActivityDefinition.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoCompoundActivityDefinition.java
@@ -1,0 +1,116 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import java.util.List;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTypeConverted;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBVersionAttribute;
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.collect.ImmutableList;
+
+import org.sagebionetworks.bridge.models.schedules.CompoundActivityDefinition;
+import org.sagebionetworks.bridge.models.schedules.SchemaReference;
+import org.sagebionetworks.bridge.models.schedules.SurveyReference;
+
+/**
+ * DynamoDB implementation of CompoundActivityDefinition. The hash key is study ID and the range key is the task ID.
+ * This allows us to namespace compound activity definitions to studies and to list all definitions in a study.
+ */
+@DynamoDBTable(tableName = "CompoundActivityDefinition")
+@JsonFilter("filter")
+public class DynamoCompoundActivityDefinition implements CompoundActivityDefinition {
+    private List<SchemaReference> schemaList = ImmutableList.of();
+    private String studyId;
+    private List<SurveyReference> surveyList = ImmutableList.of();
+    private String taskId;
+    private Long version;
+
+    /** {@inheritDoc} */
+    @DynamoDBTypeConverted(converter = SchemaReferenceListMarshaller.class)
+    @Override
+    public List<SchemaReference> getSchemaList() {
+        return schemaList;
+    }
+
+    /** @see #getSchemaList */
+    @Override
+    public void setSchemaList(List<SchemaReference> schemaList) {
+        this.schemaList = schemaList != null ? ImmutableList.copyOf(schemaList) : ImmutableList.of();
+    }
+
+    /** {@inheritDoc} */
+    @DynamoDBHashKey
+    @Override
+    public String getStudyId() {
+        return studyId;
+    }
+
+    /** @see #getStudyId */
+    @Override
+    public void setStudyId(String studyId) {
+        this.studyId = studyId;
+    }
+
+    /** {@inheritDoc} */
+    @DynamoDBTypeConverted(converter = SurveyReferenceListMarshaller.class)
+    @Override
+    public List<SurveyReference> getSurveyList() {
+        return surveyList;
+    }
+
+    /** @see #getSurveyList */
+    @Override
+    public void setSurveyList(List<SurveyReference> surveyList) {
+        this.surveyList = surveyList != null ? ImmutableList.copyOf(surveyList) : ImmutableList.of();
+    }
+
+    /** {@inheritDoc} */
+    @DynamoDBRangeKey
+    public String getTaskId() {
+        return taskId;
+    }
+
+    /** @see #getTaskId */
+    @Override
+    public void setTaskId(String taskId) {
+        this.taskId = taskId;
+    }
+
+    /** For use with DynamoDB versioning and concurrency. */
+    @DynamoDBVersionAttribute
+    public Long getVersion() {
+        return version;
+    }
+
+    /** @see #getVersion */
+    public void setVersion(Long version) {
+        this.version = version;
+    }
+
+    /** DynamoDB annotations don't work with generics, so we need to subclass ListMarshaller. */
+    public static class SchemaReferenceListMarshaller extends ListMarshaller<SchemaReference> {
+        private static final TypeReference<List<SchemaReference>> SCHEMA_REF_LIST_TYPE =
+                new TypeReference<List<SchemaReference>>() {};
+
+        /** {@inheritDoc} */
+        @Override
+        public TypeReference<List<SchemaReference>> getTypeReference() {
+            return SCHEMA_REF_LIST_TYPE;
+        }
+    }
+
+    /** Similarly for surveys. */
+    public static class SurveyReferenceListMarshaller extends ListMarshaller<SurveyReference> {
+        private static final TypeReference<List<SurveyReference>> SURVEY_REF_LIST_TYPE =
+                new TypeReference<List<SurveyReference>>() {};
+
+        /** {@inheritDoc} */
+        @Override
+        public TypeReference<List<SurveyReference>> getTypeReference() {
+            return SURVEY_REF_LIST_TYPE;
+        }
+    }
+}

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchema.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchema.java
@@ -1,21 +1,17 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import java.io.IOException;
 import java.util.List;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIgnore;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIndexHashKey;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMappingException;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTypeConverted;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTypeConverter;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBVersionAttribute;
 import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -24,7 +20,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
-import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.json.DateTimeToLongSerializer;
 import org.sagebionetworks.bridge.json.DateTimeToPrimitiveLongDeserializer;
 import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
@@ -216,28 +211,14 @@ public class DynamoUploadSchema implements UploadSchema {
     }
 
     /** Custom DynamoDB marshaller for the field definition list. This uses Jackson to convert to and from JSON. */
-    public static class FieldDefinitionListMarshaller implements DynamoDBTypeConverter<String,List<UploadFieldDefinition>> {
-        
-        private static final TypeReference<List<UploadFieldDefinition>> FIELD_LIST_TYPE = new TypeReference<List<UploadFieldDefinition>>() {
-        };
-        
+    public static class FieldDefinitionListMarshaller extends ListMarshaller<UploadFieldDefinition> {
+        private static final TypeReference<List<UploadFieldDefinition>> FIELD_LIST_TYPE =
+                new TypeReference<List<UploadFieldDefinition>>() {};
+
         /** {@inheritDoc} */
         @Override
-        public String convert(List<UploadFieldDefinition> fieldDefList) {
-            try {
-                return BridgeObjectMapper.get().writerWithDefaultPrettyPrinter().writeValueAsString(fieldDefList);
-            } catch (JsonProcessingException ex) {
-                throw new DynamoDBMappingException(ex);
-            }
-        }
-        /** {@inheritDoc} */
-        @Override
-        public List<UploadFieldDefinition> unconvert(String json) {
-            try {
-                return BridgeObjectMapper.get().readValue(json, FIELD_LIST_TYPE);
-            } catch (IOException ex) {
-                throw new DynamoDBMappingException(ex);
-            }
+        public TypeReference<List<UploadFieldDefinition>> getTypeReference() {
+            return FIELD_LIST_TYPE;
         }
     }
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/ListMarshaller.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/ListMarshaller.java
@@ -1,0 +1,43 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import java.io.IOException;
+import java.util.List;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMappingException;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTypeConverter;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+/**
+ * Generic list marshaller for DynamoDB. This converts the list into JSON for marshalling to DynamoDB. Because DynamoDB
+ * annotations don't work with generics, you'll need to subclass this and fill in getTypeReference().
+ */
+public abstract class ListMarshaller<T> implements DynamoDBTypeConverter<String, List<T>> {
+    /**
+     * Returns the type reference for Jackson to deserialize the value from DynamoDB, because Java can't infer generic
+     * types at runtime.
+     */
+    public abstract TypeReference<List<T>> getTypeReference();
+
+    /** {@inheritDoc} */
+    @Override
+    public String convert(List<T> list) {
+        try {
+            return BridgeObjectMapper.get().writerWithDefaultPrettyPrinter().writeValueAsString(list);
+        } catch (JsonProcessingException ex) {
+            throw new DynamoDBMappingException(ex);
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<T> unconvert(String json) {
+        try {
+            return BridgeObjectMapper.get().readValue(json, getTypeReference());
+        } catch (IOException ex) {
+            throw new DynamoDBMappingException(ex);
+        }
+    }
+}

--- a/app/org/sagebionetworks/bridge/models/schedules/CompoundActivityDefinition.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/CompoundActivityDefinition.java
@@ -1,0 +1,56 @@
+package org.sagebionetworks.bridge.models.schedules;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
+import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
+
+import org.sagebionetworks.bridge.dynamodb.DynamoCompoundActivityDefinition;
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.json.BridgeTypeName;
+import org.sagebionetworks.bridge.models.BridgeEntity;
+
+/**
+ * Compound activity definition, which is keyed off taskID and stored in persistent storage. This allows study
+ * developers to define a task once and use that task in multiple schedules.
+ */
+@BridgeTypeName("CompoundActivityDefinition")
+@JsonDeserialize(as = DynamoCompoundActivityDefinition.class)
+public interface CompoundActivityDefinition extends BridgeEntity {
+    ObjectWriter PUBLIC_DEFINITION_WRITER = BridgeObjectMapper.get().writer(new SimpleFilterProvider().addFilter("filter",
+            SimpleBeanPropertyFilter.serializeAllExcept("studyId")));
+
+    /** Convenience method for creating a CompoundActivityDefinition using a concrete implementation. */
+    static CompoundActivityDefinition create() {
+        return new DynamoCompoundActivityDefinition();
+    }
+
+    /** List of schemas in this activity definition. */
+    List<SchemaReference> getSchemaList();
+
+    /** @see #getSchemaList */
+    void setSchemaList(List<SchemaReference> schemaList);
+
+    /**
+     * Compound activity definitions (and task identifiers) are namespaced to studies. As such, it's important for a
+     * definition to know its study.
+     */
+    String getStudyId();
+
+    /** @see #getStudyId */
+    void setStudyId(String studyId);
+
+    /** List of surveys in this activity definition. */
+    List<SurveyReference> getSurveyList();
+
+    /** @see #getSurveyList */
+    void setSurveyList(List<SurveyReference> surveyList);
+
+    /** Task ID. This is the primary key of the compound activity definition. */
+    String getTaskId();
+
+    /** @see #getTaskId */
+    void setTaskId(String taskId);
+}

--- a/app/org/sagebionetworks/bridge/models/schedules/SurveyReference.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/SurveyReference.java
@@ -23,7 +23,7 @@ public final class SurveyReference {
     private final DateTime createdOn;
     
     @JsonCreator
-    SurveyReference(@JsonProperty("identifier") String identifier, @JsonProperty("guid") String guid,
+    public SurveyReference(@JsonProperty("identifier") String identifier, @JsonProperty("guid") String guid,
                     @JsonProperty("createdOn") DateTime createdOn) {
         this.identifier = identifier;
         this.guid = guid;

--- a/app/org/sagebionetworks/bridge/models/studies/Study.java
+++ b/app/org/sagebionetworks/bridge/models/studies/Study.java
@@ -29,6 +29,11 @@ public interface Study extends BridgeEntity, StudyIdentifier {
         new SimpleFilterProvider().addFilter("filter",
         SimpleBeanPropertyFilter.filterOutAllExcept("name", "identifier")));
 
+    /** Convenience method for creating a Study using a concrete implementation. */
+    static Study create() {
+        return new DynamoStudy();
+    }
+
     /**
      * The display name of the study (will be seen by participants in email). This name makes the 
      * most sense when it starts with "The".

--- a/app/org/sagebionetworks/bridge/play/controllers/CompoundActivityDefinitionController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/CompoundActivityDefinitionController.java
@@ -14,7 +14,6 @@ import org.sagebionetworks.bridge.models.ResourceList;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.schedules.CompoundActivityDefinition;
 import org.sagebionetworks.bridge.models.studies.Study;
-import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.services.CompoundActivityDefinitionService;
 
 /** Play controller for managing Compound Activity Definitions. */
@@ -39,14 +38,11 @@ public class CompoundActivityDefinitionController extends BaseController {
         return created(CompoundActivityDefinition.PUBLIC_DEFINITION_WRITER.writeValueAsString(createdDef));
     }
 
-    /**
-     * Deletes a compound activity definition. This is intended to be used by admin accounts to clean up after tests or
-     * other administrative tasks.
-     */
-    public Result deleteCompoundActivityDefinition(String studyId, String taskId) {
-        getAuthenticatedSession(ADMIN);
+    /** Deletes a compound activity definition. */
+    public Result deleteCompoundActivityDefinition(String taskId) {
+        UserSession session = getAuthenticatedSession(Roles.DEVELOPER);
 
-        compoundActivityDefService.deleteCompoundActivityDefinition(new StudyIdentifierImpl(studyId), taskId);
+        compoundActivityDefService.deleteCompoundActivityDefinition(session.getStudyIdentifier(), taskId);
         return okResult("Compound activity definition has been deleted.");
     }
 

--- a/app/org/sagebionetworks/bridge/play/controllers/CompoundActivityDefinitionController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/CompoundActivityDefinitionController.java
@@ -1,7 +1,5 @@
 package org.sagebionetworks.bridge.play.controllers;
 
-import static org.sagebionetworks.bridge.Roles.ADMIN;
-
 import java.util.List;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/app/org/sagebionetworks/bridge/play/controllers/CompoundActivityDefinitionController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/CompoundActivityDefinitionController.java
@@ -1,0 +1,82 @@
+package org.sagebionetworks.bridge.play.controllers;
+
+import static org.sagebionetworks.bridge.Roles.ADMIN;
+
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import play.mvc.Result;
+
+import org.sagebionetworks.bridge.Roles;
+import org.sagebionetworks.bridge.models.ResourceList;
+import org.sagebionetworks.bridge.models.accounts.UserSession;
+import org.sagebionetworks.bridge.models.schedules.CompoundActivityDefinition;
+import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
+import org.sagebionetworks.bridge.services.CompoundActivityDefinitionService;
+
+/** Play controller for managing Compound Activity Definitions. */
+@Controller
+public class CompoundActivityDefinitionController extends BaseController {
+    private CompoundActivityDefinitionService compoundActivityDefService;
+
+    /** Service for Compound Activity Definitions, managed by Spring. */
+    @Autowired
+    public final void setCompoundActivityDefService(CompoundActivityDefinitionService compoundActivityDefService) {
+        this.compoundActivityDefService = compoundActivityDefService;
+    }
+
+    /** Creates a compound activity definition. */
+    public Result createCompoundActivityDefinition() throws JsonProcessingException {
+        UserSession session = getAuthenticatedSession(Roles.DEVELOPER);
+        Study study = studyService.getStudy(session.getStudyIdentifier());
+
+        CompoundActivityDefinition requestDef = parseJson(request(), CompoundActivityDefinition.class);
+        CompoundActivityDefinition createdDef = compoundActivityDefService.createCompoundActivityDefinition(study,
+                requestDef);
+        return created(CompoundActivityDefinition.PUBLIC_DEFINITION_WRITER.writeValueAsString(createdDef));
+    }
+
+    /**
+     * Deletes a compound activity definition. This is intended to be used by admin accounts to clean up after tests or
+     * other administrative tasks.
+     */
+    public Result deleteCompoundActivityDefinition(String studyId, String taskId) {
+        getAuthenticatedSession(ADMIN);
+
+        compoundActivityDefService.deleteCompoundActivityDefinition(new StudyIdentifierImpl(studyId), taskId);
+        return okResult("Compound activity definition has been deleted.");
+    }
+
+    /** List all compound activity definitions in a study. */
+    public Result getAllCompoundActivityDefinitionsInStudy() throws JsonProcessingException {
+        UserSession session = getAuthenticatedSession(Roles.DEVELOPER);
+
+        List<CompoundActivityDefinition> defList = compoundActivityDefService.getAllCompoundActivityDefinitionsInStudy(
+                session.getStudyIdentifier());
+        ResourceList<CompoundActivityDefinition> defResourceList = new ResourceList<>(defList);
+        return ok(CompoundActivityDefinition.PUBLIC_DEFINITION_WRITER.writeValueAsString(defResourceList));
+    }
+
+    /** Get a compound activity definition by ID. */
+    public Result getCompoundActivityDefinition(String taskId) throws JsonProcessingException {
+        UserSession session = getAuthenticatedSession(Roles.DEVELOPER);
+
+        CompoundActivityDefinition def = compoundActivityDefService.getCompoundActivityDefinition(
+                session.getStudyIdentifier(), taskId);
+        return ok(CompoundActivityDefinition.PUBLIC_DEFINITION_WRITER.writeValueAsString(def));
+    }
+
+    /** Update a compound activity definition. */
+    public Result updateCompoundActivityDefinition(String taskId) throws JsonProcessingException {
+        UserSession session = getAuthenticatedSession(Roles.DEVELOPER);
+        Study study = studyService.getStudy(session.getStudyIdentifier());
+
+        CompoundActivityDefinition requestDef = parseJson(request(), CompoundActivityDefinition.class);
+        CompoundActivityDefinition updatedDef = compoundActivityDefService.updateCompoundActivityDefinition(study,
+                taskId, requestDef);
+        return ok(CompoundActivityDefinition.PUBLIC_DEFINITION_WRITER.writeValueAsString(updatedDef));
+    }
+}

--- a/app/org/sagebionetworks/bridge/services/CompoundActivityDefinitionService.java
+++ b/app/org/sagebionetworks/bridge/services/CompoundActivityDefinitionService.java
@@ -28,27 +28,20 @@ public class CompoundActivityDefinitionService {
     /** Creates a compound activity definition. */
     public CompoundActivityDefinition createCompoundActivityDefinition(Study study,
             CompoundActivityDefinition compoundActivityDefinition) {
+        // Set study to prevent people from creating defs in other studies.
+        compoundActivityDefinition.setStudyId(study.getIdentifier());
+
         // validate def
         CompoundActivityDefinitionValidator validator = new CompoundActivityDefinitionValidator(
                 study.getTaskIdentifiers());
         Validate.entityThrowingException(validator, compoundActivityDefinition);
 
         // call through to dao
-        return compoundActivityDefDao.createCompoundActivityDefinition(study.getStudyIdentifier(),
-                compoundActivityDefinition);
+        return compoundActivityDefDao.createCompoundActivityDefinition(compoundActivityDefinition);
     }
 
-    /**
-     * Deletes a compound activity definition. This is intended to be used by admin accounts to clean up after tests or
-     * other administrative tasks.
-     */
+    /** Deletes a compound activity definition. */
     public void deleteCompoundActivityDefinition(StudyIdentifier studyId, String taskId) {
-        // This is an admin API, so the study ID is user input. The object itself is created by the controller and is
-        // not null, but the string inside might be blank. Validate that.
-        if (StringUtils.isBlank(studyId.getIdentifier())) {
-            throw new BadRequestException("studyId must be specified");
-        }
-
         // validate user input (taskId)
         if (StringUtils.isBlank(taskId)) {
             throw new BadRequestException("taskId must be specified");
@@ -56,6 +49,14 @@ public class CompoundActivityDefinitionService {
 
         // call through to dao
         compoundActivityDefDao.deleteCompoundActivityDefinition(studyId, taskId);
+    }
+
+    /** Deletes all compound activity definitions in the specified study. Used when we physically delete a study. */
+    public void deleteAllCompoundActivityDefinitionsInStudy(StudyIdentifier studyId) {
+        // no user input - study comes from controller
+
+        // call through to dao
+        compoundActivityDefDao.deleteAllCompoundActivityDefinitionsInStudy(studyId);
     }
 
     /** List all compound activity definitions in a study. */
@@ -85,13 +86,17 @@ public class CompoundActivityDefinitionService {
             throw new BadRequestException("taskId must be specified");
         }
 
+        // Set the studyId and taskId. This prevents people from updating the wrong def or updating a def in another
+        // study.
+        compoundActivityDefinition.setStudyId(study.getIdentifier());
+        compoundActivityDefinition.setTaskId(taskId);
+
         // validate def
         CompoundActivityDefinitionValidator validator = new CompoundActivityDefinitionValidator(
                 study.getTaskIdentifiers());
         Validate.entityThrowingException(validator, compoundActivityDefinition);
 
         // call through to dao
-        return compoundActivityDefDao.updateCompoundActivityDefinition(study.getStudyIdentifier(), taskId,
-                compoundActivityDefinition);
+        return compoundActivityDefDao.updateCompoundActivityDefinition(compoundActivityDefinition);
     }
 }

--- a/app/org/sagebionetworks/bridge/services/CompoundActivityDefinitionService.java
+++ b/app/org/sagebionetworks/bridge/services/CompoundActivityDefinitionService.java
@@ -1,0 +1,97 @@
+package org.sagebionetworks.bridge.services;
+
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.sagebionetworks.bridge.dao.CompoundActivityDefinitionDao;
+import org.sagebionetworks.bridge.exceptions.BadRequestException;
+import org.sagebionetworks.bridge.models.schedules.CompoundActivityDefinition;
+import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
+import org.sagebionetworks.bridge.validators.CompoundActivityDefinitionValidator;
+import org.sagebionetworks.bridge.validators.Validate;
+
+/** Compound Activity Definition Service. */
+@Component
+public class CompoundActivityDefinitionService {
+    private CompoundActivityDefinitionDao compoundActivityDefDao;
+
+    /** DAO, autowired by Spring. */
+    @Autowired
+    public final void setCompoundActivityDefDao(CompoundActivityDefinitionDao compoundActivityDefDao) {
+        this.compoundActivityDefDao = compoundActivityDefDao;
+    }
+
+    /** Creates a compound activity definition. */
+    public CompoundActivityDefinition createCompoundActivityDefinition(Study study,
+            CompoundActivityDefinition compoundActivityDefinition) {
+        // validate def
+        CompoundActivityDefinitionValidator validator = new CompoundActivityDefinitionValidator(
+                study.getTaskIdentifiers());
+        Validate.entityThrowingException(validator, compoundActivityDefinition);
+
+        // call through to dao
+        return compoundActivityDefDao.createCompoundActivityDefinition(study.getStudyIdentifier(),
+                compoundActivityDefinition);
+    }
+
+    /**
+     * Deletes a compound activity definition. This is intended to be used by admin accounts to clean up after tests or
+     * other administrative tasks.
+     */
+    public void deleteCompoundActivityDefinition(StudyIdentifier studyId, String taskId) {
+        // This is an admin API, so the study ID is user input. The object itself is created by the controller and is
+        // not null, but the string inside might be blank. Validate that.
+        if (StringUtils.isBlank(studyId.getIdentifier())) {
+            throw new BadRequestException("studyId must be specified");
+        }
+
+        // validate user input (taskId)
+        if (StringUtils.isBlank(taskId)) {
+            throw new BadRequestException("taskId must be specified");
+        }
+
+        // call through to dao
+        compoundActivityDefDao.deleteCompoundActivityDefinition(studyId, taskId);
+    }
+
+    /** List all compound activity definitions in a study. */
+    public List<CompoundActivityDefinition> getAllCompoundActivityDefinitionsInStudy(StudyIdentifier studyId) {
+        // no user input - study comes from controller
+
+        // call through to dao
+        return compoundActivityDefDao.getAllCompoundActivityDefinitionsInStudy(studyId);
+    }
+
+    /** Get a compound activity definition by ID. */
+    public CompoundActivityDefinition getCompoundActivityDefinition(StudyIdentifier studyId, String taskId) {
+        // validate user input (taskId)
+        if (StringUtils.isBlank(taskId)) {
+            throw new BadRequestException("taskId must be specified");
+        }
+
+        // call through to dao
+        return compoundActivityDefDao.getCompoundActivityDefinition(studyId, taskId);
+    }
+
+    /** Update a compound activity definition. */
+    public CompoundActivityDefinition updateCompoundActivityDefinition(Study study, String taskId,
+            CompoundActivityDefinition compoundActivityDefinition) {
+        // validate user input (taskId)
+        if (StringUtils.isBlank(taskId)) {
+            throw new BadRequestException("taskId must be specified");
+        }
+
+        // validate def
+        CompoundActivityDefinitionValidator validator = new CompoundActivityDefinitionValidator(
+                study.getTaskIdentifiers());
+        Validate.entityThrowingException(validator, compoundActivityDefinition);
+
+        // call through to dao
+        return compoundActivityDefDao.updateCompoundActivityDefinition(study.getStudyIdentifier(), taskId,
+                compoundActivityDefinition);
+    }
+}

--- a/app/org/sagebionetworks/bridge/validators/CompoundActivityDefinitionValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/CompoundActivityDefinitionValidator.java
@@ -43,6 +43,11 @@ public class CompoundActivityDefinitionValidator implements Validator {
         } else {
             CompoundActivityDefinition compoundActivityDef = (CompoundActivityDefinition) target;
 
+            // studyId must be specified
+            if (isBlank(compoundActivityDef.getStudyId())) {
+                errors.rejectValue("studyId", "must be specified");
+            }
+
             // taskIdentifier must be specified and must be in the Study's list
             String taskId = compoundActivityDef.getTaskId();
             if (isBlank(taskId)) {

--- a/app/org/sagebionetworks/bridge/validators/CompoundActivityDefinitionValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/CompoundActivityDefinitionValidator.java
@@ -1,0 +1,63 @@
+package org.sagebionetworks.bridge.validators;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import java.util.Set;
+
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+
+import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.models.schedules.CompoundActivityDefinition;
+
+/** Validator for CompoundActivityDefinition. */
+public class CompoundActivityDefinitionValidator implements Validator {
+    private final Set<String> taskIdSet;
+
+    /** Constructor for validator. Takes set of valid task IDs from the study. */
+    public CompoundActivityDefinitionValidator(Set<String> taskIdSet) {
+        this.taskIdSet = taskIdSet;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean supports(Class<?> clazz) {
+        return CompoundActivityDefinition.class.isAssignableFrom(clazz);
+    }
+
+    /**
+     * <p>
+     * Compound activity definition must have a task ID that's in the study's task ID list, and it must have at least
+     * one schema or at least one survey.
+     * </p>
+     * <p>
+     * Study ID need not be specified, as the DAO will fill this in before saving it to the back-end store.
+     * </p>
+     */
+    @Override
+    public void validate(Object target, Errors errors) {
+        if (target == null) {
+            errors.rejectValue("compoundActivityDefinition", "cannot be null");
+        } else if (!(target instanceof CompoundActivityDefinition)) {
+            errors.rejectValue("compoundActivityDefinition", "is the wrong type");
+        } else {
+            CompoundActivityDefinition compoundActivityDef = (CompoundActivityDefinition) target;
+
+            // taskIdentifier must be specified and must be in the Study's list
+            String taskId = compoundActivityDef.getTaskId();
+            if (isBlank(taskId)) {
+                errors.rejectValue("taskId", "must be specified");
+            } else if (!taskIdSet.contains(taskId)) {
+                errors.rejectValue("taskId", taskId + " not in enumeration: " +
+                        BridgeUtils.COMMA_SPACE_JOINER.join(taskIdSet));
+            }
+
+            // must have at least one item in surveys and/or schemas
+            if (BridgeUtils.isEmpty(compoundActivityDef.getSchemaList()) &&
+                    BridgeUtils.isEmpty(compoundActivityDef.getSurveyList())) {
+                errors.rejectValue("compoundActivityDefinition",
+                        "must have at least one schema or at least one survey");
+            }
+        }
+    }
+}

--- a/conf/routes
+++ b/conf/routes
@@ -13,6 +13,12 @@ POST   /v3/auth/signUp                  @org.sagebionetworks.bridge.play.control
 POST   /v3/auth/verifyEmail             @org.sagebionetworks.bridge.play.controllers.AuthenticationController.verifyEmail
 POST   /v3/auth/resendEmailVerification @org.sagebionetworks.bridge.play.controllers.AuthenticationController.resendEmailVerification
 
+# Compound Activity Definitions
+GET    /v3/compoundactivitydefinitions @org.sagebionetworks.bridge.play.controllers.CompoundActivityDefinitionController.getAllCompoundActivityDefinitionsInStudy
+POST   /v3/compoundactivitydefinitions @org.sagebionetworks.bridge.play.controllers.CompoundActivityDefinitionController.createCompoundActivityDefinition
+GET    /v3/compoundactivitydefinitions/:taskId @org.sagebionetworks.bridge.play.controllers.CompoundActivityDefinitionController.getCompoundActivityDefinition(taskId: String)
+POST   /v3/compoundactivitydefinitions/:taskId @org.sagebionetworks.bridge.play.controllers.CompoundActivityDefinitionController.updateCompoundActivityDefinition(taskId: String)
+
 # Participants Researcher APIs
 GET    /v3/participants                                      @org.sagebionetworks.bridge.play.controllers.ParticipantController.getParticipants(offsetBy: String ?= null, pageSize: String ?= null, emailFilter: String ?= null, startDate: String ?= null, endDate: String ?= null)
 POST   /v3/participants                                      @org.sagebionetworks.bridge.play.controllers.ParticipantController.createParticipant(verifyEmail: String ?= "true")
@@ -158,13 +164,16 @@ GET    /v3/externalIds    @org.sagebionetworks.bridge.play.controllers.ExternalI
 POST   /v3/externalIds    @org.sagebionetworks.bridge.play.controllers.ExternalIdController.addExternalIds
 DELETE /v3/externalIds    @org.sagebionetworks.bridge.play.controllers.ExternalIdController.deleteExternalIds
 
-# APIs for getting entities across studies
+# Worker APIs for getting entities across studies
 GET    /v3/studies/:studyId/surveys/published                           @org.sagebionetworks.bridge.play.controllers.SurveyController.getAllSurveysMostRecentlyPublishedVersionForStudy(studyId: String)
 GET    /v3/studies/:studyId/uploadschemas/:schemaId/revisions/:revision @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getUploadSchemaByStudyAndSchemaAndRev(studyId: String, schemaId: String, revision: Int)
-DELETE /v3/studies/:studyId/uploadschemas/:schemaId                     @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.deleteAllRevisionsOfUploadSchema(studyId: String, schemaId: String)
 GET    /v3/studies/:studyId/reports/:identifier                         @org.sagebionetworks.bridge.play.controllers.ReportController.getPublicStudyReport(studyId: String, identifier: String, startDate: String ?= null, endDate: String ?= null)
 POST   /v3/studies/:studyId/reports/:identifier                         @org.sagebionetworks.bridge.play.controllers.ReportController.saveStudyReportForSpecifiedStudy(studyId: String, identifier: String)
 GET    /v3/studies/:studyId/uploads                                     @org.sagebionetworks.bridge.play.controllers.StudyController.getUploadsForStudy(studyId: String, startTime: String ?= null, endTime: String ?= null)
+
+# Admin APIs for deleting entities across studies
+DELETE /v3/studies/:studyId/compoundactivitydefinitions/:taskId         @org.sagebionetworks.bridge.play.controllers.CompoundActivityDefinitionController.deleteCompoundActivityDefinition(studyId: String, taskId: String)
+DELETE /v3/studies/:studyId/uploadschemas/:schemaId                     @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.deleteAllRevisionsOfUploadSchema(studyId: String, schemaId: String)
 
 # Backfills
 GET    /v3/backfill/:name          @org.sagebionetworks.bridge.play.controllers.BackfillController.backfill(name: String)

--- a/conf/routes
+++ b/conf/routes
@@ -17,6 +17,7 @@ POST   /v3/auth/resendEmailVerification @org.sagebionetworks.bridge.play.control
 GET    /v3/compoundactivitydefinitions @org.sagebionetworks.bridge.play.controllers.CompoundActivityDefinitionController.getAllCompoundActivityDefinitionsInStudy
 POST   /v3/compoundactivitydefinitions @org.sagebionetworks.bridge.play.controllers.CompoundActivityDefinitionController.createCompoundActivityDefinition
 GET    /v3/compoundactivitydefinitions/:taskId @org.sagebionetworks.bridge.play.controllers.CompoundActivityDefinitionController.getCompoundActivityDefinition(taskId: String)
+DELETE /v3/compoundactivitydefinitions/:taskId @org.sagebionetworks.bridge.play.controllers.CompoundActivityDefinitionController.deleteCompoundActivityDefinition(taskId: String)
 POST   /v3/compoundactivitydefinitions/:taskId @org.sagebionetworks.bridge.play.controllers.CompoundActivityDefinitionController.updateCompoundActivityDefinition(taskId: String)
 
 # Participants Researcher APIs
@@ -181,7 +182,6 @@ POST   /v3/studies/:studyId/reports/:identifier                         @org.sag
 GET    /v3/studies/:studyId/uploads                                     @org.sagebionetworks.bridge.play.controllers.StudyController.getUploadsForStudy(studyId: String, startTime: String ?= null, endTime: String ?= null)
 
 # Admin APIs for deleting entities across studies
-DELETE /v3/studies/:studyId/compoundactivitydefinitions/:taskId         @org.sagebionetworks.bridge.play.controllers.CompoundActivityDefinitionController.deleteCompoundActivityDefinition(studyId: String, taskId: String)
 DELETE /v3/studies/:studyId/uploadschemas/:schemaId                     @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.deleteAllRevisionsOfUploadSchema(studyId: String, schemaId: String)
 
 # Backfills

--- a/conf/shared-config.xml
+++ b/conf/shared-config.xml
@@ -87,6 +87,10 @@
         <property name="targetName" value="authenticationController"/>
     </bean>
 
+    <bean id="CompoundActivityDefinitionControllerProxied" parent="proxiedController">
+        <property name="targetName" value="compoundActivityDefinitionController"/>
+    </bean>
+
     <bean id="UserDataDownloadControllerProxied" parent="proxiedController">
         <property name="targetName" value="userDataDownloadController"/>
     </bean>

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoCompoundActivityDefinitionDaoDdbTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoCompoundActivityDefinitionDaoDdbTest.java
@@ -1,0 +1,225 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.TestUtils;
+import org.sagebionetworks.bridge.exceptions.ConcurrentModificationException;
+import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
+import org.sagebionetworks.bridge.models.schedules.CompoundActivityDefinition;
+import org.sagebionetworks.bridge.models.schedules.SchemaReference;
+import org.sagebionetworks.bridge.models.schedules.SurveyReference;
+
+@ContextConfiguration("classpath:test-context.xml")
+@RunWith(SpringJUnit4ClassRunner.class)
+public class DynamoCompoundActivityDefinitionDaoDdbTest {
+    private static final List<SchemaReference> SCHEMA_LIST = ImmutableList.of(new SchemaReference("test-schema",
+            null));
+    private static final List<SurveyReference> SURVEY_LIST = ImmutableList.of(new SurveyReference("test-survey",
+            "test-survey-guid", null));
+
+    @Autowired
+    private DynamoCompoundActivityDefinitionDao dao;
+
+    private String taskId;
+
+    @Before
+    public void setup() {
+        taskId = TestUtils.randomName(this.getClass());
+    }
+
+    @After
+    public void cleanup() {
+        try {
+            dao.deleteCompoundActivityDefinition(TestConstants.TEST_STUDY, taskId);
+        } catch (RuntimeException ex) {
+            // squelch errors
+        }
+    }
+
+    @Test
+    public void crud() {
+        // Create a def with no studyId and version 3 to test that create fills these in correctly
+        DynamoCompoundActivityDefinition defToCreate = new DynamoCompoundActivityDefinition();
+        defToCreate.setStudyId(null);
+        defToCreate.setTaskId(taskId);
+        defToCreate.setVersion(3L);
+        defToCreate.setSchemaList(SCHEMA_LIST);
+        defToCreate.setSurveyList(SURVEY_LIST);
+
+        // create and validate
+        DynamoCompoundActivityDefinition createdDef = (DynamoCompoundActivityDefinition)
+                dao.createCompoundActivityDefinition(TestConstants.TEST_STUDY, defToCreate);
+        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, createdDef.getStudyId());
+        assertEquals(taskId, createdDef.getTaskId());
+        assertEquals(1, createdDef.getVersion().longValue());
+        assertEquals(SCHEMA_LIST, createdDef.getSchemaList());
+        assertEquals(SURVEY_LIST, createdDef.getSurveyList());
+
+        // get the created def and validate
+        DynamoCompoundActivityDefinition gettedCreatedDef = (DynamoCompoundActivityDefinition)
+                dao.getCompoundActivityDefinition(TestConstants.TEST_STUDY, taskId);
+        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, gettedCreatedDef.getStudyId());
+        assertEquals(taskId, gettedCreatedDef.getTaskId());
+        assertEquals(1, gettedCreatedDef.getVersion().longValue());
+        assertEquals(SCHEMA_LIST, gettedCreatedDef.getSchemaList());
+        assertEquals(SURVEY_LIST, gettedCreatedDef.getSurveyList());
+
+        // Update def to have no surveys. Version 1 so we don't get concurrent modification. Also, use nonsense strings
+        // for Study ID and Task ID to make sure the DAO is correctly ignoring those.
+        DynamoCompoundActivityDefinition defToUpdate = new DynamoCompoundActivityDefinition();
+        defToUpdate.setStudyId("ignored-study");
+        defToUpdate.setTaskId("ignored-task");
+        defToUpdate.setVersion(1L);
+        defToUpdate.setSchemaList(SCHEMA_LIST);
+        defToUpdate.setSurveyList(ImmutableList.of());
+
+        // update and validate
+        DynamoCompoundActivityDefinition updatedDef = (DynamoCompoundActivityDefinition)
+                dao.updateCompoundActivityDefinition(TestConstants.TEST_STUDY, taskId, defToUpdate);
+        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, updatedDef.getStudyId());
+        assertEquals(taskId, updatedDef.getTaskId());
+        assertEquals(2, updatedDef.getVersion().longValue());
+        assertEquals(SCHEMA_LIST, updatedDef.getSchemaList());
+        assertTrue(updatedDef.getSurveyList().isEmpty());
+
+        // get the updated def and validate
+        DynamoCompoundActivityDefinition gettedUpdatedDef = (DynamoCompoundActivityDefinition)
+                dao.getCompoundActivityDefinition(TestConstants.TEST_STUDY, taskId);
+        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, gettedUpdatedDef.getStudyId());
+        assertEquals(taskId, gettedUpdatedDef.getTaskId());
+        assertEquals(2, gettedUpdatedDef.getVersion().longValue());
+        assertEquals(SCHEMA_LIST, gettedUpdatedDef.getSchemaList());
+        assertTrue(gettedUpdatedDef.getSurveyList().isEmpty());
+
+        // Create a second def to test list.
+        String taskId2 = taskId + "2";
+        DynamoCompoundActivityDefinition defToCreate2 = new DynamoCompoundActivityDefinition();
+        defToCreate2.setTaskId(taskId2);
+        defToCreate2.setSchemaList(SCHEMA_LIST);
+        defToCreate2.setSurveyList(SURVEY_LIST);
+        dao.createCompoundActivityDefinition(TestConstants.TEST_STUDY, defToCreate2);
+
+        // Test list. Since there might be other defs from other tests, page through the defs to find the ones
+        // corresponding to the test.
+        boolean foundDef1 = false;
+        boolean foundDef2 = false;
+        List<CompoundActivityDefinition> defList = dao.getAllCompoundActivityDefinitionsInStudy(
+                TestConstants.TEST_STUDY);
+        for (CompoundActivityDefinition oneDef : defList) {
+            DynamoCompoundActivityDefinition oneDdbDef = (DynamoCompoundActivityDefinition) oneDef;
+            String listedTaskId = oneDdbDef.getTaskId();
+            if (taskId.equals(listedTaskId)) {
+                assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, oneDdbDef.getStudyId());
+                assertEquals(2, oneDdbDef.getVersion().longValue());
+                assertEquals(SCHEMA_LIST, oneDdbDef.getSchemaList());
+                assertTrue(oneDdbDef.getSurveyList().isEmpty());
+                foundDef1 = true;
+            } else if (taskId2.equals(listedTaskId)) {
+                assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, oneDdbDef.getStudyId());
+                assertEquals(1, oneDdbDef.getVersion().longValue());
+                assertEquals(SCHEMA_LIST, oneDdbDef.getSchemaList());
+                assertEquals(SURVEY_LIST, oneDdbDef.getSurveyList());
+                foundDef2 = true;
+            }
+        }
+        assertTrue(foundDef1);
+        assertTrue(foundDef2);
+
+        // delete def 2
+        dao.deleteCompoundActivityDefinition(TestConstants.TEST_STUDY, taskId2);
+
+        // get def 2 should throw
+        try {
+            dao.getCompoundActivityDefinition(TestConstants.TEST_STUDY, taskId2);
+            fail("expected exception");
+        } catch (EntityNotFoundException ex) {
+            // expected exception
+        }
+
+        // list should not include def 2
+        List<CompoundActivityDefinition> defListWithoutDef2 = dao.getAllCompoundActivityDefinitionsInStudy(
+                TestConstants.TEST_STUDY);
+        //noinspection Convert2streamapi
+        for (CompoundActivityDefinition oneDef : defListWithoutDef2) {
+            if (taskId2.equals(oneDef.getTaskId())) {
+                fail("Found def with task ID " + taskId2 + " when it should have been deleted.");
+            }
+        }
+    }
+
+    @Test(expected = ConcurrentModificationException.class)
+    public void createConcurrentModification() {
+        // create def
+        DynamoCompoundActivityDefinition def = new DynamoCompoundActivityDefinition();
+        def.setTaskId(taskId);
+        def.setSchemaList(SCHEMA_LIST);
+        def.setSurveyList(SURVEY_LIST);
+        dao.createCompoundActivityDefinition(TestConstants.TEST_STUDY, def);
+
+        // create it again, will throw
+        dao.createCompoundActivityDefinition(TestConstants.TEST_STUDY, def);
+    }
+
+    @Test(expected = EntityNotFoundException.class)
+    public void deleteNonExistentDef() {
+        dao.deleteCompoundActivityDefinition(TestConstants.TEST_STUDY, taskId);
+    }
+
+    @Test(expected = EntityNotFoundException.class)
+    public void getNonExistentDef() {
+        dao.getCompoundActivityDefinition(TestConstants.TEST_STUDY, taskId);
+    }
+
+    @Test(expected = EntityNotFoundException.class)
+    public void updateNonExistentDef() {
+        // dummy def, to make sure we aren't throwing for a reason other than non-existent def
+        DynamoCompoundActivityDefinition def = new DynamoCompoundActivityDefinition();
+        def.setTaskId(taskId);
+        def.setSchemaList(SCHEMA_LIST);
+        def.setSurveyList(SURVEY_LIST);
+
+        // update non-existent def, will throw
+        dao.updateCompoundActivityDefinition(TestConstants.TEST_STUDY, taskId, def);
+    }
+
+    @Test(expected = ConcurrentModificationException.class)
+    public void updateConcurrentModification() {
+        // create def
+        DynamoCompoundActivityDefinition def = new DynamoCompoundActivityDefinition();
+        def.setTaskId(taskId);
+        def.setSchemaList(SCHEMA_LIST);
+        def.setSurveyList(SURVEY_LIST);
+        dao.createCompoundActivityDefinition(TestConstants.TEST_STUDY, def);
+
+        // update def to bump to version 2
+        DynamoCompoundActivityDefinition goodUpdate = new DynamoCompoundActivityDefinition();
+        goodUpdate.setTaskId(taskId);
+        goodUpdate.setSchemaList(SCHEMA_LIST);
+        goodUpdate.setSurveyList(SURVEY_LIST);
+        goodUpdate.setVersion(1L);
+        dao.updateCompoundActivityDefinition(TestConstants.TEST_STUDY, taskId, goodUpdate);
+
+        // attempt to update version 1 again, this will throw - Note we need to create a new def instance object
+        // because DDB Mapper modifies arguments
+        DynamoCompoundActivityDefinition conflictUpdate = new DynamoCompoundActivityDefinition();
+        conflictUpdate.setTaskId(taskId);
+        conflictUpdate.setSchemaList(SCHEMA_LIST);
+        conflictUpdate.setSurveyList(SURVEY_LIST);
+        conflictUpdate.setVersion(1L);
+        dao.updateCompoundActivityDefinition(TestConstants.TEST_STUDY, taskId, conflictUpdate);
+    }
+}

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoCompoundActivityDefinitionTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoCompoundActivityDefinitionTest.java
@@ -1,0 +1,132 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.Lists;
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.schedules.CompoundActivityDefinition;
+import org.sagebionetworks.bridge.models.schedules.SchemaReference;
+import org.sagebionetworks.bridge.models.schedules.SurveyReference;
+
+public class DynamoCompoundActivityDefinitionTest {
+    private static final SchemaReference FOO_SCHEMA = new SchemaReference("foo", 2);
+    private static final SchemaReference BAR_SCHEMA = new SchemaReference("bar", 3);
+    private static final SurveyReference ASDF_SURVEY = new SurveyReference("asdf", "asdf-guid", null);
+    private static final SurveyReference JKL_SURVEY = new SurveyReference("jkl", "jkl-guid", null);
+
+    @Test
+    public void immutableLists() {
+        // create def - Lists are initially empty.
+        DynamoCompoundActivityDefinition def = new DynamoCompoundActivityDefinition();
+        assertTrue(def.getSchemaList().isEmpty());
+        assertListIsImmutable(def.getSchemaList(), FOO_SCHEMA);
+        assertTrue(def.getSurveyList().isEmpty());
+        assertListIsImmutable(def.getSurveyList(), ASDF_SURVEY);
+
+        // create test mutable lists
+        List<SchemaReference> originalSchemaList = Lists.newArrayList(FOO_SCHEMA);
+        List<SurveyReference> originalSurveyList = Lists.newArrayList(ASDF_SURVEY);
+
+        // set to non-empty lists
+        def.setSchemaList(originalSchemaList);
+        def.setSurveyList(originalSurveyList);
+
+        // modify original lists
+        originalSchemaList.add(BAR_SCHEMA);
+        originalSurveyList.add(JKL_SURVEY);
+
+        // verify that the lists in the def are unchanged
+        assertEquals(1, def.getSchemaList().size());
+        assertEquals(FOO_SCHEMA, def.getSchemaList().get(0));
+        assertListIsImmutable(def.getSchemaList(), BAR_SCHEMA);
+        assertEquals(1, def.getSurveyList().size());
+        assertEquals(ASDF_SURVEY, def.getSurveyList().get(0));
+        assertListIsImmutable(def.getSurveyList(), JKL_SURVEY);
+
+        // set lists to null, validate that lists are still empty and immutable
+        def.setSchemaList(null);
+        def.setSurveyList(null);
+        assertTrue(def.getSchemaList().isEmpty());
+        assertListIsImmutable(def.getSchemaList(), FOO_SCHEMA);
+        assertTrue(def.getSurveyList().isEmpty());
+        assertListIsImmutable(def.getSurveyList(), ASDF_SURVEY);
+    }
+
+    @Test
+    public void serialize() throws Exception {
+        // Use schema and survey refs so this test doesn't depend on those implementations.
+
+        // start with JSON
+        String jsonText = "{\n" +
+                "   \"studyId\":\"test-study\",\n" +
+                "   \"taskId\":\"test-task\",\n" +
+                "   \"schemaList\":[\n" +
+                BridgeObjectMapper.get().writeValueAsString(FOO_SCHEMA) + ",\n" +
+                BridgeObjectMapper.get().writeValueAsString(BAR_SCHEMA) + "\n" +
+                "   ],\n" +
+                "   \"surveyList\":[\n" +
+                BridgeObjectMapper.get().writeValueAsString(ASDF_SURVEY) + ",\n" +
+                BridgeObjectMapper.get().writeValueAsString(JKL_SURVEY) + "\n" +
+                "   ],\n" +
+                "   \"version\":42\n" +
+                "}";
+
+        // convert to POJO - deserialize it as the base type, so we know it works with the base type
+        DynamoCompoundActivityDefinition def = (DynamoCompoundActivityDefinition) BridgeObjectMapper.get().readValue(
+                jsonText, CompoundActivityDefinition.class);
+        assertEquals("test-study", def.getStudyId());
+        assertEquals("test-task", def.getTaskId());
+        assertEquals(42, def.getVersion().longValue());
+
+        List<SchemaReference> outputSchemaList = def.getSchemaList();
+        assertEquals(2, outputSchemaList.size());
+        assertEquals(FOO_SCHEMA, outputSchemaList.get(0));
+        assertEquals(BAR_SCHEMA, outputSchemaList.get(1));
+
+        List<SurveyReference> outputSurveyList = def.getSurveyList();
+        assertEquals(2, outputSurveyList.size());
+        assertEquals(ASDF_SURVEY, outputSurveyList.get(0));
+        assertEquals(JKL_SURVEY, outputSurveyList.get(1));
+
+        // convert back to JSON
+        JsonNode jsonNode = BridgeObjectMapper.get().convertValue(def, JsonNode.class);
+        assertEquals(6, jsonNode.size());
+        assertEquals("test-study", jsonNode.get("studyId").textValue());
+        assertEquals("test-task", jsonNode.get("taskId").textValue());
+        assertEquals(42, jsonNode.get("version").intValue());
+        assertEquals("CompoundActivityDefinition", jsonNode.get("type").textValue());
+
+        // For the lists, this is already tested by the encapsulated classes. Just verify that we have a list of the
+        // right size.
+        assertTrue(jsonNode.get("schemaList").isArray());
+        assertEquals(2, jsonNode.get("schemaList").size());
+
+        assertTrue(jsonNode.get("surveyList").isArray());
+        assertEquals(2, jsonNode.get("surveyList").size());
+
+        // convert to JSON using the PUBLIC_DEFINITION_WRITER
+        // For simplicity, just test that study ID is absent and the other major key values are present
+        String publicJsonText = CompoundActivityDefinition.PUBLIC_DEFINITION_WRITER.writeValueAsString(def);
+        JsonNode publicJsonNode = BridgeObjectMapper.get().readTree(publicJsonText);
+        assertNull(publicJsonNode.get("studyId"));
+        assertEquals("test-task", publicJsonNode.get("taskId").textValue());
+        assertEquals("CompoundActivityDefinition", publicJsonNode.get("type").textValue());
+    }
+
+    private static <T> void assertListIsImmutable(List<T> list, T objToAdd) {
+        try {
+            list.add(objToAdd);
+            fail("expected exception");
+        } catch (RuntimeException ex) {
+            // expected exception
+        }
+    }
+}

--- a/test/org/sagebionetworks/bridge/dynamodb/ListMarshallerTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/ListMarshallerTest.java
@@ -1,0 +1,60 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+public class ListMarshallerTest {
+    private static final TestListMarshaller MARSHALLER = new TestListMarshaller();
+
+    private static class TestObject {
+        private String value;
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
+    private static class TestListMarshaller extends ListMarshaller<TestObject> {
+        private static final TypeReference<List<TestObject>> TYPE_REF = new TypeReference<List<TestObject>>(){};
+
+        @Override
+        public TypeReference<List<TestObject>> getTypeReference() {
+            return TYPE_REF;
+        }
+    }
+
+    @Test
+    public void testConvert() throws Exception {
+        // start with JSON
+        String jsonText = "[\n" +
+                "   {\"value\":\"foo\"},\n" +
+                "   {\"value\":\"bar\"}\n" +
+                "]";
+
+        // unconvert from JSON to list
+        List<TestObject> list = MARSHALLER.unconvert(jsonText);
+        assertEquals(2, list.size());
+        assertEquals("foo", list.get(0).getValue());
+        assertEquals("bar", list.get(1).getValue());
+
+        // convert from list to JSON
+        String convertedJsonText = MARSHALLER.convert(list);
+
+        // use Jackson to convert to a JsonNode for validation
+        JsonNode convertedJsonNode = BridgeObjectMapper.get().readTree(convertedJsonText);
+        assertEquals(2, convertedJsonNode.size());
+        assertEquals("foo", convertedJsonNode.get(0).get("value").textValue());
+        assertEquals("bar", convertedJsonNode.get(1).get("value").textValue());
+    }
+}

--- a/test/org/sagebionetworks/bridge/play/controllers/CompoundActivityDefinitionControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/CompoundActivityDefinitionControllerTest.java
@@ -102,7 +102,7 @@ public class CompoundActivityDefinitionControllerTest {
     @Test
     public void delete() throws Exception {
         // execute and validate
-        Result result = controller.deleteCompoundActivityDefinition(TestConstants.TEST_STUDY_IDENTIFIER, TASK_ID);
+        Result result = controller.deleteCompoundActivityDefinition(TASK_ID);
         assertEquals(200, result.status());
         String resultJsonText = Helpers.contentAsString(result);
         JsonNode resultJsonNode = BridgeObjectMapper.get().readTree(resultJsonText);
@@ -112,7 +112,7 @@ public class CompoundActivityDefinitionControllerTest {
         verify(defService).deleteCompoundActivityDefinition(TestConstants.TEST_STUDY, TASK_ID);
 
         // verify ADMIN permissions
-        verify(controller).getAuthenticatedSession(Roles.ADMIN);
+        verify(controller).getAuthenticatedSession(Roles.DEVELOPER);
 
         // verify no call to StudyService
         verifyZeroInteractions(studyService);

--- a/test/org/sagebionetworks/bridge/play/controllers/CompoundActivityDefinitionControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/CompoundActivityDefinitionControllerTest.java
@@ -1,0 +1,215 @@
+package org.sagebionetworks.bridge.play.controllers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableList;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import play.mvc.Result;
+import play.test.Helpers;
+
+import org.sagebionetworks.bridge.Roles;
+import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.TestUtils;
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.ResourceList;
+import org.sagebionetworks.bridge.models.accounts.UserSession;
+import org.sagebionetworks.bridge.models.schedules.CompoundActivityDefinition;
+import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.services.CompoundActivityDefinitionService;
+import org.sagebionetworks.bridge.services.StudyService;
+
+public class CompoundActivityDefinitionControllerTest {
+    // Study is just a pass-through, no need to fill it in.
+    private static final Study STUDY = Study.create();
+
+    private static final String TASK_ID = "test-task";
+
+    private CompoundActivityDefinitionController controller;
+    private CompoundActivityDefinitionService defService;
+    private StudyService studyService;
+
+    @Before
+    public void setup() {
+        // mock session
+        UserSession mockSession = new UserSession();
+        mockSession.setStudyIdentifier(TestConstants.TEST_STUDY);
+
+        // mock study service
+        studyService = mock(StudyService.class);
+        when(studyService.getStudy(TestConstants.TEST_STUDY)).thenReturn(STUDY);
+
+        // mock def service
+        defService = mock(CompoundActivityDefinitionService.class);
+
+        // spy controller
+        controller = spy(new CompoundActivityDefinitionController());
+        doReturn(mockSession).when(controller).getAuthenticatedSession(anyVararg());
+        controller.setCompoundActivityDefService(defService);
+        controller.setStudyService(studyService);
+    }
+
+    @Test
+    public void create() throws Exception{
+        // make input def - Mark it with task ID for tracing. No other params matter.
+        CompoundActivityDefinition controllerInput = CompoundActivityDefinition.create();
+        controllerInput.setTaskId(TASK_ID);
+
+        // Set it as the mock JSON input.
+        TestUtils.mockPlayContextWithJson(BridgeObjectMapper.get().writeValueAsString(controllerInput));
+
+        // mock service - Service output should have both task ID and study ID so we can test that study ID is filtered
+        // out
+        CompoundActivityDefinition serviceOutput = CompoundActivityDefinition.create();
+        serviceOutput.setStudyId(TestConstants.TEST_STUDY_IDENTIFIER);
+        serviceOutput.setTaskId(TASK_ID);
+
+        ArgumentCaptor<CompoundActivityDefinition> serviceInputCaptor = ArgumentCaptor.forClass(
+                CompoundActivityDefinition.class);
+        when(defService.createCompoundActivityDefinition(same(STUDY), serviceInputCaptor.capture())).thenReturn(
+                serviceOutput);
+
+        // execute and validate
+        Result result = controller.createCompoundActivityDefinition();
+        assertEquals(201, result.status());
+        CompoundActivityDefinition controllerOutput = getDefFromResult(result);
+        assertEquals(TASK_ID, controllerOutput.getTaskId());
+        assertNull(controllerOutput.getStudyId());
+
+        // validate service input
+        CompoundActivityDefinition serviceInput = serviceInputCaptor.getValue();
+        assertEquals(TASK_ID, serviceInput.getTaskId());
+
+        // verify DEVELOPER permissions
+        verify(controller).getAuthenticatedSession(Roles.DEVELOPER);
+    }
+
+    @Test
+    public void delete() throws Exception {
+        // execute and validate
+        Result result = controller.deleteCompoundActivityDefinition(TestConstants.TEST_STUDY_IDENTIFIER, TASK_ID);
+        assertEquals(200, result.status());
+        String resultJsonText = Helpers.contentAsString(result);
+        JsonNode resultJsonNode = BridgeObjectMapper.get().readTree(resultJsonText);
+        assertEquals("Compound activity definition has been deleted.", resultJsonNode.get("message").textValue());
+
+        // verify call through to the service
+        verify(defService).deleteCompoundActivityDefinition(TestConstants.TEST_STUDY, TASK_ID);
+
+        // verify ADMIN permissions
+        verify(controller).getAuthenticatedSession(Roles.ADMIN);
+
+        // verify no call to StudyService
+        verifyZeroInteractions(studyService);
+    }
+
+    @Test
+    public void list() throws Exception {
+        // mock service
+        CompoundActivityDefinition serviceOutput = CompoundActivityDefinition.create();
+        serviceOutput.setStudyId(TestConstants.TEST_STUDY_IDENTIFIER);
+        serviceOutput.setTaskId(TASK_ID);
+
+        when(defService.getAllCompoundActivityDefinitionsInStudy(TestConstants.TEST_STUDY)).thenReturn(
+                ImmutableList.of(serviceOutput));
+
+        // execute and validate
+        Result result = controller.getAllCompoundActivityDefinitionsInStudy();
+        assertEquals(200, result.status());
+
+        String controllerOutputJsonText = Helpers.contentAsString(result);
+        ResourceList<CompoundActivityDefinition> controllerOutputResourceList = BridgeObjectMapper.get().readValue(
+                controllerOutputJsonText, new TypeReference<ResourceList<CompoundActivityDefinition>>() {});
+        List<CompoundActivityDefinition> controllerOutputList = controllerOutputResourceList.getItems();
+        assertEquals(1, controllerOutputList.size());
+
+        CompoundActivityDefinition controllerOutput = controllerOutputList.get(0);
+        assertEquals(TASK_ID, controllerOutput.getTaskId());
+        assertNull(controllerOutput.getStudyId());
+
+        // verify DEVELOPER permissions
+        verify(controller).getAuthenticatedSession(Roles.DEVELOPER);
+
+        // verify no call to StudyService
+        verifyZeroInteractions(studyService);
+    }
+
+    @Test
+    public void get() throws Exception {
+        // mock service
+        CompoundActivityDefinition serviceOutput = CompoundActivityDefinition.create();
+        serviceOutput.setStudyId(TestConstants.TEST_STUDY_IDENTIFIER);
+        serviceOutput.setTaskId(TASK_ID);
+
+        when(defService.getCompoundActivityDefinition(TestConstants.TEST_STUDY, TASK_ID)).thenReturn(serviceOutput);
+
+        // execute and validate
+        Result result = controller.getCompoundActivityDefinition(TASK_ID);
+        assertEquals(200, result.status());
+        CompoundActivityDefinition controllerOutput = getDefFromResult(result);
+        assertEquals(TASK_ID, controllerOutput.getTaskId());
+        assertNull(controllerOutput.getStudyId());
+
+        // verify DEVELOPER permissions
+        verify(controller).getAuthenticatedSession(Roles.DEVELOPER);
+
+        // verify no call to StudyService
+        verifyZeroInteractions(studyService);
+    }
+
+    @Test
+    public void update() throws Exception {
+        // make input def
+        CompoundActivityDefinition controllerInput = CompoundActivityDefinition.create();
+        controllerInput.setTaskId(TASK_ID);
+
+        // Set it as the mock JSON input.
+        TestUtils.mockPlayContextWithJson(BridgeObjectMapper.get().writeValueAsString(controllerInput));
+
+        // mock service
+        CompoundActivityDefinition serviceOutput = CompoundActivityDefinition.create();
+        serviceOutput.setStudyId(TestConstants.TEST_STUDY_IDENTIFIER);
+        serviceOutput.setTaskId(TASK_ID);
+
+        ArgumentCaptor<CompoundActivityDefinition> serviceInputCaptor = ArgumentCaptor.forClass(
+                CompoundActivityDefinition.class);
+        when(defService.updateCompoundActivityDefinition(same(STUDY), eq(TASK_ID), serviceInputCaptor.capture()))
+                .thenReturn(serviceOutput);
+
+        // execute and validate
+        Result result = controller.updateCompoundActivityDefinition(TASK_ID);
+        assertEquals(200, result.status());
+        CompoundActivityDefinition controllerOutput = getDefFromResult(result);
+        assertEquals(TASK_ID, controllerOutput.getTaskId());
+        assertNull(controllerOutput.getStudyId());
+
+        // validate service input
+        CompoundActivityDefinition serviceInput = serviceInputCaptor.getValue();
+        assertEquals(TASK_ID, serviceInput.getTaskId());
+
+        // verify DEVELOPER permissions
+        verify(controller).getAuthenticatedSession(Roles.DEVELOPER);
+    }
+
+    private static CompoundActivityDefinition getDefFromResult(Result result) throws Exception {
+        String jsonText = Helpers.contentAsString(result);
+        CompoundActivityDefinition def = BridgeObjectMapper.get().readValue(jsonText,
+                CompoundActivityDefinition.class);
+        return def;
+    }
+}

--- a/test/org/sagebionetworks/bridge/services/CompoundActivityDefinitionServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/CompoundActivityDefinitionServiceTest.java
@@ -3,8 +3,6 @@ package org.sagebionetworks.bridge.services;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -16,6 +14,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dao.CompoundActivityDefinitionDao;
@@ -25,7 +24,6 @@ import org.sagebionetworks.bridge.models.schedules.CompoundActivityDefinition;
 import org.sagebionetworks.bridge.models.schedules.SchemaReference;
 import org.sagebionetworks.bridge.models.schedules.SurveyReference;
 import org.sagebionetworks.bridge.models.studies.Study;
-import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 
 public class CompoundActivityDefinitionServiceTest {
     private static final List<SchemaReference> SCHEMA_LIST = ImmutableList.of(new SchemaReference("test-schema",
@@ -56,12 +54,19 @@ public class CompoundActivityDefinitionServiceTest {
     @Test
     public void create() {
         // mock dao
-        CompoundActivityDefinition inputDef = makeValidDef();
         CompoundActivityDefinition daoResult = makeValidDef();
-        when(dao.createCompoundActivityDefinition(eq(TestConstants.TEST_STUDY), same(inputDef))).thenReturn(daoResult);
+        ArgumentCaptor<CompoundActivityDefinition> daoInputCaptor = ArgumentCaptor.forClass(
+                CompoundActivityDefinition.class);
+        when(dao.createCompoundActivityDefinition(daoInputCaptor.capture())).thenReturn(daoResult);
 
         // execute
-        CompoundActivityDefinition serviceResult = service.createCompoundActivityDefinition(STUDY, inputDef);
+        CompoundActivityDefinition serviceInput = makeValidDef();
+        CompoundActivityDefinition serviceResult = service.createCompoundActivityDefinition(STUDY, serviceInput);
+
+        // validate dao input - It's the same as the service input, but we also set the study ID.
+        CompoundActivityDefinition daoInput = daoInputCaptor.getValue();
+        assertSame(serviceInput, daoInput);
+        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, daoInput.getStudyId());
 
         // Validate that the service result is the same as the dao result.
         assertSame(daoResult, serviceResult);
@@ -99,41 +104,42 @@ public class CompoundActivityDefinitionServiceTest {
     }
 
     @Test
-    public void deleteEmptyStudyId() {
-        deleteBadRequest("", TASK_ID, "studyId must be specified");
-    }
-
-    @Test
-    public void deleteBlankStudyId() {
-        deleteBadRequest("   ", TASK_ID, "studyId must be specified");
-    }
-
-    @Test
     public void deleteNullTaskId() {
-        deleteBadRequest(TestConstants.TEST_STUDY_IDENTIFIER, null, "taskId must be specified");
+        deleteBadRequest(null);
     }
 
     @Test
     public void deleteEmptyTaskId() {
-        deleteBadRequest(TestConstants.TEST_STUDY_IDENTIFIER, "", "taskId must be specified");
+        deleteBadRequest("");
     }
 
     @Test
     public void deleteBlankTaskId() {
-        deleteBadRequest(TestConstants.TEST_STUDY_IDENTIFIER, "   ", "taskId must be specified");
+        deleteBadRequest("   ");
     }
 
-    private void deleteBadRequest(String studyId, String taskId, String expectedErrorMessage) {
+    private void deleteBadRequest(String taskId) {
         // execute, will throw
         try {
-            service.deleteCompoundActivityDefinition(new StudyIdentifierImpl(studyId), taskId);
+            service.deleteCompoundActivityDefinition(TestConstants.TEST_STUDY, taskId);
             fail("expected exception");
         } catch (BadRequestException ex) {
-            assertEquals(expectedErrorMessage, ex.getMessage());
+            assertEquals("taskId must be specified", ex.getMessage());
         }
 
         // verify dao is never called
         verifyZeroInteractions(dao);
+    }
+
+    // DELETE ALL
+
+    @Test
+    public void deleteAll() {
+        // execute
+        service.deleteAllCompoundActivityDefinitionsInStudy(TestConstants.TEST_STUDY);
+
+        // verify dao
+        verify(dao).deleteAllCompoundActivityDefinitionsInStudy(TestConstants.TEST_STUDY);
     }
 
     // LIST
@@ -201,13 +207,21 @@ public class CompoundActivityDefinitionServiceTest {
     @Test
     public void update() {
         // mock dao
-        CompoundActivityDefinition inputDef = makeValidDef();
         CompoundActivityDefinition daoResult = makeValidDef();
-        when(dao.updateCompoundActivityDefinition(eq(TestConstants.TEST_STUDY), eq(TASK_ID), same(inputDef)))
-                .thenReturn(daoResult);
+        ArgumentCaptor<CompoundActivityDefinition> daoInputCaptor = ArgumentCaptor.forClass(
+                CompoundActivityDefinition.class);
+        when(dao.updateCompoundActivityDefinition(daoInputCaptor.capture())).thenReturn(daoResult);
 
         // execute
-        CompoundActivityDefinition serviceResult = service.updateCompoundActivityDefinition(STUDY, TASK_ID, inputDef);
+        CompoundActivityDefinition serviceInput = makeValidDef();
+        CompoundActivityDefinition serviceResult = service.updateCompoundActivityDefinition(STUDY, TASK_ID,
+                serviceInput);
+
+        // validate dao input - It's the same as the service input, but we also set the study ID.
+        CompoundActivityDefinition daoInput = daoInputCaptor.getValue();
+        assertSame(serviceInput, daoInput);
+        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, daoInput.getStudyId());
+        assertEquals(TASK_ID, daoInput.getTaskId());
 
         // Validate that the service result is the same as the dao result.
         assertSame(daoResult, serviceResult);
@@ -215,9 +229,10 @@ public class CompoundActivityDefinitionServiceTest {
 
     @Test
     public void updateInvalidDef() {
-        // make invalid def by having it have no task ID
+        // make invalid def by having it have no schemas or surveys.
         CompoundActivityDefinition def = makeValidDef();
-        def.setTaskId(null);
+        def.setSchemaList(ImmutableList.of());
+        def.setSurveyList(ImmutableList.of());
 
         // execute, will throw
         try {

--- a/test/org/sagebionetworks/bridge/services/CompoundActivityDefinitionServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/CompoundActivityDefinitionServiceTest.java
@@ -1,0 +1,269 @@
+package org.sagebionetworks.bridge.services;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.dao.CompoundActivityDefinitionDao;
+import org.sagebionetworks.bridge.exceptions.BadRequestException;
+import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
+import org.sagebionetworks.bridge.models.schedules.CompoundActivityDefinition;
+import org.sagebionetworks.bridge.models.schedules.SchemaReference;
+import org.sagebionetworks.bridge.models.schedules.SurveyReference;
+import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
+
+public class CompoundActivityDefinitionServiceTest {
+    private static final List<SchemaReference> SCHEMA_LIST = ImmutableList.of(new SchemaReference("test-schema",
+            null));
+    private static final List<SurveyReference> SURVEY_LIST = ImmutableList.of(new SurveyReference("test-survey",
+            "test-survey-guid", null));
+    private static final String TASK_ID = "test-task";
+    private static final Study STUDY;
+    static {
+        // The only things we care about in the study are the study ID and the task ID set.
+        STUDY = Study.create();
+        STUDY.setIdentifier(TestConstants.TEST_STUDY_IDENTIFIER);
+        STUDY.setTaskIdentifiers(ImmutableSet.of(TASK_ID));
+    }
+
+    private CompoundActivityDefinitionDao dao;
+    private CompoundActivityDefinitionService service;
+
+    @Before
+    public void setup() {
+        dao = mock(CompoundActivityDefinitionDao.class);
+        service = new CompoundActivityDefinitionService();
+        service.setCompoundActivityDefDao(dao);
+    }
+
+    // CREATE
+
+    @Test
+    public void create() {
+        // mock dao
+        CompoundActivityDefinition inputDef = makeValidDef();
+        CompoundActivityDefinition daoResult = makeValidDef();
+        when(dao.createCompoundActivityDefinition(eq(TestConstants.TEST_STUDY), same(inputDef))).thenReturn(daoResult);
+
+        // execute
+        CompoundActivityDefinition serviceResult = service.createCompoundActivityDefinition(STUDY, inputDef);
+
+        // Validate that the service result is the same as the dao result.
+        assertSame(daoResult, serviceResult);
+    }
+
+    @Test
+    public void createInvalidDef() {
+        // make invalid def by having it have no task ID
+        CompoundActivityDefinition def = makeValidDef();
+        def.setTaskId(null);
+
+        // execute, will throw
+        try {
+            service.createCompoundActivityDefinition(STUDY, def);
+            fail("expected exception");
+        } catch (InvalidEntityException ex) {
+            // expected exception
+        }
+
+        // verify dao is never called
+        verifyZeroInteractions(dao);
+    }
+
+    // DELETE
+
+    @Test
+    public void delete() {
+        // note: delete has no return value
+
+        // execute
+        dao.deleteCompoundActivityDefinition(TestConstants.TEST_STUDY, TASK_ID);
+
+        // verify dao
+        verify(dao).deleteCompoundActivityDefinition(TestConstants.TEST_STUDY, TASK_ID);
+    }
+
+    @Test
+    public void deleteEmptyStudyId() {
+        deleteBadRequest("", TASK_ID, "studyId must be specified");
+    }
+
+    @Test
+    public void deleteBlankStudyId() {
+        deleteBadRequest("   ", TASK_ID, "studyId must be specified");
+    }
+
+    @Test
+    public void deleteNullTaskId() {
+        deleteBadRequest(TestConstants.TEST_STUDY_IDENTIFIER, null, "taskId must be specified");
+    }
+
+    @Test
+    public void deleteEmptyTaskId() {
+        deleteBadRequest(TestConstants.TEST_STUDY_IDENTIFIER, "", "taskId must be specified");
+    }
+
+    @Test
+    public void deleteBlankTaskId() {
+        deleteBadRequest(TestConstants.TEST_STUDY_IDENTIFIER, "   ", "taskId must be specified");
+    }
+
+    private void deleteBadRequest(String studyId, String taskId, String expectedErrorMessage) {
+        // execute, will throw
+        try {
+            service.deleteCompoundActivityDefinition(new StudyIdentifierImpl(studyId), taskId);
+            fail("expected exception");
+        } catch (BadRequestException ex) {
+            assertEquals(expectedErrorMessage, ex.getMessage());
+        }
+
+        // verify dao is never called
+        verifyZeroInteractions(dao);
+    }
+
+    // LIST
+
+    @Test
+    public void list() {
+        // mock dao
+        List<CompoundActivityDefinition> daoResultList = ImmutableList.of(makeValidDef());
+        when(dao.getAllCompoundActivityDefinitionsInStudy(TestConstants.TEST_STUDY)).thenReturn(daoResultList);
+
+        // execute
+        List<CompoundActivityDefinition> serviceResultList = service.getAllCompoundActivityDefinitionsInStudy(
+                TestConstants.TEST_STUDY);
+
+        // Validate that the service result is the same as the dao result.
+        assertSame(daoResultList, serviceResultList);
+    }
+
+    // GET
+
+    @Test
+    public void get() {
+        // mock dao
+        CompoundActivityDefinition daoResult = makeValidDef();
+        when(dao.getCompoundActivityDefinition(TestConstants.TEST_STUDY, TASK_ID)).thenReturn(daoResult);
+
+        // execute
+        CompoundActivityDefinition serviceResult = service.getCompoundActivityDefinition(TestConstants.TEST_STUDY,
+                TASK_ID);
+
+        // Validate that the service result is the same as the dao result.
+        assertSame(daoResult, serviceResult);
+    }
+
+    @Test
+    public void getNullTaskId() {
+        getBadRequest(null);
+    }
+
+    @Test
+    public void getEmptyTaskId() {
+        getBadRequest("");
+    }
+
+    @Test
+    public void getBlankTaskId() {
+        getBadRequest("   ");
+    }
+
+    private void getBadRequest(String taskId) {
+        // execute, will throw
+        try {
+            service.getCompoundActivityDefinition(TestConstants.TEST_STUDY, taskId);
+            fail("expected exception");
+        } catch (BadRequestException ex) {
+            assertEquals("taskId must be specified", ex.getMessage());
+        }
+
+        // verify dao is never called
+        verifyZeroInteractions(dao);
+    }
+
+    // UPDATE
+
+    @Test
+    public void update() {
+        // mock dao
+        CompoundActivityDefinition inputDef = makeValidDef();
+        CompoundActivityDefinition daoResult = makeValidDef();
+        when(dao.updateCompoundActivityDefinition(eq(TestConstants.TEST_STUDY), eq(TASK_ID), same(inputDef)))
+                .thenReturn(daoResult);
+
+        // execute
+        CompoundActivityDefinition serviceResult = service.updateCompoundActivityDefinition(STUDY, TASK_ID, inputDef);
+
+        // Validate that the service result is the same as the dao result.
+        assertSame(daoResult, serviceResult);
+    }
+
+    @Test
+    public void updateInvalidDef() {
+        // make invalid def by having it have no task ID
+        CompoundActivityDefinition def = makeValidDef();
+        def.setTaskId(null);
+
+        // execute, will throw
+        try {
+            service.updateCompoundActivityDefinition(STUDY, TASK_ID, def);
+            fail("expected exception");
+        } catch (InvalidEntityException ex) {
+            // expected exception
+        }
+
+        // verify dao is never called
+        verifyZeroInteractions(dao);
+    }
+
+    @Test
+    public void updateNullTaskId() {
+        updateBadRequest(null);
+    }
+
+    @Test
+    public void updateEmptyTaskId() {
+        updateBadRequest("");
+    }
+
+    @Test
+    public void updateBlankTaskId() {
+        updateBadRequest("   ");
+    }
+
+    private void updateBadRequest(String taskId) {
+        // execute, will throw
+        try {
+            service.updateCompoundActivityDefinition(STUDY, taskId, makeValidDef());
+            fail("expected exception");
+        } catch (BadRequestException ex) {
+            assertEquals("taskId must be specified", ex.getMessage());
+        }
+
+        // verify dao is never called
+        verifyZeroInteractions(dao);
+    }
+
+    private static CompoundActivityDefinition makeValidDef() {
+        CompoundActivityDefinition def = CompoundActivityDefinition.create();
+        def.setTaskId(TASK_ID);
+        def.setSchemaList(SCHEMA_LIST);
+        def.setSurveyList(SURVEY_LIST);
+        return def;
+    }
+}

--- a/test/org/sagebionetworks/bridge/validators/CompoundActivityDefinitionValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/CompoundActivityDefinitionValidatorTest.java
@@ -1,0 +1,134 @@
+package org.sagebionetworks.bridge.validators;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.HashMap;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+import org.springframework.validation.MapBindingResult;
+
+import org.sagebionetworks.bridge.dynamodb.DynamoCompoundActivityDefinition;
+import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
+import org.sagebionetworks.bridge.models.schedules.CompoundActivityDefinition;
+import org.sagebionetworks.bridge.models.schedules.SchemaReference;
+import org.sagebionetworks.bridge.models.schedules.SurveyReference;
+
+public class CompoundActivityDefinitionValidatorTest {
+    private static final List<SchemaReference> SCHEMA_LIST = ImmutableList.of(new SchemaReference("test-schema",
+            null));
+    private static final List<SurveyReference> SURVEY_LIST = ImmutableList.of(new SurveyReference("test-survey",
+            "test-survey-guid", null));
+    private static final String TASK_ID = "test-task";
+    private static final CompoundActivityDefinitionValidator VALIDATOR = new CompoundActivityDefinitionValidator(
+            ImmutableSet.of(TASK_ID));
+
+    // branch coverage
+    @Test
+    public void validatorSupportsClass() {
+        assertTrue(VALIDATOR.supports(CompoundActivityDefinition.class));
+    }
+
+    // branch coverage
+    @Test
+    public void validatorSupportsSubclass() {
+        assertTrue(VALIDATOR.supports(DynamoCompoundActivityDefinition.class));
+    }
+
+    // branch coverage
+    @Test
+    public void validatorDoesntSupportClass() {
+        assertFalse(VALIDATOR.supports(String.class));
+    }
+
+    // branch coverage
+    // we call the validator directly, since Validate.validateThrowingException filters out nulls and wrong types
+    @Test
+    public void validateNull() {
+        MapBindingResult errors = new MapBindingResult(new HashMap<>(), "CompoundActivityDefinition");
+        VALIDATOR.validate(null, errors);
+        assertTrue(errors.hasErrors());
+    }
+
+    // branch coverage
+    // we call the validator directly, since Validate.validateThrowingException filters out nulls and wrong types
+    @Test
+    public void validateWrongClass() {
+        MapBindingResult errors = new MapBindingResult(new HashMap<>(), "CompoundActivityDefinition");
+        VALIDATOR.validate("wrong class", errors);
+        assertTrue(errors.hasErrors());
+    }
+
+    @Test
+    public void valid() {
+        Validate.entityThrowingException(VALIDATOR, makeValidDef());
+    }
+
+    @Test
+    public void nullTaskId() {
+        blankTaskId(null);
+    }
+
+    @Test
+    public void emptyTaskId() {
+        blankTaskId("");
+    }
+
+    @Test
+    public void blankTaskId() {
+        blankTaskId("   ");
+    }
+
+    private static void blankTaskId(String taskId) {
+        CompoundActivityDefinition def = makeValidDef();
+        def.setTaskId(taskId);
+
+        try {
+            Validate.entityThrowingException(VALIDATOR, def);
+            fail("expected exception");
+        } catch (InvalidEntityException ex) {
+            assertTrue(ex.getMessage().contains("taskId must be specified"));
+        }
+    }
+
+    @Test
+    public void taskIdNotInStudy() {
+        CompoundActivityDefinition def = makeValidDef();
+        def.setTaskId("not-a-task");
+
+        try {
+            Validate.entityThrowingException(VALIDATOR, def);
+            fail("expected exception");
+        } catch (InvalidEntityException ex) {
+            assertTrue(ex.getMessage().contains("taskId not-a-task not in enumeration: " + TASK_ID));
+        }
+    }
+
+    // no schemas or surveys
+    @Test
+    public void noSchemasOrSurveys() {
+        CompoundActivityDefinition def = makeValidDef();
+        def.setSchemaList(null);
+        def.setSurveyList(null);
+
+        try {
+            Validate.entityThrowingException(VALIDATOR, def);
+            fail("expected exception");
+        } catch (InvalidEntityException ex) {
+            assertTrue(ex.getMessage().contains("compoundActivityDefinition must have at least one schema or at least "
+                    + "one survey"));
+        }
+    }
+
+    private static CompoundActivityDefinition makeValidDef() {
+        CompoundActivityDefinition def = CompoundActivityDefinition.create();
+        def.setTaskId(TASK_ID);
+        def.setSchemaList(SCHEMA_LIST);
+        def.setSurveyList(SURVEY_LIST);
+        return def;
+    }
+}

--- a/test/org/sagebionetworks/bridge/validators/CompoundActivityDefinitionValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/CompoundActivityDefinitionValidatorTest.java
@@ -12,6 +12,7 @@ import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 import org.springframework.validation.MapBindingResult;
 
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dynamodb.DynamoCompoundActivityDefinition;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.models.schedules.CompoundActivityDefinition;
@@ -66,6 +67,33 @@ public class CompoundActivityDefinitionValidatorTest {
     @Test
     public void valid() {
         Validate.entityThrowingException(VALIDATOR, makeValidDef());
+    }
+
+    @Test
+    public void nullStudyId() {
+        blankStudyId(null);
+    }
+
+    @Test
+    public void emptyStudyId() {
+        blankStudyId("");
+    }
+
+    @Test
+    public void blankStudyId() {
+        blankStudyId("   ");
+    }
+
+    private static void blankStudyId(String studyId) {
+        CompoundActivityDefinition def = makeValidDef();
+        def.setStudyId(studyId);
+
+        try {
+            Validate.entityThrowingException(VALIDATOR, def);
+            fail("expected exception");
+        } catch (InvalidEntityException ex) {
+            assertTrue(ex.getMessage().contains("studyId must be specified"));
+        }
     }
 
     @Test
@@ -126,6 +154,7 @@ public class CompoundActivityDefinitionValidatorTest {
 
     private static CompoundActivityDefinition makeValidDef() {
         CompoundActivityDefinition def = CompoundActivityDefinition.create();
+        def.setStudyId(TestConstants.TEST_STUDY_IDENTIFIER);
         def.setTaskId(TASK_ID);
         def.setSchemaList(SCHEMA_LIST);
         def.setSurveyList(SURVEY_LIST);


### PR DESCRIPTION
The next step in adding schema IDs to schedules. Previously, we had created CompoundActivities in schedules. However, we don't want researchers to have to re-type the same list of schemas multiple times for each schedule. So we want them to be able to define Compound Activity "Definitions" separately, which can be referenced in schedules.

This includes DDB definitions, DAO, service, validator, and controller. This doesn't include scheduler logic to automatically transcribe definitions into schedules. That's the next change list.

Testing done:
* added unit tests
* manually tested CRUD methods