### PR TITLE
add createdOn timezone to health data record

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataRecord.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataRecord.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.datatype.joda.deser.LocalDateDeserializer;
 @JsonFilter("filter")
 public class DynamoHealthDataRecord implements HealthDataRecord {
     private Long createdOn;
+    private String createdOnTimeZone;
     private JsonNode data;
     private String healthCode;
     private String id;
@@ -57,6 +58,17 @@ public class DynamoHealthDataRecord implements HealthDataRecord {
     @JsonDeserialize(using = DateTimeToLongDeserializer.class)
     public void setCreatedOn(Long createdOn) {
         this.createdOn = createdOn;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getCreatedOnTimeZone() {
+        return createdOnTimeZone;
+    }
+
+    /** @see #getCreatedOnTimeZone */
+    public void setCreatedOnTimeZone(String createdOnTimeZone) {
+        this.createdOnTimeZone = createdOnTimeZone;
     }
 
     /** {@inheritDoc} */
@@ -245,6 +257,7 @@ public class DynamoHealthDataRecord implements HealthDataRecord {
         protected HealthDataRecord buildUnvalidated() {
             DynamoHealthDataRecord record = new DynamoHealthDataRecord();
             record.setCreatedOn(getCreatedOn());
+            record.setCreatedOnTimeZone(getCreatedOnTimeZone());
             record.setData(getData());
             record.setHealthCode(getHealthCode());
             record.setId(getId());

--- a/app/org/sagebionetworks/bridge/models/healthdata/HealthDataRecord.java
+++ b/app/org/sagebionetworks/bridge/models/healthdata/HealthDataRecord.java
@@ -15,17 +15,20 @@ import org.sagebionetworks.bridge.models.BridgeEntity;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
 
 /** This class represents health data and associated metadata. */
 @BridgeTypeName("HealthData")
 @JsonDeserialize(as = DynamoHealthDataRecord.class)
 public interface HealthDataRecord extends BridgeEntity {
+    DateTimeFormatter TIME_ZONE_FORMATTER = DateTimeFormat.forPattern("Z");
     ObjectWriter PUBLIC_RECORD_WRITER = new BridgeObjectMapper().writer(
             new SimpleFilterProvider().addFilter("filter",
                     SimpleBeanPropertyFilter.serializeAllExcept("healthCode")));
 
-    public enum ExporterStatus {
-        NOT_EXPORTED, SUCCEEDED;
+    enum ExporterStatus {
+        NOT_EXPORTED, SUCCEEDED
     }
 
     /**
@@ -33,6 +36,9 @@ public interface HealthDataRecord extends BridgeEntity {
      * (start of epoch).
      */
     Long getCreatedOn();
+
+    /** Time zone of the createdOn timestamp, expressed as a 4-digit string with sign. Examples: "-0800", "+0900" */
+    String getCreatedOnTimeZone();
 
     /** Health data, in JSON format. */
     JsonNode getData();

--- a/app/org/sagebionetworks/bridge/models/healthdata/HealthDataRecordBuilder.java
+++ b/app/org/sagebionetworks/bridge/models/healthdata/HealthDataRecordBuilder.java
@@ -19,6 +19,7 @@ import org.sagebionetworks.bridge.validators.Validate;
  */
 public abstract class HealthDataRecordBuilder {
     private Long createdOn;
+    private String createdOnTimeZone;
     private JsonNode data;
     private String healthCode;
     private String id;
@@ -35,10 +36,10 @@ public abstract class HealthDataRecordBuilder {
     private Long version;
     private HealthDataRecord.ExporterStatus synapseExporterStatus;
 
-
     /** Copies all fields from the specified record into the builder. This is useful for updating records. */
     public HealthDataRecordBuilder copyOf(HealthDataRecord record) {
         createdOn = record.getCreatedOn();
+        createdOnTimeZone = record.getCreatedOnTimeZone();
         data = record.getData();
         healthCode = record.getHealthCode();
         id = record.getId();
@@ -65,6 +66,17 @@ public abstract class HealthDataRecordBuilder {
     /** @see org.sagebionetworks.bridge.models.healthdata.HealthDataRecord#getCreatedOn */
     public HealthDataRecordBuilder withCreatedOn(Long createdOn) {
         this.createdOn = createdOn;
+        return this;
+    }
+
+    /** @see HealthDataRecord#getCreatedOnTimeZone */
+    public String getCreatedOnTimeZone() {
+        return createdOnTimeZone;
+    }
+
+    /** @see HealthDataRecord#getCreatedOnTimeZone */
+    public HealthDataRecordBuilder withCreatedOnTimeZone(String createdOnTimeZone) {
+        this.createdOnTimeZone = createdOnTimeZone;
         return this;
     }
 

--- a/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2.java
+++ b/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2.java
@@ -29,6 +29,7 @@ import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.json.JsonUtils;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolderImpl;
+import org.sagebionetworks.bridge.models.healthdata.HealthDataRecord;
 import org.sagebionetworks.bridge.models.healthdata.HealthDataRecordBuilder;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.surveys.Survey;
@@ -332,11 +333,14 @@ public class IosSchemaValidationHandler2 implements UploadValidationHandler {
         }
 
         if (createdOn == null) {
-            // Recover by using current time.
+            // Recover by using current time. Don't set a timezone, since it's indeterminate.
             context.addMessage(String.format("upload ID %s has no timestamps, using current time", uploadId));
-            createdOn = DateUtils.getCurrentDateTime();
+            recordBuilder.withCreatedOn(DateUtils.getCurrentMillisFromEpoch());
+        } else {
+            // Use createdOn and timezone as specified in the upload.
+            recordBuilder.withCreatedOn(createdOn.getMillis());
+            recordBuilder.withCreatedOnTimeZone(HealthDataRecord.TIME_ZONE_FORMATTER.print(createdOn));
         }
-        recordBuilder.withCreatedOn(createdOn.getMillis());
     }
 
     private static <T> void removeTimestampsFromFilenames(Map<String, T> fileMap) {

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataDaoDdbTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataDaoDdbTest.java
@@ -34,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 @RunWith(SpringJUnit4ClassRunner.class)
 public class DynamoHealthDataDaoDdbTest {
     private static final long CREATED_ON = 1424136378727L;
+    private static final String CREATED_ON_TIME_ZONE = "+0900";
     private static final String DATA_TEXT = "{\"data\":\"dummy value\"}";
     private static final String METADATA_TEXT = "{\"metadata\":\"dummy meta value\"}";
     private static final String SCHEMA_ID = "test-schema-id";
@@ -65,10 +66,12 @@ public class DynamoHealthDataDaoDdbTest {
         // create test record and save it
         testRecord = new DynamoHealthDataRecord();
         testRecord.setCreatedOn(CREATED_ON);
+        testRecord.setCreatedOnTimeZone(CREATED_ON_TIME_ZONE);
         testRecord.setHealthCode(healthCode);
         testRecord.setSchemaId(SCHEMA_ID);
         testRecord.setId(recordId);
         testRecord.setSchemaRevision(SCHEMA_REV);
+        testRecord.setSynapseExporterStatus(HealthDataRecord.ExporterStatus.NOT_EXPORTED);
         testRecord.setUploadDate(UPLOAD_DATE);
         testRecord.setUploadedOn(UPLOADED_ON);
         testRecord.setUploadId(UPLOAD_ID);
@@ -93,11 +96,13 @@ public class DynamoHealthDataDaoDdbTest {
 
         // validate fields
         assertEquals(CREATED_ON, savedRecord.getCreatedOn().longValue());
+        assertEquals(CREATED_ON_TIME_ZONE, savedRecord.getCreatedOnTimeZone());
         assertEquals(healthCode, savedRecord.getHealthCode());
         assertEquals(recordId, savedRecord.getId());
         assertEquals(SCHEMA_ID, savedRecord.getSchemaId());
         assertEquals(SCHEMA_REV, savedRecord.getSchemaRevision());
         assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, savedRecord.getStudyId());
+        assertEquals(HealthDataRecord.ExporterStatus.NOT_EXPORTED, savedRecord.getSynapseExporterStatus());
         assertEquals(UPLOAD_DATE, savedRecord.getUploadDate());
         assertEquals(UPLOAD_ID, savedRecord.getUploadId());
         assertEquals(UPLOADED_ON, savedRecord.getUploadedOn().longValue());

--- a/test/org/sagebionetworks/bridge/models/healthdata/HealthDataRecordTest.java
+++ b/test/org/sagebionetworks/bridge/models/healthdata/HealthDataRecordTest.java
@@ -74,8 +74,10 @@ public class HealthDataRecordTest {
 
         // build
         HealthDataRecord record = DAO.getRecordBuilder().withData(data).withHealthCode("required healthcode")
-                .withId("optional record ID").withCreatedOn(arbitraryTimestamp).withMetadata(metadata)
+                .withId("optional record ID").withCreatedOn(arbitraryTimestamp).withCreatedOnTimeZone("+0900")
+                .withMetadata(metadata)
                 .withSchemaId("required schema").withSchemaRevision(3).withStudyId("required study")
+                .withSynapseExporterStatus(HealthDataRecord.ExporterStatus.NOT_EXPORTED)
                 .withUploadDate(uploadDate).withUploadId("optional upload ID").withUploadedOn(uploadedOn)
                 .withUserExternalId("optional external ID")
                 .withUserSharingScope(ParticipantOption.SharingScope.SPONSORS_AND_PARTNERS)
@@ -86,9 +88,11 @@ public class HealthDataRecordTest {
         assertEquals("required healthcode", record.getHealthCode());
         assertEquals("optional record ID", record.getId());
         assertEquals(arbitraryTimestamp, record.getCreatedOn().longValue());
+        assertEquals("+0900", record.getCreatedOnTimeZone());
         assertEquals("required schema", record.getSchemaId());
         assertEquals(3, record.getSchemaRevision());
         assertEquals("required study", record.getStudyId());
+        assertEquals(HealthDataRecord.ExporterStatus.NOT_EXPORTED, record.getSynapseExporterStatus());
         assertEquals("2014-02-12", record.getUploadDate().toString(ISODateTimeFormat.date()));
         assertEquals("optional upload ID", record.getUploadId());
         assertEquals(uploadedOn, record.getUploadedOn().longValue());
@@ -108,9 +112,11 @@ public class HealthDataRecordTest {
         assertEquals("required healthcode", copyRecord.getHealthCode());
         assertEquals("optional record ID", copyRecord.getId());
         assertEquals(arbitraryTimestamp, copyRecord.getCreatedOn().longValue());
+        assertEquals("+0900", copyRecord.getCreatedOnTimeZone());
         assertEquals("required schema", copyRecord.getSchemaId());
         assertEquals(3, copyRecord.getSchemaRevision());
         assertEquals("required study", copyRecord.getStudyId());
+        assertEquals(HealthDataRecord.ExporterStatus.NOT_EXPORTED, copyRecord.getSynapseExporterStatus());
         assertEquals("2014-02-12", copyRecord.getUploadDate().toString(ISODateTimeFormat.date()));
         assertEquals("optional upload ID", copyRecord.getUploadId());
         assertEquals(uploadedOn, copyRecord.getUploadedOn().longValue());
@@ -299,6 +305,7 @@ public class HealthDataRecordTest {
         // start with JSON
         String jsonText = "{\n" +
                 "   \"createdOn\":\"2014-02-12T13:45-0800\",\n" +
+                "   \"createdOnTimeZone\":\"-0800\",\n" +
                 "   \"data\":{\"myData\":\"myDataValue\"},\n" +
                 "   \"healthCode\":\"json healthcode\",\n" +
                 "   \"id\":\"json record ID\",\n" +
@@ -306,6 +313,7 @@ public class HealthDataRecordTest {
                 "   \"schemaId\":\"json schema\",\n" +
                 "   \"schemaRevision\":3,\n" +
                 "   \"studyId\":\"json study\",\n" +
+                "   \"synapseExporterStatus\":\"not_exported\",\n" +
                 "   \"uploadDate\":\"2014-02-12\",\n" +
                 "   \"uploadId\":\"json upload\",\n" +
                 "   \"uploadedOn\":\"" + uploadedOnStr + "\",\n" +
@@ -318,11 +326,13 @@ public class HealthDataRecordTest {
         // convert to POJO
         HealthDataRecord record = BridgeObjectMapper.get().readValue(jsonText, HealthDataRecord.class);
         assertEquals(measuredTimeMillis, record.getCreatedOn().longValue());
+        assertEquals("-0800", record.getCreatedOnTimeZone());
         assertEquals("json healthcode", record.getHealthCode());
         assertEquals("json record ID", record.getId());
         assertEquals("json schema", record.getSchemaId());
         assertEquals(3, record.getSchemaRevision());
         assertEquals("json study", record.getStudyId());
+        assertEquals(HealthDataRecord.ExporterStatus.NOT_EXPORTED, record.getSynapseExporterStatus());
         assertEquals("2014-02-12", record.getUploadDate().toString(ISODateTimeFormat.date()));
         assertEquals("json upload", record.getUploadId());
         assertEquals(uploadedOn, record.getUploadedOn().longValue());
@@ -341,12 +351,14 @@ public class HealthDataRecordTest {
 
         // then convert to a map so we can validate the raw JSON
         Map<String, Object> jsonMap = BridgeObjectMapper.get().readValue(convertedJson, JsonUtils.TYPE_REF_RAW_MAP);
-        assertEquals(15, jsonMap.size());
+        assertEquals(17, jsonMap.size());
+        assertEquals("-0800", jsonMap.get("createdOnTimeZone"));
         assertEquals("json healthcode", jsonMap.get("healthCode"));
         assertEquals("json record ID", jsonMap.get("id"));
         assertEquals("json schema", jsonMap.get("schemaId"));
         assertEquals(3, jsonMap.get("schemaRevision"));
         assertEquals("json study", jsonMap.get("studyId"));
+        assertEquals("not_exported", jsonMap.get("synapseExporterStatus"));
         assertEquals("2014-02-12", jsonMap.get("uploadDate"));
         assertEquals("json upload", jsonMap.get("uploadId"));
         assertEquals(uploadedOn, DateTime.parse((String) jsonMap.get("uploadedOn")).getMillis());
@@ -371,7 +383,7 @@ public class HealthDataRecordTest {
 
         // Convert back to map again. Only validate a few key fields are present and the filtered fields are absent.
         Map<String, Object> publicJsonMap = BridgeObjectMapper.get().readValue(publicJson, JsonUtils.TYPE_REF_RAW_MAP);
-        assertEquals(14, publicJsonMap.size());
+        assertEquals(16, publicJsonMap.size());
         assertFalse(publicJsonMap.containsKey("healthCode"));
         assertEquals("json record ID", publicJsonMap.get("id"));
     }

--- a/test/org/sagebionetworks/bridge/models/healthdata/HealthDataRecordTest.java
+++ b/test/org/sagebionetworks/bridge/models/healthdata/HealthDataRecordTest.java
@@ -397,12 +397,26 @@ public class HealthDataRecordTest {
         testTimeZoneFormatter("-0800", DateTimeZone.forOffsetHours(-8));
         testTimeZoneFormatter("+1345", DateTimeZone.forOffsetHoursMinutes(+13, +45));
         testTimeZoneFormatter("-0330", DateTimeZone.forOffsetHoursMinutes(-3, -30));
+
+        testTimeZoneFormatterForString("+0000", "Z");
+        testTimeZoneFormatterForString("+0000", "+00:00");
+        testTimeZoneFormatterForString("+0900", "+09:00");
+        testTimeZoneFormatterForString("-0800", "-08:00");
+        testTimeZoneFormatterForString("+1345", "+13:45");
+        testTimeZoneFormatterForString("-0330", "-03:30");
     }
 
     private static void testTimeZoneFormatter(String expected, DateTimeZone timeZone) {
         // The formatter only takes in DateTimes, not TimeZones. To test this, create a dummy DateTime with the given
         // TimeZone
         DateTime dateTime = new DateTime(2017, 1, 25, 2, 29, timeZone);
+        assertEquals(expected, HealthDataRecord.TIME_ZONE_FORMATTER.print(dateTime));
+    }
+
+    private static void testTimeZoneFormatterForString(String expected, String timeZoneStr) {
+        // DateTimeZone doesn't have an API to parse an ISO timezone representation, so we have to parse an entire date
+        // just to parse the timezone.
+        DateTime dateTime = DateTime.parse("2017-01-25T02:29" + timeZoneStr);
         assertEquals(expected, HealthDataRecord.TIME_ZONE_FORMATTER.print(dateTime));
     }
 }

--- a/test/org/sagebionetworks/bridge/models/healthdata/HealthDataRecordTest.java
+++ b/test/org/sagebionetworks/bridge/models/healthdata/HealthDataRecordTest.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
 import org.joda.time.format.ISODateTimeFormat;
 import org.junit.Test;
@@ -386,5 +387,22 @@ public class HealthDataRecordTest {
         assertEquals(16, publicJsonMap.size());
         assertFalse(publicJsonMap.containsKey("healthCode"));
         assertEquals("json record ID", publicJsonMap.get("id"));
+    }
+
+    @Test
+    public void testTimeZoneFormatter() {
+        testTimeZoneFormatter("+0000", DateTimeZone.UTC);
+        testTimeZoneFormatter("+0000", DateTimeZone.forOffsetHours(0));
+        testTimeZoneFormatter("+0900", DateTimeZone.forOffsetHours(+9));
+        testTimeZoneFormatter("-0800", DateTimeZone.forOffsetHours(-8));
+        testTimeZoneFormatter("+1345", DateTimeZone.forOffsetHoursMinutes(+13, +45));
+        testTimeZoneFormatter("-0330", DateTimeZone.forOffsetHoursMinutes(-3, -30));
+    }
+
+    private static void testTimeZoneFormatter(String expected, DateTimeZone timeZone) {
+        // The formatter only takes in DateTimes, not TimeZones. To test this, create a dummy DateTime with the given
+        // TimeZone
+        DateTime dateTime = new DateTime(2017, 1, 25, 2, 29, timeZone);
+        assertEquals(expected, HealthDataRecord.TIME_ZONE_FORMATTER.print(dateTime));
     }
 }

--- a/test/org/sagebionetworks/bridge/upload/UploadHandlersEndToEndTest.java
+++ b/test/org/sagebionetworks/bridge/upload/UploadHandlersEndToEndTest.java
@@ -74,6 +74,7 @@ public class UploadHandlersEndToEndTest {
 
     private static final String CREATED_ON_STRING = "2015-04-02T03:26:59.456-07:00";
     private static final long CREATED_ON_MILLIS = DateTime.parse(CREATED_ON_STRING).getMillis();
+    private static final String CREATED_ON_TIME_ZONE = "-0700";
 
     private static final DateTime MOCK_NOW = DateTime.parse("2016-06-03T11:33:55.777-0700");
     private static final long MOCK_NOW_MILLIS = MOCK_NOW.getMillis();
@@ -241,6 +242,7 @@ public class UploadHandlersEndToEndTest {
         // Ignore version - That's internal.
         // Data, metadata, and schema fields are specific to individual tests.
         assertEquals(CREATED_ON_MILLIS, record.getCreatedOn().longValue());
+        assertEquals(CREATED_ON_TIME_ZONE, record.getCreatedOnTimeZone());
         assertEquals(HEALTH_CODE, record.getHealthCode());
         assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, record.getStudyId());
         assertEquals(MOCK_TODAY, record.getUploadDate());


### PR DESCRIPTION
Currently, createdOn is being exported as epoch milliseconds. We want to export the timezone as well. This change adds timezone as a separate field to the health data record. Note that we made it a separate field instead of changing createdOn to a DateTime because (a) createdOn is used as a range key index and (b) backwards compatibility.

Added unit tests. Manually tested cases where createdOn is present and where createdOn were absent.

This will also need a corresponding change in BridgeEX, and probably a minor update in Integ Tests. (Coming soon.)

See also https://sagebionetworks.jira.com/browse/BRIDGE-1658