### PR TITLE
Enforce manual creation of activity GUID on schedule plan create

### DIFF
--- a/app/org/sagebionetworks/bridge/models/schedules/Activity.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/Activity.java
@@ -152,11 +152,6 @@ public final class Activity implements BridgeEntity {
             return this;
         }
         public Activity build() {
-            /*
-            if (guid == null) {
-                guid = BridgeUtils.generateGuid();
-            }
-            */
             ActivityType activityType = null;
             if (compoundActivity != null) {
                 activityType = COMPOUND;

--- a/app/org/sagebionetworks/bridge/models/schedules/Activity.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/Activity.java
@@ -7,7 +7,6 @@ import static org.sagebionetworks.bridge.models.schedules.ActivityType.TASK;
 import java.util.Objects;
 
 import org.joda.time.DateTime;
-import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.models.BridgeEntity;
 
@@ -153,10 +152,11 @@ public final class Activity implements BridgeEntity {
             return this;
         }
         public Activity build() {
+            /*
             if (guid == null) {
                 guid = BridgeUtils.generateGuid();
             }
-
+            */
             ActivityType activityType = null;
             if (compoundActivity != null) {
                 activityType = COMPOUND;

--- a/app/org/sagebionetworks/bridge/services/SchedulePlanService.java
+++ b/app/org/sagebionetworks/bridge/services/SchedulePlanService.java
@@ -60,14 +60,17 @@ public class SchedulePlanService {
         plan.setVersion(null);
         plan.setGuid(BridgeUtils.generateGuid());
         
-        List<Schedule> schedules = plan.getStrategy().getAllPossibleSchedules();
-        for (Schedule schedule : schedules) {
-            for (int i=0; i < schedule.getActivities().size(); i++) {
-                Activity activity = schedule.getActivities().get(i);
-                
-                Activity activityWithGuid = new Activity.Builder().withActivity(activity)
-                        .withGuid(BridgeUtils.generateGuid()).build();
-                schedule.getActivities().set(i, activityWithGuid);
+        // This can happen if the submission is invalid, we want to proceed to validation
+        if (plan.getStrategy() != null) {
+            List<Schedule> schedules = plan.getStrategy().getAllPossibleSchedules();
+            for (Schedule schedule : schedules) {
+                for (int i=0; i < schedule.getActivities().size(); i++) {
+                    Activity activity = schedule.getActivities().get(i);
+                    
+                    Activity activityWithGuid = new Activity.Builder().withActivity(activity)
+                            .withGuid(BridgeUtils.generateGuid()).build();
+                    schedule.getActivities().set(i, activityWithGuid);
+                }
             }
         }
         Validate.entityThrowingException(new SchedulePlanValidator(study.getDataGroups(), study.getTaskIdentifiers()), plan);
@@ -88,15 +91,18 @@ public class SchedulePlanService {
         SchedulePlan existing = schedulePlanDao.getSchedulePlan(study, plan.getGuid());
         Set<String> existingGuids = getAllActivityGuids(existing);
         
-        List<Schedule> schedules = plan.getStrategy().getAllPossibleSchedules();
-        for (Schedule schedule : schedules) {
-            for (int i=0; i < schedule.getActivities().size(); i++) {
-                Activity activity = schedule.getActivities().get(i);
-                if (activity.getGuid() == null || !existingGuids.contains(activity.getGuid())) {
-                    
-                    Activity activityWithGuid = new Activity.Builder().withActivity(activity)
-                            .withGuid(BridgeUtils.generateGuid()).build();
-                    schedule.getActivities().set(i, activityWithGuid);
+        // This can happen if the submission is invalid, we want to proceed to validation
+        if (plan.getStrategy() != null) {
+            List<Schedule> schedules = plan.getStrategy().getAllPossibleSchedules();
+            for (Schedule schedule : schedules) {
+                for (int i=0; i < schedule.getActivities().size(); i++) {
+                    Activity activity = schedule.getActivities().get(i);
+                    if (activity.getGuid() == null || !existingGuids.contains(activity.getGuid())) {
+                        
+                        Activity activityWithGuid = new Activity.Builder().withActivity(activity)
+                                .withGuid(BridgeUtils.generateGuid()).build();
+                        schedule.getActivities().set(i, activityWithGuid);
+                    }
                 }
             }
         }

--- a/app/org/sagebionetworks/bridge/services/SchedulePlanService.java
+++ b/app/org/sagebionetworks/bridge/services/SchedulePlanService.java
@@ -67,7 +67,6 @@ public class SchedulePlanService {
                 
                 Activity activityWithGuid = new Activity.Builder().withActivity(activity)
                         .withGuid(BridgeUtils.generateGuid()).build();
-                
                 schedule.getActivities().set(i, activityWithGuid);
             }
         }

--- a/app/org/sagebionetworks/bridge/services/SchedulePlanService.java
+++ b/app/org/sagebionetworks/bridge/services/SchedulePlanService.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.util.List;
+import java.util.Set;
 
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.dao.SchedulePlanDao;
@@ -20,6 +21,8 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.surveys.Survey;
 import org.sagebionetworks.bridge.validators.SchedulePlanValidator;
 import org.sagebionetworks.bridge.validators.Validate;
+
+import com.google.common.collect.Sets;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -81,6 +84,23 @@ public class SchedulePlanService {
         // Plan must always be in user's study
         plan.setStudyKey(study.getIdentifier());
         
+        // Verify that all GUIDs that are supplied already exist in the plan. If they don't (or GUID is null),
+        // then add a new GUID.
+        SchedulePlan existing = schedulePlanDao.getSchedulePlan(study, plan.getGuid());
+        Set<String> existingGuids = getAllActivityGuids(existing);
+        
+        List<Schedule> schedules = plan.getStrategy().getAllPossibleSchedules();
+        for (Schedule schedule : schedules) {
+            for (int i=0; i < schedule.getActivities().size(); i++) {
+                Activity activity = schedule.getActivities().get(i);
+                if (activity.getGuid() == null || !existingGuids.contains(activity.getGuid())) {
+                    
+                    Activity activityWithGuid = new Activity.Builder().withActivity(activity)
+                            .withGuid(BridgeUtils.generateGuid()).build();
+                    schedule.getActivities().set(i, activityWithGuid);
+                }
+            }
+        }
         Validate.entityThrowingException(new SchedulePlanValidator(study.getDataGroups(), study.getTaskIdentifiers()), plan);
         
         StudyIdentifier studyId = new StudyIdentifierImpl(plan.getStudyKey());
@@ -94,11 +114,27 @@ public class SchedulePlanService {
         
         schedulePlanDao.deleteSchedulePlan(studyIdentifier, guid);
     }
+    
+    /**
+     * Get all the GUIDs for all the activities that already exist. These are the only GUIDs that should be returned
+     * from the client on an update.
+     */
+    private Set<String> getAllActivityGuids(SchedulePlan plan) {
+        Set<String> activityGuids = Sets.newHashSet();
+        for (Schedule schedule : plan.getStrategy().getAllPossibleSchedules()) {
+            for (int i=0; i < schedule.getActivities().size(); i++) {
+                Activity activity = schedule.getActivities().get(i);
+                activityGuids.add(activity.getGuid());
+            }
+        }
+        return activityGuids;
+    }
 
     /**
      * If the activity has a survey reference, look up the survey's identifier. Don't trust the client to 
      * supply the correct one for the survey's primary keys. We're adding this when writing schedules because 
-     * the clients have come to depend on it, and this is more efficient than looking it up on every read.
+     * the clients have come to depend on the presence of the identifier key, and this is more efficient than 
+     * looking it up on every read.
      * 
      * @param studyId
      * @param activity

--- a/app/org/sagebionetworks/bridge/validators/ActivityValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/ActivityValidator.java
@@ -35,6 +35,9 @@ public class ActivityValidator implements Validator {
         if (isBlank(activity.getLabel())) {
             errors.rejectValue("label", CANNOT_BE_BLANK);
         }
+        if (isBlank(activity.getGuid())) {
+            errors.rejectValue("guid", CANNOT_BE_BLANK);   
+        }
 
         // an activity must be exactly one of: compound, task, or survey
         int numSources = 0;
@@ -100,7 +103,7 @@ public class ActivityValidator implements Validator {
         if (taskIdentifiers.isEmpty()) {
             message += "<no task identifiers declared>";
         } else {
-            message += COMMA_SPACE_JOINER.join(taskIdentifiers) + ".";
+            message += COMMA_SPACE_JOINER.join(taskIdentifiers);
         }
         return message;
     }

--- a/test/org/sagebionetworks/bridge/TestConstants.java
+++ b/test/org/sagebionetworks/bridge/TestConstants.java
@@ -6,7 +6,6 @@ import org.joda.time.DateTime;
 import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
-import org.sagebionetworks.bridge.models.schedules.Activity;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
@@ -43,10 +42,6 @@ public class TestConstants {
     public static final String UPLOAD_BUCKET = BridgeConfigFactory.getConfig().getProperty("upload.bucket");
     
     public static final DateTime ENROLLMENT = DateTime.parse("2015-04-10T10:40:34.000-07:00");
-    
-    public static final Activity TEST_1_ACTIVITY = new Activity.Builder().withLabel("Activity1").withPublishedSurvey("identifier1","AAA").build();
-    public static final Activity TEST_2_ACTIVITY = new Activity.Builder().withLabel("Activity2").withPublishedSurvey("identifier2","BBB").build();
-    public static final Activity TEST_3_ACTIVITY = new Activity.Builder().withLabel("Activity3").withGuid("AAA").withTask("tapTest").build();
     
     /**
      * During tests, must sometimes pause because the underlying query uses a DynamoDB global 

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -79,14 +79,10 @@ public class TestUtils {
 
     /**
      * Asserts that on validation, InvalidEntityException has been thrown with an error key that is the nested path to
-     * the object value that is invalid, and an error message that only uses the end of the key, and thus can be
-     * displayed in a UI for the user.
+     * the object value that is invalid, and the correct error message.
      */
     public static void assertValidatorMessage(Validator validator, Object object, String fieldName, String error) {
         String fieldNameAsLabel = fieldName;
-        if (fieldNameAsLabel.contains(".")) {
-            fieldNameAsLabel = fieldNameAsLabel.substring(fieldNameAsLabel.lastIndexOf(".")+1);
-        }
         if (!error.startsWith(" ")) {
             error = " " + error;
         }
@@ -275,30 +271,46 @@ public class TestUtils {
         
         SchedulePlan plan = new DynamoSchedulePlan();
         plan.setGuid("DDD");
-        plan.setStrategy(getStrategy("P3D", TestConstants.TEST_1_ACTIVITY));
+        plan.setStrategy(getStrategy("P3D", getActivity1()));
         plan.setStudyKey(studyId.getIdentifier());
         plans.add(plan);
         
         plan = new DynamoSchedulePlan();
         plan.setGuid("BBB");
-        plan.setStrategy(getStrategy("P1D", TestConstants.TEST_2_ACTIVITY));
+        plan.setStrategy(getStrategy("P1D", getActivity2()));
         plan.setStudyKey(studyId.getIdentifier());
         plans.add(plan);
         
         plan = new DynamoSchedulePlan();
         plan.setGuid("CCC");
-        plan.setStrategy(getStrategy("P2D", TestConstants.TEST_3_ACTIVITY));
+        plan.setStrategy(getStrategy("P2D", getActivity3()));
         plan.setStudyKey(studyId.getIdentifier());
         plans.add(plan);
 
         return plans;
     }
     
+    public static Activity getActivity1() {
+        return new Activity.Builder().withGuid(BridgeUtils.generateGuid()).withLabel("Activity1")
+                .withPublishedSurvey("identifier1", "AAA").build();
+    }
+    
+    public static Activity getActivity2() {
+        return new Activity.Builder().withGuid(BridgeUtils.generateGuid()).withLabel("Activity2")
+                .withPublishedSurvey("identifier2", "BBB").build();
+    }
+    
+    public static Activity getActivity3() {
+        return new Activity.Builder().withGuid(BridgeUtils.generateGuid()).withLabel("Activity3").withGuid("AAA")
+                .withTask("tapTest").build();
+    }
+    
     public static SchedulePlan getSimpleSchedulePlan(StudyIdentifier studyId) {
         Schedule schedule = new Schedule();
         schedule.setScheduleType(ScheduleType.RECURRING);
         schedule.setCronTrigger("0 0 8 ? * TUE *");
-        schedule.addActivity(new Activity.Builder().withLabel("Do task CCC").withTask("CCC").build());
+        schedule.addActivity(new Activity.Builder().withGuid(BridgeUtils.generateGuid()).withLabel("Do task CCC")
+                .withTask("CCC").build());
         schedule.setExpires(Period.parse("PT60S"));
         schedule.setLabel("Test label for the user");
         
@@ -317,7 +329,8 @@ public class TestUtils {
         Schedule schedule = new Schedule();
         schedule.setScheduleType(ScheduleType.RECURRING);
         schedule.setCronTrigger("0 0 8 ? * TUE *");
-        schedule.addActivity(new Activity.Builder().withLabel("Do task CCC").withTask("CCC").build());
+        schedule.addActivity(new Activity.Builder().withGuid(BridgeUtils.generateGuid()).withLabel("Do task CCC")
+                .withTask("CCC").build());
         schedule.setExpires(Period.parse("PT60S"));
         schedule.setLabel("Test label for the user");
         
@@ -388,21 +401,24 @@ public class TestUtils {
         Schedule schedule1 = new Schedule();
         schedule1.setScheduleType(ScheduleType.RECURRING);
         schedule1.setCronTrigger("0 0 8 ? * TUE *");
-        schedule1.addActivity(new Activity.Builder().withLabel("Do AAA task").withTask("AAA").build());
+        schedule1.addActivity(new Activity.Builder().withGuid(BridgeUtils.generateGuid()).withLabel("Do AAA task")
+                .withTask("AAA").build());
         schedule1.setExpires(Period.parse("PT1H"));
         schedule1.setLabel("Schedule 1");
 
         Schedule schedule2 = new Schedule();
         schedule2.setScheduleType(ScheduleType.RECURRING);
         schedule2.setCronTrigger("0 0 8 ? * TUE *");
-        schedule2.addActivity(new Activity.Builder().withLabel("Do BBB task").withTask("BBB").build());
+        schedule2.addActivity(new Activity.Builder().withGuid(BridgeUtils.generateGuid()).withLabel("Do BBB task")
+                .withTask("BBB").build());
         schedule2.setExpires(Period.parse("PT1H"));
         schedule2.setLabel("Schedule 2");
 
         Schedule schedule3 = new Schedule();
         schedule3.setScheduleType(ScheduleType.RECURRING);
         schedule3.setCronTrigger("0 0 8 ? * TUE *");
-        schedule3.addActivity(new Activity.Builder().withLabel("Do CCC task").withTask("CCC").build());
+        schedule3.addActivity(new Activity.Builder().withGuid(BridgeUtils.generateGuid()).withLabel("Do CCC task")
+                .withTask("CCC").build());
         schedule3.setExpires(Period.parse("PT1H"));
         schedule3.setLabel("Schedule 3");
         
@@ -422,8 +438,8 @@ public class TestUtils {
     }
     
     public static Schedule getSchedule(String label) {
-        Activity activity = new Activity.Builder().withLabel("Test survey")
-                        .withSurvey("identifier", "ABC", TEST_CREATED_ON).build();
+        Activity activity = new Activity.Builder().withGuid(BridgeUtils.generateGuid()).withLabel("Test survey")
+                .withSurvey("identifier", "ABC", TEST_CREATED_ON).build();
 
         Schedule schedule = new Schedule();
         schedule.setLabel(label);

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -311,7 +311,7 @@ public class TestUtils {
         schedule.setCronTrigger("0 0 8 ? * TUE *");
         schedule.addActivity(new Activity.Builder().withGuid(BridgeUtils.generateGuid()).withLabel("Do task CCC")
                 .withTask("CCC").build());
-        schedule.setExpires(Period.parse("PT60S"));
+        schedule.setExpires(Period.parse("PT1H"));
         schedule.setLabel("Test label for the user");
         
         SimpleScheduleStrategy strategy = new SimpleScheduleStrategy();

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSchedulePlanDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSchedulePlanDaoTest.java
@@ -16,7 +16,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dao.CriteriaDao;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
@@ -176,7 +175,7 @@ public class DynamoSchedulePlanDaoTest {
         CriteriaScheduleStrategy strategy = new CriteriaScheduleStrategy();
         Schedule schedule = new Schedule();
         schedule.setScheduleType(ScheduleType.ONCE);
-        schedule.addActivity(TestConstants.TEST_1_ACTIVITY);
+        schedule.addActivity(TestUtils.getActivity1());
         
         Criteria criteria = TestUtils.createCriteria(2, 8, null, null);
         ScheduleCriteria scheduleCriteria = new ScheduleCriteria(schedule, criteria);
@@ -186,7 +185,7 @@ public class DynamoSchedulePlanDaoTest {
         
         schedule = new Schedule();
         schedule.setScheduleType(ScheduleType.ONCE);
-        schedule.addActivity(TestConstants.TEST_2_ACTIVITY);
+        schedule.addActivity(TestUtils.getActivity2());
         scheduleCriteria = new ScheduleCriteria(schedule, criteria);
         strategy.addCriteria(scheduleCriteria);
         
@@ -197,7 +196,7 @@ public class DynamoSchedulePlanDaoTest {
         
         schedule = new Schedule();
         schedule.setScheduleType(ScheduleType.ONCE);
-        schedule.addActivity(TestConstants.TEST_3_ACTIVITY);
+        schedule.addActivity(TestUtils.getActivity3());
         scheduleCriteria = new ScheduleCriteria(schedule, criteria);
         strategy.getScheduleCriteria().set(1, scheduleCriteria);
         

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSchedulePlanTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSchedulePlanTest.java
@@ -8,7 +8,6 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Test;
 
-import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.schedules.SchedulePlan;
@@ -30,7 +29,7 @@ public class DynamoSchedulePlanTest {
     public void canSerializeDynamoSchedulePlan() throws Exception {
         DateTime datetime = DateTime.now().withZone(DateTimeZone.UTC);
         
-        ScheduleStrategy strategy = TestUtils.getStrategy("P1D", TestConstants.TEST_1_ACTIVITY);
+        ScheduleStrategy strategy = TestUtils.getStrategy("P1D", TestUtils.getActivity1());
         
         DynamoSchedulePlan plan = new DynamoSchedulePlan();
         plan.setLabel("Label");

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDaoMockTest.java
@@ -24,7 +24,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.sagebionetworks.bridge.BridgeUtils;
-import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
@@ -50,7 +49,7 @@ public class DynamoScheduledActivityDaoMockTest {
     private static final String BASE_URL = BridgeConfigFactory.getConfig().getWebservicesURL();
     private static final String ACTIVITY_1_REF = BASE_URL + "/v3/surveys/AAA/revisions/published";
     private static final String ACTIVITY_2_REF = BASE_URL + "/v3/surveys/BBB/revisions/published";
-    private static final String ACTIVITY_3_REF = TestConstants.TEST_3_ACTIVITY.getTask().getIdentifier();
+    private static final String ACTIVITY_3_REF = TestUtils.getActivity3().getTask().getIdentifier();
     
     private DynamoDBMapper mapper;
 
@@ -208,13 +207,13 @@ public class DynamoScheduledActivityDaoMockTest {
     public void canUpdateActivities() {
         DynamoScheduledActivity activity1 = new DynamoScheduledActivity();
         activity1.setHealthCode(HEALTH_CODE);
-        activity1.setActivity(TestConstants.TEST_3_ACTIVITY);
+        activity1.setActivity(TestUtils.getActivity3());
         activity1.setLocalScheduledOn(LocalDateTime.parse("2015-04-11T13:00:00"));
         activity1.setGuid(BridgeUtils.generateGuid());
 
         DynamoScheduledActivity activity2 = new DynamoScheduledActivity();
         activity2.setHealthCode(HEALTH_CODE);
-        activity2.setActivity(TestConstants.TEST_3_ACTIVITY);
+        activity2.setActivity(TestUtils.getActivity3());
         activity2.setLocalScheduledOn(LocalDateTime.parse("2015-04-11T13:00:00"));
         activity2.setStartedOn(DateTime.parse("2015-04-13T18:05:23.000-07:00").getMillis());
         activity2.setFinishedOn(DateTime.parse("2015-04-13T18:20:23.000-07:00").getMillis());

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDaoTest.java
@@ -21,7 +21,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.sagebionetworks.bridge.BridgeUtils;
-import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.PagedResourceList;
@@ -69,7 +68,7 @@ public class DynamoScheduledActivityDaoTest {
         schedule.setInterval("P1D");
         schedule.setExpires("PT6H");
         schedule.addTimes("10:00", "14:00");
-        schedule.addActivity(TestConstants.TEST_3_ACTIVITY);
+        schedule.addActivity(TestUtils.getActivity3());
         
         SimpleScheduleStrategy strategy = new SimpleScheduleStrategy();
         strategy.setSchedule(schedule);
@@ -205,22 +204,22 @@ public class DynamoScheduledActivityDaoTest {
         List<SchedulePlan> plans = Lists.newArrayList();
         SchedulePlan testPlan = new DynamoSchedulePlan();
         testPlan.setGuid(BridgeUtils.generateGuid());
-        testPlan.setStrategy(TestUtils.getStrategy("P2D", new Activity.Builder().withLabel("Activity4")
-                .withTask("tapTest").build()));
+        testPlan.setStrategy(TestUtils.getStrategy("P2D", new Activity.Builder().withGuid(BridgeUtils.generateGuid())
+                .withLabel("Activity4").withTask("tapTest").build()));
         testPlan.setStudyKey(TEST_STUDY.getIdentifier());
         plans.add(testPlan);
 
         SchedulePlan testPlan2 = new DynamoSchedulePlan();
         testPlan2.setGuid(BridgeUtils.generateGuid());
-        testPlan2.setStrategy(TestUtils.getStrategy("P2D", new Activity.Builder().withLabel("Activity5")
-                .withTask("anotherTapTest").build()));
+        testPlan2.setStrategy(TestUtils.getStrategy("P2D", new Activity.Builder().withGuid(BridgeUtils.generateGuid())
+                .withLabel("Activity5").withTask("anotherTapTest").build()));
         testPlan2.setStudyKey(TEST_STUDY.getIdentifier());
         plans.add(testPlan2);
         
         SchedulePlan testPlan3 = new DynamoSchedulePlan();
         testPlan3.setGuid(BridgeUtils.generateGuid());
-        testPlan3.setStrategy(TestUtils.getStrategy("P2D", new Activity.Builder().withLabel("Activity6")
-                .withTask("yetAnotherTapTest").build()));
+        testPlan3.setStrategy(TestUtils.getStrategy("P2D", new Activity.Builder().withGuid(BridgeUtils.generateGuid())
+                .withLabel("Activity6").withTask("yetAnotherTapTest").build()));
         testPlan3.setStudyKey(TEST_STUDY.getIdentifier());
         plans.add(testPlan3);
         

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityTest.java
@@ -15,7 +15,6 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDateTime;
 import org.junit.Test;
-import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoScheduledActivity;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
@@ -39,13 +38,13 @@ public class DynamoScheduledActivityTest {
         DynamoScheduledActivity activity1 = new DynamoScheduledActivity();
         activity1.setTimeZone(DateTimeZone.UTC);
         activity1.setLocalScheduledOn(LocalDateTime.parse("2010-10-10T01:01:01.000"));
-        activity1.setActivity(TestConstants.TEST_3_ACTIVITY);
+        activity1.setActivity(TestUtils.getActivity3());
         
         // Definitely later
         DynamoScheduledActivity activity2 = new DynamoScheduledActivity();
         activity2.setTimeZone(DateTimeZone.UTC);
         activity2.setLocalScheduledOn(LocalDateTime.parse("2011-10-10T01:01:01.000"));
-        activity2.setActivity(TestConstants.TEST_3_ACTIVITY);
+        activity2.setActivity(TestUtils.getActivity3());
         
         // The same as 2 in all respects but activity label comes earlier in alphabet
         DynamoScheduledActivity activity3 = new DynamoScheduledActivity();
@@ -66,12 +65,12 @@ public class DynamoScheduledActivityTest {
         // No time zone
         DynamoScheduledActivity activity1 = new DynamoScheduledActivity();
         activity1.setLocalScheduledOn(LocalDateTime.parse("2010-10-10T01:01:01.000"));
-        activity1.setActivity(TestConstants.TEST_3_ACTIVITY);
+        activity1.setActivity(TestUtils.getActivity3());
         
         // scheduledOn
         DynamoScheduledActivity activity2 = new DynamoScheduledActivity();
         activity2.setTimeZone(DateTimeZone.UTC);
-        activity2.setActivity(TestConstants.TEST_3_ACTIVITY);
+        activity2.setActivity(TestUtils.getActivity3());
         
         // This one is okay
         DynamoScheduledActivity activity3 = new DynamoScheduledActivity();
@@ -99,7 +98,7 @@ public class DynamoScheduledActivityTest {
         
         DynamoScheduledActivity schActivity = new DynamoScheduledActivity();
         schActivity.setTimeZone(DateTimeZone.UTC);
-        schActivity.setActivity(TestConstants.TEST_3_ACTIVITY);
+        schActivity.setActivity(TestUtils.getActivity3());
         schActivity.setLocalScheduledOn(scheduledOn);
         schActivity.setLocalExpiresOn(expiresOn);
         schActivity.setGuid("AAA-BBB-CCC");
@@ -236,7 +235,7 @@ public class DynamoScheduledActivityTest {
         act.setHealthCode("healthCode");
         act.setGuid("activityGuid");
         act.setSchedulePlanGuid("schedulePlanGuid");
-        act.setActivity(TestConstants.TEST_1_ACTIVITY);
+        act.setActivity(TestUtils.getActivity1());
         act.setStartedOn(DateTime.parse("2015-10-10T08:08:08.000Z").getMillis());
         act.setFinishedOn(DateTime.parse("2015-12-05T08:08:08.000Z").getMillis());
         act.setPersistent(true);

--- a/test/org/sagebionetworks/bridge/json/BridgeObjectMapperTest.java
+++ b/test/org/sagebionetworks/bridge/json/BridgeObjectMapperTest.java
@@ -5,7 +5,7 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Ignore;
 import org.junit.Test;
-import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
 import org.sagebionetworks.bridge.models.surveys.Survey;
 
@@ -47,7 +47,7 @@ public class BridgeObjectMapperTest {
         assertTrue(json.indexOf("type") == json.lastIndexOf("type") && json.indexOf("type") > -1);
         
         // This object does not have a filter, should still write a type property
-        json = BridgeObjectMapper.get().writeValueAsString(TestConstants.TEST_1_ACTIVITY);
+        json = BridgeObjectMapper.get().writeValueAsString(TestUtils.getActivity1());
         String prop = "\"type\":\"Activity\"";
         assertTrue(json.indexOf(prop) == json.lastIndexOf(prop) && json.indexOf(prop) > -1);
     }

--- a/test/org/sagebionetworks/bridge/models/schedules/ActivitySchedulerTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/ActivitySchedulerTest.java
@@ -23,7 +23,9 @@ import org.joda.time.Period;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.sagebionetworks.bridge.TestConstants;
+
+import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
 import org.sagebionetworks.bridge.dynamodb.DynamoScheduledActivity;
 import org.sagebionetworks.bridge.validators.ScheduleValidator;
@@ -72,7 +74,7 @@ public class ActivitySchedulerTest {
         Schedule schedule = new Schedule();
         schedule.setScheduleType(ONCE);
         schedule.setDelay("P1D");
-        schedule.addActivity(TestConstants.TEST_3_ACTIVITY);
+        schedule.addActivity(TestUtils.getActivity3());
         
         Map<String,DateTime> empty = Maps.newHashMap();
         
@@ -97,7 +99,7 @@ public class ActivitySchedulerTest {
         Schedule schedule = new Schedule();
         schedule.setScheduleType(ScheduleType.ONCE);
         schedule.setLabel("This is a label");
-        schedule.addActivity(TestConstants.TEST_3_ACTIVITY);
+        schedule.addActivity(TestUtils.getActivity3());
         schedule.setExpires("P3Y");
 
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(NOW.plusWeeks(1)));
@@ -120,12 +122,12 @@ public class ActivitySchedulerTest {
     @Test
     public void activitiesCanBeChainedTogether() throws Exception {
         Schedule schedule = new Schedule();
-        schedule.getActivities().add(TestConstants.TEST_3_ACTIVITY);
+        schedule.getActivities().add(TestUtils.getActivity3());
         schedule.setScheduleType(ONCE);
         schedule.setDelay("P1M");
         
         Schedule schedule2 = new Schedule();
-        schedule2.getActivities().add(TestConstants.TEST_3_ACTIVITY);
+        schedule2.getActivities().add(TestUtils.getActivity3());
         schedule2.setScheduleType(ONCE);
         schedule2.setEventId("task:task1");
 
@@ -148,7 +150,7 @@ public class ActivitySchedulerTest {
     @Test
     public void activitySchedulerWorksInDifferentTimezone() {
         Schedule schedule = new Schedule();
-        schedule.addActivity(TestConstants.TEST_3_ACTIVITY);
+        schedule.addActivity(TestUtils.getActivity3());
         schedule.setEventId("foo");
         schedule.setScheduleType(ScheduleType.ONCE);
         schedule.setDelay("P2D");
@@ -171,7 +173,7 @@ public class ActivitySchedulerTest {
         events.put("anEvent", asDT("2015-04-12 08:31"));
         
         Schedule schedule = new Schedule();
-        schedule.addActivity(TestConstants.TEST_3_ACTIVITY);
+        schedule.addActivity(TestUtils.getActivity3());
         schedule.setScheduleType(ScheduleType.RECURRING);
         schedule.setEventId("anEvent");
         schedule.setInterval("P1D");
@@ -190,7 +192,7 @@ public class ActivitySchedulerTest {
         events.put("anEvent", asDT("2015-04-12 08:31"));
         
         Schedule schedule = new Schedule();
-        schedule.addActivity(TestConstants.TEST_3_ACTIVITY);
+        schedule.addActivity(TestUtils.getActivity3());
         schedule.setScheduleType(ScheduleType.RECURRING);
         schedule.setEventId("anEvent");
         schedule.setCronTrigger("0 0 10 ? * MON,TUE,WED,THU,FRI,SAT,SUN *");
@@ -225,7 +227,7 @@ public class ActivitySchedulerTest {
         // Just fire this each time it is itself completed, and it never expires.
         Schedule schedule = new Schedule();
         schedule.setEventId("scheduledOn:task:foo");
-        schedule.addActivity(TestConstants.TEST_3_ACTIVITY);
+        schedule.addActivity(TestUtils.getActivity3());
         schedule.setScheduleType(ONCE);
         
         events.put("scheduledOn:task:foo", NOW.minusHours(3));
@@ -241,7 +243,7 @@ public class ActivitySchedulerTest {
     public void willSelectFirstEventIdWithARecord() throws Exception {
         Schedule schedule = new Schedule();
         schedule.setEventId("survey:event, enrollment");
-        schedule.addActivity(TestConstants.TEST_3_ACTIVITY);
+        schedule.addActivity(TestUtils.getActivity3());
         schedule.setScheduleType(ONCE);
         
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(NOW.plusDays(1)));
@@ -263,7 +265,7 @@ public class ActivitySchedulerTest {
         
         Schedule schedule = new Schedule();
         schedule.setEventId("survey:event, enrollment");
-        schedule.addActivity(TestConstants.TEST_3_ACTIVITY);
+        schedule.addActivity(TestUtils.getActivity3());
         schedule.setScheduleType(ONCE);
         schedule.addTimes(localTime);
         
@@ -304,7 +306,7 @@ public class ActivitySchedulerTest {
         schedule.setEventId("activity:AAA:finished,enrollment");
         schedule.setLabel("Test");
         schedule.addActivity(new Activity.Builder().withGuid("BBB").withLabel("Bar").withTask("bar").build());
-        schedule.addActivity(TestConstants.TEST_3_ACTIVITY);
+        schedule.addActivity(TestUtils.getActivity3());
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(NOW.plusDays(1)));
         assertFalse(scheduledActivities.get(0).getPersistent());
         assertTrue(scheduledActivities.get(1).getPersistent());
@@ -319,7 +321,7 @@ public class ActivitySchedulerTest {
         schedule.setInterval("P1D");
         schedule.setExpires("P1D");
         schedule.addTimes("10:00");
-        schedule.addActivity(new Activity.Builder().withLabel("Foo").withTask("foo").build());
+        schedule.addActivity(new Activity.Builder().withGuid("guid").withLabel("Foo").withTask("foo").build());
         Validate.entityThrowingException(new ScheduleValidator(Sets.newHashSet("foo")), schedule);
         
         // User is in Moscow, however.
@@ -342,7 +344,8 @@ public class ActivitySchedulerTest {
         schedule.setInterval("P1D");
         schedule.setExpires("P1D");
         schedule.addTimes("10:00");
-        schedule.addActivity(new Activity.Builder().withLabel("Foo").withTask("foo").build());
+        schedule.addActivity(
+                new Activity.Builder().withGuid(BridgeUtils.generateGuid()).withLabel("Foo").withTask("foo").build());
         Validate.entityThrowingException(new ScheduleValidator(Sets.newHashSet("foo")), schedule);
         
         List<ScheduledActivity> activities = schedule.getScheduler().getScheduledActivities(plan, getContext(PST, NOW.plusDays(4)));

--- a/test/org/sagebionetworks/bridge/models/schedules/ActivityTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/ActivityTest.java
@@ -3,7 +3,6 @@ package org.sagebionetworks.bridge.models.schedules;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -55,8 +54,8 @@ public class ActivityTest {
 
     @Test
     public void canSerializeTaskActivity() throws Exception {
-        Activity activity = new Activity.Builder().withLabel("Label")
-            .withLabelDetail("Label Detail").withTask("taskId").build();
+        Activity activity = new Activity.Builder().withGuid("actGuid").withLabel("Label")
+                .withLabelDetail("Label Detail").withTask("taskId").build();
         
         BridgeObjectMapper mapper = BridgeObjectMapper.get();
         String json = mapper.writeValueAsString(activity);
@@ -66,7 +65,7 @@ public class ActivityTest {
         assertEquals("Label Detail", node.get("labelDetail").asText());
         assertEquals("task", node.get("activityType").asText());
         assertEquals("taskId", node.get("task").get("identifier").asText());
-        assertNotNull("guid", node.get("guid"));
+        assertEquals("actGuid", node.get("guid").asText());
         assertEquals("Activity", node.get("type").asText());
         
         JsonNode taskRef = node.get("task");
@@ -82,8 +81,9 @@ public class ActivityTest {
     
     @Test
     public void canSerializeSurveyActivity() throws Exception {
-        Activity activity = new Activity.Builder().withLabel("Label")
-            .withLabelDetail("Label Detail").withSurvey("identifier", "guid", DateTime.parse("2015-01-01T10:10:10Z")).build();
+        Activity activity = new Activity.Builder().withGuid("actGuid").withLabel("Label")
+                .withLabelDetail("Label Detail")
+                .withSurvey("identifier", "guid", DateTime.parse("2015-01-01T10:10:10Z")).build();
         
         BridgeObjectMapper mapper = BridgeObjectMapper.get();
         String json = mapper.writeValueAsString(activity);
@@ -94,7 +94,7 @@ public class ActivityTest {
         assertEquals("survey", node.get("activityType").asText());
         String hrefString = node.get("survey").get("href").asText();
         assertTrue(hrefString.matches("http[s]?://.*/v3/surveys/guid/revisions/2015-01-01T10:10:10.000Z"));
-        assertNotNull("guid", node.get("guid"));
+        assertEquals("actGuid", node.get("guid").asText());
         assertEquals("Activity", node.get("type").asText());
         
         JsonNode ref = node.get("survey");
@@ -119,9 +119,9 @@ public class ActivityTest {
     
     @Test
     public void canSerializePublishedSurveyActivity() throws Exception {
-        Activity activity = new Activity.Builder().withLabel("Label")
-            .withLabelDetail("Label Detail").withPublishedSurvey("identifier", "guid").build();
-        
+        Activity activity = new Activity.Builder().withGuid("actGuid").withLabel("Label")
+                .withLabelDetail("Label Detail").withPublishedSurvey("identifier", "guid").build();
+
         BridgeObjectMapper mapper = BridgeObjectMapper.get();
         String json = mapper.writeValueAsString(activity);
 
@@ -131,7 +131,7 @@ public class ActivityTest {
         assertEquals("survey", node.get("activityType").asText());
         String hrefString = node.get("survey").get("href").asText();
         assertTrue(hrefString.matches("http[s]?://.*/v3/surveys/guid/revisions/published"));
-        assertNotNull("guid", node.get("guid"));
+        assertEquals("actGuid", node.get("guid").asText());
         assertEquals("Activity", node.get("type").asText());
         
         JsonNode ref = node.get("survey");
@@ -185,12 +185,6 @@ public class ActivityTest {
         Activity activity = new Activity.Builder().withSurvey("identifier", "guid", null).withLabel("Label").build();
         
         assertTrue(activity.getSurvey().getHref().matches("http[s]?://.*/v3/surveys/guid/revisions/published"));
-    }
-    
-    @Test
-    public void createAGuidIfNoneIsSet() throws Exception {
-        Activity activity = new Activity.Builder().withTask("task").withLabel("Label").build();
-        assertNotNull(activity.getGuid());
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/models/schedules/CriteriaScheduleStrategyTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/CriteriaScheduleStrategyTest.java
@@ -50,7 +50,7 @@ public class CriteriaScheduleStrategyTest {
             "Strategy with all requirements");
     
     private static final SchedulePlanValidator VALIDATOR = new SchedulePlanValidator(Sets.newHashSet(),
-            Sets.newHashSet(TestConstants.TEST_3_ACTIVITY.getTask().getIdentifier()));;
+            Sets.newHashSet(TestUtils.getActivity3().getTask().getIdentifier()));;
     private static final SchedulePlan PLAN = new DynamoSchedulePlan();
     static {
         PLAN.setLabel("Schedule plan label");
@@ -302,8 +302,8 @@ public class CriteriaScheduleStrategyTest {
     
     @Test
     public void validScheduleCriteriaPassesValidation() {
-        Activity activity = new Activity.Builder().withLabel("Label").withTask(TestConstants.TEST_3_ACTIVITY.getTask())
-                .build();
+        Activity activity = new Activity.Builder().withGuid("guid").withLabel("Label")
+                .withTask(TestUtils.getActivity3().getTask()).build();
         Schedule schedule = new Schedule();
         schedule.setScheduleType(ScheduleType.ONCE);
         schedule.addActivity(activity);
@@ -347,7 +347,7 @@ public class CriteriaScheduleStrategyTest {
     
     @Test
     public void validateScheduleCriteriaCriteriaMissing() {
-        Activity activity = new Activity.Builder().withLabel("Label").withTask(TestConstants.TEST_3_ACTIVITY.getTask())
+        Activity activity = new Activity.Builder().withLabel("Label").withTask(TestUtils.getActivity3().getTask())
                 .build();
         Schedule schedule = new Schedule();
         schedule.setScheduleType(ScheduleType.ONCE);
@@ -380,7 +380,7 @@ public class CriteriaScheduleStrategyTest {
         Schedule schedule = new Schedule();
         schedule.setLabel(label);
         schedule.setScheduleType(ScheduleType.ONCE);
-        schedule.addActivity(TestConstants.TEST_3_ACTIVITY);
+        schedule.addActivity(TestUtils.getActivity3());
         return schedule;
     }
 

--- a/test/org/sagebionetworks/bridge/models/schedules/CronActivitySchedulerTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/CronActivitySchedulerTest.java
@@ -5,7 +5,6 @@ import static org.sagebionetworks.bridge.models.schedules.ScheduleTestUtils.asDT
 import static org.sagebionetworks.bridge.models.schedules.ScheduleTestUtils.assertDates;
 import static org.sagebionetworks.bridge.models.schedules.ScheduleType.ONCE;
 import static org.sagebionetworks.bridge.models.schedules.ScheduleType.RECURRING;
-import static org.sagebionetworks.bridge.TestConstants.TEST_3_ACTIVITY;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 
 import java.util.List;
@@ -17,6 +16,8 @@ import org.joda.time.DateTimeZone;
 import org.joda.time.Period;
 import org.junit.Before;
 import org.junit.Test;
+
+import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
 
 import com.google.common.collect.Maps;
@@ -196,7 +197,7 @@ public class CronActivitySchedulerTest {
         Schedule schedule = new Schedule();
         // Wed. and Sat. at 9:15am
         schedule.setCronTrigger("0 15 9 ? * WED,SAT *");
-        schedule.getActivities().add(TEST_3_ACTIVITY);
+        schedule.getActivities().add(TestUtils.getActivity3());
         schedule.setScheduleType(type);
         return schedule;
     }

--- a/test/org/sagebionetworks/bridge/models/schedules/IntervalActivitySchedulerTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/IntervalActivitySchedulerTest.java
@@ -18,7 +18,7 @@ import org.joda.time.DateTimeZone;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
 
 import com.google.common.collect.Maps;
@@ -50,7 +50,7 @@ public class IntervalActivitySchedulerTest {
     @Test
     public void oneWeekAfterEnrollmentAt8amExpireAfter24hours() throws Exception {
         Schedule schedule = new Schedule();
-        schedule.addActivity(TestConstants.TEST_3_ACTIVITY);
+        schedule.addActivity(TestUtils.getActivity3());
         schedule.setScheduleType(ScheduleType.ONCE);
         schedule.setDelay("P1W");
         schedule.addTimes("08:00");
@@ -67,7 +67,7 @@ public class IntervalActivitySchedulerTest {
     @Test
     public void onceWithoutTimesUsesLocalTime() throws Exception {
         Schedule schedule = new Schedule();
-        schedule.addActivity(TestConstants.TEST_3_ACTIVITY);
+        schedule.addActivity(TestUtils.getActivity3());
         schedule.setScheduleType(ScheduleType.ONCE);
         schedule.setExpires("P2M");
         
@@ -509,7 +509,7 @@ public class IntervalActivitySchedulerTest {
     @Test
     public void oneDayDelayWithTimesSchedulesTheNextDayAfterAnEvent() {
         Schedule schedule = new Schedule();
-        schedule.getActivities().add(TestConstants.TEST_3_ACTIVITY);
+        schedule.getActivities().add(TestUtils.getActivity3());
         schedule.setScheduleType(ScheduleType.RECURRING);
         schedule.setEventId("survey:AAA:completedOn");
         schedule.setDelay("P1D");
@@ -531,7 +531,7 @@ public class IntervalActivitySchedulerTest {
     @Test
     public void recurringWithWindowAndMinTasksWorks() {
         Schedule schedule = new Schedule();
-        schedule.getActivities().add(TestConstants.TEST_1_ACTIVITY);
+        schedule.getActivities().add(TestUtils.getActivity1());
         schedule.setScheduleType(ScheduleType.RECURRING);
         schedule.setExpires("P5D");
         schedule.setInterval("P1W");
@@ -565,7 +565,7 @@ public class IntervalActivitySchedulerTest {
         events.put("enrollment", enrollment);
         
         Schedule schedule = new Schedule();
-        schedule.getActivities().add(TestConstants.TEST_1_ACTIVITY);
+        schedule.getActivities().add(TestUtils.getActivity1());
         schedule.setScheduleType(ScheduleType.RECURRING);
         schedule.setExpires("P1D");
         schedule.setInterval("P1D");
@@ -591,7 +591,7 @@ public class IntervalActivitySchedulerTest {
         events.put("enrollment", enrollment);
         
         Schedule schedule = new Schedule();
-        schedule.getActivities().add(TestConstants.TEST_1_ACTIVITY);
+        schedule.getActivities().add(TestUtils.getActivity1());
         schedule.setScheduleType(ScheduleType.RECURRING);
         schedule.setExpires("P1D");
         schedule.setInterval("P1D");
@@ -625,7 +625,7 @@ public class IntervalActivitySchedulerTest {
     private Schedule createScheduleWith(ScheduleType type) {
         Schedule schedule = new Schedule();
         schedule.addTimes("09:40", "13:40");
-        schedule.getActivities().add(TestConstants.TEST_3_ACTIVITY);
+        schedule.getActivities().add(TestUtils.getActivity3());
         schedule.setScheduleType(type);
         if (type == RECURRING) {
             schedule.setInterval("P2D");

--- a/test/org/sagebionetworks/bridge/models/schedules/PersistentActivitySchedulerTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/PersistentActivitySchedulerTest.java
@@ -17,7 +17,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
 
 import com.google.common.collect.Maps;
@@ -43,7 +43,7 @@ public class PersistentActivitySchedulerTest {
         
         schedule = new Schedule();
         schedule.setEventId("enrollment");
-        schedule.getActivities().add(TestConstants.TEST_3_ACTIVITY);
+        schedule.getActivities().add(TestUtils.getActivity3());
         schedule.setScheduleType(ScheduleType.PERSISTENT);
     }
     
@@ -113,13 +113,13 @@ public class PersistentActivitySchedulerTest {
         schedule.setScheduleType(ScheduleType.ONCE);
         
         assertTrue(schedule.getPersistent());
-        assertTrue(TestConstants.TEST_3_ACTIVITY.isPersistentlyRescheduledBy(schedule));
+        assertTrue(TestUtils.getActivity3().isPersistentlyRescheduledBy(schedule));
         assertTrue(schedule.schedulesImmediatelyAfterEvent());
         
         schedule.setEventId("activity:BBB:finished,enrollment");
         schedule.setDelay("P1D");
         assertFalse(schedule.getPersistent());
-        assertFalse(TestConstants.TEST_3_ACTIVITY.isPersistentlyRescheduledBy(schedule));
+        assertFalse(TestUtils.getActivity3().isPersistentlyRescheduledBy(schedule));
         assertFalse(schedule.schedulesImmediatelyAfterEvent());
     }
     

--- a/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
@@ -686,7 +686,7 @@ public class ParticipantControllerTest {
         List<ScheduledActivity> list = Lists.newArrayList();
         
         DynamoScheduledActivity activity = new DynamoScheduledActivity();
-        activity.setActivity(TestConstants.TEST_1_ACTIVITY);
+        activity.setActivity(TestUtils.getActivity1());
         activity.setHealthCode("healthCode");
         activity.setSchedulePlanGuid("schedulePlanGuid");
         list.add(activity);

--- a/test/org/sagebionetworks/bridge/play/controllers/SchedulePlanControllerMockTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SchedulePlanControllerMockTest.java
@@ -3,62 +3,158 @@ package org.sagebionetworks.bridge.play.controllers;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.sagebionetworks.bridge.Roles.DEVELOPER;
+
+import java.util.List;
 
 import static org.mockito.Mockito.spy;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import org.sagebionetworks.bridge.Roles;
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
-import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.ClientInfo;
+import org.sagebionetworks.bridge.models.GuidVersionHolder;
+import org.sagebionetworks.bridge.models.ResourceList;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.schedules.ABTestScheduleStrategy;
 import org.sagebionetworks.bridge.models.schedules.Activity;
 import org.sagebionetworks.bridge.models.schedules.Schedule;
 import org.sagebionetworks.bridge.models.schedules.SchedulePlan;
 import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.services.SchedulePlanService;
 import org.sagebionetworks.bridge.services.StudyService;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.collect.Lists;
+
+import play.mvc.Result;
+import play.test.Helpers;
+
+@RunWith(MockitoJUnitRunner.class)
 public class SchedulePlanControllerMockTest {
 
     private SchedulePlanController controller;
+    
+    @Mock
+    private StudyService mockStudyService;
+    
+    @Mock
+    private SchedulePlanService mockSchedulePlanService;
+    
+    @Mock
+    private UserSession mockUserSession;
+    
+    @Captor
+    private ArgumentCaptor<SchedulePlan> schedulePlanCaptor;
+    
+    private Study study;
     
     @Before
     public void before() {
         controller = spy(new SchedulePlanController());
         
-        Study study = new DynamoStudy();
+        study = new DynamoStudy();
         study.setIdentifier("test-study");
         
-        StudyService studyService = mock(StudyService.class);
-        when(studyService.getStudy(study.getStudyIdentifier())).thenReturn(study);
-        controller.setStudyService(studyService);
+        when(mockStudyService.getStudy(study.getStudyIdentifier())).thenReturn(study);
+        controller.setStudyService(mockStudyService);
+        controller.setSchedulePlanService(mockSchedulePlanService);
         
-        SchedulePlanService schedulePlanService = new SchedulePlanService();
-        controller.setSchedulePlanService(schedulePlanService);
-        
-        UserSession session = mock(UserSession.class);
-        when(session.getStudyIdentifier()).thenReturn(new StudyIdentifierImpl("test-study"));
-        doReturn(session).when(controller).getAuthenticatedSession(any(Roles.class));
+        when(mockUserSession.getStudyIdentifier()).thenReturn(new StudyIdentifierImpl("test-study"));
+        doReturn(mockUserSession).when(controller).getAuthenticatedSession(any(Roles.class));
     }
 
-    private void assertMessage(InvalidEntityException e, String key, String error) {
-        String message = e.getErrors().get(key).get(0);
-        assertEquals(key + " " + error, message);
+    @Test
+    public void testCreateSchedulePlan() throws Exception {
+        SchedulePlan plan = createSchedulePlan();
+
+        String json = BridgeObjectMapper.get().writeValueAsString(plan);
+        TestUtils.mockPlayContextWithJson(json);
+        
+        when(mockSchedulePlanService.createSchedulePlan(eq(study), any())).thenReturn(plan);
+        
+        controller.createSchedulePlan();
+        
+        verify(mockSchedulePlanService).createSchedulePlan(eq(study), schedulePlanCaptor.capture());
+        
+        SchedulePlan savedPlan = schedulePlanCaptor.getValue();
+        assertEquals(plan, savedPlan);
+    }
+
+    @Test
+    public void updateSchedulePlan() throws Exception {
+        SchedulePlan plan = createSchedulePlan();
+
+        String json = BridgeObjectMapper.get().writeValueAsString(plan);
+        TestUtils.mockPlayContextWithJson(json);
+        
+        when(mockSchedulePlanService.updateSchedulePlan(eq(study), any())).thenReturn(plan);
+        
+        controller.updateSchedulePlan(plan.getGuid());
+        
+        verify(mockSchedulePlanService).updateSchedulePlan(eq(study), schedulePlanCaptor.capture());
+        
+        SchedulePlan savedPlan = schedulePlanCaptor.getValue();
+        assertEquals(plan, savedPlan);
     }
     
     @Test
-    public void createSchedulePlanReturnsCompleteErrors() throws Exception {
-        // This plan has many problems, and the message should go all the way through 
-        // errors even into the second activity and report them back in the exception
+    public void getSchedulePlans() throws Exception {
+        List<SchedulePlan> plans = Lists.newArrayList(TestUtils.getSimpleSchedulePlan(TestConstants.TEST_STUDY));
+        
+        when(mockSchedulePlanService.getSchedulePlans(any(), eq(study.getStudyIdentifier()))).thenReturn(plans);
+        
+        Result result = controller.getSchedulePlans();
+        assertEquals(200, result.status());
+        
+        verify(mockSchedulePlanService).getSchedulePlans(any(), eq(study.getStudyIdentifier()));
+        
+        ResourceList<SchedulePlan> retrieved = BridgeObjectMapper.get().readValue(Helpers.contentAsString(result), new TypeReference<ResourceList<SchedulePlan>>() {});
+        assertEquals(1, retrieved.getItems().size());
+        assertEquals(plans.get(0).getGuid(), retrieved.getItems().get(0).getGuid());
+    }
+    
+    @Test
+    public void getSchedulePlan() throws Exception {
+        SchedulePlan plan = TestUtils.getSimpleSchedulePlan(TestConstants.TEST_STUDY);
+        plan.setGuid("GGG");
+        
+        when(mockSchedulePlanService.getSchedulePlan(study.getStudyIdentifier(), "GGG")).thenReturn(plan);
+        
+        Result result = controller.getSchedulePlan("GGG");
+        assertEquals(200, result.status());
+        
+        verify(mockSchedulePlanService).getSchedulePlan(study.getStudyIdentifier(), "GGG");
+        
+        SchedulePlan retrieved = BridgeObjectMapper.get().readValue(Helpers.contentAsString(result), SchedulePlan.class);
+        assertEquals(plan.getGuid(), retrieved.getGuid());
+    }
+    
+    @Test
+    public void deleteSchedulePlan() {
+        Result result = controller.deleteSchedulePlan("GGG");
+        assertEquals(200, result.status());
+        
+        verify(mockSchedulePlanService).deleteSchedulePlan(study.getStudyIdentifier(), "GGG");
+    }
+    
+    private SchedulePlan createSchedulePlan() {
         ABTestScheduleStrategy strategy = new ABTestScheduleStrategy();
         Schedule schedule = new Schedule();
         strategy.addGroup(50, schedule);
@@ -68,21 +164,8 @@ public class SchedulePlanControllerMockTest {
         strategy.addGroup(20, schedule);
         
         SchedulePlan plan = new DynamoSchedulePlan();
+        plan.setGuid("schedulePlanGuid");
         plan.setStrategy(strategy);
-
-        String json = BridgeObjectMapper.get().writeValueAsString(plan);
-        TestUtils.mockPlayContextWithJson(json);
-        
-        try {
-            controller.updateSchedulePlan("test-study");
-        } catch(InvalidEntityException e) {
-            assertMessage(e, "label", "cannot be missing, null, or blank");
-            assertMessage(e, "strategy.scheduleGroups", "groups must add up to 100%");
-            assertMessage(e, "strategy.scheduleGroups[0].schedule.activities", "are required");
-            assertMessage(e, "strategy.scheduleGroups[0].schedule.scheduleType", "is required");
-            assertMessage(e, "strategy.scheduleGroups[1].schedule.scheduleType", "is required");
-            assertMessage(e, "strategy.scheduleGroups[1].schedule.activities[0].activity",
-                    "must have exactly one of compound activity, task, or survey");
-        }
+        return plan;
     }
 }

--- a/test/org/sagebionetworks/bridge/play/controllers/SchedulePlanControllerMockTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SchedulePlanControllerMockTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 
 import java.util.List;
 
@@ -26,8 +25,6 @@ import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
-import org.sagebionetworks.bridge.models.ClientInfo;
-import org.sagebionetworks.bridge.models.GuidVersionHolder;
 import org.sagebionetworks.bridge.models.ResourceList;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.schedules.ABTestScheduleStrategy;
@@ -35,7 +32,6 @@ import org.sagebionetworks.bridge.models.schedules.Activity;
 import org.sagebionetworks.bridge.models.schedules.Schedule;
 import org.sagebionetworks.bridge.models.schedules.SchedulePlan;
 import org.sagebionetworks.bridge.models.studies.Study;
-import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.services.SchedulePlanService;
 import org.sagebionetworks.bridge.services.StudyService;

--- a/test/org/sagebionetworks/bridge/play/controllers/ScheduledActivityControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ScheduledActivityControllerTest.java
@@ -99,7 +99,7 @@ public class ScheduledActivityControllerTest {
         schActivity.setTimeZone(DateTimeZone.UTC);
         schActivity.setGuid(BridgeUtils.generateGuid());
         schActivity.setLocalScheduledOn(LocalDateTime.now().minusDays(1));
-        schActivity.setActivity(TestConstants.TEST_3_ACTIVITY);
+        schActivity.setActivity(TestUtils.getActivity3());
         List<ScheduledActivity> list = Lists.newArrayList(schActivity);
         
         String json = BridgeObjectMapper.get().writeValueAsString(list);

--- a/test/org/sagebionetworks/bridge/services/ActivityEventServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ActivityEventServiceTest.java
@@ -15,7 +15,7 @@ import org.joda.time.LocalDateTime;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dao.ActivityEventDao;
 import org.sagebionetworks.bridge.dynamodb.DynamoActivityEvent.Builder;
 import org.sagebionetworks.bridge.models.activities.ActivityEvent;
@@ -158,7 +158,7 @@ public class ActivityEventServiceTest {
         
         ScheduledActivity schActivity = ScheduledActivity.create();
         schActivity.setGuid("AAA:"+DateTime.now().toLocalDateTime());
-        schActivity.setActivity(TestConstants.TEST_1_ACTIVITY);
+        schActivity.setActivity(TestUtils.getActivity1());
         schActivity.setLocalExpiresOn(LocalDateTime.now().plusDays(1));
         schActivity.setStartedOn(DateTime.now().getMillis());
         schActivity.setFinishedOn(finishedOn);

--- a/test/org/sagebionetworks/bridge/services/SchedulePlanServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/SchedulePlanServiceMockTest.java
@@ -109,11 +109,9 @@ public class SchedulePlanServiceMockTest {
 
     @Test
     public void doNotUseIdentifierFromClient() {
-        
-        
         // The survey GUID/createdOn identify a survey, but the identifier from the client can just be 
         // mismatched by the client, so ignore it and look it up from the DB using the primary keys.
-        Activity activity = new Activity.Builder().withLabel("A survey activity")
+        Activity activity = new Activity.Builder().withGuid("guid").withLabel("A survey activity")
                 .withPublishedSurvey("junkIdentifier", surveyGuid1).build();
         SchedulePlan plan = createSchedulePlan();
         plan.getStrategy().getAllPossibleSchedules().get(0).getActivities().set(0, activity);
@@ -195,7 +193,7 @@ public class SchedulePlanServiceMockTest {
             service.createSchedulePlan(study, plan);
             fail("Should have thrown exception");
         } catch(InvalidEntityException e) {
-            assertEquals("strategy.scheduleCriteria[0].schedule.activities[0].task.identifier 'DDD' is not in enumeration: taskGuid, CCC, tapTest.", e.getErrors().get("strategy.scheduleCriteria[0].schedule.activities[0].task.identifier").get(0));
+            assertEquals("strategy.scheduleCriteria[0].schedule.activities[0].task.identifier 'DDD' is not in enumeration: taskGuid, CCC, tapTest", e.getErrors().get("strategy.scheduleCriteria[0].schedule.activities[0].task.identifier").get(0));
             assertEquals("strategy.scheduleCriteria[0].criteria.allOfGroups 'FFF' is not in enumeration: AAA", e.getErrors().get("strategy.scheduleCriteria[0].criteria.allOfGroups").get(0));
         }
     }
@@ -208,7 +206,7 @@ public class SchedulePlanServiceMockTest {
             service.updateSchedulePlan(study, plan);
             fail("Should have thrown exception");
         } catch(InvalidEntityException e) {
-            assertEquals("strategy.scheduleCriteria[0].schedule.activities[0].task.identifier 'DDD' is not in enumeration: taskGuid, CCC, tapTest.", e.getErrors().get("strategy.scheduleCriteria[0].schedule.activities[0].task.identifier").get(0));
+            assertEquals("strategy.scheduleCriteria[0].schedule.activities[0].task.identifier 'DDD' is not in enumeration: taskGuid, CCC, tapTest", e.getErrors().get("strategy.scheduleCriteria[0].schedule.activities[0].task.identifier").get(0));
             assertEquals("strategy.scheduleCriteria[0].criteria.allOfGroups 'FFF' is not in enumeration: AAA", e.getErrors().get("strategy.scheduleCriteria[0].criteria.allOfGroups").get(0));
         }
     }
@@ -249,9 +247,9 @@ public class SchedulePlanServiceMockTest {
         // No identifier, which is the key here. This is valid, but we fill it out during saves as a convenience 
         // for the client. No longer required in the API.
         // Create a schedule plan with 3 activities to verify all activities are processed.
-        schedule.addActivity(new Activity.Builder().withLabel("Activity 1").withPublishedSurvey(null, surveyGuid1).build());
-        schedule.addActivity(new Activity.Builder().withLabel("Activity 2").withTask("taskGuid").build());
-        schedule.addActivity(new Activity.Builder().withLabel("Activity 3").withSurvey(null, surveyGuid2, DateTime.now()).build());
+        schedule.addActivity(new Activity.Builder().withGuid("A").withLabel("Activity 1").withPublishedSurvey(null, surveyGuid1).build());
+        schedule.addActivity(new Activity.Builder().withGuid("B").withLabel("Activity 2").withTask("taskGuid").build());
+        schedule.addActivity(new Activity.Builder().withGuid("C").withLabel("Activity 3").withSurvey(null, surveyGuid2, DateTime.now()).build());
         
         SimpleScheduleStrategy strategy = new SimpleScheduleStrategy();
         strategy.setSchedule(schedule);

--- a/test/org/sagebionetworks/bridge/services/SchedulePlanServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/SchedulePlanServiceMockTest.java
@@ -19,6 +19,7 @@ import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dao.SchedulePlanDao;
 import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
@@ -94,11 +95,13 @@ public class SchedulePlanServiceMockTest {
         SchedulePlan plan = createSchedulePlan();
         
         ArgumentCaptor<SchedulePlan> spCaptor = ArgumentCaptor.forClass(SchedulePlan.class);
+        when(mockSchedulePlanDao.getSchedulePlan(study, plan.getGuid())).thenReturn(plan);
         when(mockSchedulePlanDao.updateSchedulePlan(any(), any())).thenReturn(plan);
         
         service.updateSchedulePlan(study, plan);
         verify(mockSurveyService).getSurveyMostRecentlyPublishedVersion(any(), any());
         verify(mockSurveyService).getSurvey(any());
+        verify(mockSchedulePlanDao).getSchedulePlan(study, plan.getGuid());
         verify(mockSchedulePlanDao).updateSchedulePlan(any(), spCaptor.capture());
         
         List<Activity> activities = spCaptor.getValue().getStrategy().getAllPossibleSchedules().get(0).getActivities();
@@ -116,6 +119,8 @@ public class SchedulePlanServiceMockTest {
         SchedulePlan plan = createSchedulePlan();
         plan.getStrategy().getAllPossibleSchedules().get(0).getActivities().set(0, activity);
         
+        when(mockSchedulePlanDao.getSchedulePlan(study, plan.getGuid())).thenReturn(plan);
+        
         // Verify that this was set.
         String identifier = plan.getStrategy().getAllPossibleSchedules().get(0).getActivities().get(0)
                 .getSurvey().getIdentifier();
@@ -127,6 +132,7 @@ public class SchedulePlanServiceMockTest {
         service.updateSchedulePlan(study, plan);
         verify(mockSurveyService).getSurveyMostRecentlyPublishedVersion(any(), any());
         verify(mockSurveyService).getSurvey(any());
+        verify(mockSchedulePlanDao).getSchedulePlan(study, plan.getGuid());
         verify(mockSchedulePlanDao).updateSchedulePlan(any(), spCaptor.capture());
         
         // It was not used.
@@ -179,6 +185,7 @@ public class SchedulePlanServiceMockTest {
         DynamoStudy anotherStudy = getAnotherStudy();
         SchedulePlan plan = getSchedulePlan();
         // Just pass it back, the service should set the studyKey
+        when(mockSchedulePlanDao.getSchedulePlan(anotherStudy, plan.getGuid())).thenReturn(plan);
         when(mockSchedulePlanDao.updateSchedulePlan(any(), any())).thenReturn(plan);
         
         plan = service.updateSchedulePlan(anotherStudy, plan);
@@ -202,6 +209,7 @@ public class SchedulePlanServiceMockTest {
     public void validatesOnUpdate() {
         // Check that 1) validation is called and 2) the study's enumerations are used in the validation
         SchedulePlan plan = createInvalidSchedulePlan();
+        when(mockSchedulePlanDao.getSchedulePlan(study, plan.getGuid())).thenReturn(plan);
         try {
             service.updateSchedulePlan(study, plan);
             fail("Should have thrown exception");

--- a/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceMockTest.java
@@ -33,7 +33,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dao.ScheduledActivityDao;
 import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
@@ -607,7 +606,7 @@ public class ScheduledActivityServiceMockTest {
     @Test
     public void schedulerInterpretsEventToCorrectDate() {
         Schedule schedule = new Schedule();
-        schedule.getActivities().add(TestConstants.TEST_1_ACTIVITY);
+        schedule.getActivities().add(TestUtils.getActivity1());
         schedule.setScheduleType(ScheduleType.RECURRING);
         schedule.setInterval("P1D");
         schedule.addTimes("23:00");
@@ -625,7 +624,7 @@ public class ScheduledActivityServiceMockTest {
     @Test
     public void schedulerInterpetsEventToRightLocalTime() {
         Schedule schedule = new Schedule();
-        schedule.getActivities().add(TestConstants.TEST_1_ACTIVITY);
+        schedule.getActivities().add(TestUtils.getActivity1());
         schedule.setScheduleType(ScheduleType.ONCE);
         schedule.setDelay(Period.parse("PT1H"));
         
@@ -642,7 +641,7 @@ public class ScheduledActivityServiceMockTest {
     @Test
     public void localTimeZonesCorrectlyApplied() {
         Schedule schedule = new Schedule();
-        schedule.getActivities().add(TestConstants.TEST_1_ACTIVITY);
+        schedule.getActivities().add(TestUtils.getActivity1());
         schedule.setScheduleType(ScheduleType.ONCE);
         schedule.setDelay(Period.parse("PT1H"));
         

--- a/test/org/sagebionetworks/bridge/services/SurveyServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SurveyServiceTest.java
@@ -454,7 +454,7 @@ public class SurveyServiceTest {
             surveyService.createSurvey(survey);
             fail("Service should have thrown an exception");
         } catch(InvalidEntityException e) {
-            assertEquals("Survey is invalid: identifier is required; title is required; prompt is required; source must be a valid URL to an image; width is required; height is required", e.getMessage());
+            assertEquals("Survey is invalid: elements[0].identifier is required; elements[0].title is required; elements[0].prompt is required; elements[0].image.source must be a valid URL to an image; elements[0].image.width is required; elements[0].image.height is required", e.getMessage());
         }
     }
 

--- a/test/org/sagebionetworks/bridge/validators/ActivityValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/ActivityValidatorTest.java
@@ -1,14 +1,14 @@
 package org.sagebionetworks.bridge.validators;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
 
 import java.util.Collections;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
-import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
+import org.springframework.validation.Validator;
+
 import org.sagebionetworks.bridge.models.schedules.Activity;
 import org.sagebionetworks.bridge.models.schedules.CompoundActivity;
 
@@ -16,136 +16,92 @@ import com.google.common.collect.Sets;
 
 public class ActivityValidatorTest {
 
-    private static final Set<String> EMPTY_TASKS = Collections.emptySet(); 
+    private static final Set<String> EMPTY_TASKS = Collections.emptySet();
+    private static final Validator VALIDATOR = new ActivityValidator(EMPTY_TASKS);
+    private static final Validator VALIDATOR_WITH_TASKS = new ActivityValidator(ImmutableSet.of("combo-activity"));
     
     @Test
     public void rejectsWithoutLabel() {
-        try {
-            Activity activity = new Activity.Builder().withPublishedSurvey("identifier", "BBB").build();
-            Validate.entityThrowingException(new ActivityValidator(EMPTY_TASKS), activity);
-            fail("Should have thrown exception");
-        } catch(InvalidEntityException e) {
-            assertEquals("label cannot be missing, null, or blank", e.getErrors().get("label").get(0));
-        }
+        Activity activity = new Activity.Builder().withPublishedSurvey("identifier", "BBB").build();
+        assertValidatorMessage(VALIDATOR, activity, "label", "cannot be missing, null, or blank");
+    }
+    
+    @Test
+    public void rejectsWithoutGuid() {
+        Activity activity = new Activity.Builder().withLabel("label").withPublishedSurvey("identifier", "BBB").build();
+        assertValidatorMessage(VALIDATOR, activity, "guid", "cannot be missing, null, or blank");
     }
 
     @Test
     public void noSources() {
-        try {
-            Activity activity = new Activity.Builder().withLabel("Label").build();
-            Validate.entityThrowingException(new ActivityValidator(EMPTY_TASKS), activity);
-            fail("Should have thrown exception");
-        } catch(InvalidEntityException e) {
-            assertEquals("activity must have exactly one of compound activity, task, or survey", e.getErrors()
-                    .get("activity").get(0));
-        }
+        Activity activity = new Activity.Builder().withLabel("Label").build();
+        assertValidatorMessage(VALIDATOR, activity, "activity", "must have exactly one of compound activity, task, or survey");
     }
 
     @Test
     public void multipleSources() {
-        try {
-            CompoundActivity compoundActivity = new CompoundActivity.Builder().withTaskIdentifier("combo-activity")
-                    .build();
-            Activity activity = new Activity.Builder().withLabel("Label").withCompoundActivity(compoundActivity)
-                    .withPublishedSurvey("My Survey", "CCC").build();
-            Validate.entityThrowingException(new ActivityValidator(ImmutableSet.of("combo-activity")), activity);
-            fail("Should have thrown exception");
-        } catch(InvalidEntityException e) {
-            assertEquals("activity must have exactly one of compound activity, task, or survey", e.getErrors()
-                    .get("activity").get(0));
-        }
+        CompoundActivity compoundActivity = new CompoundActivity.Builder().withTaskIdentifier("combo-activity").build();
+        Activity activity = new Activity.Builder().withLabel("Label").withCompoundActivity(compoundActivity)
+                .withPublishedSurvey("My Survey", "CCC").build();
+        assertValidatorMessage(VALIDATOR_WITH_TASKS, activity, "activity",
+                "must have exactly one of compound activity, task, or survey");
     }
 
     @Test
     public void validCompoundActivity() {
         CompoundActivity compoundActivity = new CompoundActivity.Builder().withTaskIdentifier("combo-activity")
                 .build();
-        Activity activity = new Activity.Builder().withLabel("Label").withCompoundActivity(compoundActivity).build();
+        Activity activity = new Activity.Builder().withGuid("guid").withLabel("Label").withCompoundActivity(compoundActivity).build();
         Validate.entityThrowingException(new ActivityValidator(ImmutableSet.of("combo-activity")), activity);
     }
 
     @Test
     public void compoundActivityWithoutTaskIdentifier() {
-        try {
-            CompoundActivity compoundActivity = new CompoundActivity.Builder().build();
-            Activity activity = new Activity.Builder().withLabel("Label").withCompoundActivity(compoundActivity)
-                    .build();
-            Validate.entityThrowingException(new ActivityValidator(ImmutableSet.of("combo-activity")), activity);
-            fail("Should have thrown exception");
-        } catch(InvalidEntityException e) {
-            assertEquals("compoundActivity.taskIdentifier cannot be missing, null, or blank", e.getErrors()
-                    .get("compoundActivity.taskIdentifier").get(0));
-        }
+        CompoundActivity compoundActivity = new CompoundActivity.Builder().build();
+        Activity activity = new Activity.Builder().withLabel("Label").withCompoundActivity(compoundActivity).build();
+        assertValidatorMessage(VALIDATOR_WITH_TASKS, activity, "compoundActivity.taskIdentifier", "cannot be missing, null, or blank");
     }
 
     @Test
     public void compoundActivityWithInvaludTaskIdentifier() {
-        try {
-            CompoundActivity compoundActivity = new CompoundActivity.Builder().withTaskIdentifier("bad-activity")
-                    .build();
-            Activity activity = new Activity.Builder().withLabel("Label").withCompoundActivity(compoundActivity)
-                    .build();
-            Validate.entityThrowingException(new ActivityValidator(ImmutableSet.of("combo-activity")), activity);
-            fail("Should have thrown exception");
-        } catch(InvalidEntityException e) {
-            assertEquals("compoundActivity.taskIdentifier 'bad-activity' is not in enumeration: combo-activity.",
-                    e.getErrors().get("compoundActivity.taskIdentifier").get(0));
-        }
+        CompoundActivity compoundActivity = new CompoundActivity.Builder().withTaskIdentifier("bad-activity").build();
+        Activity activity = new Activity.Builder().withLabel("Label").withCompoundActivity(compoundActivity).build();
+        assertValidatorMessage(VALIDATOR_WITH_TASKS, activity, "compoundActivity.taskIdentifier", "'bad-activity' is not in enumeration: combo-activity");
     }
 
     @Test
     public void surveyWithoutIdentifierIsOk() {
-        Activity activity = new Activity.Builder().withLabel("Label").withSurvey(null, "BBB", null).build();
+        Activity activity = new Activity.Builder().withGuid("guid").withLabel("Label").withSurvey(null, "BBB", null).build();
         Validate.entityThrowingException(new ActivityValidator(EMPTY_TASKS), activity);
     }
     
     @Test
     public void rejectsSurveyWithoutGuid() {
-        try {
-            Activity activity = new Activity.Builder().withLabel("Label").withSurvey("identifier", null, null).build();
-            Validate.entityThrowingException(new ActivityValidator(EMPTY_TASKS), activity);
-            fail("Should have thrown exception");
-        } catch(InvalidEntityException e) {
-            assertEquals("survey.guid cannot be missing, null, or blank", e.getErrors().get("survey.guid").get(0));
-        }
+        Activity activity = new Activity.Builder().withGuid("guid").withLabel("Label").withSurvey("identifier", null, null).build();
+        assertValidatorMessage(VALIDATOR, activity, "survey.guid", "cannot be missing, null, or blank");
     }
     
     @Test
     public void rejectsTaskWithoutIdentifier() {
-        try {
-            Activity activity = new Activity.Builder().withLabel("Label").withTask((String)null).build();
-            Validate.entityThrowingException(new ActivityValidator(EMPTY_TASKS), activity);
-            fail("Should have thrown exception");
-        } catch(InvalidEntityException e) {
-            assertEquals("task.identifier cannot be missing, null, or blank", e.getErrors().get("task.identifier").get(0));
-        }
+        Activity activity = new Activity.Builder().withLabel("Label").withTask((String)null).build();
+        assertValidatorMessage(VALIDATOR, activity, "task.identifier", "cannot be missing, null, or blank");
     }
     
     @Test
     public void rejectsTaskIdentifierNotDeclaredForStudy() {
-        try {
-            Activity activity = new Activity.Builder().withLabel("Label").withTask("foo").build();
-            Validate.entityThrowingException(new ActivityValidator(null), activity);
-            fail("Should have thrown exception");
-        } catch(InvalidEntityException e) {
-            assertEquals("task.identifier 'foo' is not in enumeration: <no task identifiers declared>", e.getErrors().get("task.identifier").get(0));
-        }
+        Activity activity = new Activity.Builder().withLabel("Label").withTask("foo").build();
+        assertValidatorMessage(VALIDATOR, activity, "task.identifier", "'foo' is not in enumeration: <no task identifiers declared>");
     }
     
     @Test
     public void rejectsTaskIdentifierNotInList() {
-        try {
-            Activity activity = new Activity.Builder().withLabel("Label").withTask("foo").build();
-            Validate.entityThrowingException(new ActivityValidator(Sets.newHashSet("bar", "baz")), activity);
-            fail("Should have thrown exception");
-        } catch(InvalidEntityException e) {
-            assertEquals("task.identifier 'foo' is not in enumeration: bar, baz.", e.getErrors().get("task.identifier").get(0));
-        }
+        Activity activity = new Activity.Builder().withLabel("Label").withTask("foo").build();
+        assertValidatorMessage(new ActivityValidator(Sets.newHashSet("bar","baz")), activity, "task.identifier", "'foo' is not in enumeration: bar, baz");
     }
     
     @Test
     public void declaredTaskIdentifierOK() {
-        Activity activity = new Activity.Builder().withLabel("Label").withTask("foo").build();
+        Activity activity = new Activity.Builder().withGuid("guid").withLabel("Label").withTask("foo").build();
         Validate.entityThrowingException(new ActivityValidator(Sets.newHashSet("foo")), activity);
     }
 }

--- a/test/org/sagebionetworks/bridge/validators/SchedulePlanValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/SchedulePlanValidatorTest.java
@@ -10,7 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.validation.Errors;
 
-import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.models.schedules.ABTestScheduleStrategy;
@@ -113,7 +113,7 @@ public class SchedulePlanValidatorTest {
         Schedule schedule = new Schedule();
         schedule.setScheduleType(ScheduleType.ONCE);
         schedule.setLabel("a label");
-        schedule.addActivity(TestConstants.TEST_3_ACTIVITY);
+        schedule.addActivity(TestUtils.getActivity3());
         return schedule;
     }
 

--- a/test/org/sagebionetworks/bridge/validators/ScheduleValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/ScheduleValidatorTest.java
@@ -9,7 +9,7 @@ import org.joda.time.LocalTime;
 import org.joda.time.Period;
 import org.junit.Before;
 import org.junit.Test;
-import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.models.schedules.Activity;
@@ -34,7 +34,7 @@ public class ScheduleValidatorTest {
     public void onTimeScheduleWithAdequateExpirationOK() {
         schedule.setScheduleType(ScheduleType.ONCE);
         schedule.setExpires(Period.parse("PT36H"));
-        schedule.addActivity(TestConstants.TEST_3_ACTIVITY);
+        schedule.addActivity(TestUtils.getActivity3());
         Validate.entityThrowingException(validator, schedule);
     }
     
@@ -42,7 +42,7 @@ public class ScheduleValidatorTest {
     public void persistentScheduleDoesNotHaveDelay() {
         schedule.setScheduleType(ScheduleType.PERSISTENT);
         schedule.setDelay(Period.parse("P2D"));
-        schedule.addActivity(TestConstants.TEST_3_ACTIVITY);
+        schedule.addActivity(TestUtils.getActivity3());
         try {
             Validate.entityThrowingException(validator, schedule);
             fail("Should have thrown InvalidEntityException");
@@ -56,7 +56,7 @@ public class ScheduleValidatorTest {
     public void persistentScheduleDoesNotHaveInterval() {
         schedule.setScheduleType(ScheduleType.PERSISTENT);
         schedule.setInterval(Period.parse("P2D"));
-        schedule.addActivity(TestConstants.TEST_3_ACTIVITY);
+        schedule.addActivity(TestUtils.getActivity3());
         try {
             Validate.entityThrowingException(validator, schedule);
             fail("Should have thrown InvalidEntityException");
@@ -70,7 +70,7 @@ public class ScheduleValidatorTest {
     public void persistentScheduleDoesNotHaveCronExpression() {
         schedule.setScheduleType(ScheduleType.PERSISTENT);
         schedule.setCronTrigger("asdf");
-        schedule.addActivity(TestConstants.TEST_3_ACTIVITY);
+        schedule.addActivity(TestUtils.getActivity3());
         try {
             Validate.entityThrowingException(validator, schedule);
             fail("Should have thrown InvalidEntityException");
@@ -84,7 +84,7 @@ public class ScheduleValidatorTest {
     public void persistentScheduleDoesNotHaveTimes() {
         schedule.setScheduleType(ScheduleType.PERSISTENT);
         schedule.addTimes(LocalTime.parse("10:00"));
-        schedule.addActivity(TestConstants.TEST_3_ACTIVITY);
+        schedule.addActivity(TestUtils.getActivity3());
         try {
             Validate.entityThrowingException(validator, schedule);
             fail("Should have thrown InvalidEntityException");
@@ -98,7 +98,7 @@ public class ScheduleValidatorTest {
     public void persistentScheduleDoesNotHaveExpiration() {
         schedule.setScheduleType(ScheduleType.PERSISTENT);
         schedule.setExpires(Period.parse("P1D"));
-        schedule.addActivity(TestConstants.TEST_3_ACTIVITY);
+        schedule.addActivity(TestUtils.getActivity3());
         try {
             Validate.entityThrowingException(validator, schedule);
             fail("Should have thrown InvalidEntityException");
@@ -122,7 +122,7 @@ public class ScheduleValidatorTest {
     @Test
     public void datesMustBeChronologicallyOrdered() {
         // make it valid except for the dates....
-        schedule.addActivity(TestConstants.TEST_3_ACTIVITY);
+        schedule.addActivity(TestUtils.getActivity3());
         schedule.setScheduleType(ScheduleType.ONCE);
 
         DateTime startsOn = DateUtils.getCurrentDateTime();
@@ -141,7 +141,7 @@ public class ScheduleValidatorTest {
     
     @Test
     public void surveyRelativePathIsTreatedAsTaskId() {
-        Activity activity = TestConstants.TEST_3_ACTIVITY;
+        Activity activity = TestUtils.getActivity3();
         schedule.addActivity(activity);
         schedule.setScheduleType(ScheduleType.ONCE);
         
@@ -207,7 +207,7 @@ public class ScheduleValidatorTest {
         Schedule schedule = new Schedule();
         schedule.setScheduleType(ScheduleType.RECURRING);
         schedule.setCronTrigger("0 0 12 1/1 * ? *");
-        Activity activity = TestConstants.TEST_3_ACTIVITY;
+        Activity activity = TestUtils.getActivity3();
         schedule.addActivity(activity);
         
         try {
@@ -345,7 +345,7 @@ public class ScheduleValidatorTest {
         schedule.setScheduleType(ScheduleType.RECURRING);
         schedule.setExpires("P1D");
         schedule.setCronTrigger("0 0 8 1/1 * ? *");
-        schedule.addActivity(TestConstants.TEST_3_ACTIVITY);
+        schedule.addActivity(TestUtils.getActivity3());
         
         Validate.entityThrowingException(validator, schedule);
     }
@@ -357,7 +357,7 @@ public class ScheduleValidatorTest {
         schedule.setInterval("P1D");
         schedule.setExpires("P1D");
         schedule.addTimes("08:00");
-        schedule.addActivity(TestConstants.TEST_3_ACTIVITY);
+        schedule.addActivity(TestUtils.getActivity3());
         
         Validate.entityThrowingException(validator, schedule);
         


### PR DESCRIPTION
We're going to index scheduled activities by the activity guid, and the current design has led to cases where, if a client does not provide GUIDs for the activities, they get recreated and break things. So we really need for that to not happen.

I may explore creating a key based on the content of an Activity, such that even if the user deletes and recreates an activity in JSON, it has a stable GUID. I think this could prevent a class of problems where people are screwing around with the schedule in the editor.

Also, in doing this:
- refactor testing of validation errors; 
- added tests of schedule plan controller
- fix survey validator which is different in behavior from all other validators

Moving toward greater consistency in how errors are reported.