### PR TITLE
Fix mime type serialization

### DIFF
--- a/app/org/sagebionetworks/bridge/json/MimeTypeSerializer.java
+++ b/app/org/sagebionetworks/bridge/json/MimeTypeSerializer.java
@@ -1,0 +1,23 @@
+package org.sagebionetworks.bridge.json;
+
+import java.io.IOException;
+
+import org.sagebionetworks.bridge.models.studies.MimeType;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+@SuppressWarnings({"rawtypes", "serial"})
+public class MimeTypeSerializer extends StdSerializer<MimeType> {
+
+    public MimeTypeSerializer() {
+        super(MimeType.class, false);
+    }
+    
+    @Override
+    public void serialize(MimeType type, JsonGenerator generator, SerializerProvider provider) throws IOException {
+        generator.writeString(type.toString());
+    }
+
+}

--- a/app/org/sagebionetworks/bridge/models/studies/MimeType.java
+++ b/app/org/sagebionetworks/bridge/models/studies/MimeType.java
@@ -1,6 +1,9 @@
 package org.sagebionetworks.bridge.models.studies;
 
+import org.sagebionetworks.bridge.json.MimeTypeSerializer;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 /**
  * Our use of mime type serialization appears to have been using values like "text" and 
@@ -8,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
  * of both values needs special handling. This enum is excepted in the LowercaseEnumModule 
  * so Jackson will use the static factory method here.
  */
+@JsonSerialize(using = MimeTypeSerializer.class)
 public enum MimeType {
     
     TEXT("text/plain"),

--- a/test/org/sagebionetworks/bridge/json/MimeTypeSerializerTest.java
+++ b/test/org/sagebionetworks/bridge/json/MimeTypeSerializerTest.java
@@ -1,0 +1,32 @@
+package org.sagebionetworks.bridge.json;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import org.sagebionetworks.bridge.models.studies.MimeType;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MimeTypeSerializerTest {
+    
+    @Mock
+    private JsonGenerator mockJGen;
+    
+    @Captor
+    ArgumentCaptor<String> stringCaptor;
+    
+    @Test
+    public void test() throws Exception {
+        new MimeTypeSerializer().serialize(MimeType.TEXT, mockJGen, null);
+        verify(mockJGen).writeString(stringCaptor.capture());
+        assertEquals("text/plain", stringCaptor.getValue());
+    }
+}

--- a/test/org/sagebionetworks/bridge/models/studies/EmailTemplateTest.java
+++ b/test/org/sagebionetworks/bridge/models/studies/EmailTemplateTest.java
@@ -7,12 +7,24 @@ import org.junit.Test;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class EmailTemplateTest {
 
     @Test
     public void equalsHashCode() {
         EqualsVerifier.forClass(EmailTemplate.class).allFieldsShouldBeUsed().verify();
+    }
+    
+    @Test
+    public void deserializeFromDynamoDB() throws Exception {
+        // Original serialization used Jackson's default enum serialization, which BridgePF deserializes to correct 
+        // MimeType enum. However client API code does not. Verify this older serialization continues to be deserialized
+        // correctly after fixing serialization for rest/SDK code.
+        String json = "{\"subject\":\"${studyName} sign in link\",\"body\":\"<p>${host}/${token}</p>\",\"mimeType\":\"HTML\"}";
+        
+        EmailTemplate template = new ObjectMapper().readValue(json, EmailTemplate.class);
+        assertEquals(MimeType.HTML, template.getMimeType());
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/models/studies/MimeTypeTest.java
+++ b/test/org/sagebionetworks/bridge/models/studies/MimeTypeTest.java
@@ -31,6 +31,15 @@ public class MimeTypeTest {
         assertEquals(MimeType.TEXT, deser);
     }
     
+    @Test
+    public void serializationUsesMimeTypeValue() throws Exception {
+        ObjectMapper mapper = BridgeObjectMapper.get();
+        
+        assertEquals("\"text/html\"", mapper.writeValueAsString(MimeType.HTML));
+        assertEquals("\"text/plain\"", mapper.writeValueAsString(MimeType.TEXT));
+        assertEquals("\"application/pdf\"", mapper.writeValueAsString(MimeType.PDF));
+    }
+    
     /**
      * Test that serialization works with a normal ObjectMapper, not just BridgeObjectMapper.
      */

--- a/test/org/sagebionetworks/bridge/models/studies/MimeTypeTest.java
+++ b/test/org/sagebionetworks/bridge/models/studies/MimeTypeTest.java
@@ -24,6 +24,9 @@ public class MimeTypeTest {
         deser = mapper.readValue("\"HTML\"", MimeType.class);
         assertEquals(MimeType.HTML, deser);
         
+        deser = mapper.readValue("\"text/html\"", MimeType.class);
+        assertEquals(MimeType.HTML, deser);
+        
         deser = mapper.readValue("\"TEXT/PLAIN\"", MimeType.class);
         assertEquals(MimeType.TEXT, deser);
     }


### PR DESCRIPTION
While Bridge PF can serialize and deserialize this type to DDB no problem, the value being returned to the client is not deserialized correctly (we document the mime types, such as plain/text, but return TEXT as the string, which the client code doesn't deserialize). Fixing here and added tests to integration tests.