### PR TITLE
fix missing ReportIndex issue

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoReportIndexDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoReportIndexDao.java
@@ -61,12 +61,20 @@ public class DynamoReportIndexDao implements ReportIndexDao {
         index.setKey(key.getIndexKeyString());
         index.setIdentifier(key.getIdentifier());
 
+        // Optimization: Reads are significantly cheaper than writes. Check to see if the index already exists. If it
+        // does, don't bother writing it.
+        DynamoReportIndex loadedIndex = mapper.load(index);
+        if (loadedIndex != null) {
+            return;
+        }
+
         try {
             mapper.save(index, DOES_NOT_EXIST_EXPRESSION);    
         } catch(ConditionalCheckFailedException e) {
-            // Do not throw an exception if the index already exists. This is called as a side
-            // effect of saving a report, and can be called multiple times for a report.
-            LOG.debug("Error saving index in DynamoReportIndexDao.addIndex(): " + e.getMessage());
+            // Read-before-write is not atomic. There's a possible race condition where two machines are creating the
+            // index at the same time. It's rare, but possible that one of these machines may have also updated the
+            // metadata before we save. So we still need this SaveExpression to prevent clobbering the index metadata.
+            LOG.warn("Race condition creating index for " + key.toString() + ": " + e.getMessage(), e);
         }
     }
 

--- a/test/org/sagebionetworks/bridge/services/ReportServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ReportServiceTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
@@ -91,7 +90,7 @@ public class ReportServiceTest {
         List<ReportData> list = Lists.newArrayList();
         list.add(createReport(LocalDate.parse("2015-02-10"), "First", "Name"));
         list.add(createReport(LocalDate.parse("2015-02-12"), "Last", "Name"));
-        results = new DateRangeResourceList<ReportData>(list, START_DATE, END_DATE);
+        results = new DateRangeResourceList<>(list, START_DATE, END_DATE);
         
         ReportIndex index = ReportIndex.create();
         index.setIdentifier(IDENTIFIER);
@@ -116,7 +115,6 @@ public class ReportServiceTest {
                 .withStudyIdentifier(TEST_STUDY).build();
         
         ReportIndex index = ReportIndex.create();
-        index.setIdentifier(IDENTIFIER);
         index.setIdentifier(IDENTIFIER);
         doReturn(index).when(mockReportIndexDao).getIndex(key);
         
@@ -197,13 +195,9 @@ public class ReportServiceTest {
     @Test
     public void saveStudyReportData() {
         ReportData someData = createReport(LocalDate.parse("2015-02-10"), "First", "Name");
-        
-        // Calling twice, the report DAO will be called twice, but the index DAO will be 
-        // called once (it caches for a minute)
-        service.saveStudyReport(TEST_STUDY, IDENTIFIER, someData);
         service.saveStudyReport(TEST_STUDY, IDENTIFIER, someData);
         
-        verify(mockReportDataDao, times(2)).saveReportData(reportDataCaptor.capture());
+        verify(mockReportDataDao).saveReportData(reportDataCaptor.capture());
         ReportData retrieved = reportDataCaptor.getValue();
         assertEquals(someData, retrieved);
         assertEquals(STUDY_REPORT_DATA_KEY.getKeyString(), retrieved.getKey());
@@ -211,7 +205,7 @@ public class ReportServiceTest {
         assertEquals("First", retrieved.getData().get("field1").asText());
         assertEquals("Name", retrieved.getData().get("field2").asText());
         
-        verify(mockReportIndexDao, times(1)).addIndex(new ReportDataKey.Builder()
+        verify(mockReportIndexDao).addIndex(new ReportDataKey.Builder()
                 .withStudyIdentifier(TEST_STUDY)
                 .withReportType(ReportType.STUDY)
                 .withIdentifier(IDENTIFIER).build());
@@ -220,13 +214,9 @@ public class ReportServiceTest {
     @Test
     public void saveParticipantReportData() throws Exception {
         ReportData someData = createReport(LocalDate.parse("2015-02-10"), "First", "Name");
-        
-        // Calling twice, the report DAO will be called twice, but the index DAO will be 
-        // called once (it caches for a minute)
-        service.saveParticipantReport(TEST_STUDY, IDENTIFIER, HEALTH_CODE, someData);
         service.saveParticipantReport(TEST_STUDY, IDENTIFIER, HEALTH_CODE, someData);
 
-        verify(mockReportDataDao, times(2)).saveReportData(reportDataCaptor.capture());
+        verify(mockReportDataDao).saveReportData(reportDataCaptor.capture());
         ReportData retrieved = reportDataCaptor.getValue();
         assertEquals(someData, retrieved);
         assertEquals(PARTICIPANT_REPORT_DATA_KEY.getKeyString(), retrieved.getKey());
@@ -234,7 +224,7 @@ public class ReportServiceTest {
         assertEquals("First", retrieved.getData().get("field1").asText());
         assertEquals("Name", retrieved.getData().get("field2").asText());
         
-        verify(mockReportIndexDao, times(1)).addIndex(new ReportDataKey.Builder()
+        verify(mockReportIndexDao).addIndex(new ReportDataKey.Builder()
                 .withHealthCode(HEALTH_CODE)
                 .withStudyIdentifier(TEST_STUDY)
                 .withReportType(ReportType.PARTICIPANT)
@@ -292,7 +282,7 @@ public class ReportServiceTest {
     public void deleteStudyReportRecord() {
         LocalDate startDate = LocalDate.parse("2015-05-05").minusDays(45);
         LocalDate endDate = LocalDate.parse("2015-05-05");
-        DateRangeResourceList<ReportData> emptyResults = new DateRangeResourceList<ReportData>(Lists.newArrayList(), START_DATE, END_DATE);
+        DateRangeResourceList<ReportData> emptyResults = new DateRangeResourceList<>(Lists.newArrayList(), START_DATE, END_DATE);
         doReturn(emptyResults).when(mockReportDataDao).getReportData(STUDY_REPORT_DATA_KEY, startDate, endDate);
         
         DateTimeUtils.setCurrentMillisFixed(DateTime.parse("2015-05-05").getMillis());


### PR DESCRIPTION
Missing ReportIndex again. Finally tracked this one down. As it turns out, the squelched ConditionalCheckFailedException from DDB was a red herring. The real culprit is, we're caching using the wrong cache key. In https://github.com/Sage-Bionetworks/BridgePF/blob/develop/app/org/sagebionetworks/bridge/services/ReportService.java#L202 we check the cache using getIndexKeyString() to see if we've already created the index, and if we have, we skip creating that index. In https://github.com/Sage-Bionetworks/BridgePF/blob/develop/app/org/sagebionetworks/bridge/models/reports/ReportDataKey.java#L62 we see that getIndexKeyString() only contains studyId and report type, not report ID. This means if we create two reports with the same type but different report IDs within a minute (cache timeout time), the second report index is never saved. This is exactly what happens in integ tests.

In addition, if there is more than one machine (which there is in Staging), there's a race condition where if you delete the report, and then immediately try to recreate it, there's a chance the request will go to the machine that still has the report index in its cache, and it will fail to recreate the report index.

After talking with Alx, we've concluded that the cache is an optimization (and not a very good one at that). Instead, we'll remove the cache entirely and use read-before-write semantics in the DAO to ensure we only create the index if it doesn't already exist. Since read-before-write is not atomic, we'll need to keep the SaveExpression in addToIndex() to prevent a more obscure race condition.

Also added integ test to catch the issue and verify the fix https://github.com/Sage-Bionetworks/BridgeIntegrationTests/pull/126