### PR TITLE
Add field to determine if external ID is part of the sign up.

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
@@ -49,6 +49,7 @@ public final class DynamoStudy implements Study {
     private boolean healthCodeExportEnabled;
     private boolean emailVerificationEnabled;
     private boolean externalIdValidationEnabled;
+    private boolean externalIdRequiredOnSignup;
     private Map<String, Integer> minSupportedAppVersions;
     private Map<String, String> pushNotificationARNs;
 
@@ -356,16 +357,24 @@ public final class DynamoStudy implements Study {
     public void setPushNotificationARNs(Map<String,String> map) {
         this.pushNotificationARNs = (map == null) ? new HashMap<>() : map;
     }
-    
-    
+
+    @Override
+    public boolean isExternalIdRequiredOnSignup() {
+        return externalIdRequiredOnSignup;
+    }
+
+    @Override
+    public void setExternalIdRequiredOnSignup(boolean externalIdRequiredOnSignup) {
+        this.externalIdRequiredOnSignup = externalIdRequiredOnSignup;
+    }
 
     @Override
     public int hashCode() {
-        return Objects.hash(identifier, minAgeOfConsent, name, sponsorName, supportEmail,
-                technicalEmail, consentNotificationEmail, stormpathHref, version, profileAttributes, taskIdentifiers,
-                dataGroups, passwordPolicy, verifyEmailTemplate, resetPasswordTemplate, active,
-                strictUploadValidationEnabled, healthCodeExportEnabled, emailVerificationEnabled,
-                externalIdValidationEnabled, minSupportedAppVersions, synapseDataAccessTeamId, synapseProjectId,
+        return Objects.hash(identifier, minAgeOfConsent, name, sponsorName, supportEmail, technicalEmail,
+                consentNotificationEmail, stormpathHref, version, profileAttributes, taskIdentifiers, dataGroups,
+                passwordPolicy, verifyEmailTemplate, resetPasswordTemplate, active, strictUploadValidationEnabled,
+                healthCodeExportEnabled, emailVerificationEnabled, externalIdValidationEnabled,
+                externalIdRequiredOnSignup, minSupportedAppVersions, synapseDataAccessTeamId, synapseProjectId,
                 usesCustomExportSchedule, pushNotificationARNs);
     }
 
@@ -397,6 +406,7 @@ public final class DynamoStudy implements Study {
                 && Objects.equals(healthCodeExportEnabled, other.healthCodeExportEnabled)
                 && Objects.equals(externalIdValidationEnabled, other.externalIdValidationEnabled)
                 && Objects.equals(emailVerificationEnabled, other.emailVerificationEnabled)
+                && Objects.equals(externalIdRequiredOnSignup, other.externalIdRequiredOnSignup)
                 && Objects.equals(minSupportedAppVersions, other.minSupportedAppVersions)
                 && Objects.equals(pushNotificationARNs, other.pushNotificationARNs);
     }
@@ -405,16 +415,16 @@ public final class DynamoStudy implements Study {
     public String toString() {
         return String.format(
             "DynamoStudy [name=%s, active=%s, sponsorName=%s, identifier=%s, stormpathHref=%s, minAgeOfConsent=%s, "
-                            + "supportEmail=%s, synapseDataAccessTeamId=%s, synapseProjectId=%s, technicalEmail=%s, "
-                            + "consentNotificationEmail=%s, version=%s, userProfileAttributes=%s, taskIdentifiers=%s, "
-                            + "dataGroups=%s, passwordPolicy=%s, verifyEmailTemplate=%s, resetPasswordTemplate=%s, "
-                            + "strictUploadValidationEnabled=%s, healthCodeExportEnabled=%s, emailVerificationEnabled=%s, "
-                            + "externalIdValidationEnabled=%s, minSupportedAppVersions=%s, usesCustomExportSchedule=%s, "
-                            + "pushNotificationARNs=%s]",
+                        + "supportEmail=%s, synapseDataAccessTeamId=%s, synapseProjectId=%s, technicalEmail=%s, "
+                        + "consentNotificationEmail=%s, version=%s, userProfileAttributes=%s, taskIdentifiers=%s, "
+                        + "dataGroups=%s, passwordPolicy=%s, verifyEmailTemplate=%s, resetPasswordTemplate=%s, "
+                        + "strictUploadValidationEnabled=%s, healthCodeExportEnabled=%s, emailVerificationEnabled=%s, "
+                        + "externalIdValidationEnabled=%s, externalIdRequiredOnSignup=%s, minSupportedAppVersions=%s, "
+                        + "usesCustomExportSchedule=%s, pushNotificationARNs=%s]",
                 name, active, sponsorName, identifier, stormpathHref, minAgeOfConsent, supportEmail, synapseDataAccessTeamId, 
                 synapseProjectId, technicalEmail, consentNotificationEmail, version, profileAttributes, taskIdentifiers, 
                 dataGroups, passwordPolicy, verifyEmailTemplate, resetPasswordTemplate, strictUploadValidationEnabled, 
-                healthCodeExportEnabled, emailVerificationEnabled, externalIdValidationEnabled, minSupportedAppVersions, 
-                usesCustomExportSchedule, pushNotificationARNs);
+                healthCodeExportEnabled, emailVerificationEnabled, externalIdValidationEnabled, externalIdRequiredOnSignup, 
+                minSupportedAppVersions, usesCustomExportSchedule, pushNotificationARNs);
     }
 }

--- a/app/org/sagebionetworks/bridge/models/studies/Study.java
+++ b/app/org/sagebionetworks/bridge/models/studies/Study.java
@@ -209,6 +209,18 @@ public interface Study extends BridgeEntity, StudyIdentifier {
     /** @see #isExternalIdValidationEnabled(); */
     void setExternalIdValidationEnabled(boolean externalIdValidationEnabled);
     
+    /** 
+     * True if the external ID must be provided when the user signs up. If validation is also 
+     * enabled, this study uses lab codes. In the lab code scenario, the external ID is used 
+     * in an email and a password, so it must be provided and cannot have been used before. 
+     * If this is false, the external ID must still be unique and unused when provided, but it 
+     * is not used to generate credentials.
+     */
+    boolean isExternalIdRequiredOnSignup();
+    
+    /** @see #isExternalIdRequiredOnSignup(); */
+    void setExternalIdRequiredOnSignup(boolean externalIdRequiredOnSignup);
+    
     /**
      * Minimum supported app version number. If set, user app clients pointing to an older version will 
      * fail with an httpResponse status code of 410.

--- a/app/org/sagebionetworks/bridge/models/studies/Study.java
+++ b/app/org/sagebionetworks/bridge/models/studies/Study.java
@@ -211,10 +211,9 @@ public interface Study extends BridgeEntity, StudyIdentifier {
     
     /** 
      * True if the external ID must be provided when the user signs up. If validation is also 
-     * enabled, this study uses lab codes. In the lab code scenario, the external ID is used 
-     * in an email and a password, so it must be provided and cannot have been used before. 
-     * If this is false, the external ID must still be unique and unused when provided, but it 
-     * is not used to generate credentials.
+     * enabled, this study is configured to use lab codes if desired (username and password auto-
+     * generated from the external ID). If this is false, the external ID is not required when 
+     * submitting a sign up. 
      */
     boolean isExternalIdRequiredOnSignup();
     

--- a/app/org/sagebionetworks/bridge/services/StudyService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyService.java
@@ -284,9 +284,10 @@ public class StudyService {
             if (!originalStudy.isActive()) {
                 throw new EntityNotFoundException(Study.class, "Study '"+ study.getIdentifier() +"' not found.");
             }
-
             study.setHealthCodeExportEnabled(originalStudy.isHealthCodeExportEnabled());
             study.setEmailVerificationEnabled(originalStudy.isEmailVerificationEnabled());
+            study.setExternalIdValidationEnabled(originalStudy.isExternalIdRequiredOnSignup());
+            study.setExternalIdRequiredOnSignup(originalStudy.isExternalIdRequiredOnSignup());
         }
 
         // prevent anyone changing active to false -- it should be done by deactivateStudy() method

--- a/app/org/sagebionetworks/bridge/services/StudyService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyService.java
@@ -286,7 +286,7 @@ public class StudyService {
             }
             study.setHealthCodeExportEnabled(originalStudy.isHealthCodeExportEnabled());
             study.setEmailVerificationEnabled(originalStudy.isEmailVerificationEnabled());
-            study.setExternalIdValidationEnabled(originalStudy.isExternalIdRequiredOnSignup());
+            study.setExternalIdValidationEnabled(originalStudy.isExternalIdValidationEnabled());
             study.setExternalIdRequiredOnSignup(originalStudy.isExternalIdRequiredOnSignup());
         }
 
@@ -337,7 +337,7 @@ public class StudyService {
         if (!physical) {
             // deactivate
             if (!existing.isActive()) {
-                throw new BadRequestException("Study '"+identifier+"' is deactivated before.");
+                throw new BadRequestException("Study '"+identifier+"' already deactivated.");
             }
             studyDao.deactivateStudy(existing.getIdentifier());
         } else {

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -353,6 +353,7 @@ public class TestUtils {
         study.setHealthCodeExportEnabled(true);
         study.setEmailVerificationEnabled(true);
         study.setExternalIdValidationEnabled(true);
+        study.setExternalIdRequiredOnSignup(true);
         study.setActive(true);
         study.setPushNotificationARNs(pushNotificationARNs);
         return study;

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
@@ -43,7 +43,7 @@ public class DynamoStudyTest {
         
         final String json = BridgeObjectMapper.get().writeValueAsString(study);
         final JsonNode node = BridgeObjectMapper.get().readTree(json);
-
+        
         assertEqualsAndNotNull(study.getConsentNotificationEmail(), node.get("consentNotificationEmail").asText());
         assertEqualsAndNotNull(study.getSupportEmail(), node.get("supportEmail").asText());
         assertEqualsAndNotNull(study.getSynapseDataAccessTeamId(), node.get("synapseDataAccessTeamId").longValue());
@@ -68,6 +68,7 @@ public class DynamoStudyTest {
         assertTrue(node.get("healthCodeExportEnabled").asBoolean());
         assertTrue(node.get("emailVerificationEnabled").asBoolean());
         assertTrue(node.get("externalIdValidationEnabled").asBoolean());
+        assertTrue(node.get("externalIdRequiredOnSignup").asBoolean());
         assertEqualsAndNotNull("Study", node.get("type").asText());
         assertEqualsAndNotNull(study.getPushNotificationARNs().get(OperatingSystem.IOS),
                 node.get("pushNotificationARNs").get(OperatingSystem.IOS).asText());

--- a/test/org/sagebionetworks/bridge/services/StudyServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceTest.java
@@ -272,21 +272,31 @@ public class StudyServiceTest {
         study = TestUtils.getValidStudy(StudyServiceTest.class);
         study.setHealthCodeExportEnabled(false);
         study.setEmailVerificationEnabled(true);
+        study.setExternalIdRequiredOnSignup(true);
+        study.setExternalIdValidationEnabled(true);
         study = studyService.createStudy(study);
         
         // Okay, now that these are set, researchers cannot change them
         study.setHealthCodeExportEnabled(true);
         study.setEmailVerificationEnabled(false);
+        study.setExternalIdRequiredOnSignup(false);
+        study.setExternalIdValidationEnabled(false);
         study = studyService.updateStudy(study, false); // nope
         assertFalse("isHealthCodeExportEnabled should be false", study.isHealthCodeExportEnabled());
         assertTrue("isEmailVerificationEnabled should be true", study.isEmailVerificationEnabled());
-        
+        assertTrue("isExternalIdRequiredOnSignup should be true", study.isExternalIdRequiredOnSignup());
+        assertTrue("isExternalIdValidationEnabled should be true", study.isExternalIdValidationEnabled());
+
         // But administrators can
         study.setHealthCodeExportEnabled(true);
         study.setEmailVerificationEnabled(false);
+        study.setExternalIdRequiredOnSignup(false);
+        study.setExternalIdValidationEnabled(false);
         study = studyService.updateStudy(study, true); // yep
         assertTrue(study.isHealthCodeExportEnabled());
         assertFalse(study.isEmailVerificationEnabled());
+        assertFalse(study.isExternalIdRequiredOnSignup());
+        assertFalse(study.isExternalIdValidationEnabled());
     }
     
     @Test(expected=InvalidEntityException.class)


### PR DESCRIPTION
Adding another flag to support a more flexible set of use cases around external ID enforcement:

**externalIdValidationEnabled=false, externalIdRequiredOnSignup=false**
    can add it optionally, it's just a string, we don't validate it
**externalIdValidationEnabled=true, externalIdRequiredOnSignup=true**
    need to enter on sign up, need to be valid and free. Makes it possible to have lab codes as well.
**externalIdValidationEnabled=true, externalIdRequiredOnSignup=false**
    optional, but if added, needs to be valid and unassigned
**externalIdValidationEnabled=false, externalIdRequiredOnSignup=true**
    must provide an external ID, it's just a string, we don't validate it (no study does this currently)

If both flags are true, our code takes a very defensive approach to creating the account that ensures the ID isn't taken by another account mid-processing, in order to support the more stricter use of lab codes, where the ID, email address, and password **must** match or things will break. However, you do **not** have to follow the lab code pattern when both these flags are true, that's up to the client implementation. **Update:** actually lab code studies are differentiated by one more flag: whether or not email validation is required.

In addition, I'm making externalIdValidationEnabled an admin setting... it is already only shown in the admin section of the Bridge Study Manager.