### PR TITLE
Changing behavior that would break existing mPower clients.

### DIFF
--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -451,11 +451,9 @@ public class ParticipantService {
                 if (isNotBlank(participant.getExternalId())) {
                     externalIdService.assignExternalId(study, participant.getExternalId(), healthCode);
                 }
-            } else {
-                if (!existingExternalId.equals(participant.getExternalId())) {
-                    throw new BadRequestException(
-                            "External ID cannot be changed or removed after assignment.");
-                }
+            } else if (!existingExternalId.equals(participant.getExternalId())) {
+                throw new BadRequestException(
+                        "External ID cannot be changed or removed after assignment.");
             }
         }
     }

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -459,6 +459,9 @@ public class ParticipantService {
     }
 
     private boolean idsDontExistOrAreNotEqual(String id1, String id2) {
+        if (isBlank(id1) && isBlank(id2)) {
+            return false;
+        }
         return (isBlank(id1) || isBlank(id2) || !id1.equals(id2));
     }
 

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -458,7 +458,7 @@ public class ParticipantService {
                 return;
             }
             throw new BadRequestException(
-                    "External ID cannot be changed, removed after assignment, or left unassigned.");
+                    "External ID cannot be changed or removed after assignment.");
         }
     }
 

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -447,7 +447,11 @@ public class ParticipantService {
             ParticipantOptionsLookup lookup = optionsService.getOptions(healthCode);
             String existingExternalId = lookup.getString(EXTERNAL_IDENTIFIER);
 
-            if (idsDontExistOrAreNotEqual(existingExternalId, participant.getExternalId())) {
+            if (isBlank(existingExternalId) && isBlank(participant.getExternalId())) {
+                return;
+            }
+            String newId = participant.getExternalId();
+            if (isBlank(existingExternalId) || isBlank(newId) || !existingExternalId.equals(newId)) {
                 if (isBlank(existingExternalId) && isNotBlank(participant.getExternalId())) {
                     externalIdService.assignExternalId(study, participant.getExternalId(), healthCode);
                 } else {
@@ -456,13 +460,6 @@ public class ParticipantService {
                 }
             }
         }
-    }
-
-    private boolean idsDontExistOrAreNotEqual(String id1, String id2) {
-        if (isBlank(id1) && isBlank(id2)) {
-            return false;
-        }
-        return (isBlank(id1) || isBlank(id2) || !id1.equals(id2));
     }
 
     private Account getAccountThrowingException(Study study, String id) {

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -447,18 +447,18 @@ public class ParticipantService {
             ParticipantOptionsLookup lookup = optionsService.getOptions(healthCode);
             String existingExternalId = lookup.getString(EXTERNAL_IDENTIFIER);
 
-            if (isBlank(existingExternalId) && isBlank(participant.getExternalId())) {
+            if (isBlank(existingExternalId) && isBlank(participant.getExternalId())) { 
                 return;
             }
-            String newId = participant.getExternalId();
-            if (isBlank(existingExternalId) || isBlank(newId) || !existingExternalId.equals(newId)) {
-                if (isBlank(existingExternalId) && isNotBlank(participant.getExternalId())) {
-                    externalIdService.assignExternalId(study, participant.getExternalId(), healthCode);
-                } else {
-                    throw new BadRequestException(
-                            "External ID cannot be changed, removed after assignment, or left unassigned.");
-                }
+            if (isBlank(existingExternalId) && isNotBlank(participant.getExternalId())) {
+                externalIdService.assignExternalId(study, participant.getExternalId(), healthCode);
+                return;
             }
+            if (existingExternalId.equals(participant.getExternalId())) {
+                return;
+            }
+            throw new BadRequestException(
+                    "External ID cannot be changed, removed after assignment, or left unassigned.");
         }
     }
 

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -447,18 +447,16 @@ public class ParticipantService {
             ParticipantOptionsLookup lookup = optionsService.getOptions(healthCode);
             String existingExternalId = lookup.getString(EXTERNAL_IDENTIFIER);
 
-            if (isBlank(existingExternalId) && isBlank(participant.getExternalId())) { 
-                return;
+            if (isBlank(existingExternalId)) {
+                if (isNotBlank(participant.getExternalId())) {
+                    externalIdService.assignExternalId(study, participant.getExternalId(), healthCode);
+                }
+            } else {
+                if (!existingExternalId.equals(participant.getExternalId())) {
+                    throw new BadRequestException(
+                            "External ID cannot be changed or removed after assignment.");
+                }
             }
-            if (isBlank(existingExternalId) && isNotBlank(participant.getExternalId())) {
-                externalIdService.assignExternalId(study, participant.getExternalId(), healthCode);
-                return;
-            }
-            if (existingExternalId.equals(participant.getExternalId())) {
-                return;
-            }
-            throw new BadRequestException(
-                    "External ID cannot be changed or removed after assignment.");
         }
     }
 

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -1046,7 +1046,7 @@ public class ParticipantServiceTest {
         when(lookup.getString(EXTERNAL_IDENTIFIER)).thenReturn(null);
         when(optionsService.getOptions(HEALTH_CODE)).thenReturn(lookup);
         
-        // Updating a validated value (with null) throws an exception
+        // Updating a validated null value (with null) does nothing
         participantService.updateParticipant(STUDY, CALLER_ROLES, NO_ID_PARTICIPANT);
         
         verifyNotSetAsReservation();

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -1041,6 +1041,19 @@ public class ParticipantServiceTest {
     }
     
     @Test
+    public void doNotFailIfValidatingButNullValueIsUpdatedWithNullValue() {
+        setupExternalIdTest(true, false);
+        when(lookup.getString(EXTERNAL_IDENTIFIER)).thenReturn(null);
+        when(optionsService.getOptions(HEALTH_CODE)).thenReturn(lookup);
+        
+        // Updating a validated value (with null) throws an exception
+        participantService.updateParticipant(STUDY, CALLER_ROLES, NO_ID_PARTICIPANT);
+        
+        verifyNotSetAsReservation();
+        verifySetAsOption(null);
+    }
+    
+    @Test
     public void updateExternalIdNotValidatedNotRequiredNoValue() {
         setupExternalIdTest(false, false);
         when(lookup.getString(EXTERNAL_IDENTIFIER)).thenReturn(EXTERNAL_ID);


### PR DESCRIPTION
If nothing has been set, and you update the account with nothing, don't throw an error, or existing clients cannot update user profile information.

This behavior has been fixed in a larger refactor to separate external ID service from participant service logic, btw.