### PR TITLE
don't create schemas for surveys with no questions

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
@@ -229,13 +229,16 @@ public class DynamoSurveyDao implements SurveyDao {
             throw new EntityNotFoundException(Survey.class);
         }
         if (!survey.isPublished()) {
-            // make schema from survey
-            UploadSchema schema = uploadSchemaDao.createUploadSchemaFromSurvey(study, survey, newSchemaRev);
-
             // update survey
             survey.setPublished(true);
             survey.setModifiedOn(DateUtils.getCurrentMillisFromEpoch());
-            survey.setSchemaRevision(schema.getRevision());
+
+            // make schema from survey
+            if (!survey.getUnmodifiableQuestionList().isEmpty()) {
+                UploadSchema schema = uploadSchemaDao.createUploadSchemaFromSurvey(study, survey, newSchemaRev);
+                survey.setSchemaRevision(schema.getRevision());
+            }
+
             try {
                 surveyMapper.save(survey);
             } catch(ConditionalCheckFailedException e) {

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDao.java
@@ -173,9 +173,14 @@ public class DynamoUploadSchemaDao implements UploadSchemaDao {
     @Override
     public @Nonnull UploadSchema createUploadSchemaFromSurvey(@Nonnull StudyIdentifier studyIdentifier,
             @Nonnull Survey survey, boolean newSchemaRev) {
+        List<SurveyQuestion> surveyQuestionList = survey.getUnmodifiableQuestionList();
+        if (surveyQuestionList.isEmpty()) {
+            throw new BadRequestException("Can't create a schema from a survey with no questions");
+        }
+
         // create upload field definitions from survey questions
         List<UploadFieldDefinition> newFieldDefList = new ArrayList<>();
-        for (SurveyQuestion oneQuestion : survey.getUnmodifiableQuestionList()) {
+        for (SurveyQuestion oneQuestion : surveyQuestionList) {
             addFieldDefsForSurveyQuestion(newFieldDefList, oneQuestion);
         }
 

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoMockTest.java
@@ -1,17 +1,24 @@
 package org.sagebionetworks.bridge.dynamodb;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.google.common.collect.ImmutableList;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
+import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -19,49 +26,99 @@ import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dao.UploadSchemaDao;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolder;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolderImpl;
+import org.sagebionetworks.bridge.models.surveys.IntegerConstraints;
 import org.sagebionetworks.bridge.models.surveys.Survey;
+import org.sagebionetworks.bridge.models.surveys.SurveyInfoScreen;
+import org.sagebionetworks.bridge.models.surveys.SurveyQuestion;
+import org.sagebionetworks.bridge.models.upload.UploadSchema;
 
 public class DynamoSurveyDaoMockTest {
     private static final DateTime MOCK_NOW = DateTime.parse("2016-08-24T15:23:57.123-0700");
     private static final long MOCK_NOW_MILLIS = MOCK_NOW.getMillis();
+
+    private static final int SCHEMA_REV = 42;
+
+    private static final String SURVEY_GUID = "test-guid";
+    private static final long SURVEY_CREATED_ON = 1337;
+    private static final GuidCreatedOnVersionHolder SURVEY_KEY = new GuidCreatedOnVersionHolderImpl(SURVEY_GUID,
+            SURVEY_CREATED_ON);
+
+    private UploadSchemaDao mockSchemaDao;
+    private DynamoDBMapper mockSurveyMapper;
+    private Survey survey;
+    private DynamoSurveyDao surveyDao;
 
     @BeforeClass
     public static void mockNow() {
         DateTimeUtils.setCurrentMillisFixed(MOCK_NOW_MILLIS);
     }
 
-    @Test
-    public void publishSurvey() {
-        // test inputs and outputs
-        GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl("test-guid", 1337);
-        Survey survey = new DynamoSurvey();
+    @AfterClass
+    public static void unmockNow() {
+        DateTimeUtils.setCurrentMillisSystem();
+    }
 
-        DynamoUploadSchema schema = new DynamoUploadSchema();
-        schema.setRevision(42);
+    @Before
+    public void setup() {
+        // set up survey
+        survey = new DynamoSurvey(SURVEY_GUID, SURVEY_CREATED_ON);
 
-        // mock survey mapper
-        DynamoDBMapper mockSurveyMapper = mock(DynamoDBMapper.class);
+        // mock mapper
+        mockSurveyMapper = mock(DynamoDBMapper.class);
 
         // mock schema dao
-        UploadSchemaDao mockSchemaDao = mock(UploadSchemaDao.class);
+        UploadSchema schema = UploadSchema.create();
+        schema.setRevision(SCHEMA_REV);
+
+        mockSchemaDao = mock(UploadSchemaDao.class);
         when(mockSchemaDao.createUploadSchemaFromSurvey(TestConstants.TEST_STUDY, survey, true)).thenReturn(schema);
 
-        // Set up DAO for test.
-        DynamoSurveyDao surveyDao = spy(new DynamoSurveyDao());
+        // set up survey dao for test
+        surveyDao = spy(new DynamoSurveyDao());
         surveyDao.setSurveyMapper(mockSurveyMapper);
         surveyDao.setUploadSchemaDao(mockSchemaDao);
 
         // spy getSurvey() - There's a lot of complex logic in that query builder that's irrelevant to what we're
         // trying to test. Rather than over-specify our test and make our tests overly complicated, we'll just spy out
         // getSurvey().
-        doReturn(survey).when(surveyDao).getSurvey(keys);
+        doReturn(survey).when(surveyDao).getSurvey(SURVEY_KEY);
+    }
+
+    @Test
+    public void publishSurvey() {
+        // populate the survey with at least one question
+        SurveyQuestion surveyQuestion = new DynamoSurveyQuestion();
+        surveyQuestion.setIdentifier("int");
+        surveyQuestion.setConstraints(new IntegerConstraints());
+
+        survey.setElements(ImmutableList.of(surveyQuestion));
 
         // execute and validate
-        Survey retval = surveyDao.publishSurvey(TestConstants.TEST_STUDY, keys, true);
+        Survey retval = surveyDao.publishSurvey(TestConstants.TEST_STUDY, SURVEY_KEY, true);
         assertTrue(retval.isPublished());
         assertEquals(MOCK_NOW_MILLIS, retval.getModifiedOn());
-        assertEquals(42, retval.getSchemaRevision().intValue());
+        assertEquals(SCHEMA_REV, retval.getSchemaRevision().intValue());
 
         verify(mockSurveyMapper).save(same(retval));
+    }
+
+    @Test
+    public void publishSurveyWithInfoScreensOnly() {
+        // populate the survey with an info screen and no questions
+        SurveyInfoScreen infoScreen = new DynamoSurveyInfoScreen();
+        infoScreen.setIdentifier("test-info-screen");
+        infoScreen.setTitle("Test Info Screen");
+        infoScreen.setPrompt("This info screen doesn't do anything, other than not being a question.");
+
+        survey.setElements(ImmutableList.of(infoScreen));
+
+        // same test as above, except we *don't* call through to the upload schema DAO
+        Survey retval = surveyDao.publishSurvey(TestConstants.TEST_STUDY, SURVEY_KEY, true);
+        assertTrue(retval.isPublished());
+        assertEquals(MOCK_NOW_MILLIS, retval.getModifiedOn());
+        assertNull(retval.getSchemaRevision());
+
+        verify(mockSurveyMapper).save(same(retval));
+        verify(mockSchemaDao, never()).createUploadSchemaFromSurvey(any(), any(), anyBoolean());
     }
 }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDaoMockTest.java
@@ -51,6 +51,7 @@ import org.sagebionetworks.bridge.models.surveys.MultiValueConstraints;
 import org.sagebionetworks.bridge.models.surveys.StringConstraints;
 import org.sagebionetworks.bridge.models.surveys.Survey;
 import org.sagebionetworks.bridge.models.surveys.SurveyElement;
+import org.sagebionetworks.bridge.models.surveys.SurveyInfoScreen;
 import org.sagebionetworks.bridge.models.surveys.SurveyQuestion;
 import org.sagebionetworks.bridge.models.surveys.SurveyQuestionOption;
 import org.sagebionetworks.bridge.models.surveys.TimeConstraints;
@@ -136,6 +137,34 @@ public class DynamoUploadSchemaDaoMockTest {
         survey.setName(SURVEY_NAME);
         survey.setElements(surveyElementList);
         return survey;
+    }
+
+    @Test
+    public void schemaFromSurveyWithInfoScreensOnly() {
+        // create a survey with an info screen and no questions
+        SurveyInfoScreen infoScreen = new DynamoSurveyInfoScreen();
+        infoScreen.setIdentifier("test-info-screen");
+        infoScreen.setTitle("Test Info Screen");
+        infoScreen.setPrompt("This info screen doesn't do anything, other than not being a question.");
+
+        Survey survey = makeSurveyWithElements(ImmutableList.of(infoScreen));
+
+        // Similarly, spy getUploadSchemaNoThrow(), createSchemaV4() and updateSchemaV4().
+        DynamoUploadSchemaDao dao = spy(new DynamoUploadSchemaDao());
+
+        // set up test dao and execute - Most of this stuff is tested elsewhere, so just test result specific to this
+        // test
+        try {
+            dao.createUploadSchemaFromSurvey(TestConstants.TEST_STUDY, survey, false);
+            fail("expected exception");
+        } catch (BadRequestException ex) {
+            assertEquals("Can't create a schema from a survey with no questions", ex.getMessage());
+        }
+
+        // We never attempt to create, get, or update any schemas.
+        verify(dao, never()).createSchemaRevisionV4(any(), any());
+        verify(dao, never()).getUploadSchemaNoThrow(any(), any());
+        verify(dao, never()).updateSchemaRevisionV4(any(), any(), anyInt(), any());
     }
 
     @Test


### PR DESCRIPTION
Fix for https://sagebionetworks.jira.com/browse/BRIDGE-1705

Previously, surveys with no questions (info screens only) were erroring out on schema generation. This fix skips schema generation if the survey has no questions.

Testing done:
* Manually tested creating and publishing survey with info screens only and no questions. Verified survey successfully created. Verified no schema created.
* unit tests and integ tests