### PR TITLE
Fixing special case of UTC time zone parsing.

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/ParticipantOption.java
+++ b/app/org/sagebionetworks/bridge/dao/ParticipantOption.java
@@ -21,23 +21,13 @@ public enum ParticipantOption {
 
     TIME_ZONE(null, "timeZone") {
         public String fromParticipant(StudyParticipant participant) {
-            if (participant.getTimeZone() == null) {
-                return null;
-            } else if (participant.getTimeZone() == DateTimeZone.UTC) {
-                // Joda represents +00:00 as the string "UTC", so special case it
-                return "+00:00";
-            }
-            return participant.getTimeZone().toString();
+            return DateUtils.timeZoneToOffsetString(participant.getTimeZone());
         }
         public String deserialize(JsonNode node) {
             checkNotNull(node);
             try {
                 DateTimeZone zone = DateUtils.parseZoneFromOffsetString(node.asText());
-                if (zone == DateTimeZone.UTC) {
-                    // Joda represents +00:00 as the string "UTC", so special case it
-                    return "+00:00";
-                }
-                return zone.toString();
+                return DateUtils.timeZoneToOffsetString(zone);
             } catch(IllegalArgumentException e) {
                 throw new BadRequestException("timeZone is an invalid time zone offset");
             }

--- a/app/org/sagebionetworks/bridge/json/DateUtils.java
+++ b/app/org/sagebionetworks/bridge/json/DateUtils.java
@@ -169,7 +169,8 @@ public final class DateUtils {
 
     /**
      * Convert at 8601 time zone offset string (e.g. "-07:00") to a DateTimeZone 
-     * object. 
+     * object. Can also catch "UTC" which is the string returned by a DateTimeZone 
+     * instance that was originally parsed from "+00:00"
      * @param offsetString
      * @return
      */
@@ -177,7 +178,9 @@ public final class DateUtils {
         DateTimeZone zone = null;
         if (StringUtils.isNotBlank(offsetString)) {
             try {
-                if (OFFSET_PATTERN_HOURS_ONLY.matcher(offsetString).matches()) {
+                if (DateTimeZone.UTC.toString().equals(offsetString)) {
+                    zone = DateTimeZone.UTC;
+                } else if (OFFSET_PATTERN_HOURS_ONLY.matcher(offsetString).matches()) {
                     int hours = Integer.parseInt(offsetString);
                     zone = DateTimeZone.forOffsetHours(hours);
                 } else if (OFFSET_PATTERN.matcher(offsetString).matches()) {

--- a/app/org/sagebionetworks/bridge/json/DateUtils.java
+++ b/app/org/sagebionetworks/bridge/json/DateUtils.java
@@ -200,6 +200,17 @@ public final class DateUtils {
         return zone;
     }
     
+    public static String timeZoneToOffsetString(DateTimeZone timeZone) {
+        if (timeZone == null) {
+            return null;
+        }
+        String zoneString = timeZone.toString();
+        if ("UTC".equals(zoneString)) {
+            return "+00:00";
+        }
+        return zoneString;
+    }
+    
     /**
      * If no value is provided, returns the default datetime value. Otherwise, returns the datetime 
      * of the string if it can be parsed or an exception if it's not a valid ISO 8601 timestamp.

--- a/app/org/sagebionetworks/bridge/services/ParticipantOptionsService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantOptionsService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Component;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.dao.ParticipantOption;
 import org.sagebionetworks.bridge.dao.ParticipantOptionsDao;
+import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.models.accounts.AllParticipantOptionsLookup;
 import org.sagebionetworks.bridge.models.accounts.ParticipantOptionsLookup;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
@@ -111,7 +112,7 @@ public class ParticipantOptionsService {
         checkArgument(isNotBlank(healthCode));
         checkNotNull(option);
 
-        optionsDao.setOption(studyIdentifier, healthCode, option, zone.toString());
+        optionsDao.setOption(studyIdentifier, healthCode, option, DateUtils.timeZoneToOffsetString(zone));
     }
     
     public void setAllOptions(StudyIdentifier studyIdentifier, String healthCode, Map<ParticipantOption,String> options) {

--- a/test/org/sagebionetworks/bridge/dao/ParticipantOptionTest.java
+++ b/test/org/sagebionetworks/bridge/dao/ParticipantOptionTest.java
@@ -41,6 +41,10 @@ public class ParticipantOptionTest {
         result = ParticipantOption.TIME_ZONE.deserialize(node);
         assertEquals("+03:00", result);
         
+        node = BridgeObjectMapper.get().readTree(TestUtils.createJson("'+0:00'"));
+        result = ParticipantOption.TIME_ZONE.deserialize(node);
+        assertEquals("+00:00", result);
+        
         node = BridgeObjectMapper.get().readTree(TestUtils.createJson("'sponsors_and_partners'"));
         result = ParticipantOption.SHARING_SCOPE.deserialize(node);
         assertEquals(SharingScope.SPONSORS_AND_PARTNERS.name(), result);
@@ -75,6 +79,16 @@ public class ParticipantOptionTest {
         
         result = ParticipantOption.TIME_ZONE.fromParticipant(participant);
         assertEquals("-07:00", result);
+    }
+    
+    @Test
+    public void canRetrieveUTCFromParticipant() {
+        StudyParticipant participant = new StudyParticipant.Builder()
+                .withTimeZone(DateTimeZone.forOffsetHours(0))
+                .build();
+        
+        assertEquals("UTC", participant.getTimeZone().toString());
+        assertEquals("+00:00", ParticipantOption.TIME_ZONE.fromParticipant(participant));
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/json/DateUtilsTest.java
+++ b/test/org/sagebionetworks/bridge/json/DateUtilsTest.java
@@ -156,6 +156,17 @@ public class DateUtilsTest {
     }
     
     @Test
+    public void canParseSpecialValueUTC() {
+        // When you parse an offset of 0 and get a time zone, that time zone expressed as a string
+        // will be "UTC", not "+00:00". The parser should correctly handle this special case.
+        DateTimeZone zone = DateUtils.parseZoneFromOffsetString("UTC");
+        assertEquals(DateTimeZone.UTC, zone);
+        
+        zone = DateUtils.parseZoneFromOffsetString("+00:00");
+        assertEquals(DateTimeZone.UTC, zone);
+    }
+    
+    @Test
     public void emptyOrNullReturnNull() {
         DateTimeZone zone = DateUtils.parseZoneFromOffsetString(null);
         assertNull(zone);

--- a/test/org/sagebionetworks/bridge/json/DateUtilsTest.java
+++ b/test/org/sagebionetworks/bridge/json/DateUtilsTest.java
@@ -203,6 +203,15 @@ public class DateUtilsTest {
     }
     
     @Test
+    public void canParseHalfOffsets() {
+        DateTimeZone timeZone = DateUtils.parseZoneFromOffsetString("-07:30");
+        assertEquals("-07:30", timeZone.toString());
+        
+        timeZone = DateUtils.parseZoneFromOffsetString("+05:45");
+        assertEquals("+05:45", timeZone.toString());
+    }
+    
+    @Test
     public void getDateTimeOrDefaultReturnsDefaultOnNull() {
         DateTime timestamp = DateTime.now();
         
@@ -221,6 +230,16 @@ public class DateUtilsTest {
     @Test(expected = BadRequestException.class)
     public void getDateTimeOrDefaultThrowsException() {
         DateUtils.getDateTimeOrDefault("6/7/2016", null);
+    }
+    
+    @Test
+    public void testTimeZoneToOffsetString() {
+        assertEquals("+00:00", DateUtils.timeZoneToOffsetString(DateTimeZone.forOffsetHours(0)));
+        assertEquals("+00:00", DateUtils.timeZoneToOffsetString(DateTimeZone.UTC));
+        assertEquals("+07:00", DateUtils.timeZoneToOffsetString(DateTimeZone.forOffsetHours(7)));
+        assertEquals("-05:00", DateUtils.timeZoneToOffsetString(DateTimeZone.forOffsetHours(-5)));
+        assertEquals("-05:30", DateUtils.timeZoneToOffsetString(DateTimeZone.forOffsetHoursMinutes(-5, 30)));
+        assertEquals("+02:30", DateUtils.timeZoneToOffsetString(DateTimeZone.forOffsetHoursMinutes(2, 30)));
     }
     
     // This method is dealing with local time, but we're casting to UTC so that 

--- a/test/org/sagebionetworks/bridge/play/controllers/ScheduledActivityControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ScheduledActivityControllerTest.java
@@ -160,6 +160,16 @@ public class ScheduledActivityControllerTest {
     }
     
     @Test
+    public void utcTimeZoneParsedCorrectly() throws Exception {
+        controller.getScheduledActivities(null, "+0:00", "3", "5");
+        
+        verify(scheduledActivityService).getScheduledActivities(contextCaptor.capture());
+        ScheduleContext context = contextCaptor.getValue();
+        assertEquals("+00:00", context.getInitialTimeZone().toString());
+        
+    }
+    
+    @Test
     public void getScheduledActivtiesAssemblesCorrectContext() throws Exception {
         List<ScheduledActivity> list = Lists.newArrayList();
         scheduledActivityService = mock(ScheduledActivityService.class);

--- a/test/org/sagebionetworks/bridge/services/ParticipantOptionsServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantOptionsServiceTest.java
@@ -112,6 +112,13 @@ public class ParticipantOptionsServiceTest {
     }
     
     @Test
+    public void setTimeZoneUTC() {
+        service.setDateTimeZone(TEST_STUDY, HEALTH_CODE, TIME_ZONE, DateTimeZone.UTC);
+        verify(mockDao).setOption(TEST_STUDY, HEALTH_CODE, TIME_ZONE, "+00:00");
+        verifyNoMoreInteractions(mockDao);
+    }
+    
+    @Test
     public void setAllOptions() {
         Map<ParticipantOption,String> options = Maps.newHashMap();
         service.setAllOptions(TEST_STUDY, HEALTH_CODE, options);


### PR DESCRIPTION
When you parse "+00:00" into a Joda DateTimeZone object, and call toString() on it, you get back the string "UTC". Changed ParticipantOption to preserve this as "+00:00" and improved our utility for parsing time zones so it returns DateTimeZone.UTC if it encounters "UTC" as the string.

This is the only case I could find of this in the documentation, the other offsets are recorded as we'd expect, so far as I can tell.