### PR TITLE
APIs to import shared module to local

### DIFF
--- a/app/org/sagebionetworks/bridge/models/sharedmodules/SharedModuleImportStatus.java
+++ b/app/org/sagebionetworks/bridge/models/sharedmodules/SharedModuleImportStatus.java
@@ -1,0 +1,80 @@
+package org.sagebionetworks.bridge.models.sharedmodules;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.apache.commons.lang3.StringUtils;
+
+import org.sagebionetworks.bridge.json.BridgeTypeName;
+import org.sagebionetworks.bridge.json.DateTimeToLongSerializer;
+import org.sagebionetworks.bridge.models.BridgeEntity;
+
+/**
+ * This struct contains the results of importing a shared module into the local study, including what type of module it
+ * is, and its key params (schema ID/revision or survey GUID/createdOn) in the local study.
+ */
+@BridgeTypeName("SharedModuleImportStatus")
+public class SharedModuleImportStatus implements BridgeEntity {
+    private final String schemaId;
+    private final Integer schemaRevision;
+    private final Long surveyCreatedOn;
+    private final String surveyGuid;
+
+    /** Constructs status object with a schema. */
+    public SharedModuleImportStatus(String schemaId, int schemaRevision) {
+        checkNotNull(schemaId, "schema ID must be specified");
+        checkArgument(StringUtils.isNotBlank(schemaId), "schema ID must be specified");
+        checkArgument(schemaRevision > 0, "schema revision must be positive");
+
+        this.schemaId = schemaId;
+        this.schemaRevision = schemaRevision;
+        this.surveyCreatedOn = null;
+        this.surveyGuid = null;
+    }
+
+    /** Constructs status object with a survey. */
+    public SharedModuleImportStatus(String surveyGuid, long surveyCreatedOn) {
+        checkNotNull(surveyGuid, "survey GUID must be specified");
+        checkArgument(StringUtils.isNotBlank(surveyGuid), "survey GUID must be specified");
+        checkArgument(surveyCreatedOn > 0, "survey createdOn must be positive");
+
+        this.schemaId = null;
+        this.schemaRevision = null;
+        this.surveyCreatedOn = surveyCreatedOn;
+        this.surveyGuid = surveyGuid;
+    }
+
+    /** Whether this module is a schema or a survey. Throws if the module is neither. */
+    public SharedModuleType getModuleType() {
+        if (getSchemaId() != null) {
+            return SharedModuleType.SCHEMA;
+        } else if (getSurveyGuid() != null) {
+            return SharedModuleType.SURVEY;
+        } else {
+            // If we ever hit this code block, something has gone terribly terribly wrong.
+            throw new IllegalStateException("Unexpected error: Somehow, module is neither a schema nor survey.");
+        }
+    }
+
+    /** Schema ID, if this module is a schema. */
+    public String getSchemaId() {
+        return schemaId;
+    }
+
+    /** Schema revision, if this module is a schema. */
+    public Integer getSchemaRevision() {
+        return schemaRevision;
+    }
+
+    /** Survey created-on timestamp (in epoch milliseconds), if this module is a survey. */
+    @JsonSerialize(using = DateTimeToLongSerializer.class)
+    public Long getSurveyCreatedOn() {
+        return surveyCreatedOn;
+    }
+
+    /** Survey GUID, if this module is a survey. */
+    public String getSurveyGuid() {
+        return surveyGuid;
+    }
+}

