### PR TITLE
Added fields to describe and report on pattern-based string constraints

### DIFF
--- a/app/org/sagebionetworks/bridge/models/surveys/Constraints.java
+++ b/app/org/sagebionetworks/bridge/models/surveys/Constraints.java
@@ -21,7 +21,7 @@ import com.google.common.collect.Lists;
     @Type(name="time", value=TimeConstraints.class),
     @Type(name="duration", value=DurationConstraints.class)
 })
-public abstract class Constraints {
+public class Constraints {
 
     private EnumSet<UIHint> hints;
     private List<SurveyRule> rules = Lists.newArrayList();

--- a/app/org/sagebionetworks/bridge/models/surveys/Constraints.java
+++ b/app/org/sagebionetworks/bridge/models/surveys/Constraints.java
@@ -21,7 +21,7 @@ import com.google.common.collect.Lists;
     @Type(name="time", value=TimeConstraints.class),
     @Type(name="duration", value=DurationConstraints.class)
 })
-public class Constraints {
+public abstract class Constraints {
 
     private EnumSet<UIHint> hints;
     private List<SurveyRule> rules = Lists.newArrayList();
@@ -51,37 +51,5 @@ public class Constraints {
     // or it's supposed to. But SurveyControllerTest says otherwise.
     public String getType() {
         return this.getClass().getSimpleName();
-    }
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((dataType == null) ? 0 : dataType.hashCode());
-        result = prime * result + ((hints == null) ? 0 : hints.hashCode());
-        result = prime * result + ((rules == null) ? 0 : rules.hashCode());
-        return result;
-    }
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        Constraints other = (Constraints) obj;
-        if (dataType != other.dataType)
-            return false;
-        if (hints == null) {
-            if (other.hints != null)
-                return false;
-        } else if (!hints.equals(other.hints))
-            return false;
-        if (rules == null) {
-            if (other.rules != null)
-                return false;
-        } else if (!rules.equals(other.rules))
-            return false;
-        return true;
     }
 }

--- a/app/org/sagebionetworks/bridge/models/surveys/DateConstraints.java
+++ b/app/org/sagebionetworks/bridge/models/surveys/DateConstraints.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.bridge.models.surveys;
 
 import java.util.EnumSet;
-import java.util.Objects;
 
 import org.joda.time.LocalDate;
 
@@ -27,25 +26,4 @@ public class DateConstraints extends TimeBasedConstraints {
     public void setLatestValue(LocalDate latestValue) {
         this.latestValue = latestValue;
     }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + Objects.hash(earliestValue);
-        result = prime * result + Objects.hash(latestValue);
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (!super.equals(obj) || getClass() != obj.getClass())
-            return false;
-        DateConstraints other = (DateConstraints) obj;
-        return (Objects.equals(earliestValue, other.earliestValue) &&
-                Objects.equals(latestValue, other.latestValue));            
-    }
-    
 }

--- a/app/org/sagebionetworks/bridge/models/surveys/DateTimeConstraints.java
+++ b/app/org/sagebionetworks/bridge/models/surveys/DateTimeConstraints.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.bridge.models.surveys;
 
 import java.util.EnumSet;
-import java.util.Objects;
 
 import org.joda.time.DateTime;
 import org.sagebionetworks.bridge.json.DateTimeDeserializer;
@@ -35,25 +34,4 @@ public class DateTimeConstraints extends TimeBasedConstraints {
     public void setLatestValue(DateTime latestValue) {
         this.latestValue = latestValue;
     }
-    
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + Objects.hash(earliestValue);
-        result = prime * result + Objects.hash(latestValue);
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (!super.equals(obj) || getClass() != obj.getClass())
-            return false;
-        DateTimeConstraints other = (DateTimeConstraints) obj;
-        return (Objects.equals(earliestValue, other.earliestValue) &&
-                Objects.equals(latestValue, other.latestValue));            
-    }
-    
 }

--- a/app/org/sagebionetworks/bridge/models/surveys/MultiValueConstraints.java
+++ b/app/org/sagebionetworks/bridge/models/surveys/MultiValueConstraints.java
@@ -63,34 +63,4 @@ public class MultiValueConstraints extends Constraints {
     public void setAllowMultiple(boolean allowMultiple) {
         this.allowMultiple = allowMultiple;
     }
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + (allowMultiple ? 1231 : 1237);
-        result = prime * result + (allowOther ? 1231 : 1237);
-        result = prime * result + ((enumeration == null) ? 0 : enumeration.hashCode());
-        return result;
-    }
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (!super.equals(obj))
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        MultiValueConstraints other = (MultiValueConstraints) obj;
-        if (allowMultiple != other.allowMultiple)
-            return false;
-        if (allowOther != other.allowOther)
-            return false;
-        if (enumeration == null) {
-            if (other.enumeration != null)
-                return false;
-        } else if (!enumeration.equals(other.enumeration))
-            return false;
-        return true;
-    }
-
 }

--- a/app/org/sagebionetworks/bridge/models/surveys/NumericalConstraints.java
+++ b/app/org/sagebionetworks/bridge/models/surveys/NumericalConstraints.java
@@ -37,44 +37,4 @@ public class NumericalConstraints extends Constraints {
     public void setStep(Double step) {
         this.step = step;
     }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + ((maxValue == null) ? 0 : maxValue.hashCode());
-        result = prime * result + ((minValue == null) ? 0 : minValue.hashCode());
-        result = prime * result + ((step == null) ? 0 : step.hashCode());
-        result = prime * result + ((unit == null) ? 0 : unit.hashCode());
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (!super.equals(obj))
-            return false;
-        if (!(obj instanceof NumericalConstraints))
-            return false;
-        NumericalConstraints other = (NumericalConstraints) obj;
-        if (maxValue == null) {
-            if (other.maxValue != null)
-                return false;
-        } else if (!maxValue.equals(other.maxValue))
-            return false;
-        if (minValue == null) {
-            if (other.minValue != null)
-                return false;
-        } else if (!minValue.equals(other.minValue))
-            return false;
-        if (step == null) {
-            if (other.step != null)
-                return false;
-        } else if (!step.equals(other.step))
-            return false;
-        if (unit != other.unit)
-            return false;
-        return true;
-    }
 }

--- a/app/org/sagebionetworks/bridge/models/surveys/StringConstraints.java
+++ b/app/org/sagebionetworks/bridge/models/surveys/StringConstraints.java
@@ -2,74 +2,62 @@ package org.sagebionetworks.bridge.models.surveys;
 
 import java.util.EnumSet;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-
