### PR TITLE
add DateAndTime to Upload Validation

### DIFF
--- a/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2.java
+++ b/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2.java
@@ -78,6 +78,7 @@ public class IosSchemaValidationHandler2 implements UploadValidationHandler {
     private static final Map<String, String> SURVEY_TYPE_TO_ANSWER_KEY_MAP = ImmutableMap.<String, String>builder()
             .put("Boolean", "booleanAnswer")
             .put("Date", "dateAnswer")
+            .put("DateAndTime", "dateAnswer")
             .put("Decimal", "numericAnswer")
             .put("Integer", "numericAnswer")
             .put("MultipleChoice", "choiceAnswers")

--- a/test/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2Test.java
+++ b/test/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2Test.java
@@ -298,7 +298,7 @@ public class IosSchemaValidationHandler2Test {
                 "   \"questionType\":0,\n" +
                 "   \"dateAnswer\":\"2017-01-31T16:42:52.256-0800\",\n" +
                 "   \"startDate\":\"2015-04-02T03:23:59-07:00\",\n" +
-                "   \"questionTypeName\":\"DateAndTime\",\n" +
+                "   \"questionTypeName\":\"Date\",\n" +
                 "   \"item\":\"legacy-date-time\",\n" +
                 "   \"endDate\":\"2015-04-02T03:24:01-07:00\"\n" +
                 "}";


### PR DESCRIPTION
Sometime between mPower 1.05 and mPower 1.1, ResearchKit/AppCore changed the format for DateTime from questionTypeName=Date to questionTypeName=DateAndTime. This prevents us from parsing survey answers using the Date & Time Picker.

This change allows us to parse DateTimes again.

 See also https://sagebionetworks.jira.com/browse/BRIDGE-1677