--- a/app/org/sagebionetworks/bridge/play/controllers/SharedModuleController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/SharedModuleController.java
@@ -1,0 +1,42 @@
+package org.sagebionetworks.bridge.play.controllers;
+
+import static org.sagebionetworks.bridge.Roles.DEVELOPER;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import play.mvc.Result;
+
+import org.sagebionetworks.bridge.models.accounts.UserSession;
+import org.sagebionetworks.bridge.models.sharedmodules.SharedModuleImportStatus;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
+import org.sagebionetworks.bridge.services.SharedModuleService;
+
+/** Play controller for importing shared modules. */
+@Controller
+public class SharedModuleController extends BaseController {
+    private SharedModuleService moduleService;
+
+    /** Shared Module Service, configured by Spring. */
+    @Autowired
+    public void setModuleService(SharedModuleService moduleService) {
+        this.moduleService = moduleService;
+    }
+
+    /** Imports a specific module version into the current study. */
+    public Result importModuleByIdAndVersion(String moduleId, int moduleVersion) {
+        UserSession session = getAuthenticatedSession(DEVELOPER);
+        StudyIdentifier studyId = session.getStudyIdentifier();
+
+        SharedModuleImportStatus status = moduleService.importModuleByIdAndVersion(studyId, moduleId, moduleVersion);
+        return okResult(status);
+    }
+
+    /** Imports the latest published version of a module into the current study. */
+    public Result importModuleByIdLatestPublishedVersion(String moduleId) {
+        UserSession session = getAuthenticatedSession(DEVELOPER);
+        StudyIdentifier studyId = session.getStudyIdentifier();
+
+        SharedModuleImportStatus status = moduleService.importModuleByIdLatestPublishedVersion(studyId, moduleId);
+        return okResult(status);
+    }
+}

