### PR TITLE
pull updated bridge-base to allow multiple DDB indices to use the same range key

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ libraryDependencies ++= Seq(
   cache,
   filters,
   // Sage packages
-  "org.sagebionetworks" % "bridge-base" % "2.7.1",
+  "org.sagebionetworks" % "bridge-base" % "2.7.4",
   "org.sagebionetworks" % "synapseJavaClient" % "161.0-4-g843de2c",
   // AWS
   "com.amazonaws" % "aws-java-sdk-s3" % "1.10.20",


### PR DESCRIPTION
Pulls in the change from https://github.com/Sage-Bionetworks/bridge-base/pull/30

Testing done: Created new tables under a clean namespace and verified a sample of the indices.