### PR TITLE
Restore cookie

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge.play.controllers;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.sagebionetworks.bridge.BridgeConstants.STUDY_PROPERTY;
 
+import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.exceptions.ConcurrentModificationException;
 import org.sagebionetworks.bridge.exceptions.ConsentRequiredException;
@@ -41,6 +42,7 @@ public class AuthenticationController extends BaseController {
         if (session != null) {
             authenticationService.signOut(session);
         }
+        response().discardCookie(BridgeConstants.SESSION_TOKEN_HEADER);
         return okResult("Signed out.");
     }
 
@@ -108,6 +110,8 @@ public class AuthenticationController extends BaseController {
                 throw e;
             }
             writeSessionInfoToMetrics(session);
+            response().setCookie(BridgeConstants.SESSION_TOKEN_HEADER, session.getSessionToken(),
+                    BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS, "/");
             
             RequestInfo requestInfo = new RequestInfo.Builder()
                     .withUserId(session.getId())

--- a/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
@@ -194,13 +194,17 @@ public abstract class BaseController extends Controller {
     /** Package-scoped to make available in unit tests. */
     String getSessionToken() {
         String[] session = request().headers().get(SESSION_TOKEN_HEADER);
-        if (session == null || session.length == 0 || session[0].isEmpty()) {
-            Cookie sessionCookie = request().cookie(SESSION_TOKEN_HEADER);
-            if (sessionCookie != null && sessionCookie.value() != null && !"".equals(sessionCookie.value())) {
-                return sessionCookie.value();
-            }            
+        if (session != null && session.length > 0 && !session[0].isEmpty()) {
+            return session[0];
         }
-        return session[0];
+        Cookie sessionCookie = request().cookie(SESSION_TOKEN_HEADER);
+        if (sessionCookie != null && sessionCookie.value() != null && !"".equals(sessionCookie.value())) {
+            String sessionToken = sessionCookie.value();
+            response().setCookie(BridgeConstants.SESSION_TOKEN_HEADER, sessionToken,
+                    BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS, "/");
+            return sessionToken;
+        }
+        return null;
     }
     
     void verifySupportedVersionOrThrowException(Study study) throws UnsupportedVersionException {

--- a/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
@@ -49,6 +49,7 @@ import play.cache.Cache;
 import play.libs.Json;
 import play.mvc.Controller;
 import play.mvc.Http;
+import play.mvc.Http.Cookie;
 import play.mvc.Http.Request;
 import play.mvc.Result;
 
@@ -194,7 +195,10 @@ public abstract class BaseController extends Controller {
     String getSessionToken() {
         String[] session = request().headers().get(SESSION_TOKEN_HEADER);
         if (session == null || session.length == 0 || session[0].isEmpty()) {
-            return null;
+            Cookie sessionCookie = request().cookie(SESSION_TOKEN_HEADER);
+            if (sessionCookie != null && sessionCookie.value() != null && !"".equals(sessionCookie.value())) {
+                return sessionCookie.value();
+            }            
         }
         return session[0];
     }

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -158,7 +158,7 @@ public class TestUtils {
         when(context.request()).thenReturn(request);
         when(context.response()).thenReturn(response);
 
-        Http.Context.current.set(context);        
+        Http.Context.current.set(context);
     }
     
     /**

--- a/test/org/sagebionetworks/bridge/play/controllers/AuthenticationControllerMockTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/AuthenticationControllerMockTest.java
@@ -27,6 +27,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
@@ -48,6 +49,7 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.services.AuthenticationService;
 import org.sagebionetworks.bridge.services.StudyService;
 
+import play.mvc.Http;
 import play.mvc.Result;
 import play.test.Helpers;
 
@@ -288,6 +290,7 @@ public class AuthenticationControllerMockTest {
         signInExistingSession(false, Roles.WORKER, false);
     }
 
+    @SuppressWarnings("static-access")
     private void signInNewSession(boolean isConsented, Roles role, boolean shouldThrow) throws Exception {
         // mock getSessionToken and getMetrics
         doReturn(null).when(controller).getSessionToken();
@@ -321,7 +324,12 @@ public class AuthenticationControllerMockTest {
             }
             assertSessionInPlayResult(result);
             
+            Http.Response mockResponse = controller.response();
+
             verify(cacheProvider).updateRequestInfo(requestInfoCaptor.capture());
+            verify(mockResponse).setCookie(BridgeConstants.SESSION_TOKEN_HEADER, session.getSessionToken(),
+                    BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS, "/");
+            
             RequestInfo requestInfo = requestInfoCaptor.getValue();
             assertEquals("spId", requestInfo.getUserId());
             assertEquals(TEST_STUDY_ID, requestInfo.getStudyIdentifier());
@@ -378,6 +386,8 @@ public class AuthenticationControllerMockTest {
 
     @Test
     public void signOut() throws Exception {
+        TestUtils.mockPlayContext();
+        
         // mock getSessionToken and getMetrics
         doReturn(TEST_SESSION_TOKEN).when(controller).getSessionToken();
 
@@ -392,8 +402,12 @@ public class AuthenticationControllerMockTest {
         Result result = controller.signOut();
         assertEquals(HttpStatus.SC_OK, result.status());
         assertSessionInfoInMetrics(metrics);
+        
+        @SuppressWarnings("static-access")
+        Http.Response mockResponse = controller.response();
 
         verify(authenticationService).signOut(session);
+        verify(mockResponse).discardCookie(BridgeConstants.SESSION_TOKEN_HEADER);
     }
 
     @Test


### PR DESCRIPTION
This restores the setting of a session cookie on sign in, passing it back to the client whenever it is provided, and deleting it on sign out. This supports browser-based applications like Postman that are used in development to work against the API.