### PR TITLE
set copyright notice when updating a survey

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
@@ -263,6 +263,7 @@ public class DynamoSurveyDao implements SurveyDao {
         existing.setIdentifier(survey.getIdentifier());
         existing.setName(survey.getName());
         existing.setElements(survey.getElements());
+        existing.setCopyrightNotice(survey.getCopyrightNotice());
 
         // copy over DDB version so we can handle concurrent modification exceptions
         existing.setVersion(survey.getVersion());

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoTest.java
@@ -139,6 +139,7 @@ public class DynamoSurveyDaoTest {
         // These fields are updateable.
         survey.setIdentifier("newIdentifier");
         survey.setName("New Name");
+        survey.setCopyrightNotice("New notice");
 
         // These fields are not.
         long originalModifiedOn = survey.getModifiedOn();
@@ -157,6 +158,7 @@ public class DynamoSurveyDaoTest {
         // Verify fields updated.
         assertEquals("Identifier has been changed", "newIdentifier", updatedSurvey.getIdentifier());
         assertEquals("New Name", updatedSurvey.getName());
+        assertEquals("New notice", updatedSurvey.getCopyrightNotice());
 
         // Verify fields not updated.
         assertEquals(TEST_STUDY_IDENTIFIER, updatedSurvey.getStudyIdentifier());


### PR DESCRIPTION
Fixes issue where edits to existing survey's copyright notice in study manager weren't persisted.