### PR TITLE
add Shared Module Library study to bootstrapper; prevent encryption keys from being recreated

### DIFF
--- a/app/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/app/org/sagebionetworks/bridge/BridgeConstants.java
@@ -7,11 +7,21 @@ import org.jsoup.safety.Whitelist;
 
 import com.google.common.collect.ImmutableSet;
 
+import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
+
 public class BridgeConstants {
+    // Study ID for the test study, used in local tests and most integ tests.
+    public static final String API_STUDY_ID_STRING = "api";
+    public static final StudyIdentifier API_STUDY_ID = new StudyIdentifierImpl(API_STUDY_ID_STRING);
 
     /** A common string constraint we place on model identifiers. */
     public static final String BRIDGE_IDENTIFIER_PATTERN = "^[a-z0-9-]+$";
-    
+
+    // Study ID used for the Shared Module Library
+    public static final String SHARED_STUDY_ID_STRING = "shared";
+    public static final StudyIdentifier SHARED_STUDY_ID = new StudyIdentifierImpl(SHARED_STUDY_ID_STRING);
+
     /** A common string constraint Synapse places on model identifiers. */
     public static final String SYNAPSE_IDENTIFIER_PATTERN = "^[a-zA-Z0-9_-]+$";
     

--- a/app/org/sagebionetworks/bridge/services/UploadCertificateService.java
+++ b/app/org/sagebionetworks/bridge/services/UploadCertificateService.java
@@ -30,8 +30,10 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 public class UploadCertificateService {
 
     private static final BridgeConfig CONFIG = BridgeConfigFactory.getConfig();
-    private static final String PRIVATE_KEY_BUCKET = CONFIG.getProperty("upload.cms.priv.bucket");
-    private static final String CERT_BUCKET = CONFIG.getProperty("upload.cms.cert.bucket");
+
+    // S3 buckets for priv keys and certs. Package-scoped to facilitate unit tests.
+    static final String PRIVATE_KEY_BUCKET = CONFIG.getProperty("upload.cms.priv.bucket");
+    static final String CERT_BUCKET = CONFIG.getProperty("upload.cms.cert.bucket");
 
     private final CertificateFactory certificateFactory;
     private AmazonS3 s3CmsClient;
@@ -56,40 +58,46 @@ public class UploadCertificateService {
      */
     public void createCmsKeyPair(final StudyIdentifier studyIdentifier) {
         checkNotNull(studyIdentifier);
-        final KeyPair keyPair = KeyPairFactory.newRsa2048();
-        final CertificateInfo certInfo = new CertificateInfo.Builder()
-                .country(CONFIG.getProperty("upload.cms.certificate.country"))
-                .state(CONFIG.getProperty("upload.cms.certificate.state"))
-                .city(CONFIG.getProperty("upload.cms.certificate.city"))
-                .organization(CONFIG.getProperty("upload.cms.certificate.organization"))
-                .team(CONFIG.getProperty("upload.cms.certificate.team"))
-                .email(CONFIG.getProperty("upload.cms.certificate.email")).fqdn(CONFIG.getWebservicesURL()).build();
-        final X509Certificate cert = certificateFactory.newCertificate(keyPair, certInfo);
-        final String name = studyIdentifier.getIdentifier() + ".pem";
-        try {
-            s3Put(PRIVATE_KEY_BUCKET, name, PemUtils.toPem(keyPair.getPrivate()));
-            s3Put(CERT_BUCKET, name, PemUtils.toPem(cert));
-        } catch (CertificateEncodingException e) {
-            throw new BridgeServiceException(e);
+        String pemFilename = getPemFilename(studyIdentifier);
+        if (!s3CmsClient.doesObjectExist(PRIVATE_KEY_BUCKET, pemFilename) ||
+                !s3CmsClient.doesObjectExist(CERT_BUCKET, pemFilename)) {
+            final KeyPair keyPair = KeyPairFactory.newRsa2048();
+            final CertificateInfo certInfo = new CertificateInfo.Builder()
+                    .country(CONFIG.getProperty("upload.cms.certificate.country"))
+                    .state(CONFIG.getProperty("upload.cms.certificate.state"))
+                    .city(CONFIG.getProperty("upload.cms.certificate.city"))
+                    .organization(CONFIG.getProperty("upload.cms.certificate.organization"))
+                    .team(CONFIG.getProperty("upload.cms.certificate.team"))
+                    .email(CONFIG.getProperty("upload.cms.certificate.email")).fqdn(CONFIG.getWebservicesURL()).build();
+            final X509Certificate cert = certificateFactory.newCertificate(keyPair, certInfo);
+            try {
+                s3Put(PRIVATE_KEY_BUCKET, pemFilename, PemUtils.toPem(keyPair.getPrivate()));
+                s3Put(CERT_BUCKET, pemFilename, PemUtils.toPem(cert));
+            } catch (CertificateEncodingException e) {
+                throw new BridgeServiceException(e);
+            }
         }
+    }
+
+    // Helper function to get the PEM filename. Package-scoped to facilitate unit tests.
+    static String getPemFilename(StudyIdentifier studyId) {
+        return studyId.getIdentifier() + ".pem";
     }
 
     /**
      * Get the PEM file for the public key of the CMS key pair. Study developers need 
      * access to this certificate to encrypt data they send to us.
-     * 
-     * @param studyIdentifier
-     * @return
      */
     public String getPublicKeyAsPem(StudyIdentifier studyIdentifier) {
         try {
-            return s3CmsHelper.readS3FileAsString(CERT_BUCKET, studyIdentifier.getIdentifier() + ".pem");
+            return s3CmsHelper.readS3FileAsString(CERT_BUCKET, getPemFilename(studyIdentifier));
         } catch (IOException e) {
             throw new BridgeServiceException(e);
         }
     }
 
-    private void s3Put(String bucket, String name, String pem) {
+    // package-scoped to facilitate unit tests
+    void s3Put(String bucket, String name, String pem) {
         byte[] bytes = pem.getBytes(StandardCharsets.UTF_8);
         try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes)) {
             ObjectMetadata metadata = new ObjectMetadata();

--- a/test/org/sagebionetworks/bridge/DefaultStudyBootstrapperTest.java
+++ b/test/org/sagebionetworks/bridge/DefaultStudyBootstrapperTest.java
@@ -1,9 +1,13 @@
 package org.sagebionetworks.bridge;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.util.List;
 
 import com.google.common.collect.Sets;
 import org.junit.Before;
@@ -14,8 +18,10 @@ import org.sagebionetworks.bridge.dynamodb.DynamoInitializer;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.studies.PasswordPolicy;
 import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.services.StudyService;
 
+@SuppressWarnings("unchecked")
 public class DefaultStudyBootstrapperTest {
 
     private StudyService studyService;
@@ -26,9 +32,7 @@ public class DefaultStudyBootstrapperTest {
     public void before() {
         studyService = mock(StudyService.class);
 
-        when(studyService.getStudy("api")).thenThrow(new EntityNotFoundException(Study.class,
-                "Study 'api' not found."
-        ));
+        when(studyService.getStudy(any(StudyIdentifier.class))).thenThrow(EntityNotFoundException.class);
         defaultStudyBootstrapper = new DefaultStudyBootstrapper(studyService,
                 mock(AnnotationBasedTableCreator.class),
                 mock(DynamoInitializer.class)
@@ -40,11 +44,14 @@ public class DefaultStudyBootstrapperTest {
         defaultStudyBootstrapper.initializeDatabase();
 
         ArgumentCaptor<Study> argument = ArgumentCaptor.forClass(Study.class);
-        verify(studyService).createStudy(argument.capture());
+        verify(studyService, times(2)).createStudy(argument.capture());
 
-        Study study = argument.getValue();
+        List<Study> createdStudyList = argument.getAllValues();
+
+        // Validate api study.
+        Study study = createdStudyList.get(0);
         assertEquals("Test Study", study.getName());
-        assertEquals("api", study.getIdentifier());
+        assertEquals(BridgeConstants.API_STUDY_ID_STRING, study.getIdentifier());
         assertEquals("Sage Bionetworks", study.getSponsorName());
         assertEquals(18, study.getMinAgeOfConsent());
         assertEquals("bridge-testing+consent@sagebase.org", study.getConsentNotificationEmail());
@@ -53,6 +60,12 @@ public class DefaultStudyBootstrapperTest {
         assertEquals("https://enterprise.stormpath.io/v1/directories/3OBNJsxNxvaaK5nSFwv8RD", study.getStormpathHref());
         assertEquals(Sets.newHashSet("phone", "can_be_recontacted"), study.getUserProfileAttributes());
         assertEquals(new PasswordPolicy(2, false, false, false, false), study.getPasswordPolicy());
-    }
 
+        // Validate shared study. No need to test every attribute. Just validate the important attributes.
+        Study sharedStudy = createdStudyList.get(1);
+        assertEquals("Shared Module Library", sharedStudy.getName());
+        assertEquals(BridgeConstants.SHARED_STUDY_ID_STRING, sharedStudy.getIdentifier());
+        assertEquals("https://enterprise.stormpath.io/v1/directories/4VaJ0y63TCKDmJTIV8YGAs",
+                sharedStudy.getStormpathHref());
+    }
 }

--- a/test/org/sagebionetworks/bridge/services/UploadCertificateServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/UploadCertificateServiceMockTest.java
@@ -1,0 +1,96 @@
+package org.sagebionetworks.bridge.services;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.services.s3.AmazonS3;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
+
+public class UploadCertificateServiceMockTest {
+    // For safety, don't use api study. Otherwise, if we botch the test, we risk stomping over the api PEM keys again.
+    private static final String STUDY_ID_STRING = "cert-test-study";
+    private static final StudyIdentifier STUDY_ID = new StudyIdentifierImpl(STUDY_ID_STRING);
+    private static final String PEM_FILENAME = UploadCertificateService.getPemFilename(STUDY_ID);
+
+    private AmazonS3 mockS3client;
+    private UploadCertificateService svc;
+
+    @Before
+    public void before() {
+        // Mock S3 client. We'll fill in the details during the test.
+        mockS3client = mock(AmazonS3.class);
+
+        // Spy UploadCertificateService. This allows us to mock s3Put without doing a bunch of complex logic.
+        svc = spy(new UploadCertificateService());
+        svc.setS3CmsClient(mockS3client);
+        doNothing().when(svc).s3Put(any(), any(), any());
+    }
+
+    @Test
+    public void createKeyPair() {
+        when(mockS3client.doesObjectExist(UploadCertificateService.CERT_BUCKET, PEM_FILENAME)).thenReturn(false);
+        when(mockS3client.doesObjectExist(UploadCertificateService.PRIVATE_KEY_BUCKET, PEM_FILENAME)).thenReturn(
+                false);
+        testCreateKeyPair();
+    }
+
+    @Test
+    public void certExists() {
+        when(mockS3client.doesObjectExist(UploadCertificateService.CERT_BUCKET, PEM_FILENAME)).thenReturn(true);
+        when(mockS3client.doesObjectExist(UploadCertificateService.PRIVATE_KEY_BUCKET, PEM_FILENAME)).thenReturn(
+                false);
+        testCreateKeyPair();
+    }
+
+    @Test
+    public void privKeyExists() {
+        when(mockS3client.doesObjectExist(UploadCertificateService.CERT_BUCKET, PEM_FILENAME)).thenReturn(false);
+        when(mockS3client.doesObjectExist(UploadCertificateService.PRIVATE_KEY_BUCKET, PEM_FILENAME)).thenReturn(
+                true);
+        testCreateKeyPair();
+    }
+
+    private void testCreateKeyPair() {
+        // execute
+        svc.createCmsKeyPair(STUDY_ID);
+
+        // verify key pair were created
+        ArgumentCaptor<String> certCaptor = ArgumentCaptor.forClass(String.class);
+        verify(svc).s3Put(eq(UploadCertificateService.CERT_BUCKET), eq(PEM_FILENAME), certCaptor.capture());
+        String cert = certCaptor.getValue();
+        assertTrue(cert.contains("-----BEGIN CERTIFICATE-----"));
+        assertTrue(cert.contains("-----END CERTIFICATE-----"));
+
+        ArgumentCaptor<String> privKeyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(svc).s3Put(eq(UploadCertificateService.PRIVATE_KEY_BUCKET), eq(PEM_FILENAME), privKeyCaptor.capture());
+        String privKey = privKeyCaptor.getValue();
+        assertTrue(privKey.contains("-----BEGIN RSA PRIVATE KEY-----"));
+        assertTrue(privKey.contains("-----END RSA PRIVATE KEY-----"));
+    }
+
+    @Test
+    public void bothKeysAlreadyExist() {
+        // Mock S3 client. Both keys exist.
+        when(mockS3client.doesObjectExist(UploadCertificateService.CERT_BUCKET, PEM_FILENAME)).thenReturn(true);
+        when(mockS3client.doesObjectExist(UploadCertificateService.PRIVATE_KEY_BUCKET, PEM_FILENAME)).thenReturn(
+                true);
+
+        // execute
+        svc.createCmsKeyPair(STUDY_ID);
+
+        // We never upload to S3.
+        verify(svc, never()).s3Put(any(), any(), any());
+    }
+}


### PR DESCRIPTION
Added Shared Module Library "shared" study to the default bootstrapper. This allows other devs to have this study in their local envs, if they need to test Shared Module Library stuff. (For dev, staging, and prod, we still need to create these studies manually, which I've already done.) See https://sagebionetworks.jira.com/browse/BRIDGE-1542

As a side effect, this also prevents encryption certs from being recreated when you recreate a study https://sagebionetworks.jira.com/browse/BRIDGE-593