--- a/app/org/sagebionetworks/bridge/services/SharedModuleService.java
+++ b/app/org/sagebionetworks/bridge/services/SharedModuleService.java
@@ -1,0 +1,138 @@
+package org.sagebionetworks.bridge.services;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.sagebionetworks.bridge.BridgeConstants;
+import org.sagebionetworks.bridge.exceptions.BadRequestException;
+import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
+import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolder;
+import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolderImpl;
+import org.sagebionetworks.bridge.models.sharedmodules.SharedModuleImportStatus;
+import org.sagebionetworks.bridge.models.sharedmodules.SharedModuleMetadata;
+import org.sagebionetworks.bridge.models.sharedmodules.SharedModuleType;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
+import org.sagebionetworks.bridge.models.surveys.Survey;
+import org.sagebionetworks.bridge.models.upload.UploadSchema;
+
+/**
+ * Service for importing shared modules into the local study, and recursively importing schemas and surveys as well.
+ */
+@Component
+public class SharedModuleService {
+    private static final Logger LOG = LoggerFactory.getLogger(SharedModuleService.class);
+
+    private SharedModuleMetadataService moduleMetadataService;
+    private UploadSchemaService schemaService;
+    private SurveyService surveyService;
+
+    /** Module metadata service, so we can know what module we need to import. Configured by Spring. */
+    @Autowired
+    public final void setModuleMetadataService(SharedModuleMetadataService moduleMetadataService) {
+        this.moduleMetadataService = moduleMetadataService;
+    }
+
+    /**
+     * Schema service, used to get the schema from shared and write the schema to the local study, where applicable.
+     * Configured by Spring.
+     */
+    @Autowired
+    public final void setSchemaService(UploadSchemaService schemaService) {
+        this.schemaService = schemaService;
+    }
+
+    /** Survey service, also used to copy from shared to local. Configured by Spring */
+    @Autowired
+    public final void setSurveyService(SurveyService surveyService) {
+        this.surveyService = surveyService;
+    }
+
+    /** Imports a specific module version into the specified study. */
+    public SharedModuleImportStatus importModuleByIdAndVersion(StudyIdentifier studyId, String moduleId,
+            int moduleVersion) {
+        // studyId is provided by the controller. Validate the rest of the args.
+        if (StringUtils.isBlank(moduleId)) {
+            throw new BadRequestException("module ID must be specified");
+        }
+        if (moduleVersion <= 0) {
+            throw new BadRequestException("moduleVersion must be positive");
+        }
+
+        // Get metadata and import.
+        SharedModuleMetadata metadata = moduleMetadataService.getMetadataByIdAndVersion(moduleId, moduleVersion);
+        return importModule(studyId, metadata);
+    }
+
+    /** Imports the latest published version of a module into the specified study. */
+    public SharedModuleImportStatus importModuleByIdLatestPublishedVersion(StudyIdentifier studyId, String moduleId) {
+        // studyId is provided by the controller. Validate the rest of the args.
+        if (StringUtils.isBlank(moduleId)) {
+            throw new BadRequestException("module ID must be specified");
+        }
+
+        // Query for most recent published version.
+        List<SharedModuleMetadata> metadataList = moduleMetadataService.queryMetadataById(moduleId, true, true, null,
+                null);
+        if (metadataList.isEmpty()) {
+            throw new EntityNotFoundException(SharedModuleMetadata.class);
+        }
+        if (metadataList.size() > 1) {
+            // Error, because this represents a coding error that we should fix.
+            LOG.error("Module " + moduleId + " has more than one most recent publisher version.");
+        }
+        return importModule(studyId, metadataList.get(0));
+    }
+
+    // Helper method to import a module given the module metadata object.
+    private SharedModuleImportStatus importModule(StudyIdentifier studyId, SharedModuleMetadata metadata) {
+        // Callers will have passed in a non-null metadata object. This preconditions check is just to check against
+        // bad coding.
+        checkNotNull(metadata, "metadata must be specified");
+
+        SharedModuleType moduleType = metadata.getModuleType();
+        if (moduleType == SharedModuleType.SCHEMA) {
+            // Copy schema from shared to local.
+            String schemaId = metadata.getSchemaId();
+            int schemaRev = metadata.getSchemaRevision();
+            UploadSchema schema = schemaService.getUploadSchemaByIdAndRev(BridgeConstants.SHARED_STUDY_ID, schemaId,
+                    schemaRev);
+            schemaService.createSchemaRevisionV4(studyId, schema);
+
+            // Schema ID and rev are the same in the shared study and in the local study.
+            return new SharedModuleImportStatus(schemaId, schemaRev);
+        } else if (moduleType == SharedModuleType.SURVEY) {
+            // Copy survey from shared to local.
+            String sharedSurveyGuid = metadata.getSurveyGuid();
+            long sharedSurveyCreatedOn = metadata.getSurveyCreatedOn();
+            GuidCreatedOnVersionHolder sharedSurveyKey = new GuidCreatedOnVersionHolderImpl(sharedSurveyGuid,
+                    sharedSurveyCreatedOn);
+            Survey sharedSurvey = surveyService.getSurvey(sharedSurveyKey);
+
+            // Survey keys don't include study ID. Instead, we need to set the study ID directly in the survey object.
+            sharedSurvey.setStudyIdentifier(studyId.getIdentifier());
+            Survey localSurvey = surveyService.createSurvey(sharedSurvey);
+            GuidCreatedOnVersionHolder localSurveyKey = new GuidCreatedOnVersionHolderImpl(localSurvey.getGuid(),
+                    localSurvey.getCreatedOn());
+
+            // Publish the survey, so that (a) the survey is ready for immediate use and (b) if someone changes the
+            // survey, we preserve the "official" survey version from the shared library.
+            //
+            // Cut a new schema rev, because if somehow this conflicts with an existing survey, we want to have a clean
+            // version so it doesn't get munged with an "unofficial" version.
+            surveyService.publishSurvey(studyId, localSurveyKey, true);
+
+            // Survey GUID and createdOn are changed when we create the survey in a new study. Return the new ones.
+            return new SharedModuleImportStatus(localSurveyKey.getGuid(), localSurveyKey.getCreatedOn());
+        } else {
+            // If we ever hit this code block, something has gone terribly terribly wrong.
+            throw new IllegalStateException("Unexpected error: Somehow, module is neither a schema nor survey.");
+        }
+    }
+}

