### PR TITLE
Add constraint check to verify that compound activity definition is not currently in use in a schedule.

### DIFF
--- a/app/org/sagebionetworks/bridge/services/CompoundActivityDefinitionService.java
+++ b/app/org/sagebionetworks/bridge/services/CompoundActivityDefinitionService.java
@@ -109,7 +109,6 @@ public class CompoundActivityDefinitionService {
         return compoundActivityDefDao.updateCompoundActivityDefinition(compoundActivityDefinition);
     }
     
-    
     private void checkConstraintViolations(StudyIdentifier studyId, String taskId) {
         // Cannot delete a definition if it is referenced in any schedule plan.
         List<SchedulePlan> plans = schedulePlanService.getSchedulePlans(ClientInfo.UNKNOWN_CLIENT, studyId);


### PR DESCRIPTION
Cannot delete a CompoundActivityDefinition if a CompoundActivity refers to it (through the task ID).