### PR TITLE
Add a route for researcher to withdraw a user from a single consent.

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
@@ -246,6 +246,19 @@ public class ParticipantController extends BaseController {
         return okResult("User has been withdrawn from the study.");
     }
     
+    public Result withdrawConsent(String userId, String guid) {
+        UserSession session = getAuthenticatedSession(RESEARCHER);
+        Study study = studyService.getStudy(session.getStudyIdentifier());
+        
+        Withdrawal withdrawal = parseJson(request(), Withdrawal.class);
+        long withdrewOn = DateTime.now().getMillis();
+        SubpopulationGuid subpopGuid = SubpopulationGuid.create(guid);
+        
+        participantService.withdrawConsent(study, userId, subpopGuid, withdrawal, withdrewOn);
+        
+        return okResult("User has been withdrawn from subpopulation '"+guid+"'.");
+    }
+    
     public Result getUploads(String userId, String startTimeString, String endTimeString) {
         UserSession session = getAuthenticatedSession(RESEARCHER);
         Study study = studyService.getStudy(session.getStudyIdentifier());

--- a/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
@@ -224,11 +224,11 @@ public class ParticipantController extends BaseController {
         return okResult("Email verification request has been resent to user.");
     }
     
-    public Result resendConsentAgreement(String userId, String guid) {
+    public Result resendConsentAgreement(String userId, String subpopulationGuid) {
         UserSession session = getAuthenticatedSession(RESEARCHER);
         Study study = studyService.getStudy(session.getStudyIdentifier());
         
-        SubpopulationGuid subpopGuid = SubpopulationGuid.create(guid);
+        SubpopulationGuid subpopGuid = SubpopulationGuid.create(subpopulationGuid);
         participantService.resendConsentAgreement(study, subpopGuid, userId);
         
         return okResult("Consent agreement resent to user.");
@@ -246,17 +246,17 @@ public class ParticipantController extends BaseController {
         return okResult("User has been withdrawn from the study.");
     }
     
-    public Result withdrawConsent(String userId, String guid) {
+    public Result withdrawConsent(String userId, String subpopulationGuid) {
         UserSession session = getAuthenticatedSession(RESEARCHER);
         Study study = studyService.getStudy(session.getStudyIdentifier());
         
         Withdrawal withdrawal = parseJson(request(), Withdrawal.class);
         long withdrewOn = DateTime.now().getMillis();
-        SubpopulationGuid subpopGuid = SubpopulationGuid.create(guid);
+        SubpopulationGuid subpopGuid = SubpopulationGuid.create(subpopulationGuid);
         
         participantService.withdrawConsent(study, userId, subpopGuid, withdrawal, withdrewOn);
         
-        return okResult("User has been withdrawn from subpopulation '"+guid+"'.");
+        return okResult("User has been withdrawn from subpopulation '"+subpopulationGuid+"'.");
     }
     
     public Result getUploads(String userId, String startTimeString, String endTimeString) {

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -352,6 +352,19 @@ public class ParticipantService {
         consentService.withdrawAllConsents(study, account, withdrawal, withdrewOn);
     }
 
+    public void withdrawConsent(Study study, String userId, SubpopulationGuid subpopGuid, Withdrawal withdrawal,
+            long withdrewOn) {
+        checkNotNull(study);
+        checkNotNull(userId);
+        checkNotNull(subpopGuid);
+        checkNotNull(withdrawal);
+        checkArgument(withdrewOn > 0);
+
+        Account account = getAccountThrowingException(study, userId);
+
+        consentService.withdrawConsent(study, subpopGuid, account, withdrawal, withdrewOn);
+    }
+    
     public void resendConsentAgreement(Study study, SubpopulationGuid subpopGuid, String userId) {
         checkNotNull(study);
         checkNotNull(subpopGuid);

--- a/conf/routes
+++ b/conf/routes
@@ -39,6 +39,7 @@ POST   /v3/participants/:userId/requestResetPassword         @org.sagebionetwork
 POST   /v3/participants/:userId/resendEmailVerification      @org.sagebionetworks.bridge.play.controllers.ParticipantController.resendEmailVerification(userId: String)
 POST   /v3/participants/:userId/consents/withdraw            @org.sagebionetworks.bridge.play.controllers.ParticipantController.withdrawFromAllConsents(userId: String)
 POST   /v3/participants/:userId/consents/:guid/resendConsent @org.sagebionetworks.bridge.play.controllers.ParticipantController.resendConsentAgreement(userId: String, guid: String)
+POST   /v3/participants/:userId/consents/:guid/withdraw      @org.sagebionetworks.bridge.play.controllers.ParticipantController.withdrawConsent(userId: String, guid: String)
 
 # Study Subpopulations
 GET    /v3/subpopulations        @org.sagebionetworks.bridge.play.controllers.SubpopulationController.getAllSubpopulations

--- a/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
@@ -79,6 +79,8 @@ import org.sagebionetworks.bridge.services.StudyService;
 @RunWith(MockitoJUnitRunner.class)
 public class ParticipantControllerTest {
 
+    private static final String SUBPOP_GUID = "subpopGuid";
+
     private static final BridgeObjectMapper MAPPER = BridgeObjectMapper.get();
     
     private static final TypeReference<ForwardCursorPagedResourceList<ScheduledActivity>> FORWARD_CURSOR_PAGED_ACTIVITIES_REF = new TypeReference<ForwardCursorPagedResourceList<ScheduledActivity>>() {
@@ -654,9 +656,9 @@ public class ParticipantControllerTest {
     
     @Test
     public void resendConsentAgreement() throws Exception {
-        controller.resendConsentAgreement(ID, "subpopGuid");
+        controller.resendConsentAgreement(ID, SUBPOP_GUID);
         
-        verify(mockParticipantService).resendConsentAgreement(study, SubpopulationGuid.create("subpopGuid"), ID);
+        verify(mockParticipantService).resendConsentAgreement(study, SubpopulationGuid.create(SUBPOP_GUID), ID);
     }
 
     @Test
@@ -669,6 +671,22 @@ public class ParticipantControllerTest {
             controller.withdrawFromAllConsents(ID);
             
             verify(mockParticipantService).withdrawAllConsents(study, ID, new Withdrawal("Because, reasons."), 20000);
+        } finally {
+            DateTimeUtils.setCurrentMillisSystem();
+        }
+    }
+    
+    @Test
+    public void withdrawConsent() throws Exception {
+        DateTimeUtils.setCurrentMillisFixed(20000);
+        try {
+            String json = "{\"reason\":\"Because, reasons.\"}";
+            TestUtils.mockPlayContextWithJson(json);
+            
+            controller.withdrawConsent(ID, SUBPOP_GUID);
+            
+            verify(mockParticipantService).withdrawConsent(study, ID, SubpopulationGuid.create(SUBPOP_GUID),
+                    new Withdrawal("Because, reasons."), 20000);
         } finally {
             DateTimeUtils.setCurrentMillisSystem();
         }

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -811,6 +811,18 @@ public class ParticipantServiceTest {
     }
     
     @Test
+    public void withdrawConsent() {
+        mockHealthCodeAndAccountRetrieval();
+        
+        Withdrawal withdrawal = new Withdrawal("Reasons");
+        long withdrewOn = DateTime.now().getMillis();
+        
+        participantService.withdrawConsent(STUDY, ID, SUBPOP_GUID, withdrawal, withdrewOn);
+        
+        verify(consentService).withdrawConsent(STUDY, SUBPOP_GUID, account, withdrawal, withdrewOn);
+    }
+    
+    @Test
     public void getUploads() {
         mockHealthCodeAndAccountRetrieval();
         DateTime startTime = DateTime.parse("2015-11-01T00:00:00.000Z");


### PR DESCRIPTION
BRIDGE-1656. Right now researchers can withdraw a user from all consents, we've had requests to withdraw from individual consents, so, here's an API for that.