### PR TITLE
Update scheduled activity table

### DIFF
--- a/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
+++ b/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
@@ -88,15 +88,14 @@ import org.sagebionetworks.bridge.upload.UploadValidationHandler;
  * production-only Spring configs, see {@link BridgeProductionSpringConfig}. For test-only Spring configs, see
  * BridgeTestSpringConfig in tests.
  */
-@ComponentScan(basePackages = "org.sagebionetworks.bridge", excludeFilters = @ComponentScan.Filter(
-        type = FilterType.ANNOTATION, value = Configuration.class))
+@ComponentScan(basePackages = "org.sagebionetworks.bridge", excludeFilters = @ComponentScan.Filter(type = FilterType.ANNOTATION, value = Configuration.class))
 @Configuration
 public class BridgeSpringConfig {
     @Bean(name = "redisProviders")
     public List<String> redisProviders() {
         return Lists.newArrayList("REDISCLOUD_URL", "REDISTOGO_URL");
     }
-    
+
     @Bean(name = "bridgeObjectMapper")
     public BridgeObjectMapper bridgeObjectMapper() {
         return BridgeObjectMapper.get();
@@ -121,17 +120,15 @@ public class BridgeSpringConfig {
     @Bean(name = "awsCredentials")
     public BasicAWSCredentials awsCredentials() {
         BridgeConfig bridgeConfig = bridgeConfig();
-        return new BasicAWSCredentials(bridgeConfig.getProperty("aws.key"),
-                bridgeConfig.getProperty("aws.secret.key"));
+        return new BasicAWSCredentials(bridgeConfig.getProperty("aws.key"), bridgeConfig.getProperty("aws.secret.key"));
     }
 
     @Bean(name = "snsCredentials")
     public BasicAWSCredentials snsCredentials() {
         BridgeConfig bridgeConfig = bridgeConfig();
-        return new BasicAWSCredentials(bridgeConfig.getProperty("sns.key"),
-                bridgeConfig.getProperty("sns.secret.key"));
+        return new BasicAWSCredentials(bridgeConfig.getProperty("sns.key"), bridgeConfig.getProperty("sns.secret.key"));
     }
-    
+
     @Bean(name = "s3UploadCredentials")
     @Resource(name = "bridgeConfig")
     public BasicAWSCredentials s3UploadCredentials(BridgeConfig bridgeConfig) {
@@ -154,7 +151,7 @@ public class BridgeSpringConfig {
                 .withMaxErrorRetry(maxRetries);
         return new AmazonDynamoDBClient(awsCredentials(), awsClientConfig);
     }
-    
+
     @Bean(name = "snsClient")
     @Resource(name = "snsCredentials")
     public AmazonSNSClient snsClient() {
@@ -185,7 +182,7 @@ public class BridgeSpringConfig {
         return new AmazonS3Client(s3CmsCredentials);
     }
 
-    @Bean(name ="uploadTokenServiceClient")
+    @Bean(name = "uploadTokenServiceClient")
     @Resource(name = "s3UploadCredentials")
     public AWSSecurityTokenServiceClient uploadTokenServiceClient(BasicAWSCredentials s3UploadCredentials) {
         return new AWSSecurityTokenServiceClient(s3UploadCredentials);
@@ -229,7 +226,7 @@ public class BridgeSpringConfig {
     }
 
     @Bean(name = "sesClient")
-    @Resource(name="awsCredentials")
+    @Resource(name = "awsCredentials")
     public AmazonSimpleEmailServiceClient sesClient(BasicAWSCredentials awsCredentials) {
         return new AmazonSimpleEmailServiceClient(awsCredentials);
     }
@@ -287,13 +284,13 @@ public class BridgeSpringConfig {
     public DynamoDBMapper reportDataMapper(DynamoUtils dynamoUtils) {
         return dynamoUtils.getMapper(DynamoReportData.class);
     }
-    
+
     @Bean(name = "reportIndexMapper")
     @Autowired
     public DynamoDBMapper reportIndexMapper(DynamoUtils dynamoUtils) {
         return dynamoUtils.getMapper(DynamoReportIndex.class);
     }
-    
+
     @Bean(name = "healthDataDdbMapper")
     @Autowired
     public DynamoDBMapper healthDataDdbMapper(DynamoUtils dynamoUtils) {
@@ -317,7 +314,7 @@ public class BridgeSpringConfig {
     public DynamoDBMapper subpopulationDdbMapper(DynamoUtils dynamoUtils) {
         return dynamoUtils.getMapper(DynamoSubpopulation.class);
     }
-    
+
     @Bean(name = "surveyMapper")
     @Autowired
     public DynamoDBMapper surveyDdbMapper(DynamoUtils dynamoUtils) {
@@ -335,84 +332,93 @@ public class BridgeSpringConfig {
     public DynamoDBMapper criteriaMapper(DynamoUtils dynamoUtils) {
         return dynamoUtils.getMapper(DynamoCriteria.class);
     }
-    
+
     @Bean(name = "schedulePlanMapper")
     @Autowired
     public DynamoDBMapper schedulePlanMapper(DynamoUtils dynamoUtils) {
         return dynamoUtils.getMapper(DynamoSchedulePlan.class);
     }
-    
+
     @Bean(name = "notificationRegistrationMapper")
     @Autowired
     public DynamoDBMapper notificationRegistrationMapper(DynamoUtils dynamoUtils) {
         return dynamoUtils.getMapper(DynamoNotificationRegistration.class);
     }
-    
+
     @Bean(name = "notificationTopicMapper")
     @Autowired
     public DynamoDBMapper notificationTopicMapper(DynamoUtils dynamoUtils) {
         return dynamoUtils.getMapper(DynamoNotificationTopic.class);
     }
-    
+
     @Bean(name = "topicSubscriptionMapper")
     @Autowired
     public DynamoDBMapper topicSubscriptionMapper(DynamoUtils dynamoUtils) {
         return dynamoUtils.getMapper(DynamoTopicSubscription.class);
     }
-    
+
     @Bean(name = "uploadHealthCodeRequestedOnIndex")
     @Autowired
-    public DynamoIndexHelper uploadHealthCodeRequestedOnIndex(AmazonDynamoDBClient dynamoDBClient, DynamoUtils dynamoUtils,
-            DynamoNamingHelper dynamoNamingHelper) {
-        return DynamoIndexHelper.create(DynamoUpload2.class, "healthCode-requestedOn-index", dynamoDBClient, dynamoNamingHelper, dynamoUtils);
+    public DynamoIndexHelper uploadHealthCodeRequestedOnIndex(AmazonDynamoDBClient dynamoDBClient,
+            DynamoUtils dynamoUtils, DynamoNamingHelper dynamoNamingHelper) {
+        return DynamoIndexHelper.create(DynamoUpload2.class, "healthCode-requestedOn-index", dynamoDBClient,
+                dynamoNamingHelper, dynamoUtils);
     }
-    
+
+    @Bean(name = "healthCodeActivityGuidIndex")
+    @Autowired
+    public DynamoIndexHelper healthCodeActivityGuidIndex(AmazonDynamoDBClient dynamoDBClient, DynamoUtils dynamoUtils,
+            DynamoNamingHelper dynamoNamingHelper) {
+        return DynamoIndexHelper.create(DynamoScheduledActivity.class, "healthCodeActivityGuid-scheduledOnUTC-index",
+                dynamoDBClient, dynamoNamingHelper, dynamoUtils);
+    }
+
     @Bean(name = "uploadStudyIdRequestedOnIndex")
     @Autowired
     public DynamoIndexHelper uploadStudyIdRequestedOnIndex(AmazonDynamoDBClient dynamoDBClient, DynamoUtils dynamoUtils,
             DynamoNamingHelper dynamoNamingHelper) {
-        return DynamoIndexHelper.create(DynamoUpload2.class, "studyId-requestedOn-index", dynamoDBClient, dynamoNamingHelper, dynamoUtils);
+        return DynamoIndexHelper.create(DynamoUpload2.class, "studyId-requestedOn-index", dynamoDBClient,
+                dynamoNamingHelper, dynamoUtils);
     }
-    
+
     @Bean(name = "healthDataHealthCodeIndex")
     @Autowired
-    public DynamoIndexHelper healthDataHealthCodeIndex(AmazonDynamoDBClient dynamoDBClient,
-                                                       DynamoUtils dynamoUtils,
-                                                       DynamoNamingHelper dynamoNamingHelper) {
-        return DynamoIndexHelper.create(DynamoHealthDataRecord.class, "healthCode-index", dynamoDBClient, dynamoNamingHelper, dynamoUtils);
+    public DynamoIndexHelper healthDataHealthCodeIndex(AmazonDynamoDBClient dynamoDBClient, DynamoUtils dynamoUtils,
+            DynamoNamingHelper dynamoNamingHelper) {
+        return DynamoIndexHelper.create(DynamoHealthDataRecord.class, "healthCode-index", dynamoDBClient,
+                dynamoNamingHelper, dynamoUtils);
     }
 
     @Bean(name = "healthDataHealthCodeCreatedOnIndex")
     @Autowired
     public DynamoIndexHelper healthDataHealthCodeCreatedOnIndex(AmazonDynamoDBClient dynamoDBClient,
-                                                       DynamoUtils dynamoUtils,
-                                                       DynamoNamingHelper dynamoNamingHelper) {
-        return DynamoIndexHelper.create(DynamoHealthDataRecord.class, "healthCode-createdOn-index", dynamoDBClient, dynamoNamingHelper, dynamoUtils);
+            DynamoUtils dynamoUtils, DynamoNamingHelper dynamoNamingHelper) {
+        return DynamoIndexHelper.create(DynamoHealthDataRecord.class, "healthCode-createdOn-index", dynamoDBClient,
+                dynamoNamingHelper, dynamoUtils);
     }
 
     @Bean(name = "healthDataUploadDateIndex")
     @Autowired
     public DynamoIndexHelper healthDataUploadDateIndexDynamoUtils(AmazonDynamoDBClient dynamoDBClient,
-                                                                  DynamoUtils dynamoUtils,
-                                                                  DynamoNamingHelper dynamoNamingHelper) {
-        return DynamoIndexHelper.create(DynamoHealthDataRecord.class, "uploadDate-index", dynamoDBClient, dynamoNamingHelper, dynamoUtils);
+            DynamoUtils dynamoUtils, DynamoNamingHelper dynamoNamingHelper) {
+        return DynamoIndexHelper.create(DynamoHealthDataRecord.class, "uploadDate-index", dynamoDBClient,
+                dynamoNamingHelper, dynamoUtils);
     }
 
     @Bean(name = "activitySchedulePlanGuidIndex")
     @Autowired
-    public DynamoIndexHelper activitySchedulePlanGuidIndex(AmazonDynamoDBClient dynamoDBClient,
-                                                           DynamoUtils dynamoUtils,
-                                                           DynamoNamingHelper dynamoNamingHelper) {
-        return DynamoIndexHelper
-                .create(DynamoScheduledActivity.class, "schedulePlanGuid-index", dynamoDBClient, dynamoNamingHelper, dynamoUtils);
+    public DynamoIndexHelper activitySchedulePlanGuidIndex(AmazonDynamoDBClient dynamoDBClient, DynamoUtils dynamoUtils,
+            DynamoNamingHelper dynamoNamingHelper) {
+        return DynamoIndexHelper.create(DynamoScheduledActivity.class, "schedulePlanGuid-index", dynamoDBClient,
+                dynamoNamingHelper, dynamoUtils);
     }
 
     @Bean(name = "uploadSchemaStudyIdIndex")
     @Autowired
-    public DynamoIndexHelper uploadSchemaStudyIdIndex(AmazonDynamoDBClient dynamoDBClient,
-                                                      DynamoUtils dynamoUtils,
-                                                      DynamoNamingHelper dynamoNamingHelper) {
-        return DynamoIndexHelper.create(DynamoUploadSchema.class, "studyId-index", dynamoDBClient, dynamoNamingHelper, dynamoUtils);
+    public DynamoIndexHelper uploadSchemaStudyIdIndex(AmazonDynamoDBClient dynamoDBClient, DynamoUtils dynamoUtils,
+            DynamoNamingHelper dynamoNamingHelper) {
+        return DynamoIndexHelper.create(DynamoUploadSchema.class, "studyId-index", dynamoDBClient, dynamoNamingHelper,
+                dynamoUtils);
     }
 
     @Bean(name = "uploadDdbMapper")
@@ -425,19 +431,19 @@ public class BridgeSpringConfig {
     public DynamoDBMapper uploadDedupeDdbMapper(DynamoUtils dynamoUtils) {
         return dynamoUtils.getMapper(DynamoUploadDedupe.class);
     }
-    
+
     @Bean(name = "fphsExternalIdDdbMapper")
     @Autowired
     public DynamoDBMapper fphsExternalIdDdbMapper(DynamoUtils dynamoUtils) {
         return dynamoUtils.getMapper(DynamoFPHSExternalIdentifier.class);
     }
-    
+
     @Bean(name = "externalIdDdbMapper")
     @Autowired
     public DynamoDBMapper externalIdDdbMapper(DynamoUtils dynamoUtils) {
         return dynamoUtils.getMapper(DynamoExternalIdentifier.class);
     }
-    
+
     @Bean(name = "participantOptionsDbMapper")
     @Autowired
     public DynamoDBMapper participantOptionsDbMapper(DynamoUtils dynamoUtils) {
@@ -448,12 +454,10 @@ public class BridgeSpringConfig {
     @Autowired
     public List<UploadValidationHandler> uploadValidationHandlerList(S3DownloadHandler s3DownloadHandler,
             DecryptHandler decryptHandler, UnzipHandler unzipHandler, ParseJsonHandler parseJsonHandler,
-            IosSchemaValidationHandler2 iosSchemaValidationHandler2,
-            StrictValidationHandler strictValidationHandler, TranscribeConsentHandler transcribeConsentHandler,
-            UploadArtifactsHandler uploadArtifactsHandler) {
+            IosSchemaValidationHandler2 iosSchemaValidationHandler2, StrictValidationHandler strictValidationHandler,
+            TranscribeConsentHandler transcribeConsentHandler, UploadArtifactsHandler uploadArtifactsHandler) {
         return ImmutableList.of(s3DownloadHandler, decryptHandler, unzipHandler, parseJsonHandler,
-                iosSchemaValidationHandler2, strictValidationHandler, transcribeConsentHandler,
-                uploadArtifactsHandler);
+                iosSchemaValidationHandler2, strictValidationHandler, transcribeConsentHandler, uploadArtifactsHandler);
     }
 
     @Bean(name = "uploadSchemaDdbMapper")
@@ -472,12 +476,11 @@ public class BridgeSpringConfig {
     @Bean(name = "stormpathClient")
     @Autowired
     public Client getStormpathClient(BridgeConfig bridgeConfig) {
-        ApiKey apiKey = ApiKeys.builder()
-            .setId(bridgeConfig.getStormpathId())
-            .setSecret(bridgeConfig.getStormpathSecret()).build();
+        ApiKey apiKey = ApiKeys.builder().setId(bridgeConfig.getStormpathId())
+                .setSecret(bridgeConfig.getStormpathSecret()).build();
         ClientBuilder clientBuilder = Clients.builder().setApiKey(apiKey);
-        ((DefaultClientBuilder)clientBuilder).setBaseUrl("https://enterprise.stormpath.io/v1");
-        return clientBuilder.build();        
+        ((DefaultClientBuilder) clientBuilder).setBaseUrl("https://enterprise.stormpath.io/v1");
+        return clientBuilder.build();
     }
 
     // Do NOT reference this bean outside of StormpathAccountDao. Injected for testing purposes.
@@ -486,13 +489,13 @@ public class BridgeSpringConfig {
     public Application getStormpathApplication(BridgeConfig bridgeConfig, Client stormpathClient) {
         return stormpathClient.getResource(bridgeConfig.getStormpathApplicationHref(), Application.class);
     }
-    
+
     @Bean(name = "sessionExpireInSeconds")
     public int getSessionExpireInSeconds() {
         return BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS;
     }
 
-    @Bean(name="bridgePFSynapseClient")
+    @Bean(name = "bridgePFSynapseClient")
     public SynapseClient synapseClient() throws IOException {
         SynapseClient synapseClient = new SynapseAdminClientImpl();
         synapseClient.setUserName(bridgeConfig().get("synapse.user"));

--- a/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
+++ b/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
@@ -88,14 +88,15 @@ import org.sagebionetworks.bridge.upload.UploadValidationHandler;
  * production-only Spring configs, see {@link BridgeProductionSpringConfig}. For test-only Spring configs, see
  * BridgeTestSpringConfig in tests.
  */
-@ComponentScan(basePackages = "org.sagebionetworks.bridge", excludeFilters = @ComponentScan.Filter(type = FilterType.ANNOTATION, value = Configuration.class))
+@ComponentScan(basePackages = "org.sagebionetworks.bridge", excludeFilters = @ComponentScan.Filter(
+        type = FilterType.ANNOTATION, value = Configuration.class))
 @Configuration
 public class BridgeSpringConfig {
     @Bean(name = "redisProviders")
     public List<String> redisProviders() {
         return Lists.newArrayList("REDISCLOUD_URL", "REDISTOGO_URL");
     }
-
+    
     @Bean(name = "bridgeObjectMapper")
     public BridgeObjectMapper bridgeObjectMapper() {
         return BridgeObjectMapper.get();
@@ -120,15 +121,17 @@ public class BridgeSpringConfig {
     @Bean(name = "awsCredentials")
     public BasicAWSCredentials awsCredentials() {
         BridgeConfig bridgeConfig = bridgeConfig();
-        return new BasicAWSCredentials(bridgeConfig.getProperty("aws.key"), bridgeConfig.getProperty("aws.secret.key"));
+        return new BasicAWSCredentials(bridgeConfig.getProperty("aws.key"),
+                bridgeConfig.getProperty("aws.secret.key"));
     }
 
     @Bean(name = "snsCredentials")
     public BasicAWSCredentials snsCredentials() {
         BridgeConfig bridgeConfig = bridgeConfig();
-        return new BasicAWSCredentials(bridgeConfig.getProperty("sns.key"), bridgeConfig.getProperty("sns.secret.key"));
+        return new BasicAWSCredentials(bridgeConfig.getProperty("sns.key"),
+                bridgeConfig.getProperty("sns.secret.key"));
     }
-
+    
     @Bean(name = "s3UploadCredentials")
     @Resource(name = "bridgeConfig")
     public BasicAWSCredentials s3UploadCredentials(BridgeConfig bridgeConfig) {
@@ -151,7 +154,7 @@ public class BridgeSpringConfig {
                 .withMaxErrorRetry(maxRetries);
         return new AmazonDynamoDBClient(awsCredentials(), awsClientConfig);
     }
-
+    
     @Bean(name = "snsClient")
     @Resource(name = "snsCredentials")
     public AmazonSNSClient snsClient() {
@@ -182,7 +185,7 @@ public class BridgeSpringConfig {
         return new AmazonS3Client(s3CmsCredentials);
     }
 
-    @Bean(name = "uploadTokenServiceClient")
+    @Bean(name ="uploadTokenServiceClient")
     @Resource(name = "s3UploadCredentials")
     public AWSSecurityTokenServiceClient uploadTokenServiceClient(BasicAWSCredentials s3UploadCredentials) {
         return new AWSSecurityTokenServiceClient(s3UploadCredentials);
@@ -226,7 +229,7 @@ public class BridgeSpringConfig {
     }
 
     @Bean(name = "sesClient")
-    @Resource(name = "awsCredentials")
+    @Resource(name="awsCredentials")
     public AmazonSimpleEmailServiceClient sesClient(BasicAWSCredentials awsCredentials) {
         return new AmazonSimpleEmailServiceClient(awsCredentials);
     }
@@ -284,13 +287,13 @@ public class BridgeSpringConfig {
     public DynamoDBMapper reportDataMapper(DynamoUtils dynamoUtils) {
         return dynamoUtils.getMapper(DynamoReportData.class);
     }
-
+    
     @Bean(name = "reportIndexMapper")
     @Autowired
     public DynamoDBMapper reportIndexMapper(DynamoUtils dynamoUtils) {
         return dynamoUtils.getMapper(DynamoReportIndex.class);
     }
-
+    
     @Bean(name = "healthDataDdbMapper")
     @Autowired
     public DynamoDBMapper healthDataDdbMapper(DynamoUtils dynamoUtils) {
@@ -314,7 +317,7 @@ public class BridgeSpringConfig {
     public DynamoDBMapper subpopulationDdbMapper(DynamoUtils dynamoUtils) {
         return dynamoUtils.getMapper(DynamoSubpopulation.class);
     }
-
+    
     @Bean(name = "surveyMapper")
     @Autowired
     public DynamoDBMapper surveyDdbMapper(DynamoUtils dynamoUtils) {
@@ -332,93 +335,91 @@ public class BridgeSpringConfig {
     public DynamoDBMapper criteriaMapper(DynamoUtils dynamoUtils) {
         return dynamoUtils.getMapper(DynamoCriteria.class);
     }
-
+    
     @Bean(name = "schedulePlanMapper")
     @Autowired
     public DynamoDBMapper schedulePlanMapper(DynamoUtils dynamoUtils) {
         return dynamoUtils.getMapper(DynamoSchedulePlan.class);
     }
-
+    
     @Bean(name = "notificationRegistrationMapper")
     @Autowired
     public DynamoDBMapper notificationRegistrationMapper(DynamoUtils dynamoUtils) {
         return dynamoUtils.getMapper(DynamoNotificationRegistration.class);
     }
-
+    
     @Bean(name = "notificationTopicMapper")
     @Autowired
     public DynamoDBMapper notificationTopicMapper(DynamoUtils dynamoUtils) {
         return dynamoUtils.getMapper(DynamoNotificationTopic.class);
     }
-
+    
     @Bean(name = "topicSubscriptionMapper")
     @Autowired
     public DynamoDBMapper topicSubscriptionMapper(DynamoUtils dynamoUtils) {
         return dynamoUtils.getMapper(DynamoTopicSubscription.class);
     }
-
+    
     @Bean(name = "uploadHealthCodeRequestedOnIndex")
     @Autowired
-    public DynamoIndexHelper uploadHealthCodeRequestedOnIndex(AmazonDynamoDBClient dynamoDBClient,
-            DynamoUtils dynamoUtils, DynamoNamingHelper dynamoNamingHelper) {
-        return DynamoIndexHelper.create(DynamoUpload2.class, "healthCode-requestedOn-index", dynamoDBClient,
-                dynamoNamingHelper, dynamoUtils);
+    public DynamoIndexHelper uploadHealthCodeRequestedOnIndex(AmazonDynamoDBClient dynamoDBClient, DynamoUtils dynamoUtils,
+            DynamoNamingHelper dynamoNamingHelper) {
+        return DynamoIndexHelper.create(DynamoUpload2.class, "healthCode-requestedOn-index", dynamoDBClient, dynamoNamingHelper, dynamoUtils);
     }
-
+    
     @Bean(name = "healthCodeActivityGuidIndex")
     @Autowired
     public DynamoIndexHelper healthCodeActivityGuidIndex(AmazonDynamoDBClient dynamoDBClient, DynamoUtils dynamoUtils,
             DynamoNamingHelper dynamoNamingHelper) {
-        return DynamoIndexHelper.create(DynamoScheduledActivity.class, "healthCodeActivityGuid-scheduledOnUTC-index",
-                dynamoDBClient, dynamoNamingHelper, dynamoUtils);
+        return DynamoIndexHelper.create(DynamoUpload2.class, "healthCodeActivityGuid-localScheduledOn-index", dynamoDBClient, dynamoNamingHelper, dynamoUtils);
     }
-
+    
     @Bean(name = "uploadStudyIdRequestedOnIndex")
     @Autowired
     public DynamoIndexHelper uploadStudyIdRequestedOnIndex(AmazonDynamoDBClient dynamoDBClient, DynamoUtils dynamoUtils,
             DynamoNamingHelper dynamoNamingHelper) {
-        return DynamoIndexHelper.create(DynamoUpload2.class, "studyId-requestedOn-index", dynamoDBClient,
-                dynamoNamingHelper, dynamoUtils);
+        return DynamoIndexHelper.create(DynamoUpload2.class, "studyId-requestedOn-index", dynamoDBClient, dynamoNamingHelper, dynamoUtils);
     }
-
+    
     @Bean(name = "healthDataHealthCodeIndex")
     @Autowired
-    public DynamoIndexHelper healthDataHealthCodeIndex(AmazonDynamoDBClient dynamoDBClient, DynamoUtils dynamoUtils,
-            DynamoNamingHelper dynamoNamingHelper) {
-        return DynamoIndexHelper.create(DynamoHealthDataRecord.class, "healthCode-index", dynamoDBClient,
-                dynamoNamingHelper, dynamoUtils);
+    public DynamoIndexHelper healthDataHealthCodeIndex(AmazonDynamoDBClient dynamoDBClient,
+                                                       DynamoUtils dynamoUtils,
+                                                       DynamoNamingHelper dynamoNamingHelper) {
+        return DynamoIndexHelper.create(DynamoHealthDataRecord.class, "healthCode-index", dynamoDBClient, dynamoNamingHelper, dynamoUtils);
     }
 
     @Bean(name = "healthDataHealthCodeCreatedOnIndex")
     @Autowired
     public DynamoIndexHelper healthDataHealthCodeCreatedOnIndex(AmazonDynamoDBClient dynamoDBClient,
-            DynamoUtils dynamoUtils, DynamoNamingHelper dynamoNamingHelper) {
-        return DynamoIndexHelper.create(DynamoHealthDataRecord.class, "healthCode-createdOn-index", dynamoDBClient,
-                dynamoNamingHelper, dynamoUtils);
+                                                       DynamoUtils dynamoUtils,
+                                                       DynamoNamingHelper dynamoNamingHelper) {
+        return DynamoIndexHelper.create(DynamoHealthDataRecord.class, "healthCode-createdOn-index", dynamoDBClient, dynamoNamingHelper, dynamoUtils);
     }
 
     @Bean(name = "healthDataUploadDateIndex")
     @Autowired
     public DynamoIndexHelper healthDataUploadDateIndexDynamoUtils(AmazonDynamoDBClient dynamoDBClient,
-            DynamoUtils dynamoUtils, DynamoNamingHelper dynamoNamingHelper) {
-        return DynamoIndexHelper.create(DynamoHealthDataRecord.class, "uploadDate-index", dynamoDBClient,
-                dynamoNamingHelper, dynamoUtils);
+                                                                  DynamoUtils dynamoUtils,
+                                                                  DynamoNamingHelper dynamoNamingHelper) {
+        return DynamoIndexHelper.create(DynamoHealthDataRecord.class, "uploadDate-index", dynamoDBClient, dynamoNamingHelper, dynamoUtils);
     }
 
     @Bean(name = "activitySchedulePlanGuidIndex")
     @Autowired
-    public DynamoIndexHelper activitySchedulePlanGuidIndex(AmazonDynamoDBClient dynamoDBClient, DynamoUtils dynamoUtils,
-            DynamoNamingHelper dynamoNamingHelper) {
-        return DynamoIndexHelper.create(DynamoScheduledActivity.class, "schedulePlanGuid-index", dynamoDBClient,
-                dynamoNamingHelper, dynamoUtils);
+    public DynamoIndexHelper activitySchedulePlanGuidIndex(AmazonDynamoDBClient dynamoDBClient,
+                                                           DynamoUtils dynamoUtils,
+                                                           DynamoNamingHelper dynamoNamingHelper) {
+        return DynamoIndexHelper
+                .create(DynamoScheduledActivity.class, "schedulePlanGuid-index", dynamoDBClient, dynamoNamingHelper, dynamoUtils);
     }
 
     @Bean(name = "uploadSchemaStudyIdIndex")
     @Autowired
-    public DynamoIndexHelper uploadSchemaStudyIdIndex(AmazonDynamoDBClient dynamoDBClient, DynamoUtils dynamoUtils,
-            DynamoNamingHelper dynamoNamingHelper) {
-        return DynamoIndexHelper.create(DynamoUploadSchema.class, "studyId-index", dynamoDBClient, dynamoNamingHelper,
-                dynamoUtils);
+    public DynamoIndexHelper uploadSchemaStudyIdIndex(AmazonDynamoDBClient dynamoDBClient,
+                                                      DynamoUtils dynamoUtils,
+                                                      DynamoNamingHelper dynamoNamingHelper) {
+        return DynamoIndexHelper.create(DynamoUploadSchema.class, "studyId-index", dynamoDBClient, dynamoNamingHelper, dynamoUtils);
     }
 
     @Bean(name = "uploadDdbMapper")
@@ -431,19 +432,19 @@ public class BridgeSpringConfig {
     public DynamoDBMapper uploadDedupeDdbMapper(DynamoUtils dynamoUtils) {
         return dynamoUtils.getMapper(DynamoUploadDedupe.class);
     }
-
+    
     @Bean(name = "fphsExternalIdDdbMapper")
     @Autowired
     public DynamoDBMapper fphsExternalIdDdbMapper(DynamoUtils dynamoUtils) {
         return dynamoUtils.getMapper(DynamoFPHSExternalIdentifier.class);
     }
-
+    
     @Bean(name = "externalIdDdbMapper")
     @Autowired
     public DynamoDBMapper externalIdDdbMapper(DynamoUtils dynamoUtils) {
         return dynamoUtils.getMapper(DynamoExternalIdentifier.class);
     }
-
+    
     @Bean(name = "participantOptionsDbMapper")
     @Autowired
     public DynamoDBMapper participantOptionsDbMapper(DynamoUtils dynamoUtils) {
@@ -454,10 +455,12 @@ public class BridgeSpringConfig {
     @Autowired
     public List<UploadValidationHandler> uploadValidationHandlerList(S3DownloadHandler s3DownloadHandler,
             DecryptHandler decryptHandler, UnzipHandler unzipHandler, ParseJsonHandler parseJsonHandler,
-            IosSchemaValidationHandler2 iosSchemaValidationHandler2, StrictValidationHandler strictValidationHandler,
-            TranscribeConsentHandler transcribeConsentHandler, UploadArtifactsHandler uploadArtifactsHandler) {
+            IosSchemaValidationHandler2 iosSchemaValidationHandler2,
+            StrictValidationHandler strictValidationHandler, TranscribeConsentHandler transcribeConsentHandler,
+            UploadArtifactsHandler uploadArtifactsHandler) {
         return ImmutableList.of(s3DownloadHandler, decryptHandler, unzipHandler, parseJsonHandler,
-                iosSchemaValidationHandler2, strictValidationHandler, transcribeConsentHandler, uploadArtifactsHandler);
+                iosSchemaValidationHandler2, strictValidationHandler, transcribeConsentHandler,
+                uploadArtifactsHandler);
     }
 
     @Bean(name = "uploadSchemaDdbMapper")
@@ -476,11 +479,12 @@ public class BridgeSpringConfig {
     @Bean(name = "stormpathClient")
     @Autowired
     public Client getStormpathClient(BridgeConfig bridgeConfig) {
-        ApiKey apiKey = ApiKeys.builder().setId(bridgeConfig.getStormpathId())
-                .setSecret(bridgeConfig.getStormpathSecret()).build();
+        ApiKey apiKey = ApiKeys.builder()
+            .setId(bridgeConfig.getStormpathId())
+            .setSecret(bridgeConfig.getStormpathSecret()).build();
         ClientBuilder clientBuilder = Clients.builder().setApiKey(apiKey);
-        ((DefaultClientBuilder) clientBuilder).setBaseUrl("https://enterprise.stormpath.io/v1");
-        return clientBuilder.build();
+        ((DefaultClientBuilder)clientBuilder).setBaseUrl("https://enterprise.stormpath.io/v1");
+        return clientBuilder.build();        
     }
 
     // Do NOT reference this bean outside of StormpathAccountDao. Injected for testing purposes.
@@ -489,13 +493,13 @@ public class BridgeSpringConfig {
     public Application getStormpathApplication(BridgeConfig bridgeConfig, Client stormpathClient) {
         return stormpathClient.getResource(bridgeConfig.getStormpathApplicationHref(), Application.class);
     }
-
+    
     @Bean(name = "sessionExpireInSeconds")
     public int getSessionExpireInSeconds() {
         return BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS;
     }
 
-    @Bean(name = "bridgePFSynapseClient")
+    @Bean(name="bridgePFSynapseClient")
     public SynapseClient synapseClient() throws IOException {
         SynapseClient synapseClient = new SynapseAdminClientImpl();
         synapseClient.setUserName(bridgeConfig().get("synapse.user"));

--- a/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
+++ b/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
@@ -371,7 +371,7 @@ public class BridgeSpringConfig {
     @Autowired
     public DynamoIndexHelper healthCodeActivityGuidIndex(AmazonDynamoDBClient dynamoDBClient, DynamoUtils dynamoUtils,
             DynamoNamingHelper dynamoNamingHelper) {
-        return DynamoIndexHelper.create(DynamoUpload2.class, "healthCodeActivityGuid-localScheduledOn-index", dynamoDBClient, dynamoNamingHelper, dynamoUtils);
+        return DynamoIndexHelper.create(DynamoScheduledActivity.class, "healthCodeActivityGuid-scheduledOnUTC-index", dynamoDBClient, dynamoNamingHelper, dynamoUtils);
     }
     
     @Bean(name = "uploadStudyIdRequestedOnIndex")

--- a/app/org/sagebionetworks/bridge/dao/ScheduledActivityDao.java
+++ b/app/org/sagebionetworks/bridge/dao/ScheduledActivityDao.java
@@ -2,8 +2,10 @@ package org.sagebionetworks.bridge.dao;
 
 import java.util.List;
 
+import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
+import org.sagebionetworks.bridge.models.ForwardCursorPagedResourceList;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.schedules.ScheduledActivity;
 
@@ -13,6 +15,13 @@ public interface ScheduledActivityDao {
      * Get paged results of the scheduled activities that have been created for this user. 
      */
     PagedResourceList<? extends ScheduledActivity> getActivityHistory(String healthCode, String offsetKey, int pageSize);
+    
+    /**
+     * Get paged results of scheduled activities by an activity GUID.
+     */
+    ForwardCursorPagedResourceList<? extends ScheduledActivity> getActivityHistoryV2(String healthCode,
+            DateTime scheduledOnOrAfter, DateTime scheduledOnOrBefore, String activityGuid, Long offsetBy,
+            int pageSize);
     
     /**
      * Load an individual activity.

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoIndexHelper.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoIndexHelper.java
@@ -12,8 +12,12 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 import com.amazonaws.services.dynamodbv2.document.DynamoDB;
 import com.amazonaws.services.dynamodbv2.document.Index;
 import com.amazonaws.services.dynamodbv2.document.Item;
+import com.amazonaws.services.dynamodbv2.document.Page;
+import com.amazonaws.services.dynamodbv2.document.QueryOutcome;
 import com.amazonaws.services.dynamodbv2.document.RangeKeyCondition;
 import com.amazonaws.services.dynamodbv2.document.Table;
+import com.amazonaws.services.dynamodbv2.document.spec.QuerySpec;
+
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 
@@ -39,7 +43,7 @@ public class DynamoIndexHelper {
     private DynamoDBMapper mapper;
 
     /** DynamoDB index. This is used to query the secondary index. This is configured by Spring. */
-    private void setIndex(Index index) {
+    final void setIndex(Index index) {
         this.index = index;
     }
 
@@ -47,8 +51,13 @@ public class DynamoIndexHelper {
      * DynamoDB mapper. This is used to re-query the DynamoDB table to get full entries from the key objects. This setter is
      * called by tests.
      */
-    public void setMapper(DynamoDBMapper mapper) {
+    final void setMapper(DynamoDBMapper mapper) {
         this.mapper = mapper;
+    }
+    
+    public QueryOutcome query(@Nonnull QuerySpec spec) {
+        Page<Item,QueryOutcome> page = index.query(spec).firstPage();
+        return page.getLowLevelResult();
     }
 
     /**

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivity.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivity.java
@@ -118,9 +118,9 @@ public final class DynamoScheduledActivity implements ScheduledActivity, BridgeE
      * The scheduled time without a time zone. This value is stored, but not returned in the JSON of the API. It is
      * localized using the caller's time zone.
      */
-    @JsonIgnore
     @DynamoDBAttribute
     @DynamoDBTypeConverted(converter = LocalDateTimeMarshaller.class)
+    @JsonIgnore
     public LocalDateTime getLocalScheduledOn() {
         return localScheduledOn;
     }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivity.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivity.java
@@ -39,11 +39,13 @@ public final class DynamoScheduledActivity implements ScheduledActivity, BridgeE
 
     private String healthCode;
     private String guid;
+    private String healthCodeActivityGuid;
     private String schedulePlanGuid;
     private Long startedOn;
     private Long finishedOn;
     private LocalDateTime localScheduledOn;
     private LocalDateTime localExpiresOn;
+    private Long scheduledOnUTC;
     private Activity activity;
     private boolean persistent;
     private DateTimeZone timeZone;
@@ -97,6 +99,17 @@ public final class DynamoScheduledActivity implements ScheduledActivity, BridgeE
         return getInstant(getLocalExpiresOn());
     }
 
+    @Override
+    @DynamoDBAttribute
+    @JsonIgnore
+    public Long getScheduledOnUTC() {
+        return scheduledOnUTC;
+    }
+
+    public void setScheduledOnUTC(Long scheduledOnUTC) {
+        this.scheduledOnUTC = scheduledOnUTC;
+    }
+    
     private DateTime getInstant(LocalDateTime localDateTime) {
         return (localDateTime == null || timeZone == null) ? null : localDateTime.toDateTime(timeZone);
     }
@@ -105,9 +118,9 @@ public final class DynamoScheduledActivity implements ScheduledActivity, BridgeE
      * The scheduled time without a time zone. This value is stored, but not returned in the JSON of the API. It is
      * localized using the caller's time zone.
      */
+    @JsonIgnore
     @DynamoDBAttribute
     @DynamoDBTypeConverted(converter = LocalDateTimeMarshaller.class)
-    @JsonIgnore
     public LocalDateTime getLocalScheduledOn() {
         return localScheduledOn;
     }
@@ -155,6 +168,19 @@ public final class DynamoScheduledActivity implements ScheduledActivity, BridgeE
         this.guid = guid;
     }
 
+    @DynamoDBAttribute
+    @JsonIgnore
+    @Override
+    @DynamoDBIndexHashKey(attributeName = "healthCodeActivityGuid", globalSecondaryIndexName = "healthCodeActivityGuid-scheduledOnUTC-index")
+    public String getHealthCodeActivityGuid() {
+        return healthCodeActivityGuid;
+    }
+    
+    @Override
+    public void setHealthCodeActivityGuid(String healthCodeActivityGuid) {
+        this.healthCodeActivityGuid = healthCodeActivityGuid;
+    }
+    
     @DynamoDBIndexHashKey(attributeName = "schedulePlanGuid", globalSecondaryIndexName = "schedulePlanGuid-index")
     @DynamoProjection(projectionType = ProjectionType.KEYS_ONLY, globalSecondaryIndexName = "schedulePlanGuid-index")
     @Override
@@ -229,8 +255,8 @@ public final class DynamoScheduledActivity implements ScheduledActivity, BridgeE
 
     @Override
     public int hashCode() {
-        return Objects.hash(activity, guid, localScheduledOn, localExpiresOn, startedOn, finishedOn, healthCode,
-                persistent, timeZone, schedulePlanGuid);
+        return Objects.hash(activity, guid, localScheduledOn, scheduledOnUTC, localExpiresOn, startedOn, finishedOn,
+                healthCodeActivityGuid, healthCode, persistent, timeZone, schedulePlanGuid);
     }
 
     @Override
@@ -240,9 +266,14 @@ public final class DynamoScheduledActivity implements ScheduledActivity, BridgeE
         if (obj == null || getClass() != obj.getClass())
             return false;
         DynamoScheduledActivity other = (DynamoScheduledActivity) obj;
-        return (Objects.equals(activity, other.activity) && Objects.equals(localExpiresOn, other.localExpiresOn)
-                && Objects.equals(localScheduledOn, other.localScheduledOn) && Objects.equals(guid, other.guid)
-                && Objects.equals(startedOn, other.startedOn) && Objects.equals(finishedOn, other.finishedOn)
+        return (Objects.equals(activity, other.activity) 
+                && Objects.equals(localExpiresOn, other.localExpiresOn)
+                && Objects.equals(localScheduledOn, other.localScheduledOn)
+                && Objects.equals(healthCodeActivityGuid, other.healthCodeActivityGuid)
+                && Objects.equals(guid, other.guid)
+                && Objects.equals(scheduledOnUTC, other.scheduledOnUTC) 
+                && Objects.equals(startedOn, other.startedOn) 
+                && Objects.equals(finishedOn, other.finishedOn)
                 && Objects.equals(healthCode, other.healthCode) && Objects.equals(persistent, other.persistent)
                 && Objects.equals(timeZone, other.timeZone)
                 && Objects.equals(schedulePlanGuid, other.schedulePlanGuid));
@@ -251,8 +282,8 @@ public final class DynamoScheduledActivity implements ScheduledActivity, BridgeE
     @Override
     public String toString() {
         return String.format(
-                "DynamoScheduledActivity [healthCode=%s, guid=%s, localScheduledOn=%s, localExpiresOn=%s, startedOn=%s, finishedOn=%s, persistent=%s, timeZone=%s, activity=%s, schedulePlanGuid=%s]",
-                healthCode, guid, localScheduledOn, localExpiresOn, startedOn, finishedOn, persistent, timeZone,
+                "DynamoScheduledActivity [healthCode=%s, guid=%s, healthCodeActivityGuid=%s, healthCodeActivityGuidlocalScheduledOn=%s, scheduledOnUTC=%s, localExpiresOn=%s, startedOn=%s, finishedOn=%s, persistent=%s, timeZone=%s, activity=%s, schedulePlanGuid=%s]",
+                healthCode, guid, healthCodeActivityGuid, localScheduledOn, scheduledOnUTC, localExpiresOn, startedOn, finishedOn, persistent, timeZone,
                 activity, schedulePlanGuid);
     }
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDao.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge.dynamodb;
 
 import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -15,15 +16,23 @@ import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.dao.ScheduledActivityDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
+import org.sagebionetworks.bridge.models.ForwardCursorPagedResourceList;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.schedules.ScheduledActivity;
 
+import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.springframework.stereotype.Component;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper.FailedBatch;
+import com.amazonaws.services.dynamodbv2.document.Item;
+import com.amazonaws.services.dynamodbv2.document.KeyAttribute;
+import com.amazonaws.services.dynamodbv2.document.QueryOutcome;
+import com.amazonaws.services.dynamodbv2.document.RangeKeyCondition;
+import com.amazonaws.services.dynamodbv2.document.spec.QuerySpec;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.QueryResult;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
 import com.amazonaws.services.dynamodbv2.datamodeling.PaginatedQueryList;
 import com.amazonaws.services.dynamodbv2.datamodeling.QueryResultPage;
@@ -34,6 +43,14 @@ import com.google.common.collect.Lists;
 @Component
 public class DynamoScheduledActivityDao implements ScheduledActivityDao {
     
+    private static final String SCHEDULED_ON_OR_BEFORE = "scheduledOnOrBefore";
+
+    private static final String SCHEDULED_ON_OR_AFTER = "scheduledOnOrAfter";
+
+    private static final String SCHEDULED_ON_UTC = "scheduledOnUTC";
+
+    private static final String HEALTH_CODE_ACTIVITY_GUID = "healthCodeActivityGuid";
+
     private static final String HEALTH_CODE = "healthCode";
 
     private static final String GUID = "guid";
@@ -42,9 +59,16 @@ public class DynamoScheduledActivityDao implements ScheduledActivityDao {
     
     private DynamoDBMapper mapper;
     
+    private DynamoIndexHelper indexHelper;
+    
     @Resource(name = "activityDdbMapper")
     public final void setDdbMapper(DynamoDBMapper mapper) {
         this.mapper = mapper;
+    }
+    
+    @Resource(name = "healthCodeActivityGuidIndex")
+    final void setHealthCodeActivityGuidIndex(DynamoIndexHelper healthCodeActivityGuidIndex) {
+        this.indexHelper = healthCodeActivityGuidIndex;
     }
     
     @Override
@@ -67,6 +91,62 @@ public class DynamoScheduledActivityDao implements ScheduledActivityDao {
             activity.setTimeZone(DateTimeZone.UTC);
         }
         return resourceList;
+    }
+    
+    @Override
+    public ForwardCursorPagedResourceList<ScheduledActivity> getActivityHistoryV2(String healthCode,
+            DateTime scheduledOnOrAfter, DateTime scheduledOnOrBefore, String activityGuid, Long offsetBy,
+            int pageSize) {
+        checkNotNull(healthCode);
+        checkNotNull(scheduledOnOrAfter);
+        checkNotNull(scheduledOnOrBefore);
+        checkNotNull(activityGuid);
+        
+        if (pageSize < API_MINIMUM_PAGE_SIZE || pageSize > API_MAXIMUM_PAGE_SIZE) {
+            throw new BadRequestException(PAGE_SIZE_ERROR);
+        }
+        String healthCodeActivityGuid = healthCode + ":" + activityGuid;
+        
+        // The range is exclusive, so bump the timestamps back/forward by one millisecond
+        long startTimestamp = scheduledOnOrAfter.minusMillis(1).getMillis();
+        long endTimestamp = scheduledOnOrBefore.plusMillis(1).getMillis();
+        RangeKeyCondition dateRangeCondition = new RangeKeyCondition(SCHEDULED_ON_UTC).between(startTimestamp,endTimestamp);
+
+        QuerySpec spec = new QuerySpec()
+                .withHashKey(new KeyAttribute(HEALTH_CODE_ACTIVITY_GUID, healthCodeActivityGuid))
+                .withMaxPageSize(pageSize)
+                .withScanIndexForward(false)
+                .withRangeKeyCondition(dateRangeCondition);
+
+        // It does not appear it is possible to use an exclusive start key with a GSI (though that's not definitive):
+        // https://forums.aws.amazon.com/thread.jspa?threadID=146102&tstart=0. I could not get it to work, so using 
+        // a range key condition instead.
+        if (offsetBy != null) {
+            RangeKeyCondition cursorPosCondition = new RangeKeyCondition(SCHEDULED_ON_UTC).gt(offsetBy);
+            spec.withRangeKeyCondition(cursorPosCondition);
+        }
+        
+        QueryOutcome queryOutcome = indexHelper.query(spec);
+        List<Item> items = queryOutcome.getItems();
+        QueryResult queryResult = queryOutcome.getQueryResult();
+        
+        // Index only includes keys. Load the items.
+        List<ScheduledActivity> results = new ArrayList<>(items.size());
+        for (Item item : items) {
+            ScheduledActivity activity = getActivity(healthCode, item.getString(GUID));
+            results.add(activity);
+        }
+        
+        // There's no total count with a DynamoDB record set, but if there's an offset, there is a further
+        // page of records.
+        Long nextPageOffsetBy = null;
+        if (queryResult.getLastEvaluatedKey() != null) {
+            nextPageOffsetBy = Long.parseLong(queryResult.getLastEvaluatedKey().get(SCHEDULED_ON_UTC).getN());
+        }
+        
+        return new ForwardCursorPagedResourceList<ScheduledActivity>(results, nextPageOffsetBy, pageSize)
+                .withFilter(SCHEDULED_ON_OR_AFTER, scheduledOnOrAfter)
+                .withFilter(SCHEDULED_ON_OR_BEFORE, scheduledOnOrBefore);
     }
 
     /**

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDao.java
@@ -62,7 +62,7 @@ public class DynamoScheduledActivityDao implements ScheduledActivityDao {
     private DynamoIndexHelper indexHelper;
     
     @Resource(name = "activityDdbMapper")
-    public final void setDdbMapper(DynamoDBMapper mapper) {
+    final void setDdbMapper(DynamoDBMapper mapper) {
         this.mapper = mapper;
     }
     

--- a/app/org/sagebionetworks/bridge/models/ForwardCursorPagedResourceList.java
+++ b/app/org/sagebionetworks/bridge/models/ForwardCursorPagedResourceList.java
@@ -1,0 +1,84 @@
+package org.sagebionetworks.bridge.models;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import org.joda.time.DateTime;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+
+/**
+ * A paged list of items from a data store that can provide a pointer to the next page of records, but 
+ * which cannot return the total number of records across all pages (DynamoDB).
+ */
+public class ForwardCursorPagedResourceList<T> {
+
+    private final List<T> items;
+    private final int pageSize;
+    private final @Nullable Long offsetBy;
+    private final Map<String,String> filters = Maps.newHashMap();
+
+    @JsonCreator
+    public ForwardCursorPagedResourceList(
+            @JsonProperty("items") List<T> items, 
+            @JsonProperty("offsetBy") Long offsetBy,
+            @JsonProperty("pageSize") int pageSize) {
+        this.items = items;
+        this.offsetBy = offsetBy;
+        this.pageSize = pageSize;
+    }
+
+    /**
+     * A convenience method for adding filters without having to construct an intermediate map of filters.
+     * e.g. PagedResourceList<T> page = new PagedResourceList<T>(....).withFilterValue("a","b");
+     */
+    public ForwardCursorPagedResourceList<T> withFilter(String key, String value) {
+        if (isNotBlank(key) && isNotBlank(value)) {
+            filters.put(key, value);
+        }
+        return this;
+    }
+    /**
+     * A convenience method for adding a date filter.
+     */
+    public ForwardCursorPagedResourceList<T> withFilter(String key, DateTime value) {
+        if (isNotBlank(key) && value != null) {
+            filters.put(key, value.toString());
+        }
+        return this;
+    }
+    public List<T> getItems() {
+        return items;
+    }
+    public Long getOffsetBy() {
+        return offsetBy;
+    }
+    public int getPageSize() {
+        return pageSize;
+    }
+    @JsonAnyGetter
+    public Map<String, String> getFilters() {
+        return ImmutableMap.copyOf(filters);
+    }
+    @JsonAnySetter
+    private void setFilter(String key, String value) {
+        if (isNotBlank(key) && isNotBlank(value)) {
+            filters.put(key, value);    
+        }
+    }
+    @Override
+    public String toString() {
+        return "ForwardCursorPagedResourceList [items=" + items + ", offsetBy=" + offsetBy + ", pageSize=" + pageSize
+                + ", filters=" + filters + "]";
+    }
+
+}

--- a/app/org/sagebionetworks/bridge/models/ForwardCursorPagedResourceList.java
+++ b/app/org/sagebionetworks/bridge/models/ForwardCursorPagedResourceList.java
@@ -62,6 +62,10 @@ public class ForwardCursorPagedResourceList<T> {
     public Long getOffsetBy() {
         return offsetBy;
     }
+    @JsonProperty("hasNext")
+    public boolean hasNext() {
+        return (offsetBy != null);
+    }
     public int getPageSize() {
         return pageSize;
     }

--- a/app/org/sagebionetworks/bridge/models/schedules/ActivityScheduler.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/ActivityScheduler.java
@@ -68,9 +68,13 @@ public abstract class ActivityScheduler {
                     schActivity.setTimeZone(context.getEndsOn().getZone());
                     schActivity.setHealthCode(context.getCriteriaContext().getHealthCode());
                     schActivity.setActivity(activity);
-                    schActivity.setLocalScheduledOn(localDate.toLocalDateTime(localTime));
+                    LocalDateTime localScheduledOn = localDate.toLocalDateTime(localTime);
+                    schActivity.setLocalScheduledOn(localScheduledOn);
+                    schActivity.setScheduledOnUTC(localScheduledOn.toDateTime(context.getEndsOn().getZone()).getMillis());
                     schActivity.setGuid(activity.getGuid() + ":" + localDate.toLocalDateTime(localTime));
                     schActivity.setPersistent(activity.isPersistentlyRescheduledBy(schedule));
+                    schActivity.setHealthCodeActivityGuid(
+                            context.getCriteriaContext().getHealthCode() + ":" + activity.getGuid());
                     if (expiresOn != null) {
                         schActivity.setLocalExpiresOn(expiresOn);
                     }

--- a/app/org/sagebionetworks/bridge/models/schedules/ScheduledActivity.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/ScheduledActivity.java
@@ -85,6 +85,10 @@ public interface ScheduledActivity extends BridgeEntity {
 
     void setHealthCode(String healthCode);
 
+    String getHealthCodeActivityGuid();
+    
+    void setHealthCodeActivityGuid(String healthCodeActivityGuid);
+    
     Activity getActivity();
 
     void setActivity(Activity activity);
@@ -93,6 +97,10 @@ public interface ScheduledActivity extends BridgeEntity {
 
     void setLocalScheduledOn(LocalDateTime localScheduledOn);
 
+    Long getScheduledOnUTC();
+
+    void setScheduledOnUTC(Long scheduledOnUTC);
+    
     DateTime getExpiresOn();
 
     void setLocalExpiresOn(LocalDateTime expiresOn);

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityTest.java
@@ -104,10 +104,12 @@ public class DynamoScheduledActivityTest {
         schActivity.setGuid("AAA-BBB-CCC");
         schActivity.setHealthCode("FFF-GGG-HHH");
         schActivity.setPersistent(true);
+        schActivity.setHealthCodeActivityGuid("FFF-GGG-HHH:AAA-BBB-CCC");
+        schActivity.setScheduledOnUTC(scheduledOn.toDateTime(DateTimeZone.UTC).getMillis());
         
         BridgeObjectMapper mapper = BridgeObjectMapper.get();
         String output = ScheduledActivity.SCHEDULED_ACTIVITY_WRITER.writeValueAsString(schActivity);
-
+        
         JsonNode node = mapper.readTree(output);
         assertEquals("AAA-BBB-CCC", node.get("guid").asText());
         assertEquals(scheduledOnString, node.get("scheduledOn").asText());
@@ -116,6 +118,7 @@ public class DynamoScheduledActivityTest {
         assertEquals("ScheduledActivity", node.get("type").asText());
         assertTrue(node.get("persistent").asBoolean());
         assertNull(node.get("schedule"));
+        assertEquals(7, node.size());
         
         JsonNode activityNode = node.get("activity");
         assertEquals("Activity3", activityNode.get("label").asText());
@@ -132,6 +135,8 @@ public class DynamoScheduledActivityTest {
         newActivity.setTimeZone(DateTimeZone.UTC);
         newActivity.setLocalScheduledOn(scheduledOn);
         newActivity.setLocalExpiresOn(expiresOn);
+        newActivity.setHealthCodeActivityGuid("FFF-GGG-HHH:AAA-BBB-CCC");
+        newActivity.setScheduledOnUTC(scheduledOn.toDateTime(DateTimeZone.UTC).getMillis());
         
         // Also works without having to reset the timezone.
         assertEquals(schActivity, newActivity);

--- a/test/org/sagebionetworks/bridge/models/ForwardCursorPagedResourceListTest.java
+++ b/test/org/sagebionetworks/bridge/models/ForwardCursorPagedResourceListTest.java
@@ -1,0 +1,107 @@
+package org.sagebionetworks.bridge.models;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.List;
+
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.accounts.AccountStatus;
+import org.sagebionetworks.bridge.models.accounts.AccountSummary;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.google.common.collect.Lists;
+
+public class ForwardCursorPagedResourceListTest {
+    @Test
+    public void canSerialize() throws Exception {
+        List<AccountSummary> accounts = Lists.newArrayListWithCapacity(2);
+        accounts.add(new AccountSummary("firstName1", "lastName1", "email1@email.com", "id", DateTime.now(),
+                AccountStatus.DISABLED, TestConstants.TEST_STUDY));
+        accounts.add(new AccountSummary("firstName2", "lastName2", "email2@email.com", "id2", DateTime.now(),
+                AccountStatus.ENABLED, TestConstants.TEST_STUDY));
+        
+        ForwardCursorPagedResourceList<AccountSummary> page = new ForwardCursorPagedResourceList<AccountSummary>(
+                accounts, 2L, 100).withFilter("emailFilter", "filterString");
+        
+        JsonNode node = BridgeObjectMapper.get().valueToTree(page);
+        assertEquals(2, node.get("offsetBy").asInt());
+        assertEquals(100, node.get("pageSize").asInt());
+        assertEquals("filterString", node.get("emailFilter").asText());
+        assertEquals("ForwardCursorPagedResourceList", node.get("type").asText());
+        
+        ArrayNode items = (ArrayNode)node.get("items");
+        assertEquals(2, items.size());
+        
+        JsonNode child1 = items.get(0);
+        assertEquals("firstName1", child1.get("firstName").asText());
+        assertEquals("lastName1", child1.get("lastName").asText());
+        assertEquals("email1@email.com", child1.get("email").asText());
+        assertEquals("id", child1.get("id").asText());
+        assertEquals("disabled", child1.get("status").asText());
+        
+        ForwardCursorPagedResourceList<AccountSummary> serPage = BridgeObjectMapper.get().readValue(node.toString(),
+                new TypeReference<ForwardCursorPagedResourceList<AccountSummary>>() {
+                });
+
+        assertEquals(page.getOffsetBy(), serPage.getOffsetBy());
+        assertEquals(page.getPageSize(), serPage.getPageSize());
+        assertEquals(page.getFilters().get("emailFilter"), serPage.getFilters().get("emailFilter"));
+        
+        assertEquals(page.getItems(), serPage.getItems());
+    }
+    
+    @Test
+    public void offsetByCanBeNull() throws Exception {
+        List<AccountSummary> accounts = Lists.newArrayListWithCapacity(2);
+        ForwardCursorPagedResourceList<AccountSummary> page = new ForwardCursorPagedResourceList<AccountSummary>(
+                accounts, null, 100).withFilter("emailFilter", "filterString");
+        
+        JsonNode node = BridgeObjectMapper.get().valueToTree(page);
+        assertNull(node.get("offsetBy"));
+        assertEquals(100, node.get("pageSize").asInt());
+        assertEquals("filterString", node.get("emailFilter").asText());
+        assertEquals("ForwardCursorPagedResourceList", node.get("type").asText());
+        assertEquals(4, node.size());
+    }
+    
+    // This test was moved from another class that implemented PagedResourceList for
+    // DynamoDB, that was easily incorporated into this implementation. This test verifies
+    // that the results are the same as before.
+    @Test
+    public void canSerializeWithDynamoOffsetKey() throws Exception {
+        List<String> accounts = Lists.newArrayListWithCapacity(2);
+        accounts.add("value1");
+        accounts.add("value2");
+        
+        ForwardCursorPagedResourceList<String> page = new ForwardCursorPagedResourceList<>(accounts, null, 100)
+                .withFilter("idFilter", "foo").withFilter("assignmentFilter", "bar");
+        JsonNode node = BridgeObjectMapper.get().valueToTree(page);
+        assertEquals(100, node.get("pageSize").asInt());
+        assertEquals("foo", node.get("idFilter").asText());
+        assertEquals("bar", node.get("assignmentFilter").asText());
+        assertEquals("ForwardCursorPagedResourceList", node.get("type").asText());
+        
+        ArrayNode items = (ArrayNode)node.get("items");
+        assertEquals(2, items.size());
+        assertEquals("value1", items.get(0).asText());
+        assertEquals("value2", items.get(1).asText());
+        
+        // We don't deserialize this, but let's verify for the SDK
+        PagedResourceList<String> serPage = BridgeObjectMapper.get().readValue(node.toString(), 
+                new TypeReference<PagedResourceList<String>>() {});
+        
+        assertEquals(page.getPageSize(), serPage.getPageSize());
+        assertEquals(page.getFilters().get("offsetBy"), serPage.getFilters().get("offsetBy"));
+        assertEquals(page.getOffsetBy(), serPage.getOffsetBy());
+        assertEquals(page.getFilters().get("idFilter"), serPage.getFilters().get("idFilter"));
+        assertEquals(page.getFilters().get("assignmentFilter"), serPage.getFilters().get("assignmentFilter"));
+        assertEquals(page.getItems(), serPage.getItems());
+    }
+}

--- a/test/org/sagebionetworks/bridge/models/ForwardCursorPagedResourceListTest.java
+++ b/test/org/sagebionetworks/bridge/models/ForwardCursorPagedResourceListTest.java
@@ -1,7 +1,9 @@
 package org.sagebionetworks.bridge.models;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
@@ -34,6 +36,7 @@ public class ForwardCursorPagedResourceListTest {
         assertEquals(2, node.get("offsetBy").asInt());
         assertEquals(100, node.get("pageSize").asInt());
         assertEquals("filterString", node.get("emailFilter").asText());
+        assertTrue(node.get("hasNext").asBoolean());
         assertEquals("ForwardCursorPagedResourceList", node.get("type").asText());
         
         ArrayNode items = (ArrayNode)node.get("items");
@@ -53,6 +56,7 @@ public class ForwardCursorPagedResourceListTest {
         assertEquals(page.getOffsetBy(), serPage.getOffsetBy());
         assertEquals(page.getPageSize(), serPage.getPageSize());
         assertEquals(page.getFilters().get("emailFilter"), serPage.getFilters().get("emailFilter"));
+        assertEquals(page.hasNext(), serPage.hasNext());
         
         assertEquals(page.getItems(), serPage.getItems());
     }
@@ -68,7 +72,8 @@ public class ForwardCursorPagedResourceListTest {
         assertEquals(100, node.get("pageSize").asInt());
         assertEquals("filterString", node.get("emailFilter").asText());
         assertEquals("ForwardCursorPagedResourceList", node.get("type").asText());
-        assertEquals(4, node.size());
+        assertFalse(node.get("hasNext").asBoolean());
+        assertEquals(5, node.size());
     }
     
     // This test was moved from another class that implemented PagedResourceList for

--- a/test/org/sagebionetworks/bridge/models/schedules/ActivitySchedulerTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/ActivitySchedulerTest.java
@@ -110,8 +110,12 @@ public class ActivitySchedulerTest {
         assertEquals("BBB", schActivity.getSchedulePlanGuid());
         assertNotNull(schActivity.getScheduledOn());
         assertNotNull(schActivity.getExpiresOn());
-        assertEquals("AAA", schActivity.getHealthCode());
+        assertEquals("healthCode", schActivity.getHealthCode());
         assertEquals(PST, schActivity.getTimeZone());
+        assertEquals((Long)1427104800000L, schActivity.getScheduledOnUTC());
+        assertEquals("healthCode:AAA", schActivity.getHealthCodeActivityGuid());
+        // The start time for a one-time task is the enrollment time
+        assertEquals((Long)ENROLLMENT.getMillis(), schActivity.getScheduledOnUTC());
     }
     
     /**
@@ -443,7 +447,7 @@ public class ActivitySchedulerTest {
 
     private ScheduleContext getContext(DateTimeZone zone, DateTime endsOn) {
         return new ScheduleContext.Builder().withStudyIdentifier(TEST_STUDY)
-            .withInitialTimeZone(zone).withEndsOn(endsOn).withHealthCode("AAA").withEvents(events).build();
+            .withInitialTimeZone(zone).withEndsOn(endsOn).withHealthCode("healthCode").withEvents(events).build();
     }
     
 }


### PR DESCRIPTION
As a prelude to being able to save arbitrary client data with a task, a new method for retrieving tasks by the scheduled on timestamp. This is per activity in a schedule plan.

This was branched from another PR that must be merged first (that does some work to ensure that activity GUIDs are stable and don't change when clients make certain mistakes with the JSON they send to the server).