### PR TITLE
setup bridge deployment to aws

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ production.txt
 # Scala-IDE
 .cache-main
 .cache-tests
+
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,23 @@
 sudo: false
 language: scala
+services:
+- redis-server
 scala:
 - 2.11
 jdk:
 - oraclejdk8
 env:
   global:
-  - BRIDGE_USER=travis
+  - BRIDGE_USER=heroku
   - BRIDGE_ENV=dev
+  - WEBSERVICES_URL="https://webservices-develop.sagebridge.org"
+  - HOST_POSTFIX="-develop.sagebridge.org"
+  - UDD_SQS_QUEUE_URL="https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-WorkerPlatform-Request-dev"
+  - UPLOAD_CMS_CERT_BUCKET="org-sagebridge-upload-cms-cert-develop"
+  - CONSENTS_BUCKET="org-sagebridge-consents-develop"
+  - UPLOAD_BUCKET="org-sagebridge-upload-develop"
+  - UPLOAD_CMS_PRIV_BUCKET="org-sagebridge-upload-cms-priv-develop"
+  - ATTACHMENT_BUCKET="org-sagebridge-attachment-develop"
   - secure: SsM07kjCSWjGTFDhkCtTuZdM5WrChFXgRmeMMRJr4JlbtJoaaVUXcXDofZ+4NrESiOvW7CiRXK6Oz3I9eL7vn8RCwlN5jf2OlmD4vKIiiINlvuuEe6hEu738RO7nUGN8SFh2k4ryzJ6XldghjBiBvBEqzVhwXteLhF3AVCsRB1s=
   - secure: kByWq5ygVVnXuBcHKhe6BdcGhUugS1Ux4nbrR/MY23KI7FC1vJ3LCx6N5TIVbOhjwCPwnWNfkydPlfO48hco6gpz8mJ6Sz7OdjyAWb1Ofx/XO5mI+8AIW0P1gXN9jbThSLEaTGUZlrDNfkcfkFUaLJHmmWOQ5CWCPzo5sw2cEDg=
   - secure: VSoOGViuAi98dBrveHw61gHz0zersdtn8raolu/uzpNQEI1csMdVr09SokygjtiSEt5uIVNma1zkuABRAEgfncT3rYqPq0mdeM+hxPEz2igxEMUXYHx3H9Osbo5oOrTZXnRg18kmzyupUQ98L5Y6/8lg67sgJkPBJEx9dwNKhMY=
@@ -23,18 +33,32 @@ env:
 before_script:
 - mkdir -p $HOME/.sbt/launchers/0.13.8/
 - curl -L -o $HOME/.sbt/launchers/0.13.8/sbt-launch.jar http://dl.bintray.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.13.8/sbt-launch.jar
+- ./dist/create_bridge_config.sh
 script:
-- sbt clean test
+- sbt clean test dist
 branches:
   only:
   - develop
   - uat
   - prod
 deploy:
-  provider: heroku
-  api_key:
-    secure: dsrD0lN7luCXQCI+AK4wBZEWpxv/ji2xbbSMWWo3snBYb8CbuzqmH3KHSWStd9kSTKojWzatGFfIoIGGj6qoyG7gAk4E/PR1tb2Gelz+t6yWQUcRQclLHNd/WkozHLb5Z9Bg7N4HLcyupl7OMICixAaQ92+o2M+xhHq3/r2aOFs=
-  app:
-    develop: bridge-develop
-    uat: bridge-uat
-    prod: bridge-prod
+  matrix:
+  - provider: heroku
+    api_key:
+      secure: dsrD0lN7luCXQCI+AK4wBZEWpxv/ji2xbbSMWWo3snBYb8CbuzqmH3KHSWStd9kSTKojWzatGFfIoIGGj6qoyG7gAk4E/PR1tb2Gelz+t6yWQUcRQclLHNd/WkozHLb5Z9Bg7N4HLcyupl7OMICixAaQ92+o2M+xhHq3/r2aOFs=
+    app:
+      develop: bridge-develop
+      uat: bridge-uat
+      prod: bridge-prod
+  - provider: elasticbeanstalk
+    skip_cleanup: true
+    bucket_name: org-sagebridge-deployment-dev
+    zip_file: target/universal/bridgepf-0.1-SNAPSHOT.zip
+    access_key_id: AKIAIG6T67NMROEIMC7A
+    secret_access_key:
+      secure: L3Z9f5KvDbMr6HvDXz9PfEQBdRTF8PUkoqGe2JsCOFADSvwPUWlnLOjrEtCVpSyf88b0F3TUQp5AKd8qS7waHwiYBRpXWV5ABM8bF7SOSCurt41C1iuyJ+oiN6czqmRkW3ijMTtfFPxf+n86XIArp/26l8LxIDaaNwiZbU+X190=
+    region: us-east-1
+    app: BridgePF-heroku-dev
+    env: brid-Brid-106ZUS69MYEIL
+    on:
+      branch: develop

