### PR TITLE
Compound Activities don't validate Task IDs

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/CompoundActivityDefinitionController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/CompoundActivityDefinitionController.java
@@ -11,7 +11,6 @@ import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.models.ResourceList;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.schedules.CompoundActivityDefinition;
-import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.services.CompoundActivityDefinitionService;
 
 /** Play controller for managing Compound Activity Definitions. */
@@ -28,11 +27,10 @@ public class CompoundActivityDefinitionController extends BaseController {
     /** Creates a compound activity definition. */
     public Result createCompoundActivityDefinition() throws JsonProcessingException {
         UserSession session = getAuthenticatedSession(Roles.DEVELOPER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
 
         CompoundActivityDefinition requestDef = parseJson(request(), CompoundActivityDefinition.class);
-        CompoundActivityDefinition createdDef = compoundActivityDefService.createCompoundActivityDefinition(study,
-                requestDef);
+        CompoundActivityDefinition createdDef = compoundActivityDefService.createCompoundActivityDefinition(
+                session.getStudyIdentifier(), requestDef);
         return created(CompoundActivityDefinition.PUBLIC_DEFINITION_WRITER.writeValueAsString(createdDef));
     }
 
@@ -66,11 +64,10 @@ public class CompoundActivityDefinitionController extends BaseController {
     /** Update a compound activity definition. */
     public Result updateCompoundActivityDefinition(String taskId) throws JsonProcessingException {
         UserSession session = getAuthenticatedSession(Roles.DEVELOPER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
 
         CompoundActivityDefinition requestDef = parseJson(request(), CompoundActivityDefinition.class);
-        CompoundActivityDefinition updatedDef = compoundActivityDefService.updateCompoundActivityDefinition(study,
-                taskId, requestDef);
+        CompoundActivityDefinition updatedDef = compoundActivityDefService.updateCompoundActivityDefinition(
+                session.getStudyIdentifier(), taskId, requestDef);
         return ok(CompoundActivityDefinition.PUBLIC_DEFINITION_WRITER.writeValueAsString(updatedDef));
     }
 }

--- a/app/org/sagebionetworks/bridge/services/CompoundActivityDefinitionService.java
+++ b/app/org/sagebionetworks/bridge/services/CompoundActivityDefinitionService.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Component;
 import org.sagebionetworks.bridge.dao.CompoundActivityDefinitionDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.models.schedules.CompoundActivityDefinition;
-import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.validators.CompoundActivityDefinitionValidator;
 import org.sagebionetworks.bridge.validators.Validate;
@@ -26,15 +25,13 @@ public class CompoundActivityDefinitionService {
     }
 
     /** Creates a compound activity definition. */
-    public CompoundActivityDefinition createCompoundActivityDefinition(Study study,
+    public CompoundActivityDefinition createCompoundActivityDefinition(StudyIdentifier studyId,
             CompoundActivityDefinition compoundActivityDefinition) {
         // Set study to prevent people from creating defs in other studies.
-        compoundActivityDefinition.setStudyId(study.getIdentifier());
+        compoundActivityDefinition.setStudyId(studyId.getIdentifier());
 
         // validate def
-        CompoundActivityDefinitionValidator validator = new CompoundActivityDefinitionValidator(
-                study.getTaskIdentifiers());
-        Validate.entityThrowingException(validator, compoundActivityDefinition);
+        Validate.entityThrowingException(CompoundActivityDefinitionValidator.INSTANCE, compoundActivityDefinition);
 
         // call through to dao
         return compoundActivityDefDao.createCompoundActivityDefinition(compoundActivityDefinition);
@@ -79,7 +76,7 @@ public class CompoundActivityDefinitionService {
     }
 
     /** Update a compound activity definition. */
-    public CompoundActivityDefinition updateCompoundActivityDefinition(Study study, String taskId,
+    public CompoundActivityDefinition updateCompoundActivityDefinition(StudyIdentifier studyId, String taskId,
             CompoundActivityDefinition compoundActivityDefinition) {
         // validate user input (taskId)
         if (StringUtils.isBlank(taskId)) {
@@ -88,13 +85,11 @@ public class CompoundActivityDefinitionService {
 
         // Set the studyId and taskId. This prevents people from updating the wrong def or updating a def in another
         // study.
-        compoundActivityDefinition.setStudyId(study.getIdentifier());
+        compoundActivityDefinition.setStudyId(studyId.getIdentifier());
         compoundActivityDefinition.setTaskId(taskId);
 
         // validate def
-        CompoundActivityDefinitionValidator validator = new CompoundActivityDefinitionValidator(
-                study.getTaskIdentifiers());
-        Validate.entityThrowingException(validator, compoundActivityDefinition);
+        Validate.entityThrowingException(CompoundActivityDefinitionValidator.INSTANCE, compoundActivityDefinition);
 
         // call through to dao
         return compoundActivityDefDao.updateCompoundActivityDefinition(compoundActivityDefinition);

--- a/app/org/sagebionetworks/bridge/validators/CompoundActivityDefinitionValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/CompoundActivityDefinitionValidator.java
@@ -2,8 +2,6 @@ package org.sagebionetworks.bridge.validators;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
-import java.util.Set;
-
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
@@ -12,12 +10,8 @@ import org.sagebionetworks.bridge.models.schedules.CompoundActivityDefinition;
 
 /** Validator for CompoundActivityDefinition. */
 public class CompoundActivityDefinitionValidator implements Validator {
-    private final Set<String> taskIdSet;
-
-    /** Constructor for validator. Takes set of valid task IDs from the study. */
-    public CompoundActivityDefinitionValidator(Set<String> taskIdSet) {
-        this.taskIdSet = taskIdSet;
-    }
+    /** Singleton instance. */
+    public static final CompoundActivityDefinitionValidator INSTANCE = new CompoundActivityDefinitionValidator();
 
     /** {@inheritDoc} */
     @Override
@@ -52,9 +46,6 @@ public class CompoundActivityDefinitionValidator implements Validator {
             String taskId = compoundActivityDef.getTaskId();
             if (isBlank(taskId)) {
                 errors.rejectValue("taskId", "must be specified");
-            } else if (!taskIdSet.contains(taskId)) {
-                errors.rejectValue("taskId", taskId + " not in enumeration: " +
-                        BridgeUtils.COMMA_SPACE_JOINER.join(taskIdSet));
             }
 
             // must have at least one item in surveys and/or schemas

--- a/test/org/sagebionetworks/bridge/services/CompoundActivityDefinitionServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/CompoundActivityDefinitionServiceTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -23,7 +22,6 @@ import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.models.schedules.CompoundActivityDefinition;
 import org.sagebionetworks.bridge.models.schedules.SchemaReference;
 import org.sagebionetworks.bridge.models.schedules.SurveyReference;
-import org.sagebionetworks.bridge.models.studies.Study;
 
 public class CompoundActivityDefinitionServiceTest {
     private static final List<SchemaReference> SCHEMA_LIST = ImmutableList.of(new SchemaReference("test-schema",
@@ -31,13 +29,6 @@ public class CompoundActivityDefinitionServiceTest {
     private static final List<SurveyReference> SURVEY_LIST = ImmutableList.of(new SurveyReference("test-survey",
             "test-survey-guid", null));
     private static final String TASK_ID = "test-task";
-    private static final Study STUDY;
-    static {
-        // The only things we care about in the study are the study ID and the task ID set.
-        STUDY = Study.create();
-        STUDY.setIdentifier(TestConstants.TEST_STUDY_IDENTIFIER);
-        STUDY.setTaskIdentifiers(ImmutableSet.of(TASK_ID));
-    }
 
     private CompoundActivityDefinitionDao dao;
     private CompoundActivityDefinitionService service;
@@ -61,7 +52,8 @@ public class CompoundActivityDefinitionServiceTest {
 
         // execute
         CompoundActivityDefinition serviceInput = makeValidDef();
-        CompoundActivityDefinition serviceResult = service.createCompoundActivityDefinition(STUDY, serviceInput);
+        CompoundActivityDefinition serviceResult = service.createCompoundActivityDefinition(TestConstants.TEST_STUDY,
+                serviceInput);
 
         // validate dao input - It's the same as the service input, but we also set the study ID.
         CompoundActivityDefinition daoInput = daoInputCaptor.getValue();
@@ -80,7 +72,7 @@ public class CompoundActivityDefinitionServiceTest {
 
         // execute, will throw
         try {
-            service.createCompoundActivityDefinition(STUDY, def);
+            service.createCompoundActivityDefinition(TestConstants.TEST_STUDY, def);
             fail("expected exception");
         } catch (InvalidEntityException ex) {
             // expected exception
@@ -214,8 +206,8 @@ public class CompoundActivityDefinitionServiceTest {
 
         // execute
         CompoundActivityDefinition serviceInput = makeValidDef();
-        CompoundActivityDefinition serviceResult = service.updateCompoundActivityDefinition(STUDY, TASK_ID,
-                serviceInput);
+        CompoundActivityDefinition serviceResult = service.updateCompoundActivityDefinition(TestConstants.TEST_STUDY,
+                TASK_ID, serviceInput);
 
         // validate dao input - It's the same as the service input, but we also set the study ID.
         CompoundActivityDefinition daoInput = daoInputCaptor.getValue();
@@ -236,7 +228,7 @@ public class CompoundActivityDefinitionServiceTest {
 
         // execute, will throw
         try {
-            service.updateCompoundActivityDefinition(STUDY, TASK_ID, def);
+            service.updateCompoundActivityDefinition(TestConstants.TEST_STUDY, TASK_ID, def);
             fail("expected exception");
         } catch (InvalidEntityException ex) {
             // expected exception
@@ -264,7 +256,7 @@ public class CompoundActivityDefinitionServiceTest {
     private void updateBadRequest(String taskId) {
         // execute, will throw
         try {
-            service.updateCompoundActivityDefinition(STUDY, taskId, makeValidDef());
+            service.updateCompoundActivityDefinition(TestConstants.TEST_STUDY, taskId, makeValidDef());
             fail("expected exception");
         } catch (BadRequestException ex) {
             assertEquals("taskId must be specified", ex.getMessage());

--- a/test/org/sagebionetworks/bridge/validators/CompoundActivityDefinitionValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/CompoundActivityDefinitionValidatorTest.java
@@ -8,7 +8,6 @@ import java.util.HashMap;
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 import org.springframework.validation.MapBindingResult;
 
@@ -25,25 +24,23 @@ public class CompoundActivityDefinitionValidatorTest {
     private static final List<SurveyReference> SURVEY_LIST = ImmutableList.of(new SurveyReference("test-survey",
             "test-survey-guid", null));
     private static final String TASK_ID = "test-task";
-    private static final CompoundActivityDefinitionValidator VALIDATOR = new CompoundActivityDefinitionValidator(
-            ImmutableSet.of(TASK_ID));
 
     // branch coverage
     @Test
     public void validatorSupportsClass() {
-        assertTrue(VALIDATOR.supports(CompoundActivityDefinition.class));
+        assertTrue(CompoundActivityDefinitionValidator.INSTANCE.supports(CompoundActivityDefinition.class));
     }
 
     // branch coverage
     @Test
     public void validatorSupportsSubclass() {
-        assertTrue(VALIDATOR.supports(DynamoCompoundActivityDefinition.class));
+        assertTrue(CompoundActivityDefinitionValidator.INSTANCE.supports(DynamoCompoundActivityDefinition.class));
     }
 
     // branch coverage
     @Test
     public void validatorDoesntSupportClass() {
-        assertFalse(VALIDATOR.supports(String.class));
+        assertFalse(CompoundActivityDefinitionValidator.INSTANCE.supports(String.class));
     }
 
     // branch coverage
@@ -51,7 +48,7 @@ public class CompoundActivityDefinitionValidatorTest {
     @Test
     public void validateNull() {
         MapBindingResult errors = new MapBindingResult(new HashMap<>(), "CompoundActivityDefinition");
-        VALIDATOR.validate(null, errors);
+        CompoundActivityDefinitionValidator.INSTANCE.validate(null, errors);
         assertTrue(errors.hasErrors());
     }
 
@@ -60,13 +57,13 @@ public class CompoundActivityDefinitionValidatorTest {
     @Test
     public void validateWrongClass() {
         MapBindingResult errors = new MapBindingResult(new HashMap<>(), "CompoundActivityDefinition");
-        VALIDATOR.validate("wrong class", errors);
+        CompoundActivityDefinitionValidator.INSTANCE.validate("wrong class", errors);
         assertTrue(errors.hasErrors());
     }
 
     @Test
     public void valid() {
-        Validate.entityThrowingException(VALIDATOR, makeValidDef());
+        Validate.entityThrowingException(CompoundActivityDefinitionValidator.INSTANCE, makeValidDef());
     }
 
     @Test
@@ -89,7 +86,7 @@ public class CompoundActivityDefinitionValidatorTest {
         def.setStudyId(studyId);
 
         try {
-            Validate.entityThrowingException(VALIDATOR, def);
+            Validate.entityThrowingException(CompoundActivityDefinitionValidator.INSTANCE, def);
             fail("expected exception");
         } catch (InvalidEntityException ex) {
             assertTrue(ex.getMessage().contains("studyId must be specified"));
@@ -116,23 +113,10 @@ public class CompoundActivityDefinitionValidatorTest {
         def.setTaskId(taskId);
 
         try {
-            Validate.entityThrowingException(VALIDATOR, def);
+            Validate.entityThrowingException(CompoundActivityDefinitionValidator.INSTANCE, def);
             fail("expected exception");
         } catch (InvalidEntityException ex) {
             assertTrue(ex.getMessage().contains("taskId must be specified"));
-        }
-    }
-
-    @Test
-    public void taskIdNotInStudy() {
-        CompoundActivityDefinition def = makeValidDef();
-        def.setTaskId("not-a-task");
-
-        try {
-            Validate.entityThrowingException(VALIDATOR, def);
-            fail("expected exception");
-        } catch (InvalidEntityException ex) {
-            assertTrue(ex.getMessage().contains("taskId not-a-task not in enumeration: " + TASK_ID));
         }
     }
 
@@ -144,7 +128,7 @@ public class CompoundActivityDefinitionValidatorTest {
         def.setSurveyList(null);
 
         try {
-            Validate.entityThrowingException(VALIDATOR, def);
+            Validate.entityThrowingException(CompoundActivityDefinitionValidator.INSTANCE, def);
             fail("expected exception");
         } catch (InvalidEntityException ex) {
             assertTrue(ex.getMessage().contains("compoundActivityDefinition must have at least one schema or at least "


### PR DESCRIPTION
**_IMPORTANT:_** Do not merge this until after we deal with https://sagebionetworks.jira.com/browse/BRIDGE-1732 Otherwise, the various merges and reverts might get messy.

As per Alx: I would like to decouple the compound activity definitions from task identifiers so people can create them and add them in parallel to schedules, without having to create task identifiers first. This will allow people to migrate from one to the other.

This changelist removes the requirement that Compound Activity Definition's Task ID come from the config in the study. (Task ID must still be a non-null, non-empty, non-blank string, however.) It also fixes the plumbing through the Service and Controller to not call StudyService when all we need is the Study ID.

Testing done:
* updated unit tests
* manual tests - Simple CRUD test. Verified validator still validates other parts of Compound Activity Definition.

Integ tests to come soon.