### PR TITLE
Enable pattern error message validation.

### DIFF
--- a/app/org/sagebionetworks/bridge/validators/SurveyValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/SurveyValidator.java
@@ -263,11 +263,9 @@ public class SurveyValidator implements Validator {
             } catch (PatternSyntaxException exception) {
                 rejectField(errors, "pattern", "is not a valid regular expression: %s", con.getPattern());
             }
-            /* disabled until we can provide SDK/integration test support.
             if (StringUtils.isBlank(con.getPatternErrorMessage())) {
                 rejectField(errors, "patternErrorMessage", "is required if pattern is defined");
             }
-            */
         }
         // It's okay to provide the error message without a pattern... it's not useful, but it's allowed
         Integer min = con.getMinLength();

--- a/test/org/sagebionetworks/bridge/validators/SurveyValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/SurveyValidatorTest.java
@@ -8,7 +8,6 @@ import com.google.common.collect.ImmutableList;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import org.sagebionetworks.bridge.TestUtils;
@@ -335,9 +334,7 @@ public class SurveyValidatorTest {
         Validate.entityThrowingException(validator, survey);
     }
     
-    // Ignore until we have time to provide SDK and integration test support.
     @Test
-    @Ignore
     public void whenPatternIsSetPatternErrorMessageMustBeSet() {
         survey = new TestSurvey(SurveyValidatorTest.class, false);
         SurveyQuestion question = ((TestSurvey) survey).getStringQuestion();


### PR DESCRIPTION
I've updated the integration tests in all environments to pass once this is enabled, so this is now ok to push out.