--- a/dist/.ebextensions/01_bridgecf.config
+++ b/dist/.ebextensions/01_bridgecf.config
@@ -4,11 +4,12 @@ files:
     owner: root
     group: root
     content: |
-        #!/bin/env bash -x
+        #!/bin/bash
         # Script to dynamically build bridge server config from env variables
-        # Brian Holt <beholt@gmail.com> 02.09.2017
-        mkdir -p ${HOME}/.bridge
-        cat <<-EOF > ${HOME}/.bridge/bridge-server.conf
+        # Brian Holt <beholt@gmail.com> 03.30.2017
+        mkdir -p /home/webapp/.bridge
+        chown ${EXECUSER} /home/webapp/.bridge
+        cat <<-EOF > /home/webapp/.bridge/bridge-server.conf
         bridge.env=${BRIDGE_ENV:-dummy-value}
         bridge.user=${BRIDGE_USER:-dummy-value}
 
@@ -35,7 +36,7 @@ files:
         ${BRIDGE_ENV}.external.id.add.limit = ${EXTERNAL_ID_ADD_LIMIT:-100}
         ${BRIDGE_ENV}.host.postfix = ${HOST_POSTFIX:--develop.sagebridge.org}
         ${BRIDGE_ENV}.webservices.url = ${WEBSERVICES_URL:-https://webservices-develop.sagebridge.org}
-        ${BRIDGE_ENV}.upload.bucket = ${DUPLOAD_BUCKET:-org-sagebridge-upload-develop}
+        ${BRIDGE_ENV}.upload.bucket = ${UPLOAD_BUCKET:-org-sagebridge-upload-develop}
         ${BRIDGE_ENV}.attachment.bucket = ${ATTACHMENT_BUCKET:-org-sagebridge-attachment-develop}
         ${BRIDGE_ENV}.upload.cms.cert.bucket = ${UPLOAD_CMS_CERT_BUCKET:-org-sagebridge-upload-cms-cert-develop}
         ${BRIDGE_ENV}.upload.cms.priv.bucket = ${UPLOAD_CMS_PRIV_BUCKET:-org-sagebridge-upload-cms-priv-develop}
@@ -60,7 +61,7 @@ files:
         redis.min.idle = ${REDIS_MIN_IDLE:-3}
         redis.max.idle = ${REDIS_MAX_IDLE:-50}
         redis.timeout = ${REDIS_TIMEOUT:-2000}
-        redis.url = ${REDIS_URL:-redis://provider:password@localhost:6379}
+        redis.url = ${REDIS_URL:-redis://AWS:AWS@localhost:6379}
 
         route53.zone = ${ROUTE53_ZONE:-ZP0HNVK1V670D}
         sns.key = ${SNS_KEY:-dummy-value}
@@ -68,8 +69,8 @@ files:
 
         support.email = ${SUPPORT_EMAIL:-Bridge (Sage Bionetworks) <support@sagebridge.org>}
 
-        synapse.api.key = ${NAPSE_API_KEY:-your-api-key-here}
-        synapse.user = ${SYNAPSE_USR:-your-username-here}
+        synapse.api.key = ${SYNAPSE_API_KEY:-your-api-key-here}
+        synapse.user = ${SYNAPSE_USER:-your-username-here}
         sysops.email = ${SYSOP_EMAIL:-Bridge IT <bridge-testing+sysops@sagebase.org>}
 
         test.synapse.user.id = ${TEST_SYNAPSE_USER_ID:-3348228}

--- a/dist/create_bridge_config.sh
+++ b/dist/create_bridge_config.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash -x
+#!/bin/bash
 # Script to dynamically build bridge server config from env variables
 # Brian Holt <beholt@gmail.com> 02.09.2017
 mkdir -p ${HOME}/.bridge
@@ -62,9 +62,9 @@ sns.secret.key = ${SNS_SECRET_KEY:-dummy-value}
 
 support.email = ${SUPPORT_EMAIL:-Bridge (Sage Bionetworks) <support@sagebridge.org>}
 
-synapse.api.key = ${NAPSE_API_KEY:-your-api-key-here}
-synapse.user = ${SYNAPSE_USR:-your-username-here}
-sysops.email = ${SYSOP_EMAIL:-Bridge IT <bridge-testing+sysops@sagebase.org>}
+synapse.api.key = ${SYNAPSE_API_KEY:-your-api-key-here}
+synapse.user = ${SYNAPSE_USER:-your-username-here}
+sysops.email = ${SYSOPS_EMAIL:-Bridge IT <bridge-testing+sysops@sagebase.org>}
 
 test.synapse.user.id = ${TEST_SYNAPSE_USER_ID:-3348228}
 


### PR DESCRIPTION
This change facilitates the migration of bridge from heroku to aws.
It sets up travis to build bridge and then deploy it to a preconfigure
aws elastic beanstalk environment.  We continue to deploy to heroku
to have both stacks running until we can deprecate heroku.