--- a/conf/routes
+++ b/conf/routes
@@ -40,6 +40,10 @@ POST   /v3/participants/:userId/consents/withdraw            @org.sagebionetwork
 POST   /v3/participants/:userId/consents/:guid/resendConsent @org.sagebionetworks.bridge.play.controllers.ParticipantController.resendConsentAgreement(userId: String, guid: String)
 POST   /v3/participants/:userId/consents/:guid/withdraw      @org.sagebionetworks.bridge.play.controllers.ParticipantController.withdrawConsent(userId: String, guid: String)
 
+# Shared Module
+POST   /v3/sharedmodules/:id/import                   @org.sagebionetworks.bridge.play.controllers.SharedModuleController.importModuleByIdLatestPublishedVersion(id: String)
+POST   /v3/sharedmodules/:id/versions/:version/import @org.sagebionetworks.bridge.play.controllers.SharedModuleController.importModuleByIdAndVersion(id: String, version: Int)
+
 # Shared Module Metadata
 GET    /v3/sharedmodules/metadata                       @org.sagebionetworks.bridge.play.controllers.SharedModuleMetadataController.queryAllMetadata(mostrecent: String ?= "true", published: String ?= "false", where: String ?= null, tags: String ?= null)
 POST   /v3/sharedmodules/metadata                       @org.sagebionetworks.bridge.play.controllers.SharedModuleMetadataController.createMetadata

--- a/conf/shared-config.xml
+++ b/conf/shared-config.xml
@@ -91,6 +91,10 @@
         <property name="targetName" value="compoundActivityDefinitionController"/>
     </bean>
 
+    <bean id="SharedModuleControllerProxied" parent="proxiedController">
+        <property name="targetName" value="sharedModuleController"/>
+    </bean>
+
     <bean id="SharedModuleMetadataControllerProxied" parent="proxiedController">
         <property name="targetName" value="sharedModuleMetadataController"/>
     </bean>

