### PR TITLE
Referential integrity checks for survey deletes

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/SurveyDao.java
+++ b/app/org/sagebionetworks/bridge/dao/SurveyDao.java
@@ -45,7 +45,7 @@ public interface SurveyDao {
      * retrieved in any list of surveys, and is no longer considered when finding the most recently 
      * published version of the survey. 
      */
-    void deleteSurvey(GuidCreatedOnVersionHolder keys);
+    void deleteSurvey(Survey survey);
 
     /**
      * Admin API to remove the survey from the backing store. This exists to clean up surveys from tests. This will

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
@@ -296,13 +296,6 @@ public class DynamoSurveyDao implements SurveyDao {
         if (existing.isDeleted()) {
             throw new EntityNotFoundException(Survey.class);
         }
-        // If a survey has been published, you can't delete the last published version of that survey.
-        if (existing.isPublished()) {
-            int publishedVersionCount = new QueryBuilder().setSurvey(keys.getGuid()).isPublished().isNotDeleted().getCount();
-            if (publishedVersionCount < 2) {
-                throw new PublishedSurveyException(existing, "You cannot delete the last published version of a published survey.");
-            }
-        }
         existing.setDeleted(true);
         saveSurvey(existing);
     }
@@ -313,7 +306,6 @@ public class DynamoSurveyDao implements SurveyDao {
         deleteAllElements(existing.getGuid(), existing.getCreatedOn());
         surveyMapper.delete(existing);
         
-        // Delete the schemas as well, or they accumulate.
         try {
             StudyIdentifier studyId = new StudyIdentifierImpl(existing.getStudyIdentifier());
             uploadSchemaDao.deleteUploadSchemaById(studyId, existing.getIdentifier());

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
@@ -293,7 +293,7 @@ public class DynamoSurveyDao implements SurveyDao {
     @Override
     public void deleteSurvey(Survey survey) {
         checkNotNull(survey);
-
+        
         survey.setDeleted(true);
         saveSurvey(survey);
     }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
@@ -297,7 +297,6 @@ public class DynamoSurveyDao implements SurveyDao {
             throw new EntityNotFoundException(Survey.class);
         }
         // If a survey has been published, you can't delete the last published version of that survey.
-        // This is going to create a lot of test errors.
         if (existing.isPublished()) {
             int publishedVersionCount = new QueryBuilder().setSurvey(keys.getGuid()).isPublished().isNotDeleted().getCount();
             if (publishedVersionCount < 2) {

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
@@ -306,6 +306,7 @@ public class DynamoSurveyDao implements SurveyDao {
         deleteAllElements(existing.getGuid(), existing.getCreatedOn());
         surveyMapper.delete(existing);
         
+        // Delete the schemas as well, or they accumulate.
         try {
             StudyIdentifier studyId = new StudyIdentifierImpl(existing.getStudyIdentifier());
             uploadSchemaDao.deleteUploadSchemaById(studyId, existing.getIdentifier());

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
@@ -291,13 +291,11 @@ public class DynamoSurveyDao implements SurveyDao {
     }
 
     @Override
-    public void deleteSurvey(GuidCreatedOnVersionHolder keys) {
-        Survey existing = getSurvey(keys);
-        if (existing.isDeleted()) {
-            throw new EntityNotFoundException(Survey.class);
-        }
-        existing.setDeleted(true);
-        saveSurvey(existing);
+    public void deleteSurvey(Survey survey) {
+        checkNotNull(survey);
+
+        survey.setDeleted(true);
+        saveSurvey(survey);
     }
 
     @Override

--- a/app/org/sagebionetworks/bridge/exceptions/ConstraintViolationException.java
+++ b/app/org/sagebionetworks/bridge/exceptions/ConstraintViolationException.java
@@ -11,7 +11,9 @@ import com.google.common.collect.ImmutableMap;
 /**
  * For other data store constraint issues besides concurrent modification (most notably, foreign 
  * key constraint violations). The exception only provides information about the first object that 
- * references the entity that cannot be changed.
+ * references the entity that cannot be changed. As a general rule, provide the "type" of the 
+ * entity as we expose it in the API for both the entity and the referrer, so callers can trace 
+ * back the entities involved when there are multiple calls being made.
  */
 @SuppressWarnings("serial")
 @NoStackTraceException

--- a/app/org/sagebionetworks/bridge/models/schedules/SurveyReference.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/SurveyReference.java
@@ -69,6 +69,9 @@ public final class SurveyReference {
     }
 
     public boolean equalsSurvey(GuidCreatedOnVersionHolder keys) {
+        if (keys == null) {
+            return false;
+        }
         return (keys.getGuid().equals(guid) && createdOn != null && keys.getCreatedOn() == createdOn.getMillis());
     }
     

--- a/app/org/sagebionetworks/bridge/models/schedules/SurveyReference.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/SurveyReference.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import org.joda.time.DateTime;
 import org.joda.time.format.ISODateTimeFormat;
 import org.sagebionetworks.bridge.config.BridgeConfigFactory;
+import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolder;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -67,6 +68,10 @@ public final class SurveyReference {
             Objects.equals(identifier, other.identifier));
     }
 
