### PR TITLE
Revert "Fixing test by allowing getUploadSchemaNoThrow to not throw, it is then validated which I believe is what we want."

### DIFF
--- a/app/org/sagebionetworks/bridge/services/UploadSchemaService.java
+++ b/app/org/sagebionetworks/bridge/services/UploadSchemaService.java
@@ -552,10 +552,10 @@ public class UploadSchemaService {
      * exist.
      */
     private UploadSchema getUploadSchemaNoThrow(StudyIdentifier studyId, String schemaId) {
-        if (!StringUtils.isBlank(schemaId)) {
-            return uploadSchemaDao.getUploadSchemaLatestRevisionById(studyId, schemaId);
+        if (StringUtils.isBlank(schemaId)) {
+            throw new BadRequestException("Schema ID must be specified");
         }
-        return null;
+        return uploadSchemaDao.getUploadSchemaLatestRevisionById(studyId, schemaId);
     }
 
     /**

--- a/test/org/sagebionetworks/bridge/play/controllers/UploadSchemaControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/UploadSchemaControllerTest.java
@@ -2,7 +2,6 @@ package org.sagebionetworks.bridge.play.controllers;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyVararg;
 import static org.mockito.Mockito.doReturn;
@@ -247,7 +246,6 @@ public class UploadSchemaControllerTest {
         // execute and validate
         try {
             controller.createOrUpdateUploadSchema();
-            fail("Should have thrown exception");
         } catch(InvalidEntityException e) {
             assertEquals("schemaId is required", e.getErrors().get("schemaId").get(0));
             assertEquals("name is required", e.getErrors().get("name").get(0));


### PR DESCRIPTION
Reverts Sage-Bionetworks/BridgePF#1401

The previous change breaks a bunch of other tests, and changes semantics by making us not validate user inputs. Reverting this.