-public class StringConstraints extends Constraints {
+public final class StringConstraints extends Constraints {
 
     private Integer minLength;
     private Integer maxLength;
     private String pattern;
+    private String patternErrorMessage;
+    private String patternPlaceholder;
 
     public StringConstraints() {
         setDataType(DataType.STRING);
         setSupportedHints(EnumSet.of(UIHint.MULTILINETEXT, UIHint.TEXTFIELD));
     }
+
     public Integer getMinLength() {
         return minLength;
     }
+
     public void setMinLength(Integer minLength) {
         this.minLength = minLength;
     }
+
     public Integer getMaxLength() {
         return maxLength;
     }
+
     public void setMaxLength(Integer maxLength) {
         this.maxLength = maxLength;
     }
-    @JsonInclude(JsonInclude.Include.NON_NULL)
+
     public String getPattern() {
         return pattern;
     }
+
     public void setPattern(String pattern) {
         this.pattern = pattern;
     }
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + ((maxLength == null) ? 0 : maxLength.hashCode());
-        result = prime * result + ((minLength == null) ? 0 : minLength.hashCode());
-        result = prime * result + ((pattern == null) ? 0 : pattern.hashCode());
-        return result;
+
+    public String getPatternErrorMessage() {
+        return patternErrorMessage;
     }
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (!super.equals(obj))
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        StringConstraints other = (StringConstraints) obj;
-        if (maxLength == null) {
-            if (other.maxLength != null)
-                return false;
-        } else if (!maxLength.equals(other.maxLength))
-            return false;
-        if (minLength == null) {
-            if (other.minLength != null)
-                return false;
-        } else if (!minLength.equals(other.minLength))
-            return false;
-        if (pattern == null) {
-            if (other.pattern != null)
-                return false;
-        } else if (!pattern.equals(other.pattern))
-            return false;
-        return true;
+
+    public void setPatternErrorMessage(String patternErrorMessage) {
+        this.patternErrorMessage = patternErrorMessage;
     }
+    
+    public String getPatternPlaceholder() {
+        return patternPlaceholder;
+    }
+
+    public void setPatternPlaceholder(String patternPlaceholder) {
+        this.patternPlaceholder = patternPlaceholder;
+    }
+
     @Override
     public String toString() {
-        return "StringConstraints [minLength=" + minLength + ", maxLength=" + maxLength + ", pattern=" + pattern + "]";
+        return "StringConstraints [minLength=" + minLength + ", maxLength=" + maxLength + ", pattern=" + pattern
+                + ", patternErrorMessage=" + patternErrorMessage + ", patternPlaceholder=" + patternPlaceholder + "]";
     }
 }

--- a/app/org/sagebionetworks/bridge/models/surveys/TimeBasedConstraints.java
+++ b/app/org/sagebionetworks/bridge/models/surveys/TimeBasedConstraints.java
@@ -10,24 +10,4 @@ public abstract class TimeBasedConstraints extends Constraints {
     public void setAllowFuture(boolean allowFuture) {
         this.allowFuture = allowFuture;
     }
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + (allowFuture ? 1231 : 1237);
-        return result;
-    }
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (!super.equals(obj))
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        TimeBasedConstraints other = (TimeBasedConstraints) obj;
-        if (allowFuture != other.allowFuture)
-            return false;
-        return true;
-    }
 }

--- a/app/org/sagebionetworks/bridge/play/controllers/StudyController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/StudyController.java
@@ -7,9 +7,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.StringUtils;
 import org.sagebionetworks.bridge.config.BridgeConfigFactory;
-import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.models.CmsPublicKey;
@@ -29,7 +27,6 @@ import org.sagebionetworks.bridge.services.UploadCertificateService;
 import org.sagebionetworks.bridge.services.UploadService;
 
 import org.joda.time.DateTime;
-import org.sagebionetworks.bridge.validators.Validate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 
@@ -37,7 +34,6 @@ import play.libs.Json;
 import play.mvc.BodyParser;
 import play.mvc.Result;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.sagebionetworks.bridge.Roles.*;
 
 @Controller

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -73,12 +73,24 @@ public class TestUtils {
     
     private static final DateTime TEST_CREATED_ON = DateTime.parse("2015-01-27T00:38:32.486Z");
 
+    /**
+     * Asserts that on validation, InvalidEntityException has been thrown with an error key that is the nested path to
+     * the object value that is invalid, and an error message that only uses the end of the key, and thus can be
+     * displayed in a UI for the user.
+     */
     public static void assertValidatorMessage(Validator validator, Object object, String fieldName, String error) {
+        String fieldNameAsLabel = fieldName;
+        if (fieldNameAsLabel.contains(".")) {
+            fieldNameAsLabel = fieldNameAsLabel.substring(fieldNameAsLabel.lastIndexOf(".")+1);
+        }
+        if (!error.startsWith(" ")) {
+            error = " " + error;
+        }
         try {
             Validate.entityThrowingException(validator, object);
             fail("Should have thrown exception");
         } catch(InvalidEntityException e) {
-            assertEquals(fieldName+error, e.getErrors().get(fieldName).get(0));
+            assertEquals(fieldNameAsLabel+error, e.getErrors().get(fieldName).get(0));
         }
     }
     

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyQuestionTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyQuestionTest.java
@@ -36,7 +36,19 @@ public class DynamoSurveyQuestionTest {
         assertEquals("{\"surveyCompoundKey\":\"AAA:1444471810000\",\"guid\":\"AAA\",\"identifier\":\"identifier\",\"type\":\"type\",\"prompt\":\"Prompt\",\"promptDetail\":\"Prompt Detail\",\"fireEvent\":false,\"constraints\":{\"rules\":[],\"dataType\":\"integer\",\"unit\":\"days\",\"minValue\":2.0,\"maxValue\":6.0,\"step\":2.0,\"type\":\"IntegerConstraints\"},\"uiHint\":\"checkbox\"}", string);
         
         DynamoSurveyQuestion question2 = (DynamoSurveyQuestion)DynamoSurveyQuestion.fromJson(BridgeObjectMapper.get().readTree(string));
-        assertEquals(question, question2);
+        assertEquals(question.getPromptDetail(), question2.getPromptDetail());
+        assertEquals(question.getPrompt(), question2.getPrompt());
+        assertEquals(question.getIdentifier(), question2.getIdentifier());
+        assertEquals(question.getGuid(), question2.getGuid());
+        assertEquals(question.getOrder(), question2.getOrder());
+        assertEquals(question.getType(), question2.getType());
+        assertEquals(question.getUiHint(), question2.getUiHint());
+        
+        IntegerConstraints c2 = (IntegerConstraints)question2.getConstraints();
+        assertEquals(c.getMinValue(), c2.getMinValue());
+        assertEquals(c.getMaxValue(), c2.getMaxValue());
+        assertEquals(c.getStep(), c2.getStep());
+        assertEquals(c.getUnit(), c2.getUnit());
     }
     
 }

--- a/test/org/sagebionetworks/bridge/json/JsonUtilsTest.java
+++ b/test/org/sagebionetworks/bridge/json/JsonUtilsTest.java
@@ -120,7 +120,11 @@ public class JsonUtilsTest {
         JsonNode node = mapper.readTree(esc("{'key':"+mapper.writeValueAsString(c)+"}"));
         assertNull(JsonUtils.asConstraints(node, null));
         assertNull(JsonUtils.asConstraints(node, "badProp"));
-        assertEquals(c, JsonUtils.asConstraints(node, "key"));
+        
+        IntegerConstraints copy = (IntegerConstraints)JsonUtils.asConstraints(node, "key");
+        assertEquals(c.getType(), copy.getType());
+        assertEquals(c.getMinValue(), copy.getMinValue());
+        assertEquals(c.getMaxValue(), copy.getMaxValue());
     }
 
     @Test