--- a/test/org/sagebionetworks/bridge/models/sharedmodules/SharedModuleImportStatusTest.java
+++ b/test/org/sagebionetworks/bridge/models/sharedmodules/SharedModuleImportStatusTest.java
@@ -1,0 +1,108 @@
+package org.sagebionetworks.bridge.models.sharedmodules;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.json.DateUtils;
+
+public class SharedModuleImportStatusTest {
+    private static final String SCHEMA_ID = "test-schema";
+    private static final int SCHEMA_REV = 7;
+    private static final String SURVEY_GUID = "test-survey-guid";
+
+    private static final String SURVEY_CREATED_ON_STRING = "2017-04-05T20:54:53.625Z";
+    private static final long SURVEY_CREATED_ON_MILLIS = DateUtils.convertToMillisFromEpoch(SURVEY_CREATED_ON_STRING);
+
+    @Test(expected = NullPointerException.class)
+    public void nullSchemaId() {
+        new SharedModuleImportStatus(null, SCHEMA_REV);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void emptySchemaId() {
+        new SharedModuleImportStatus("", SCHEMA_REV);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void blankSchemaId() {
+        new SharedModuleImportStatus("   ", SCHEMA_REV);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void negativeSchemaRev() {
+        new SharedModuleImportStatus(SCHEMA_ID, -1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void zeroSchemaRev() {
+        new SharedModuleImportStatus(SCHEMA_ID, 0);
+    }
+
+    @Test
+    public void schemaModule() {
+        // Test constructor and getters.
+        SharedModuleImportStatus status = new SharedModuleImportStatus(SCHEMA_ID, SCHEMA_REV);
+        assertEquals(SharedModuleType.SCHEMA, status.getModuleType());
+        assertEquals(SCHEMA_ID, status.getSchemaId());
+        assertEquals(SCHEMA_REV, status.getSchemaRevision().intValue());
+        assertNull(status.getSurveyCreatedOn());
+        assertNull(status.getSurveyGuid());
+
+        // Test JSON serialization. We only ever write this to JSON, never read it from JSON, so we only need to test
+        // this one way.
+        JsonNode jsonNode = BridgeObjectMapper.get().convertValue(status, JsonNode.class);
+        assertEquals(4, jsonNode.size());
+        assertEquals("schema", jsonNode.get("moduleType").textValue());
+        assertEquals(SCHEMA_ID, jsonNode.get("schemaId").textValue());
+        assertEquals(SCHEMA_REV, jsonNode.get("schemaRevision").intValue());
+        assertEquals("SharedModuleImportStatus", jsonNode.get("type").textValue());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void nullSurveyGuid() {
+        new SharedModuleImportStatus(null, SURVEY_CREATED_ON_MILLIS);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void emptySurveyGuid() {
+        new SharedModuleImportStatus("", SURVEY_CREATED_ON_MILLIS);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void blankSurveyGuid() {
+        new SharedModuleImportStatus("   ", SURVEY_CREATED_ON_MILLIS);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void negativeSurveyCreatedOn() {
+        new SharedModuleImportStatus(SURVEY_GUID, -1L);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void zeroSurveyCreatedOn() {
+        new SharedModuleImportStatus(SURVEY_GUID, 0L);
+    }
+
+    @Test
+    public void surveyModule() {
+        // Test constructor and getters.
+        SharedModuleImportStatus status = new SharedModuleImportStatus(SURVEY_GUID, SURVEY_CREATED_ON_MILLIS);
+        assertEquals(SharedModuleType.SURVEY, status.getModuleType());
+        assertNull(status.getSchemaId());
+        assertNull(status.getSchemaRevision());
+        assertEquals(SURVEY_GUID, status.getSurveyGuid());
+        assertEquals(SURVEY_CREATED_ON_MILLIS, status.getSurveyCreatedOn().longValue());
+
+        // Test JSON serialization.
+        JsonNode jsonNode = BridgeObjectMapper.get().convertValue(status, JsonNode.class);
+        assertEquals(4, jsonNode.size());
+        assertEquals("survey", jsonNode.get("moduleType").textValue());
+        assertEquals(SURVEY_CREATED_ON_STRING, jsonNode.get("surveyCreatedOn").textValue());
+        assertEquals(SURVEY_GUID, jsonNode.get("surveyGuid").textValue());
+        assertEquals("SharedModuleImportStatus", jsonNode.get("type").textValue());
+    }
+}

--- a/test/org/sagebionetworks/bridge/play/controllers/SharedModuleControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SharedModuleControllerTest.java
@@ -1,0 +1,82 @@
+package org.sagebionetworks.bridge.play.controllers;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.Before;
+import org.junit.Test;
+import play.mvc.Result;
+import play.test.Helpers;
+
+import org.sagebionetworks.bridge.Roles;
+import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.accounts.UserSession;
+import org.sagebionetworks.bridge.models.sharedmodules.SharedModuleImportStatus;
+import org.sagebionetworks.bridge.services.SharedModuleService;
+
+public class SharedModuleControllerTest {
+    private static final String MODULE_ID = "test-module";
+    private static final int MODULE_VERSION = 3;
+    private static final String SCHEMA_ID = "test-schema";
+    private static final int SCHEMA_REV = 7;
+
+    private SharedModuleController controller;
+    private SharedModuleService mockSvc;
+
+    @Before
+    public void before() {
+        // mock service and controller
+        mockSvc = mock(SharedModuleService.class);
+        controller = spy(new SharedModuleController());
+        controller.setModuleService(mockSvc);
+
+        // mock session
+        UserSession mockSession = new UserSession();
+        mockSession.setStudyIdentifier(TestConstants.TEST_STUDY);
+        doReturn(mockSession).when(controller).getAuthenticatedSession(Roles.DEVELOPER);
+    }
+
+    @Test
+    public void byIdAndVersion() throws Exception {
+        // mock service
+        when(mockSvc.importModuleByIdAndVersion(TestConstants.TEST_STUDY, MODULE_ID, MODULE_VERSION)).thenReturn(
+                new SharedModuleImportStatus(SCHEMA_ID, SCHEMA_REV));
+
+        // setup, execute, and validate
+        Result result = controller.importModuleByIdAndVersion(MODULE_ID, MODULE_VERSION);
+        assertEquals(200, result.status());
+        assertStatus(result);
+
+        // validate permissions
+        verify(controller).getAuthenticatedSession(Roles.DEVELOPER);
+    }
+
+    @Test
+    public void latestPublished() throws Exception {
+        // mock service
+        when(mockSvc.importModuleByIdLatestPublishedVersion(TestConstants.TEST_STUDY, MODULE_ID)).thenReturn(
+                new SharedModuleImportStatus(SCHEMA_ID, SCHEMA_REV));
+
+        // setup, execute, and validate
+        Result result = controller.importModuleByIdLatestPublishedVersion(MODULE_ID);
+        assertEquals(200, result.status());
+        assertStatus(result);
+
+        // validate permissions
+        verify(controller).getAuthenticatedSession(Roles.DEVELOPER);
+    }
+
+    private static void assertStatus(Result result) throws Exception {
+        String jsonText = Helpers.contentAsString(result);
+        JsonNode jsonNode = BridgeObjectMapper.get().readTree(jsonText);
+        assertEquals("schema", jsonNode.get("moduleType").textValue());
+        assertEquals(SCHEMA_ID, jsonNode.get("schemaId").textValue());
+        assertEquals(SCHEMA_REV, jsonNode.get("schemaRevision").intValue());
+    }
+}

--- a/test/org/sagebionetworks/bridge/services/SharedModuleServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SharedModuleServiceTest.java
@@ -1,0 +1,207 @@
+package org.sagebionetworks.bridge.services;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import org.sagebionetworks.bridge.BridgeConstants;
+import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.exceptions.BadRequestException;
+import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
+import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolder;
+import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolderImpl;
+import org.sagebionetworks.bridge.models.sharedmodules.SharedModuleImportStatus;
+import org.sagebionetworks.bridge.models.sharedmodules.SharedModuleMetadata;
+import org.sagebionetworks.bridge.models.sharedmodules.SharedModuleType;
+import org.sagebionetworks.bridge.models.surveys.Survey;
+import org.sagebionetworks.bridge.models.upload.UploadSchema;
+
+public class SharedModuleServiceTest {
+    private static final String MODULE_ID = "test-module";
+    private static final String MODULE_NAME = "Test Module";
+    private static final int MODULE_VERSION = 3;
+    private static final String SCHEMA_ID = "test-schema";
+    private static final int SCHEMA_REV = 7;
+
+    private static final long LOCAL_SURVEY_CREATED_ON = 567890L;
+    private static final String LOCAL_SURVEY_GUID = "local-survey-guid";
+    private static final GuidCreatedOnVersionHolder LOCAL_SURVEY_KEY = new GuidCreatedOnVersionHolderImpl(
+            LOCAL_SURVEY_GUID, LOCAL_SURVEY_CREATED_ON);
+
+    private static final long SHARED_SURVEY_CREATED_ON = 123456L;
+    private static final String SHARED_SURVEY_GUID = "shared-survey-guid";
+    private static final GuidCreatedOnVersionHolder SHARED_SURVEY_KEY = new GuidCreatedOnVersionHolderImpl(
+            SHARED_SURVEY_GUID, SHARED_SURVEY_CREATED_ON);
+
+    private SharedModuleMetadataService mockMetadataService;
+    private UploadSchemaService mockSchemaService;
+    private SurveyService mockSurveyService;
+    private SharedModuleService moduleService;
+
+    @Before
+    public void before() {
+        mockMetadataService = mock(SharedModuleMetadataService.class);
+        mockSchemaService = mock(UploadSchemaService.class);
+        mockSurveyService = mock(SurveyService.class);
+
+        moduleService = new SharedModuleService();
+        moduleService.setModuleMetadataService(mockMetadataService);
+        moduleService.setSchemaService(mockSchemaService);
+        moduleService.setSurveyService(mockSurveyService);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void byIdAndVersionNullId() {
+        moduleService.importModuleByIdAndVersion(TestConstants.TEST_STUDY, null, MODULE_VERSION);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void byIdAndVersionEmptyId() {
+        moduleService.importModuleByIdAndVersion(TestConstants.TEST_STUDY, "", MODULE_VERSION);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void byIdAndVersionBlankId() {
+        moduleService.importModuleByIdAndVersion(TestConstants.TEST_STUDY, "   ", MODULE_VERSION);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void byIdAndVersionNegativeVersion() {
+        moduleService.importModuleByIdAndVersion(TestConstants.TEST_STUDY, MODULE_ID, -1);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void byIdAndVersionZeroVersion() {
+        moduleService.importModuleByIdAndVersion(TestConstants.TEST_STUDY, MODULE_ID, 0);
+    }
+
+    @Test
+    public void byIdAndVersionSchemaSuccess() {
+        // mock metadata service
+        when(mockMetadataService.getMetadataByIdAndVersion(MODULE_ID, MODULE_VERSION)).thenReturn(
+                makeValidMetadataWithSchema());
+
+        // mock schema service
+        UploadSchema sharedSchema = UploadSchema.create();
+        when(mockSchemaService.getUploadSchemaByIdAndRev(BridgeConstants.SHARED_STUDY_ID, SCHEMA_ID, SCHEMA_REV))
+                .thenReturn(sharedSchema);
+
+        // execute and validate import status
+        SharedModuleImportStatus status = moduleService.importModuleByIdAndVersion(TestConstants.TEST_STUDY, MODULE_ID,
+                MODULE_VERSION);
+        assertEquals(SharedModuleType.SCHEMA, status.getModuleType());
+        assertEquals(SCHEMA_ID, status.getSchemaId());
+        assertEquals(SCHEMA_REV, status.getSchemaRevision().intValue());
+
+        // verify calls to create schema
+        verify(mockSchemaService).createSchemaRevisionV4(TestConstants.TEST_STUDY, sharedSchema);
+    }
+
+    @Test
+    public void byIdAndVersionSurveySuccess() {
+        // mock metadata service
+        when(mockMetadataService.getMetadataByIdAndVersion(MODULE_ID, MODULE_VERSION)).thenReturn(
+                makeValidMetadataWithSurvey());
+
+        // mock survey service
+        Survey sharedSurvey = Survey.create();
+        when(mockSurveyService.getSurvey(SHARED_SURVEY_KEY)).thenReturn(sharedSurvey);
+
+        Survey localSurvey = Survey.create();
+        localSurvey.setGuid(LOCAL_SURVEY_GUID);
+        localSurvey.setCreatedOn(LOCAL_SURVEY_CREATED_ON);
+        when(mockSurveyService.createSurvey(any())).thenReturn(localSurvey);
+
+        // execute and validate import status
+        SharedModuleImportStatus status = moduleService.importModuleByIdAndVersion(TestConstants.TEST_STUDY, MODULE_ID,
+                MODULE_VERSION);
+        assertEquals(SharedModuleType.SURVEY, status.getModuleType());
+        assertEquals(LOCAL_SURVEY_CREATED_ON, status.getSurveyCreatedOn().longValue());
+        assertEquals(LOCAL_SURVEY_GUID, status.getSurveyGuid());
+
+        // Verify calls to create survey. Verify that we set the study ID.
+        ArgumentCaptor<Survey> surveyToCreateCaptor = ArgumentCaptor.forClass(Survey.class);
+        verify(mockSurveyService).createSurvey(surveyToCreateCaptor.capture());
+        Survey surveyToCreate = surveyToCreateCaptor.getValue();
+        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, surveyToCreate.getStudyIdentifier());
+
+        // verify call to publish survey
+        verify(mockSurveyService).publishSurvey(TestConstants.TEST_STUDY, LOCAL_SURVEY_KEY, true);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void latestPublishedNullId() {
+        moduleService.importModuleByIdLatestPublishedVersion(TestConstants.TEST_STUDY, null);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void latestPublishedEmptyId() {
+        moduleService.importModuleByIdLatestPublishedVersion(TestConstants.TEST_STUDY, "");
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void latestPublishedBlankId() {
+        moduleService.importModuleByIdLatestPublishedVersion(TestConstants.TEST_STUDY, "   ");
+    }
+
+    @Test(expected = EntityNotFoundException.class)
+    public void latestPublishedNotFound() {
+        // mock metadataService to return empty list
+        when(mockMetadataService.queryMetadataById(MODULE_ID, true, true, null, null)).thenReturn(ImmutableList.of());
+
+        // execute
+        moduleService.importModuleByIdLatestPublishedVersion(TestConstants.TEST_STUDY, MODULE_ID);
+    }
+
+    @Test
+    public void latestPublishedSuccess() {
+        // mock metadata service
+        when(mockMetadataService.queryMetadataById(MODULE_ID, true, true, null, null)).thenReturn(ImmutableList.of(
+                makeValidMetadataWithSchema()));
+
+        // mock schema service
+        UploadSchema sharedSchema = UploadSchema.create();
+        when(mockSchemaService.getUploadSchemaByIdAndRev(BridgeConstants.SHARED_STUDY_ID, SCHEMA_ID, SCHEMA_REV))
+                .thenReturn(sharedSchema);
+
+        // execute and validate import status
+        SharedModuleImportStatus status = moduleService.importModuleByIdLatestPublishedVersion(
+                TestConstants.TEST_STUDY, MODULE_ID);
+        assertEquals(SharedModuleType.SCHEMA, status.getModuleType());
+        assertEquals(SCHEMA_ID, status.getSchemaId());
+        assertEquals(SCHEMA_REV, status.getSchemaRevision().intValue());
+
+        // verify calls to create schema
+        verify(mockSchemaService).createSchemaRevisionV4(TestConstants.TEST_STUDY, sharedSchema);
+    }
+
+    private static SharedModuleMetadata makeValidMetadataWithSchema() {
+        SharedModuleMetadata metadata = makeValidMetadataWithoutSchemaOrSurvey();
+        metadata.setSchemaId(SCHEMA_ID);
+        metadata.setSchemaRevision(SCHEMA_REV);
+        return metadata;
+    }
+
+    private static SharedModuleMetadata makeValidMetadataWithSurvey() {
+        SharedModuleMetadata metadata = makeValidMetadataWithoutSchemaOrSurvey();
+        metadata.setSurveyCreatedOn(SHARED_SURVEY_CREATED_ON);
+        metadata.setSurveyGuid(SHARED_SURVEY_GUID);
+        return metadata;
+    }
+
+    // slight misnomer: This isn't *quite* valid until you add a schema or survey.
+    private static SharedModuleMetadata makeValidMetadataWithoutSchemaOrSurvey() {
+        SharedModuleMetadata metadata = SharedModuleMetadata.create();
+        metadata.setId(MODULE_ID);
+        metadata.setName(MODULE_NAME);
+        metadata.setVersion(MODULE_VERSION);
+        return metadata;
+    }
+}


### PR DESCRIPTION
Next key step for Shared Module Library: API to import a shared module into the local study.

Testing done: Added unit tests and integ tests.

See also:
* https://github.com/Sage-Bionetworks/BridgePF/pull/1420
* https://github.com/Sage-Bionetworks/BridgeDocs/pull/137
* https://github.com/Sage-Bionetworks/BridgeJavaSDK/pull/392
* https://github.com/Sage-Bionetworks/BridgeIntegrationTests/pull/147