### PR TITLE
bug fixes related to Compound Activities

### DIFF
--- a/app/org/sagebionetworks/bridge/exceptions/InvalidEntityException.java
+++ b/app/org/sagebionetworks/bridge/exceptions/InvalidEntityException.java
@@ -40,7 +40,7 @@ public class InvalidEntityException extends BridgeServiceException {
     }
     
     public Class<? extends BridgeEntity> getEntityClass() {
-        return entity.getClass();
+        return entity != null ? entity.getClass() : null;
     }
     
     public BridgeEntity getEntity() {

--- a/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
+++ b/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
@@ -255,7 +255,8 @@ public class ScheduledActivityService {
 
                     if (!resolvedSchemaRef.equals(schemaRef)) {
                         TaskReference resolvedTaskRef = new TaskReference(taskRef.getIdentifier(), resolvedSchemaRef);
-                        resolvedActivity = new Activity.Builder().withTask(resolvedTaskRef).build();
+                        resolvedActivity = new Activity.Builder().withActivity(activity).withTask(resolvedTaskRef)
+                                .build();
                     }
                 }
             }

--- a/app/org/sagebionetworks/bridge/validators/ActivityValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/ActivityValidator.java
@@ -66,8 +66,6 @@ public class ActivityValidator implements Validator {
         String taskIdentifier = compoundActivity.getTaskIdentifier();
         if (isBlank(taskIdentifier)) {
             errors.rejectValue("taskIdentifier", CANNOT_BE_BLANK);
-        } else if (!taskIdentifiers.contains(taskIdentifier)) {
-            errors.rejectValue("taskIdentifier", getTaskIdentifierMessage(taskIdentifier));
         }
 
         errors.popNestedPath();

--- a/test/org/sagebionetworks/bridge/validators/ActivityValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/ActivityValidatorTest.java
@@ -79,21 +79,6 @@ public class ActivityValidatorTest {
     }
 
     @Test
-    public void compoundActivityWithInvaludTaskIdentifier() {
-        try {
-            CompoundActivity compoundActivity = new CompoundActivity.Builder().withTaskIdentifier("bad-activity")
-                    .build();
-            Activity activity = new Activity.Builder().withLabel("Label").withCompoundActivity(compoundActivity)
-                    .build();
-            Validate.entityThrowingException(new ActivityValidator(ImmutableSet.of("combo-activity")), activity);
-            fail("Should have thrown exception");
-        } catch(InvalidEntityException e) {
-            assertEquals("compoundActivity.taskIdentifier 'bad-activity' is not in enumeration: combo-activity.",
-                    e.getErrors().get("compoundActivity.taskIdentifier").get(0));
-        }
-    }
-
-    @Test
     public void surveyWithoutIdentifierIsOk() {
         Activity activity = new Activity.Builder().withLabel("Label").withSurvey(null, "BBB", null).build();
         Validate.entityThrowingException(new ActivityValidator(EMPTY_TASKS), activity);


### PR DESCRIPTION
Found some bugs while writing integ tests for Compound Activities.

Bugs fixed:
* When parsing JSON through SurveyElementFactory, a parse error results in an obscure NullPointerException and an HTTP 500 instead of a 400 InvalidEntityException.
* When resolving schema references, we lose other metadata on the Activity, such as label.
* Compound Activities in schedules shouldn't enforce task IDs.

Testing done:
* Updated unit tests.
* Wrote new integ tests to test these cases: https://github.com/Sage-Bionetworks/BridgeIntegrationTests/pull/135