--- a/test/org/sagebionetworks/bridge/models/surveys/TestSurvey.java
+++ b/test/org/sagebionetworks/bridge/models/surveys/TestSurvey.java
@@ -65,7 +65,8 @@ public class TestSurvey extends DynamoSurvey {
             c.setMinLength(2);
             c.setMaxLength(255);
             c.setPattern("\\d{3}-\\d{3}-\\d{4}");
-            setPrompt("Please enter an emergency phone number (###-###-####)?");
+            c.setPatternErrorMessage("Provide phone number in format ###-###-####");
+            setPrompt("Please enter an emergency phone number");
             setPromptDetail("This should be for someone besides yourself.");
             setIdentifier("name");
             setUiHint(UIHint.TEXTFIELD);

--- a/test/org/sagebionetworks/bridge/play/controllers/StudyControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/StudyControllerTest.java
@@ -17,7 +17,6 @@ import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.Roles.WORKER;
-import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 import static org.sagebionetworks.bridge.TestUtils.mockPlayContext;
 
 import java.util.List;

--- a/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
@@ -257,6 +257,7 @@ public class StudyServiceMockTest {
         assertEquals(retStudy.getSynapseDataAccessTeamId().toString(), TEST_TEAM_ID);
     }
 
+    @SuppressWarnings("unchecked")
     @Test(expected = BadRequestException.class)
     public void createSynapseProjectTeamNonExistUserID() throws SynapseException {
         Study study = getTestStudy();

--- a/test/org/sagebionetworks/bridge/services/StudyServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.sagebionetworks.bridge.services.StudyService.EXPORTER_SYNAPSE_USER_ID;
 
 import javax.annotation.Resource;
 
@@ -23,7 +22,6 @@ import org.junit.runner.RunWith;
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.cache.CacheProvider;
-import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 import org.sagebionetworks.bridge.dao.DirectoryDao;
 import org.sagebionetworks.bridge.dao.SubpopulationDao;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
@@ -40,31 +38,16 @@ import org.sagebionetworks.bridge.models.subpopulations.StudyConsentView;
 import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 
-import org.sagebionetworks.client.SynapseClient;
 import org.sagebionetworks.client.exceptions.SynapseException;
-import org.sagebionetworks.reflection.model.PaginatedResults;
-import org.sagebionetworks.repo.model.AccessControlList;
-import org.sagebionetworks.repo.model.Entity;
-import org.sagebionetworks.repo.model.MembershipInvtnSubmission;
-import org.sagebionetworks.repo.model.Project;
-import org.sagebionetworks.repo.model.ResourceAccess;
-import org.sagebionetworks.repo.model.Team;
-import org.sagebionetworks.repo.model.util.ModelConstants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import com.google.common.collect.Sets;
 
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 @ContextConfiguration("classpath:test-context.xml")
 @RunWith(SpringJUnit4ClassRunner.class)
 public class StudyServiceTest {
-
-    private static final Long TEST_USER_ID = Long.parseLong(BridgeConfigFactory.getConfig().getTestSynapseUserId()); // test user exists in synapse
 
     @Resource
     StudyService studyService;
@@ -91,9 +74,6 @@ public class StudyServiceTest {
     
     private Study study;
 
-    private Project project;
-    private Team team;
-    
     @Before
     public void before() throws SynapseException {
         mockCache = mock(CacheProvider.class);

--- a/test/org/sagebionetworks/bridge/services/SurveyServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SurveyServiceTest.java
@@ -453,7 +453,7 @@ public class SurveyServiceTest {
             surveyService.createSurvey(survey);
             fail("Service should have thrown an exception");
         } catch(InvalidEntityException e) {
-            assertEquals("Survey is invalid: elements[0].identifier is required; elements[0].title is required; elements[0].prompt is required; elements[0].image.source must be a valid URL to an image; elements[0].image.width is required; elements[0].image.height is required", e.getMessage());
+            assertEquals("Survey is invalid: identifier is required; title is required; prompt is required; source must be a valid URL to an image; width is required; height is required", e.getMessage());
         }
     }
 

--- a/test/org/sagebionetworks/bridge/validators/SurveyValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/SurveyValidatorTest.java
@@ -1,8 +1,6 @@
 package org.sagebionetworks.bridge.validators;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
 
 import java.util.List;
 
@@ -16,7 +14,6 @@ import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoSurvey;
 import org.sagebionetworks.bridge.dynamodb.DynamoSurveyInfoScreen;
 import org.sagebionetworks.bridge.dynamodb.DynamoSurveyQuestion;
-import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.surveys.DateConstraints;
 import org.sagebionetworks.bridge.models.surveys.DateTimeConstraints;
@@ -54,13 +51,6 @@ public class SurveyValidatorTest {
         validator = new SurveyValidator();
     }
 
-    private String errorFor(InvalidEntityException e, String field) {
-        List<String> errors = e.getErrors().get(field);
-        assertNotNull(errors);
-        assertEquals(1, errors.size());
-        return errors.get(0);
-    }
-
     private SurveyInfoScreen createSurveyInfoScreen() {
         SurveyInfoScreen screen = new DynamoSurveyInfoScreen();
         screen.setTitle("title");
@@ -81,188 +71,120 @@ public class SurveyValidatorTest {
 
     @Test
     public void nameRequired() {
-        try {
-            survey.setName("");
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("name is required", errorFor(e, "name"));
-        }
+        survey.setName("");
+        assertValidatorMessage(validator, survey, "name", "is required");
     }
 
     @Test
     public void identifierRequired() {
-        try {
-            survey.setIdentifier(" ");
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("identifier is required", errorFor(e, "identifier"));
-        }
+        survey.setIdentifier(" ");
+        assertValidatorMessage(validator, survey, "identifier", "is required");
     }
 
     @Test
     public void studyIdentifierRequired() {
-        try {
-            survey.setStudyIdentifier("");
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("studyIdentifier is required", errorFor(e, "studyIdentifier"));
-        }
+        survey.setStudyIdentifier("");
+        assertValidatorMessage(validator, survey, "studyIdentifier", "is required");
     }
 
     @Test
     public void guidRequired() {
-        try {
-            survey.setGuid(null);
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("guid is required", errorFor(e, "guid"));
-        }
+        survey.setGuid(null);
+        assertValidatorMessage(validator, survey, "guid", "is required");
     }
 
     @Test
     public void preventsDuplicateElementIdentfiers() {
-        try {
-            survey = new TestSurvey(SurveyValidatorTest.class, true);
-            String identifier = survey.getElements().get(0).getIdentifier();
-            survey.getElements().get(1).setIdentifier(identifier);
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("elements[1].identifier exists in an earlier survey element", errorFor(e, "elements[1].identifier"));
-        }
+        survey = new TestSurvey(SurveyValidatorTest.class, true);
+        String identifier = survey.getElements().get(0).getIdentifier();
+        survey.getElements().get(1).setIdentifier(identifier);
+
+        survey.setGuid(null);
+        assertValidatorMessage(validator, survey, "elements[1].identifier", "exists in an earlier survey element");
     }
 
     @Test
     public void infoScreenIdentifierRequired() {
-        try {
-            survey = new TestSurvey(SurveyValidatorTest.class, true);
-            survey.getElements().add(createSurveyInfoScreen());
-            SurveyInfoScreen screen = (SurveyInfoScreen) last(survey);
-            screen.setIdentifier("");
+        survey = new TestSurvey(SurveyValidatorTest.class, true);
+        survey.getElements().add(createSurveyInfoScreen());
+        SurveyInfoScreen screen = (SurveyInfoScreen) last(survey);
+        screen.setIdentifier("");
 
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("elements[9].identifier is required", errorFor(e, "elements[9].identifier"));
-        }
+        assertValidatorMessage(validator, survey, "elements[9].identifier", "is required");
     }
 
     @Test
     public void infoScreenTitleRequired() {
-        try {
-            survey = new TestSurvey(SurveyValidatorTest.class, true);
-            survey.getElements().add(createSurveyInfoScreen());
-            SurveyInfoScreen screen = (SurveyInfoScreen) last(survey);
-            screen.setTitle("");
+        survey = new TestSurvey(SurveyValidatorTest.class, true);
+        survey.getElements().add(createSurveyInfoScreen());
+        SurveyInfoScreen screen = (SurveyInfoScreen) last(survey);
+        screen.setTitle("");
 
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("elements[9].title is required", errorFor(e, "elements[9].title"));
-        }
+        assertValidatorMessage(validator, survey, "elements[9].title", "is required");
     }
 
     @Test
     public void infoScreenPromptRequired() {
-        try {
-            survey = new TestSurvey(SurveyValidatorTest.class, true);
-            survey.getElements().add(createSurveyInfoScreen());
-            SurveyInfoScreen screen = (SurveyInfoScreen) last(survey);
-            screen.setPrompt("");
+        survey = new TestSurvey(SurveyValidatorTest.class, true);
+        survey.getElements().add(createSurveyInfoScreen());
+        SurveyInfoScreen screen = (SurveyInfoScreen) last(survey);
+        screen.setPrompt("");
 
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("elements[9].prompt is required", errorFor(e, "elements[9].prompt"));
-        }
+        assertValidatorMessage(validator, survey, "elements[9].prompt", "is required");
     }
 
     @Test
     public void ifPresentAllFieldsOfSurveyScreenImageRequired() {
-        try {
-            survey = new TestSurvey(SurveyValidatorTest.class, false);
-            survey.getElements().add(createSurveyInfoScreen());
-            SurveyInfoScreen screen = (SurveyInfoScreen) last(survey);
-            screen.setImage(new Image("", 0, 0));
+        survey = new TestSurvey(SurveyValidatorTest.class, false);
+        survey.getElements().add(createSurveyInfoScreen());
+        SurveyInfoScreen screen = (SurveyInfoScreen) last(survey);
+        screen.setImage(new Image("", 0, 0));
 
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("elements[9].image.width is required", errorFor(e, "elements[9].image.width"));
-            assertEquals("elements[9].image.height is required", errorFor(e, "elements[9].image.height"));
-            assertEquals("elements[9].image.source is required", errorFor(e, "elements[9].image.source"));
-        }
+        assertValidatorMessage(validator, survey, "elements[9].image.width", "is required");
+        assertValidatorMessage(validator, survey, "elements[9].image.height", "is required");
+        assertValidatorMessage(validator, survey, "elements[9].image.source", "is required");
     }
 
     @Test
     public void questionIdentifierRequired() {
-        try {
-            survey = new TestSurvey(SurveyValidatorTest.class, false);
-            survey.getElements().get(0).setIdentifier("");
+        survey = new TestSurvey(SurveyValidatorTest.class, false);
+        survey.getElements().get(0).setIdentifier("");
 
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("elements[0].identifier is required", errorFor(e, "elements[0].identifier"));
-        }
+        assertValidatorMessage(validator, survey, "elements[0].identifier", "is required");
     }
 
     @Test
     public void questionIdentifierInvalid() {
         String fieldName = "**invalid!q##";
-        try {
-            survey = new TestSurvey(SurveyValidatorTest.class, false);
-            survey.getElements().get(0).setIdentifier(fieldName);
+        survey = new TestSurvey(SurveyValidatorTest.class, false);
+        survey.getElements().get(0).setIdentifier(fieldName);
 
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("elements[0].identifier " + String.format(UploadUtil.INVALID_FIELD_NAME_ERROR_MESSAGE, fieldName),
-                    errorFor(e, "elements[0].identifier"));
-        }
+        assertValidatorMessage(validator, survey, "elements[0].identifier",
+                String.format(UploadUtil.INVALID_FIELD_NAME_ERROR_MESSAGE, fieldName));
     }
 
     @Test
     public void questionUiHintRequired() {
-        try {
-            survey = new TestSurvey(SurveyValidatorTest.class, false);
-            survey.getUnmodifiableQuestionList().get(0).setUiHint(null);
+        survey = new TestSurvey(SurveyValidatorTest.class, false);
+        survey.getUnmodifiableQuestionList().get(0).setUiHint(null);
 
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("elements[0].uiHint is required", errorFor(e, "elements[0].uiHint"));
-        }
+        assertValidatorMessage(validator, survey, "elements[0].uiHint", "is required");
     }
 
     @Test
     public void questionPromptRequired() {
-        try {
-            survey = new TestSurvey(SurveyValidatorTest.class, false);
-            survey.getUnmodifiableQuestionList().get(0).setPrompt("");
+        survey = new TestSurvey(SurveyValidatorTest.class, false);
+        survey.getUnmodifiableQuestionList().get(0).setPrompt("");
 
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("elements[0].prompt is required", errorFor(e, "elements[0].prompt"));
-        }
+        assertValidatorMessage(validator, survey, "elements[0].prompt", "is required");
     }
 
     @Test
     public void questionConstraintsRequired() {
-        try {
-            survey = new TestSurvey(SurveyValidatorTest.class, false);
-            survey.getUnmodifiableQuestionList().get(0).setConstraints(null);
+        survey = new TestSurvey(SurveyValidatorTest.class, false);
+        survey.getUnmodifiableQuestionList().get(0).setConstraints(null);
 
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("elements[0].constraints is required", errorFor(e, "elements[0].constraints"));
-        }
+        assertValidatorMessage(validator, survey, "elements[0].constraints", "is required");
     }
 
     // Constraints are largely optional, but each constraint must have a data type.
@@ -271,90 +193,61 @@ public class SurveyValidatorTest {
 
     @Test
     public void constraintDataTypeRequired() {
-        try {
-            survey = new TestSurvey(SurveyValidatorTest.class, false);
-            survey.getUnmodifiableQuestionList().get(0).getConstraints().setDataType(null);
+        survey = new TestSurvey(SurveyValidatorTest.class, false);
+        survey.getUnmodifiableQuestionList().get(0).getConstraints().setDataType(null);
 
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("elements[0].constraints.dataType is required", errorFor(e, "elements[0].constraints.dataType"));
-        }
+        assertValidatorMessage(validator, survey, "elements[0].constraints.dataType", "is required");
     }
 
     @Test
     public void uiHintMustBeSupportedByConstraintsType() {
-        try {
-            survey = new TestSurvey(SurveyValidatorTest.class, false);
-            // Boolean constraints do not jive with lists (which are normally for select multiple)
-            survey.getUnmodifiableQuestionList().get(0).setUiHint(UIHint.LIST);
+        survey = new TestSurvey(SurveyValidatorTest.class, false);
+        // Boolean constraints do not jive with lists (which are normally for select multiple)
+        survey.getUnmodifiableQuestionList().get(0).setUiHint(UIHint.LIST);
 
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("data type 'boolean' doesn't match the UI hint of 'list'",
-                            errorFor(e, "elements[0].constraints.dataType"));
-        }
+        assertValidatorMessage(validator, survey, "elements[0].constraints.dataType",
+                "'boolean' doesn't match the UI hint of 'list'");
     }
 
     @Test
     public void multiValueWithComboboxLimitsConstraints() {
-        try {
-            survey = new TestSurvey(SurveyValidatorTest.class, false);
-            SurveyQuestion question = ((TestSurvey) survey).getMultiValueQuestion();
-            question.setUiHint(UIHint.COMBOBOX);
-            ((MultiValueConstraints) question.getConstraints()).setAllowMultiple(true);
+        survey = new TestSurvey(SurveyValidatorTest.class, false);
+        SurveyQuestion question = ((TestSurvey) survey).getMultiValueQuestion();
+        question.setUiHint(UIHint.COMBOBOX);
+        ((MultiValueConstraints) question.getConstraints()).setAllowMultiple(true);
 
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("'combobox' is only valid when multiple = false and other = true",
-                            errorFor(e, "elements[7].constraints.uiHint"));
-        }
-        try {
-            survey = new TestSurvey(SurveyValidatorTest.class, false);
-            SurveyQuestion question = ((TestSurvey) survey).getMultiValueQuestion();
-            question.setUiHint(UIHint.COMBOBOX);
-            ((MultiValueConstraints) question.getConstraints()).setAllowOther(false);
+        assertValidatorMessage(validator, survey, "elements[7].constraints.uiHint",
+                "'combobox' is only valid when multiple = false and other = true");
 
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("'combobox' is only valid when multiple = false and other = true",
-                            errorFor(e, "elements[7].constraints.uiHint"));
-        }
+        survey = new TestSurvey(SurveyValidatorTest.class, false);
+        question = ((TestSurvey) survey).getMultiValueQuestion();
+        question.setUiHint(UIHint.COMBOBOX);
+        ((MultiValueConstraints) question.getConstraints()).setAllowOther(false);
+
+        assertValidatorMessage(validator, survey, "elements[7].constraints.uiHint",
+                "'combobox' is only valid when multiple = false and other = true");
     }
 
     @Test
     public void multiValueWithMultipleAnswersLimitsConstraints() {
-        try {
-            survey = new TestSurvey(SurveyValidatorTest.class, false);
-            SurveyQuestion question = ((TestSurvey) survey).getMultiValueQuestion();
-            question.setUiHint(UIHint.SLIDER);
-            ((MultiValueConstraints) question.getConstraints()).setAllowMultiple(true);
+        survey = new TestSurvey(SurveyValidatorTest.class, false);
+        SurveyQuestion question = ((TestSurvey) survey).getMultiValueQuestion();
+        question.setUiHint(UIHint.SLIDER);
+        ((MultiValueConstraints) question.getConstraints()).setAllowMultiple(true);
 
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("allows multiples but the 'slider' UI hint doesn't gather more than one answer",
-                            errorFor(e, "elements[7].constraints.uiHint"));
-        }
+        assertValidatorMessage(validator, survey, "elements[7].constraints.uiHint",
+                "allows multiples but the 'slider' UI hint doesn't gather more than one answer");
     }
 
     @Test
     public void multiValueWithOneAnswerLimitsConstraints() {
-        try {
-            survey = new TestSurvey(SurveyValidatorTest.class, false);
-            SurveyQuestion question = ((TestSurvey) survey).getMultiValueQuestion();
-            question.setUiHint(UIHint.CHECKBOX);
-            ((MultiValueConstraints) question.getConstraints()).setAllowMultiple(false);
+        survey = new TestSurvey(SurveyValidatorTest.class, false);
+        SurveyQuestion question = ((TestSurvey) survey).getMultiValueQuestion();
+        question.setUiHint(UIHint.CHECKBOX);
+        ((MultiValueConstraints) question.getConstraints()).setAllowMultiple(false);
 
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("doesn't allow multiples but the 'checkbox' UI hint gathers more than one answer",
-                            errorFor(e, "elements[7].constraints.uiHint"));
-        }
+        assertValidatorMessage(validator, survey, "elements[7].constraints.uiHint",
+                "doesn't allow multiples but the 'checkbox' UI hint gathers more than one answer");
     }
 
     @Test
@@ -362,16 +255,11 @@ public class SurveyValidatorTest {
         List<SurveyQuestionOption>[] testCases = new List[] { null, ImmutableList.of() };
 
         for (List<SurveyQuestionOption> oneTestCase : testCases) {
-            try {
-                SurveyQuestion question = ((TestSurvey) survey).getMultiValueQuestion();
-                ((MultiValueConstraints) question.getConstraints()).setEnumeration(oneTestCase);
+            SurveyQuestion question = ((TestSurvey) survey).getMultiValueQuestion();
+            ((MultiValueConstraints) question.getConstraints()).setEnumeration(oneTestCase);
 
-                Validate.entityThrowingException(validator, survey);
-                fail("Should have thrown exception");
-            } catch (InvalidEntityException e) {
-                assertEquals("enumeration must have non-null, non-empty choices list",
-                        errorFor(e, "elements[7].constraints.enumeration"));
-            }
+            assertValidatorMessage(validator, survey, "elements[7].constraints.enumeration",
+                    "must have non-null, non-empty choices list");
         }
     }
 
@@ -380,17 +268,12 @@ public class SurveyValidatorTest {
         String[] testCases = { null, "", "   " };
 
         for (String oneTestCase : testCases) {
-            try {
-                List<SurveyQuestionOption> optionList = ImmutableList.of(new SurveyQuestionOption(oneTestCase));
+            List<SurveyQuestionOption> optionList = ImmutableList.of(new SurveyQuestionOption(oneTestCase));
 
-                SurveyQuestion question = ((TestSurvey) survey).getMultiValueQuestion();
-                ((MultiValueConstraints) question.getConstraints()).setEnumeration(optionList);
+            SurveyQuestion question = ((TestSurvey) survey).getMultiValueQuestion();
+            ((MultiValueConstraints) question.getConstraints()).setEnumeration(optionList);
 
-                Validate.entityThrowingException(validator, survey);
-                fail("Should have thrown exception");
-            } catch (InvalidEntityException e) {
-                assertEquals("label must be specified", errorFor(e, "elements[7].constraints.enumeration[0].label"));
-            }
+            assertValidatorMessage(validator, survey, "elements[7].constraints.enumeration[0].label", "is required");
         }
     }
 
@@ -409,58 +292,58 @@ public class SurveyValidatorTest {
     @Test
     public void multiValueWithOptionWithInvalidValue() {
         String answerChoice = "@invalid#answer$";
-        try {
-            List<SurveyQuestionOption> optionList = ImmutableList.of(new SurveyQuestionOption("My Question", null,
-                    answerChoice, null));
+        List<SurveyQuestionOption> optionList = ImmutableList
+                .of(new SurveyQuestionOption("My Question", null, answerChoice, null));
 
-            SurveyQuestion question = ((TestSurvey) survey).getMultiValueQuestion();
-            ((MultiValueConstraints) question.getConstraints()).setEnumeration(optionList);
+        SurveyQuestion question = ((TestSurvey) survey).getMultiValueQuestion();
+        ((MultiValueConstraints) question.getConstraints()).setEnumeration(optionList);
 
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("elements[7].constraints.enumeration[0].value " +
-                            String.format(UploadUtil.INVALID_ANSWER_CHOICE_ERROR_MESSAGE, answerChoice),
-                    errorFor(e, "elements[7].constraints.enumeration[0].value"));
-        }
+        assertValidatorMessage(validator, survey, "elements[7].constraints.enumeration[0].value",
+                String.format(UploadUtil.INVALID_ANSWER_CHOICE_ERROR_MESSAGE, answerChoice));
     }
 
     @Test
     public void multiValueWithDupeOptions() {
-        try {
-            List<SurveyQuestionOption> optionList = ImmutableList.of(
-                    new SurveyQuestionOption("a", null, "a", null),
-                    new SurveyQuestionOption("b1", null, "b", null),
-                    new SurveyQuestionOption("b2", null, "b", null),
-                    new SurveyQuestionOption("c", null, "c", null),
-                    new SurveyQuestionOption("d1", null, "d", null),
-                    new SurveyQuestionOption("d2", null, "d", null),
-                    new SurveyQuestionOption("e", null, "e", null));
+        List<SurveyQuestionOption> optionList = ImmutableList.of(new SurveyQuestionOption("a", null, "a", null),
+                new SurveyQuestionOption("b1", null, "b", null), new SurveyQuestionOption("b2", null, "b", null),
+                new SurveyQuestionOption("c", null, "c", null), new SurveyQuestionOption("d1", null, "d", null),
+                new SurveyQuestionOption("d2", null, "d", null), new SurveyQuestionOption("e", null, "e", null));
 
-            SurveyQuestion question = ((TestSurvey) survey).getMultiValueQuestion();
-            ((MultiValueConstraints) question.getConstraints()).setEnumeration(optionList);
+        SurveyQuestion question = ((TestSurvey) survey).getMultiValueQuestion();
+        ((MultiValueConstraints) question.getConstraints()).setEnumeration(optionList);
 
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("enumeration must have unique values", errorFor(e, "elements[7].constraints.enumeration"));
-        }
+        assertValidatorMessage(validator, survey, "elements[7].constraints.enumeration", "must have unique values");
     }
 
     @Test
     public void stringConstraintsMustHaveValidRegularExpressionPattern() {
-        try {
-            survey = new TestSurvey(SurveyValidatorTest.class, false);
-            SurveyQuestion question = ((TestSurvey) survey).getStringQuestion();
-            ((StringConstraints) question.getConstraints()).setPattern("?");
+        survey = new TestSurvey(SurveyValidatorTest.class, false);
+        SurveyQuestion question = ((TestSurvey) survey).getStringQuestion();
+        ((StringConstraints) question.getConstraints()).setPattern("?");
 
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("pattern is not a valid regular expression: ?", errorFor(e, "elements[8].constraints.pattern"));
-        }
+        assertValidatorMessage(validator, survey, "elements[8].constraints.pattern",
+                "is not a valid regular expression: ?");
     }
     
+    @Test
+    public void stringConstraintsCanHaveValidRegularExpressionPattern() {
+        survey = new TestSurvey(SurveyValidatorTest.class, false);
+        SurveyQuestion question = ((TestSurvey) survey).getStringQuestion();
+        ((StringConstraints) question.getConstraints()).setPattern("{1,3}\\d-{1,3}\\d-");
+
+        Validate.entityThrowingException(validator, survey);
+    }
+    
+    @Test
+    public void whenPatternIsSetPatternErrorMessageMustBeSet() {
+        survey = new TestSurvey(SurveyValidatorTest.class, false);
+        SurveyQuestion question = ((TestSurvey) survey).getStringQuestion();
+        ((StringConstraints) question.getConstraints()).setPatternErrorMessage(null);
+
+        assertValidatorMessage(validator, survey, "elements[8].constraints.patternErrorMessage",
+                "is required if pattern is defined");
+    }
+
     @Test
     public void willValidateRuleReferencesToNonQuestions() {
         // ie this is valid because it is looking at identifiers in survey info screens.
@@ -469,31 +352,31 @@ public class SurveyValidatorTest {
         survey.setIdentifier("Identifier");
         survey.setStudyIdentifier("study-key");
         survey.setGuid("guid");
-        
+
         StringConstraints constraints = new StringConstraints();
-        
+
         constraints.getRules().add(
                 new SurveyRule.Builder().withOperator(Operator.EQ).withValue("No").withSkipToTarget("theend").build());
-        
+
         SurveyQuestion question = new DynamoSurveyQuestion();
         question.setIdentifier("start-q");
         question.setUiHint(UIHint.TEXTFIELD);
         question.setPrompt("Prompt");
         question.setConstraints(constraints);
-        
+
         SurveyInfoScreen info = new DynamoSurveyInfoScreen();
         info.setTitle("Title");
         info.setPrompt("Prompt");
         info.setIdentifier("theend");
-        
+
         survey.getElements().add(question);
         survey.getElements().add(info);
-        
+
         // Anticlimactic, but this used to throw an exception, and it should not have,
         // because the second element is a SurveyInfoScreen
         Validate.entityThrowingException(validator, survey);
     }
-    
+
     @Test
     public void willVerifyRuleDoesntHaveSkipToAndEndSurvey() throws Exception {
         Survey survey = new DynamoSurvey();
@@ -501,36 +384,31 @@ public class SurveyValidatorTest {
         survey.setIdentifier("Identifier");
         survey.setStudyIdentifier("study-key");
         survey.setGuid("guid");
-        
+
         StringConstraints constraints = new StringConstraints();
-        
+
         // This is actually the only way to create an invalid rule (deserializing JSON).
-        String json = TestUtils.createJson("{'operator':'eq','value':'No',"+
-                "'skipTo':'theend','endSurvey':true}");
+        String json = TestUtils.createJson("{'operator':'eq','value':'No'," + "'skipTo':'theend','endSurvey':true}");
         SurveyRule rule = BridgeObjectMapper.get().readValue(json, SurveyRule.class);
         constraints.getRules().add(rule);
-        
+
         SurveyQuestion question = new DynamoSurveyQuestion();
         question.setIdentifier("start-q");
         question.setUiHint(UIHint.TEXTFIELD);
         question.setPrompt("Prompt");
         question.setConstraints(constraints);
         survey.getElements().add(question);
-        
+
         SurveyInfoScreen info = new DynamoSurveyInfoScreen();
         info.setTitle("Title");
         info.setPrompt("Prompt");
         info.setIdentifier("theend");
         survey.getElements().add(info);
 
-        try {
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("rule cannot have a skipTo target and an endSurvey property", errorFor(e, "elements[0].rule"));
-        }
+        assertValidatorMessage(validator, survey, "elements[0].rule",
+                "cannot have a skipTo target and an endSurvey property");
     }
-    
+
     @Test
     public void willVerifyRuleHasEitherSkipToTargetOrEndSurvey() throws Exception {
         Survey survey = new DynamoSurvey();
@@ -538,14 +416,14 @@ public class SurveyValidatorTest {
         survey.setIdentifier("Identifier");
         survey.setStudyIdentifier("study-key");
         survey.setGuid("guid");
-        
+
         StringConstraints constraints = new StringConstraints();
-        
+
         // This is actually the only way to create an invalid rule (deserializing JSON).
         String json = TestUtils.createJson("{'operator':'eq','value':'No'}");
         SurveyRule rule = BridgeObjectMapper.get().readValue(json, SurveyRule.class);
         constraints.getRules().add(rule);
-        
+
         SurveyQuestion question = new DynamoSurveyQuestion();
         question.setIdentifier("start-q");
         question.setUiHint(UIHint.TEXTFIELD);
@@ -553,207 +431,156 @@ public class SurveyValidatorTest {
         question.setConstraints(constraints);
         survey.getElements().add(question);
 
-        try {
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("rule must have a skipTo target or an endSurvey property", errorFor(e, "elements[0].rule"));
-        }
+        assertValidatorMessage(validator, survey, "elements[0].rule",
+                "must have a skipTo target or an endSurvey property");
     }
-    
+
     @Test
     public void willValidateStringMaxLengthNotLowerThanMinLength() {
-        try {
-            survey = new TestSurvey(SurveyValidatorTest.class, false);
-            SurveyQuestion question = ((TestSurvey) survey).getStringQuestion();
-            StringConstraints constraints = (StringConstraints)question.getConstraints();
-            constraints.setMaxLength(2);
-            constraints.setMinLength(3);
+        survey = new TestSurvey(SurveyValidatorTest.class, false);
+        SurveyQuestion question = ((TestSurvey) survey).getStringQuestion();
+        StringConstraints constraints = (StringConstraints) question.getConstraints();
+        constraints.setMaxLength(2);
+        constraints.setMinLength(3);
 
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("minLength is longer than the maxLength", errorFor(e, "elements[8].constraints.minLength"));
-        }
+        assertValidatorMessage(validator, survey, "elements[8].constraints.minLength", "is longer than the maxLength");
     }
-    
+
     @Test
     public void willValidateMaxValueNotLowerThanMinValueForInteger() {
-        try {
-            survey = new TestSurvey(SurveyValidatorTest.class, false);
-            SurveyQuestion question = ((TestSurvey) survey).getIntegerQuestion();
-            IntegerConstraints constraints = (IntegerConstraints)question.getConstraints();
-            constraints.setMaxValue(2d);
-            constraints.setMinValue(3d);
+        survey = new TestSurvey(SurveyValidatorTest.class, false);
+        SurveyQuestion question = ((TestSurvey) survey).getIntegerQuestion();
+        IntegerConstraints constraints = (IntegerConstraints) question.getConstraints();
+        constraints.setMaxValue(2d);
+        constraints.setMinValue(3d);
 
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("minValue is greater than the maxValue", errorFor(e, "elements[4].constraints.minValue"));
-        }
+        assertValidatorMessage(validator, survey, "elements[4].constraints.minValue", "is greater than the maxValue");
     }
-    
+
     @Test
     public void willValidateMaxValueNotLowerThanMinValueForDecimal() {
-        try {
-            survey = new TestSurvey(SurveyValidatorTest.class, false);
-            SurveyQuestion question = ((TestSurvey) survey).getDecimalQuestion();
-            DecimalConstraints constraints = (DecimalConstraints)question.getConstraints();
-            constraints.setMaxValue(2d);
-            constraints.setMinValue(3d);
+        survey = new TestSurvey(SurveyValidatorTest.class, false);
+        SurveyQuestion question = ((TestSurvey) survey).getDecimalQuestion();
+        DecimalConstraints constraints = (DecimalConstraints) question.getConstraints();
+        constraints.setMaxValue(2d);
+        constraints.setMinValue(3d);
 
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("minValue is greater than the maxValue", errorFor(e, "elements[3].constraints.minValue"));
-        }
+        assertValidatorMessage(validator, survey, "elements[3].constraints.minValue", "is greater than the maxValue");
     }
-    
+
     @Test
     public void willValidateMaxValueNotLowerThanMinValueForDuration() {
-        try {
-            survey = new TestSurvey(SurveyValidatorTest.class, false);
-            SurveyQuestion question = ((TestSurvey) survey).getDurationQuestion();
-            DurationConstraints constraints = (DurationConstraints)question.getConstraints();
-            constraints.setMaxValue(2d);
-            constraints.setMinValue(3d);
+        survey = new TestSurvey(SurveyValidatorTest.class, false);
+        SurveyQuestion question = ((TestSurvey) survey).getDurationQuestion();
+        DurationConstraints constraints = (DurationConstraints) question.getConstraints();
+        constraints.setMaxValue(2d);
+        constraints.setMinValue(3d);
 
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("minValue is greater than the maxValue", errorFor(e, "elements[5].constraints.minValue"));
-        }
+        assertValidatorMessage(validator, survey, "elements[5].constraints.minValue", "is greater than the maxValue");
     }
-    
+
     @Test
     public void willValidateStepValueNotHigherThanRangeOfInteger() {
-        try {
-            survey = new TestSurvey(SurveyValidatorTest.class, false);
-            SurveyQuestion question = ((TestSurvey) survey).getIntegerQuestion();
-            IntegerConstraints constraints = (IntegerConstraints)question.getConstraints();
-            constraints.setMinValue(2d);
-            constraints.setMaxValue(4d);
-            constraints.setStep(3d);
+        survey = new TestSurvey(SurveyValidatorTest.class, false);
+        SurveyQuestion question = ((TestSurvey) survey).getIntegerQuestion();
+        IntegerConstraints constraints = (IntegerConstraints) question.getConstraints();
+        constraints.setMinValue(2d);
+        constraints.setMaxValue(4d);
+        constraints.setStep(3d);
 
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("step is larger than the range of allowable values", errorFor(e, "elements[4].constraints.step"));
-        }
+        assertValidatorMessage(validator, survey, "elements[4].constraints.step",
+                "is larger than the range of allowable values");
     }
-    
+
     @Test
     public void willValidateStepValueNotHigherThanRangeOfDecimal() {
-        try {
-            survey = new TestSurvey(SurveyValidatorTest.class, false);
-            SurveyQuestion question = ((TestSurvey) survey).getDecimalQuestion();
-            DecimalConstraints constraints = (DecimalConstraints)question.getConstraints();
-            constraints.setMinValue(2d);
-            constraints.setMaxValue(4d);
-            constraints.setStep(3d);
+        survey = new TestSurvey(SurveyValidatorTest.class, false);
+        SurveyQuestion question = ((TestSurvey) survey).getDecimalQuestion();
+        DecimalConstraints constraints = (DecimalConstraints) question.getConstraints();
+        constraints.setMinValue(2d);
+        constraints.setMaxValue(4d);
+        constraints.setStep(3d);
 
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("step is larger than the range of allowable values", errorFor(e, "elements[3].constraints.step"));
-        }
+        assertValidatorMessage(validator, survey, "elements[3].constraints.step",
+                "is larger than the range of allowable values");
     }
-    
+
     @Test
     public void willValidateStepValueNotHigherThanRangeOfDuration() {
-        try {
-            survey = new TestSurvey(SurveyValidatorTest.class, false);
-            SurveyQuestion question = ((TestSurvey) survey).getDurationQuestion();
-            DurationConstraints constraints = (DurationConstraints)question.getConstraints();
-            constraints.setMinValue(2d);
-            constraints.setMaxValue(2d);
-            constraints.setStep(3d);
+        survey = new TestSurvey(SurveyValidatorTest.class, false);
+        SurveyQuestion question = ((TestSurvey) survey).getDurationQuestion();
+        DurationConstraints constraints = (DurationConstraints) question.getConstraints();
+        constraints.setMinValue(2d);
+        constraints.setMaxValue(2d);
+        constraints.setStep(3d);
 
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("step is larger than the range of allowable values", errorFor(e, "elements[5].constraints.step"));
-        }
+        assertValidatorMessage(validator, survey, "elements[5].constraints.step",
+                "is larger than the range of allowable values");
     }
-    
+
     @Test
     public void willValidateEarliestLocalDateIsNotAfterLatestLocalDate() {
-        try {
-            survey = new TestSurvey(SurveyValidatorTest.class, false);
-            SurveyQuestion question = ((TestSurvey) survey).getDateTimeQuestion();
-            DateTimeConstraints constraints = (DateTimeConstraints)question.getConstraints();
-            constraints.setEarliestValue(DateTime.parse("2010-10-10T10:10:00.000Z"));
-            constraints.setLatestValue(DateTime.parse("2010-10-10T10:09:00.000Z"));
+        survey = new TestSurvey(SurveyValidatorTest.class, false);
+        SurveyQuestion question = ((TestSurvey) survey).getDateTimeQuestion();
+        DateTimeConstraints constraints = (DateTimeConstraints) question.getConstraints();
+        constraints.setEarliestValue(DateTime.parse("2010-10-10T10:10:00.000Z"));
+        constraints.setLatestValue(DateTime.parse("2010-10-10T10:09:00.000Z"));
 
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("earliestValue is after the latest value", errorFor(e, "elements[2].constraints.earliestValue"));
-        }
+        assertValidatorMessage(validator, survey, "elements[2].constraints.earliestValue", "is after the latest value");
     }
 
     @Test
     public void willValidateEarliestDateTimeIsNotAfterLatestDateTime() {
-        try {
-            survey = new TestSurvey(SurveyValidatorTest.class, false);
-            SurveyQuestion question = ((TestSurvey) survey).getDateQuestion();
-            DateConstraints constraints = (DateConstraints)question.getConstraints();
-            constraints.setEarliestValue(LocalDate.parse("2010-10-11"));
-            constraints.setLatestValue(LocalDate.parse("2010-10-10"));
+        survey = new TestSurvey(SurveyValidatorTest.class, false);
+        SurveyQuestion question = ((TestSurvey) survey).getDateQuestion();
+        DateConstraints constraints = (DateConstraints) question.getConstraints();
+        constraints.setEarliestValue(LocalDate.parse("2010-10-11"));
+        constraints.setLatestValue(LocalDate.parse("2010-10-10"));
 
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("earliestValue is after the latest value", errorFor(e, "elements[1].constraints.earliestValue"));
-        }
+        assertValidatorMessage(validator, survey, "elements[1].constraints.earliestValue", "is after the latest value");
     }
-    
+
     @Test
     public void backreferenceSkipToTargetInvalid() throws Exception {
-        try {
-            survey = new TestSurvey(SurveyValidatorTest.class, false);
-            
-            // The integer question is after the high_bp question. Create a rule that would backgtrack, verify it doesn't validate.
-            SurveyQuestion question = ((TestSurvey) survey).getIntegerQuestion();
+        survey = new TestSurvey(SurveyValidatorTest.class, false);
 
-            SurveyRule rule = new SurveyRule.Builder().withOperator(SurveyRule.Operator.EQ).withValue(1).withSkipToTarget("high_bp").build();
-            question.getConstraints().setRules(Lists.newArrayList(rule));
-            
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("back references question high_bp", errorFor(e, "elements[4].rule"));
-        }
+        // The integer question is after the high_bp question. Create a rule that would backgtrack, verify it
+        // doesn't validate.
+        SurveyQuestion question = ((TestSurvey) survey).getIntegerQuestion();
+
+        SurveyRule rule = new SurveyRule.Builder().withOperator(SurveyRule.Operator.EQ).withValue(1)
+                .withSkipToTarget("high_bp").build();
+        question.getConstraints().setRules(Lists.newArrayList(rule));
+
+        assertValidatorMessage(validator, survey, "elements[4].rule", "back references question high_bp");
     }
-    
+
     @Test
     public void endSurveyRuleValid() {
         survey = new TestSurvey(SurveyValidatorTest.class, false);
-        
+
         // This rule is a valid "end the survey" rule, and passes validation.
         SurveyQuestion question = ((TestSurvey) survey).getIntegerQuestion();
-        SurveyRule rule = new SurveyRule.Builder().withOperator(SurveyRule.Operator.EQ).withValue(1).withEndSurvey(Boolean.TRUE).build();
+        SurveyRule rule = new SurveyRule.Builder().withOperator(SurveyRule.Operator.EQ).withValue(1)
+                .withEndSurvey(Boolean.TRUE).build();
         question.getConstraints().setRules(Lists.newArrayList(rule));
-        
+
         Validate.entityThrowingException(validator, survey);
     }
-    
+
     @Test
     public void noSkipToTargetInvalid() {
-        try {
-            survey = new TestSurvey(SurveyValidatorTest.class, false);
-            
-            // The integer question is after the high_bp question. Create a rule that would backgtrack, verify it doesn't validate.
-            SurveyQuestion question = ((TestSurvey) survey).getIntegerQuestion();
+        survey = new TestSurvey(SurveyValidatorTest.class, false);
 
-            SurveyRule rule = new SurveyRule.Builder().withOperator(SurveyRule.Operator.EQ).withValue(1)
-                    .withSkipToTarget("this_does_not_exist").build();
-            question.getConstraints().setRules(Lists.newArrayList(rule));
-            
-            Validate.entityThrowingException(validator, survey);
-            fail("Should have thrown exception");
-        } catch (InvalidEntityException e) {
-            assertEquals("has a skipTo identifier that doesn't exist: this_does_not_exist", errorFor(e, "elements[4].rule"));
-        }
+        // The integer question is after the high_bp question. Create a rule that would backgtrack, verify it
+        // doesn't validate.
+        SurveyQuestion question = ((TestSurvey) survey).getIntegerQuestion();
+
+        SurveyRule rule = new SurveyRule.Builder().withOperator(SurveyRule.Operator.EQ).withValue(1)
+                .withSkipToTarget("this_does_not_exist").build();
+        question.getConstraints().setRules(Lists.newArrayList(rule));
+
+        assertValidatorMessage(validator, survey, "elements[4].rule",
+                "has a skipTo identifier that doesn't exist: this_does_not_exist");
     }
 }


### PR DESCRIPTION
Also did the following clean-up:

- Switched survey validation tests over to use a more stringent utility method and found many minor errors in the formatting of error messages for surveys, which are cleaned up;

- Removed the equals/hashCode methods from constraints. These had no tests and failed equalVerifier testing, and are not used except for convenience in a couple of tests, so there was no justification to keep them;

- Removed a number of unused import statements and variables left by prior check-ins;