+    public boolean equalsSurvey(GuidCreatedOnVersionHolder keys) {
+        return (keys.getGuid().equals(guid) && createdOn != null && keys.getCreatedOn() == createdOn.getMillis());
+    }
+    
     @Override
     public String toString() {
         return String.format("SurveyReference [identifier=%s, guid=%s, createdOn=%s, href=%s]",

--- a/app/org/sagebionetworks/bridge/play/controllers/SurveyController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/SurveyController.java
@@ -164,7 +164,7 @@ public class SurveyController extends BaseController {
         if ("true".equals(physical) && session.isInRole(ADMIN)) {
             surveyService.deleteSurveyPermanently(studyId, survey);
         } else if (session.isInRole(DEVELOPER)) {
-            surveyService.deleteSurvey(studyId, survey);    
+            surveyService.deleteSurvey(survey);    
         } else {
             // An admin calling for a logical delete. That wasn't allowed before so we don't allow it now.
             throw new UnauthorizedException();

--- a/app/org/sagebionetworks/bridge/play/controllers/SurveyController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/SurveyController.java
@@ -162,9 +162,9 @@ public class SurveyController extends BaseController {
         Survey survey = getSurveyWithoutCacheInternal(surveyGuid, createdOnString, session);
         
         if ("true".equals(physical) && session.isInRole(ADMIN)) {
-            surveyService.deleteSurveyPermanently(survey);
+            surveyService.deleteSurveyPermanently(studyId, survey);
         } else if (session.isInRole(DEVELOPER)) {
-            surveyService.deleteSurvey(survey);    
+            surveyService.deleteSurvey(studyId, survey);    
         } else {
             // An admin calling for a logical delete. That wasn't allowed before so we don't allow it now.
             throw new UnauthorizedException();

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoTest.java
@@ -165,6 +165,7 @@ public class DynamoSurveyDaoTest {
         assertNotEquals(originalModifiedOn, updatedSurvey.getModifiedOn());
         assertNull(updatedSurvey.getSchemaRevision());
 
+        survey.setVersion(updatedSurvey.getVersion());
         surveyDao.deleteSurvey(survey);
 
         try {

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoTest.java
@@ -583,6 +583,20 @@ public class DynamoSurveyDaoTest {
         assertNotNull(survey);
     }
 
+    @Test
+    public void canDeleteSurveyPermanently() {
+        Survey survey = createSurvey(testSurvey);
+
+        Survey savedSurvey = surveyDao.createSurvey(survey);
+        surveyDao.deleteSurveyPermanently(savedSurvey);
+        
+        try {
+            surveyDao.getSurvey(survey);
+            fail("Should have thrown exception");
+        } catch(EntityNotFoundException e) {
+        }
+    }
+    
     private static void assertContainsAllKeys(Set<GuidCreatedOnVersionHolderImpl> expected, List<Survey> actual) {
         for (GuidCreatedOnVersionHolder oneExpected : expected) {
             boolean found = false;

--- a/test/org/sagebionetworks/bridge/exceptions/ConstraintViolationExceptionTest.java
+++ b/test/org/sagebionetworks/bridge/exceptions/ConstraintViolationExceptionTest.java
@@ -75,7 +75,7 @@ public class ConstraintViolationExceptionTest {
     }
     
     @Test
-    public void collectionsExistEvenIfEntiy() throws Throwable {
+    public void collectionsExistEvenIfEmpty() throws Throwable {
         ConstraintViolationException e = new ConstraintViolationException.Builder()
                 .withMessage("Referenced in survey").build();
         

--- a/test/org/sagebionetworks/bridge/models/schedules/SurveyReferenceTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/SurveyReferenceTest.java
@@ -35,6 +35,8 @@ public class SurveyReferenceTest {
         ref = new SurveyReference(IDENTIFIER, GUID, null);
         assertFalse(ref.equalsSurvey(keys1));
         assertFalse(ref.equalsSurvey(keys2));
+        
+        assertFalse(ref.equalsSurvey(null));
     }
     
 }

--- a/test/org/sagebionetworks/bridge/models/schedules/SurveyReferenceTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/SurveyReferenceTest.java
@@ -37,6 +37,11 @@ public class SurveyReferenceTest {
         assertFalse(ref.equalsSurvey(keys2));
         
         assertFalse(ref.equalsSurvey(null));
+        
+        // Same guid, different createdOn
+        GuidCreatedOnVersionHolder keys3 = new GuidCreatedOnVersionHolderImpl("def", DateTime.now().getMillis());
+        assertFalse(ref.equalsSurvey(keys3));
+        
     }
     
 }

--- a/test/org/sagebionetworks/bridge/models/schedules/SurveyReferenceTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/SurveyReferenceTest.java
@@ -36,12 +36,16 @@ public class SurveyReferenceTest {
         assertFalse(ref.equalsSurvey(keys1));
         assertFalse(ref.equalsSurvey(keys2));
         
+        // Null test (should return false)
         assertFalse(ref.equalsSurvey(null));
         
         // Same guid, different createdOn
-        GuidCreatedOnVersionHolder keys3 = new GuidCreatedOnVersionHolderImpl("def", DateTime.now().getMillis());
+        GuidCreatedOnVersionHolder keys3 = new GuidCreatedOnVersionHolderImpl(GUID, DateTime.now().getMillis());
         assertFalse(ref.equalsSurvey(keys3));
         
+        // Different guid, different createdOn
+        GuidCreatedOnVersionHolder keys4 = new GuidCreatedOnVersionHolderImpl("def", DateTime.now().getMillis());
+        assertFalse(ref.equalsSurvey(keys4));
     }
     
 }

--- a/test/org/sagebionetworks/bridge/models/schedules/SurveyReferenceTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/SurveyReferenceTest.java
@@ -1,0 +1,40 @@
+package org.sagebionetworks.bridge.models.schedules;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolder;
+import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolderImpl;
+
+public class SurveyReferenceTest {
+
+    private static final String IDENTIFIER = "id";
+    private static final String GUID = "abc";
+    private static final DateTime CREATED_ON = DateTime.parse("2017-02-09T20:15:59.558Z");
+    
+    @Test
+    public void test() {
+        SurveyReference ref = new SurveyReference(IDENTIFIER, GUID, CREATED_ON);
+        
+        assertEquals(IDENTIFIER, ref.getIdentifier());
+        assertEquals(GUID, ref.getGuid());
+        assertEquals(CREATED_ON, ref.getCreatedOn());
+        assertTrue(ref.getHref().contains("/v3/surveys/abc/revisions/2017-02-09T20:15:59.558Z"));
+        
+        GuidCreatedOnVersionHolder keys1 = new GuidCreatedOnVersionHolderImpl(GUID, CREATED_ON.getMillis());
+        assertTrue(ref.equalsSurvey(keys1));
+        
+        GuidCreatedOnVersionHolder keys2 = new GuidCreatedOnVersionHolderImpl("def", CREATED_ON.getMillis());
+        assertFalse(ref.equalsSurvey(keys2));
+        
+        // Doesn't match published links, only specific ones.
+        ref = new SurveyReference(IDENTIFIER, GUID, null);
+        assertFalse(ref.equalsSurvey(keys1));
+        assertFalse(ref.equalsSurvey(keys2));
+    }
+    
+}

--- a/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
@@ -411,7 +411,7 @@ public class SurveyControllerTest {
         controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "false");
 
         verify(service).getSurvey(KEYS);
-        verify(service).deleteSurvey(survey);
+        verify(service).deleteSurvey(API_STUDY_ID, survey);
         verifyNoMoreInteractions(service);
     }
     
@@ -425,7 +425,7 @@ public class SurveyControllerTest {
         controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "true");
         
         verify(service).getSurvey(KEYS);
-        verify(service).deleteSurvey(survey);
+        verify(service).deleteSurvey(API_STUDY_ID, survey);
         verifyNoMoreInteractions(service);
     }
     
@@ -439,7 +439,7 @@ public class SurveyControllerTest {
         controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "true");
         
         verify(service).getSurvey(KEYS);
-        verify(service).deleteSurveyPermanently(survey);
+        verify(service).deleteSurveyPermanently(API_STUDY_ID, survey);
         verifyNoMoreInteractions(service);
     }
     

--- a/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
@@ -411,7 +411,7 @@ public class SurveyControllerTest {
         controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "false");
 
         verify(service).getSurvey(KEYS);
-        verify(service).deleteSurvey(API_STUDY_ID, survey);
+        verify(service).deleteSurvey(survey);
         verifyNoMoreInteractions(service);
     }
     
@@ -425,7 +425,7 @@ public class SurveyControllerTest {
         controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "true");
         
         verify(service).getSurvey(KEYS);
-        verify(service).deleteSurvey(API_STUDY_ID, survey);
+        verify(service).deleteSurvey(survey);
         verifyNoMoreInteractions(service);
     }
     

--- a/test/org/sagebionetworks/bridge/services/SurveyServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/SurveyServiceMockTest.java
@@ -58,6 +58,9 @@ public class SurveyServiceMockTest {
     @Captor
     ArgumentCaptor<GuidCreatedOnVersionHolder> keysCaptor;
     
+    @Captor
+    ArgumentCaptor<Survey> surveyCaptor;
+    
     SurveyService service;
     
     @Before
@@ -94,10 +97,10 @@ public class SurveyServiceMockTest {
         Survey survey = createSurvey();
         doReturn(survey).when(mockSurveyDao).getSurvey(any());
         
-        service.deleteSurvey(TEST_STUDY, survey);
+        service.deleteSurvey(survey);
         
-        verify(mockSurveyDao).deleteSurvey(keysCaptor.capture());
-        assertEquals(survey, keysCaptor.getValue());
+        verify(mockSurveyDao).deleteSurvey(surveyCaptor.capture());
+        assertEquals(survey, surveyCaptor.getValue());
     }
     
     @Test
@@ -125,7 +128,7 @@ public class SurveyServiceMockTest {
         doReturn(survey).when(mockSurveyDao).getSurvey(any());
         
         try {
-            service.deleteSurvey(TEST_STUDY, survey);
+            service.deleteSurvey(survey);
             fail("Should have thrown exception");
         } catch(PublishedSurveyException e) {
             verify(mockSurveyDao, never()).deleteSurvey(any());
@@ -140,7 +143,7 @@ public class SurveyServiceMockTest {
         doReturn(survey).when(mockSurveyDao).getSurvey(any());
         
         try {
-            service.deleteSurvey(TEST_STUDY, survey);
+            service.deleteSurvey(survey);
             fail("Should have thrown exception");
         } catch(EntityNotFoundException e) {
             verify(mockSurveyDao, never()).deleteSurvey(any());

--- a/test/org/sagebionetworks/bridge/services/SurveyServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/SurveyServiceMockTest.java
@@ -1,19 +1,62 @@
 package org.sagebionetworks.bridge.services;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
-import static org.mockito.Mockito.mock;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 
+import java.util.List;
+import java.util.function.Function;
+
+import org.joda.time.DateTime;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
-import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dao.SurveyDao;
+import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
 import org.sagebionetworks.bridge.dynamodb.DynamoSurvey;
+import org.sagebionetworks.bridge.exceptions.ConstraintViolationException;
+import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolder;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolderImpl;
+import org.sagebionetworks.bridge.models.schedules.Activity;
+import org.sagebionetworks.bridge.models.schedules.CompoundActivity;
+import org.sagebionetworks.bridge.models.schedules.Schedule;
+import org.sagebionetworks.bridge.models.schedules.SchedulePlan;
+import org.sagebionetworks.bridge.models.schedules.SimpleScheduleStrategy;
+import org.sagebionetworks.bridge.models.schedules.SurveyReference;
 import org.sagebionetworks.bridge.models.surveys.Survey;
 
+import com.google.common.collect.Lists;
+
+@RunWith(MockitoJUnitRunner.class)
 public class SurveyServiceMockTest {
+
+    private static final String SCHEDULE_PLAN_GUID = "schedulePlanGuid";
+    private static final String SURVEY_GUID = "surveyGuid";
+    private static final DateTime SURVEY_CREATED_ON = DateTime.parse("2017-02-08T20:07:57.179Z");
+    
+    @Mock
+    SurveyDao mockSurveyDao;
+    
+    @Mock
+    SchedulePlanService mockSchedulePlanService;
+    
+    SurveyService service;
+    
+    @Before
+    public void before() {
+        service = new SurveyService();
+        service.setSurveyDao(mockSurveyDao);
+        service.setSchedulePlanService(mockSchedulePlanService);
+    }
+    
     @Test
     public void publishSurvey() {
         // test inputs and outputs
@@ -21,15 +64,300 @@ public class SurveyServiceMockTest {
         Survey survey = new DynamoSurvey();
 
         // mock DAO
-        SurveyDao mockDao = mock(SurveyDao.class);
-        when(mockDao.publishSurvey(TestConstants.TEST_STUDY, keys, true)).thenReturn(survey);
-
-        // set up test
-        SurveyService svc = new SurveyService();
-        svc.setSurveyDao(mockDao);
+        when(mockSurveyDao.publishSurvey(TEST_STUDY, keys, true)).thenReturn(survey);
 
         // execute and validate
-        Survey retval = svc.publishSurvey(TestConstants.TEST_STUDY, keys, true);
+        Survey retval = service.publishSurvey(TEST_STUDY, keys, true);
         assertSame(survey, retval);
+    }
+    
+    @Test
+    public void successfulDelete() {
+        List<SchedulePlan> plans = createSchedulePlanListWithSurveyReference(false);
+        
+        Activity oldActivity = getActivityList(plans).get(0);
+        Activity activity = new Activity.Builder().withActivity(oldActivity)
+                .withSurvey("Survey", "otherGuid", SURVEY_CREATED_ON).build();
+        getActivityList(plans).set(0, activity);
+        
+        doReturn(plans).when(mockSchedulePlanService).getSchedulePlans(ClientInfo.UNKNOWN_CLIENT, TEST_STUDY);
+        Survey survey = createSurvey();
+        
+        service.deleteSurvey(TEST_STUDY, survey);
+    }
+    
+    @Test
+    public void successfulDeletePermanently() {
+        List<SchedulePlan> plans = createSchedulePlanListWithSurveyReference(false);
+        
+        Activity oldActivity = getActivityList(plans).get(0);
+        Activity activity = new Activity.Builder().withActivity(oldActivity)
+                .withSurvey("Survey", "otherGuid", SURVEY_CREATED_ON).build();
+        getActivityList(plans).set(0, activity);
+        
+        doReturn(plans).when(mockSchedulePlanService).getSchedulePlans(ClientInfo.UNKNOWN_CLIENT, TEST_STUDY);
+        Survey survey = createSurvey();
+        
+        service.deleteSurveyPermanently(TEST_STUDY, survey);    }
+    
+    @Test
+    public void deleteSurveyConstrainedBySchedule() {
+        List<SchedulePlan> plans = createSchedulePlanListWithSurveyReference(false);
+        doReturn(plans).when(mockSchedulePlanService).getSchedulePlans(ClientInfo.UNKNOWN_CLIENT, TEST_STUDY);
+        Survey survey = createSurvey();
+        
+        try {
+            service.deleteSurvey(TEST_STUDY, survey);
+            fail("Should have thrown exception");
+        } catch(ConstraintViolationException e) {
+            assertTrue(e.getMessage().contains("Operation not permitted because entity"));
+            assertEquals(SCHEDULE_PLAN_GUID, e.getReferrerKeys().get("guid"));
+            assertEquals("SchedulePlan", e.getReferrerKeys().get("type"));
+            assertEquals(SURVEY_GUID, e.getEntityKeys().get("guid"));
+            assertEquals(SURVEY_CREATED_ON.toString(), e.getEntityKeys().get("createdOn"));
+            assertEquals("Survey", e.getEntityKeys().get("type"));
+        }
+    }
+    
+    @Test
+    public void deleteSurveyPermanentlyConstrainedBySchedule() {
+        List<SchedulePlan> plans = createSchedulePlanListWithSurveyReference(false);
+        doReturn(plans).when(mockSchedulePlanService).getSchedulePlans(ClientInfo.UNKNOWN_CLIENT, TEST_STUDY);
+        Survey survey = createSurvey();
+        
+        try {
+            service.deleteSurveyPermanently(TEST_STUDY, survey);
+            fail("Should have thrown exception");
+        } catch(ConstraintViolationException e) {
+            assertTrue(e.getMessage().contains("Operation not permitted because entity"));
+            assertEquals(SCHEDULE_PLAN_GUID, e.getReferrerKeys().get("guid"));
+            assertEquals("SchedulePlan", e.getReferrerKeys().get("type"));
+            assertEquals(SURVEY_GUID, e.getEntityKeys().get("guid"));
+            assertEquals(SURVEY_CREATED_ON.toString(), e.getEntityKeys().get("createdOn"));
+            assertEquals("Survey", e.getEntityKeys().get("type"));
+        }
+    }
+    
+    @Test
+    public void deleteSurveyConstrainedByScheduleWithPublishedSurvey() {
+        List<SchedulePlan> plans = createSchedulePlanListWithSurveyReference(true);
+        doReturn(plans).when(mockSchedulePlanService).getSchedulePlans(ClientInfo.UNKNOWN_CLIENT, TEST_STUDY);
+        
+        // One published survey, should throw exception
+        Survey survey = createSurvey();
+        Survey unpubSurvey = createSurvey();
+        unpubSurvey.setPublished(false);
+        doReturn(Lists.newArrayList(unpubSurvey, survey)).when(mockSurveyDao).getSurveyAllVersions(TEST_STUDY, SURVEY_GUID);
+        
+        try {
+            service.deleteSurvey(TEST_STUDY, survey);
+            fail("Should have thrown exception");
+        } catch(ConstraintViolationException e) {
+            assertTrue(e.getMessage().contains("Operation not permitted because entity"));
+            assertEquals(SCHEDULE_PLAN_GUID, e.getReferrerKeys().get("guid"));
+            assertEquals("SchedulePlan", e.getReferrerKeys().get("type"));
+            assertEquals(SURVEY_GUID, e.getEntityKeys().get("guid"));
+            assertEquals(SURVEY_CREATED_ON.toString(), e.getEntityKeys().get("createdOn"));
+            assertEquals("Survey", e.getEntityKeys().get("type"));
+        }
+    }
+    
+    @Test
+    public void deleteSurveyPermanentlyConstrainedByScheduleWithPublishedSurvey() {
+        List<SchedulePlan> plans = createSchedulePlanListWithSurveyReference(true);
+        doReturn(plans).when(mockSchedulePlanService).getSchedulePlans(ClientInfo.UNKNOWN_CLIENT, TEST_STUDY);
+        
+        // One published survey, should throw exception
+        Survey survey = createSurvey();
+        Survey unpubSurvey = createSurvey();
+        unpubSurvey.setPublished(false);
+        doReturn(Lists.newArrayList(unpubSurvey, survey)).when(mockSurveyDao).getSurveyAllVersions(TEST_STUDY, SURVEY_GUID);
+        
+        try {
+            service.deleteSurveyPermanently(TEST_STUDY, survey);
+            fail("Should have thrown exception");
+        } catch(ConstraintViolationException e) {
+            assertTrue(e.getMessage().contains("Operation not permitted because entity"));
+            assertEquals(SCHEDULE_PLAN_GUID, e.getReferrerKeys().get("guid"));
+            assertEquals("SchedulePlan", e.getReferrerKeys().get("type"));
+            assertEquals(SURVEY_GUID, e.getEntityKeys().get("guid"));
+            assertEquals(SURVEY_CREATED_ON.toString(), e.getEntityKeys().get("createdOn"));
+            assertEquals("Survey", e.getEntityKeys().get("type"));
+        }
+    }
+    
+    @Test
+    public void deleteSurveyNotConstrainedByScheduleWithMultiplePublishedSurveys() {
+        List<SchedulePlan> plans = createSchedulePlanListWithSurveyReference(true);
+        doReturn(plans).when(mockSchedulePlanService).getSchedulePlans(ClientInfo.UNKNOWN_CLIENT, TEST_STUDY);
+        
+        // Two published surveys in the list, no exception thrown
+        Survey survey = createSurvey();
+        doReturn(Lists.newArrayList(survey, survey)).when(mockSurveyDao).getSurveyAllVersions(TEST_STUDY, SURVEY_GUID);
+        
+        service.deleteSurvey(TEST_STUDY, survey);
+    }
+
+    @Test
+    public void deleteSurveyPermanentlyNotConstrainedByScheduleWithMultiplePublishedSurveys() {
+        List<SchedulePlan> plans = createSchedulePlanListWithSurveyReference(true);
+        doReturn(plans).when(mockSchedulePlanService).getSchedulePlans(ClientInfo.UNKNOWN_CLIENT, TEST_STUDY);
+        
+        // Two published surveys in the list, no exception thrown
+        Survey survey = createSurvey();
+        doReturn(Lists.newArrayList(survey, survey)).when(mockSurveyDao).getSurveyAllVersions(TEST_STUDY, SURVEY_GUID);
+        
+        service.deleteSurveyPermanently(TEST_STUDY, survey);
+    }
+    
+    @Test
+    public void deleteSurveyConstrainedByCompoundSchedule() {
+        List<SchedulePlan> plans = createSchedulePlanListWithCompoundActivity(false);
+        doReturn(plans).when(mockSchedulePlanService).getSchedulePlans(ClientInfo.UNKNOWN_CLIENT, TEST_STUDY);
+        Survey survey = createSurvey();
+        
+        try {
+            service.deleteSurvey(TEST_STUDY, survey);
+            fail("Should have thrown exception");
+        } catch(ConstraintViolationException e) {
+            assertTrue(e.getMessage().contains("Operation not permitted because entity"));
+            assertEquals(SCHEDULE_PLAN_GUID, e.getReferrerKeys().get("guid"));
+            assertEquals("SchedulePlan", e.getReferrerKeys().get("type"));
+            assertEquals(SURVEY_GUID, e.getEntityKeys().get("guid"));
+            assertEquals(SURVEY_CREATED_ON.toString(), e.getEntityKeys().get("createdOn"));
+            assertEquals("Survey", e.getEntityKeys().get("type"));
+        }
+    }
+    
+    @Test
+    public void deleteSurveyPermanentlyConstrainedByCompoundSchedule() {
+        List<SchedulePlan> plans = createSchedulePlanListWithCompoundActivity(false);
+        doReturn(plans).when(mockSchedulePlanService).getSchedulePlans(ClientInfo.UNKNOWN_CLIENT, TEST_STUDY);
+        Survey survey = createSurvey();
+        
+        try {
+            service.deleteSurveyPermanently(TEST_STUDY, survey);
+            fail("Should have thrown exception");
+        } catch(ConstraintViolationException e) {
+            assertTrue(e.getMessage().contains("Operation not permitted because entity"));
+            assertEquals(SCHEDULE_PLAN_GUID, e.getReferrerKeys().get("guid"));
+            assertEquals("SchedulePlan", e.getReferrerKeys().get("type"));
+            assertEquals(SURVEY_GUID, e.getEntityKeys().get("guid"));
+            assertEquals(SURVEY_CREATED_ON.toString(), e.getEntityKeys().get("createdOn"));
+            assertEquals("Survey", e.getEntityKeys().get("type"));
+        }
+    }
+    
+    @Test
+    public void deleteSurveyConstrainedByCompoundScheduleWithPublishedSurvey() {
+        List<SchedulePlan> plans = createSchedulePlanListWithCompoundActivity(true);
+        doReturn(plans).when(mockSchedulePlanService).getSchedulePlans(ClientInfo.UNKNOWN_CLIENT, TEST_STUDY);
+        
+        // One published survey, should throw exception
+        Survey survey = createSurvey();
+        Survey unpubSurvey = createSurvey();
+        unpubSurvey.setPublished(false);
+        doReturn(Lists.newArrayList(unpubSurvey, survey)).when(mockSurveyDao).getSurveyAllVersions(TEST_STUDY, SURVEY_GUID);
+        
+        try {
+            service.deleteSurvey(TEST_STUDY, survey);
+            fail("Should have thrown exception");
+        } catch(ConstraintViolationException e) {
+            assertTrue(e.getMessage().contains("Operation not permitted because entity"));
+            assertEquals(SCHEDULE_PLAN_GUID, e.getReferrerKeys().get("guid"));
+            assertEquals("SchedulePlan", e.getReferrerKeys().get("type"));
+            assertEquals(SURVEY_GUID, e.getEntityKeys().get("guid"));
+            assertEquals(SURVEY_CREATED_ON.toString(), e.getEntityKeys().get("createdOn"));
+            assertEquals("Survey", e.getEntityKeys().get("type"));
+        }
+    }
+    
+    @Test
+    public void deleteSurveyPermanentlyConstrainedByCompoundScheduleWithPublishedSurvey() {
+        List<SchedulePlan> plans = createSchedulePlanListWithCompoundActivity(true);
+        doReturn(plans).when(mockSchedulePlanService).getSchedulePlans(ClientInfo.UNKNOWN_CLIENT, TEST_STUDY);
+        
+        // One published survey, should throw exception
+        Survey survey = createSurvey();
+        Survey unpubSurvey = createSurvey();
+        unpubSurvey.setPublished(false);
+        doReturn(Lists.newArrayList(unpubSurvey, survey)).when(mockSurveyDao).getSurveyAllVersions(TEST_STUDY, SURVEY_GUID);
+        
+        try {
+            service.deleteSurveyPermanently(TEST_STUDY, survey);
+            fail("Should have thrown exception");
+        } catch(ConstraintViolationException e) {
+            assertTrue(e.getMessage().contains("Operation not permitted because entity"));
+            assertEquals(SCHEDULE_PLAN_GUID, e.getReferrerKeys().get("guid"));
+            assertEquals("SchedulePlan", e.getReferrerKeys().get("type"));
+            assertEquals(SURVEY_GUID, e.getEntityKeys().get("guid"));
+            assertEquals(SURVEY_CREATED_ON.toString(), e.getEntityKeys().get("createdOn"));
+            assertEquals("Survey", e.getEntityKeys().get("type"));
+        }
+    }
+    
+    @Test
+    public void deleteSurveyNotConstrainedByCompoundScheduleWithMultiplePublishedSurveys() {
+        List<SchedulePlan> plans = createSchedulePlanListWithCompoundActivity(true);
+        doReturn(plans).when(mockSchedulePlanService).getSchedulePlans(ClientInfo.UNKNOWN_CLIENT, TEST_STUDY);
+        
+        // Two published surveys in the list, no exception thrown
+        Survey survey = createSurvey();
+        doReturn(Lists.newArrayList(survey, survey)).when(mockSurveyDao).getSurveyAllVersions(TEST_STUDY, SURVEY_GUID);
+        
+        service.deleteSurvey(TEST_STUDY, survey);
+    }
+
+    @Test
+    public void deleteSurveyPermanentlyNotConstrainedByCompoundScheduleWithMultiplePublishedSurveys() {
+        List<SchedulePlan> plans = createSchedulePlanListWithCompoundActivity(true);
+        doReturn(plans).when(mockSchedulePlanService).getSchedulePlans(ClientInfo.UNKNOWN_CLIENT, TEST_STUDY);
+        
+        // Two published surveys in the list, no exception thrown
+        Survey survey = createSurvey();
+        doReturn(Lists.newArrayList(survey, survey)).when(mockSurveyDao).getSurveyAllVersions(TEST_STUDY, SURVEY_GUID);
+        
+        service.deleteSurveyPermanently(TEST_STUDY, survey);
+    }    
+    
+    private List<Activity> getActivityList(List<SchedulePlan> plans) {
+        return ((SimpleScheduleStrategy) plans.get(0).getStrategy()).getSchedule().getActivities();
+    }
+
+    private Survey createSurvey() {
+        Survey survey = new DynamoSurvey();
+        survey.setGuid(SURVEY_GUID);
+        survey.setCreatedOn(SURVEY_CREATED_ON.getMillis());
+        survey.setPublished(true);
+        return survey;
+    }
+
+    private List<SchedulePlan> createSchedulePlanListWithSurveyReference(boolean publishedSurveyRef) {
+        return createSchedulePlan(publishedSurveyRef, (surveyReference) -> {
+            return new Activity.Builder().withSurvey(surveyReference).build();
+        });
+    }
+
+    private List<SchedulePlan> createSchedulePlanListWithCompoundActivity(boolean publishedSurveyRef) {
+        return createSchedulePlan(publishedSurveyRef, (surveyReference) -> {
+            CompoundActivity compoundActivity = new CompoundActivity.Builder()
+                    .withSurveyList(Lists.newArrayList(surveyReference)).build();
+            return new Activity.Builder().withCompoundActivity(compoundActivity).build();
+        });
+    }
+    
+    private List<SchedulePlan> createSchedulePlan(boolean publishedSurveyRef, Function<SurveyReference,Activity> supplier) {
+        SurveyReference surveyReference = (publishedSurveyRef) ? 
+                new SurveyReference("Survey", SURVEY_GUID, null) : 
+                new SurveyReference("Survey", SURVEY_GUID, SURVEY_CREATED_ON);
+        SchedulePlan plan = new DynamoSchedulePlan();
+        plan.setGuid(SCHEDULE_PLAN_GUID);
+        Schedule schedule = new Schedule();
+        SimpleScheduleStrategy strategy = new SimpleScheduleStrategy();
+        Activity activity = supplier.apply(surveyReference);
+        schedule.addActivity(activity);
+        strategy.setSchedule(schedule);
+        plan.setStrategy(strategy);
+        return Lists.newArrayList(plan);
     }
 }

--- a/test/org/sagebionetworks/bridge/services/SurveyServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SurveyServiceTest.java
@@ -136,7 +136,7 @@ public class SurveyServiceTest {
         survey = surveyService.getSurvey(survey);
         assertEquals("Identifier has been changed", "newIdentifier", survey.getIdentifier());
         assertEquals("Be honest: do you have high blood pressue?", question.getPromptDetail());
-        surveyService.deleteSurvey(TEST_STUDY, survey);
+        surveyService.deleteSurvey(survey);
 
         try {
             surveyService.getSurveyMostRecentlyPublishedVersion(TEST_STUDY, survey.getGuid());

--- a/test/org/sagebionetworks/bridge/services/SurveyServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SurveyServiceTest.java
@@ -18,6 +18,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.sagebionetworks.bridge.dynamodb.DynamoSurveyInfoScreen;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.exceptions.ConcurrentModificationException;
@@ -70,7 +71,7 @@ public class SurveyServiceTest {
         // clean up surveys
         for (GuidCreatedOnVersionHolder oneSurvey : surveysToDelete) {
             try {
-                surveyService.deleteSurveyPermanently(oneSurvey);
+                surveyService.deleteSurveyPermanently(TEST_STUDY, oneSurvey);
             } catch (Exception ex) {
                 logger.error(ex.getMessage(), ex);
             }
@@ -135,7 +136,7 @@ public class SurveyServiceTest {
         survey = surveyService.getSurvey(survey);
         assertEquals("Identifier has been changed", "newIdentifier", survey.getIdentifier());
         assertEquals("Be honest: do you have high blood pressue?", question.getPromptDetail());
-        surveyService.deleteSurvey(survey);
+        surveyService.deleteSurvey(TEST_STUDY, survey);
 
         try {
             surveyService.getSurveyMostRecentlyPublishedVersion(TEST_STUDY, survey.getGuid());


### PR DESCRIPTION
Survey deletion rules. Note that I have rewritten the DAO and moved these more complicated rules into the service. If there's concern about accessing the DAO directly, I can reorganize packages so the DAO is only visible to the service.

Logical deletes (hiding survey but keeping in db): once published, you cannot delete a survey. This means that once the survey might be used in a scheduled activity, you can always find it in the user interface, look up its schema, etc. This is more strict than it was before. This is how developers delete.

Physical deletes (remove from db): these are only used during tests or by admins, but we now verify that the survey is not in use in a schedule before allowing it. This is because we ignore the publication flag when doing these deletes. Tests must delete schedules first, the integration tests pass as is (I'll add a test for the constraint itself). There are two rules:

- If a schedule references to a specific survey version, don't allow it to be deleted. You can't make these through the Bridge Study Manager, but they're allowable in the API;

- If a schedule references the most-recently published version of a survey, verify this delete is not removing the last published instance of the survey. This is the more common case right now.