### PR TITLE
Rename ScheduleContext.now to ScheduleContext.startsOn, which is more accurate.

### DIFF
--- a/app/org/sagebionetworks/bridge/models/schedules/ActivityScheduler.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/ActivityScheduler.java
@@ -69,7 +69,7 @@ public abstract class ActivityScheduler {
         if (isInWindow(localDateTime)) {
             // As long at the activities are not already expired, add them.
             LocalDateTime expiresOn = getExpiresOn(localDate, localTime);
-            if (expiresOn == null || expiresOn.isAfter(context.getNow().toLocalDateTime())) {
+            if (expiresOn == null || expiresOn.isAfter(context.getStartsOn().toLocalDateTime())) {
                 ScheduledActivity schActivity = ScheduledActivity.create();
                 schActivity.setSchedulePlanGuid(plan.getGuid());
                 // Use the time zone of the request, not the initial time zone that is used for event dates

--- a/app/org/sagebionetworks/bridge/models/schedules/ScheduleContext.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/ScheduleContext.java
@@ -180,7 +180,9 @@ public final class ScheduleContext {
             return this;
         }
         public Builder withAccountCreatedOn(DateTime accountCreatedOn) {
-            this.accountCreatedOn = new DateTime(accountCreatedOn, DateTimeZone.UTC);
+            if (accountCreatedOn != null) {
+                this.accountCreatedOn = new DateTime(accountCreatedOn, DateTimeZone.UTC);    
+            }
             return this;
         }
         public Builder withLanguages(LinkedHashSet<String> languages) {

--- a/app/org/sagebionetworks/bridge/models/schedules/ScheduleContext.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/ScheduleContext.java
@@ -24,19 +24,19 @@ import com.google.common.collect.ImmutableMap;
 public final class ScheduleContext {
     
     private final DateTimeZone initialTimeZone;
+    private final DateTime startsOn;
     private final DateTime endsOn;
     private final Map<String,DateTime> events;
-    private final DateTime now;
     private final DateTime accountCreatedOn;
     private final int minimumPerSchedule;
     private final CriteriaContext criteriaContext;
     
-    private ScheduleContext(DateTimeZone initialTimeZone, DateTime endsOn, Map<String, DateTime> events, DateTime now,
+    private ScheduleContext(DateTimeZone initialTimeZone, DateTime startsOn, DateTime endsOn, Map<String, DateTime> events,
             int minimumPerSchedule, DateTime accountCreatedOn, CriteriaContext criteriaContext) {
         this.initialTimeZone = initialTimeZone;
         this.endsOn = endsOn;
         this.events = events;
-        this.now = now;
+        this.startsOn = startsOn;
         this.minimumPerSchedule = minimumPerSchedule;
         this.accountCreatedOn = accountCreatedOn;
         this.criteriaContext = criteriaContext;
@@ -78,12 +78,11 @@ public final class ScheduleContext {
     }
     
     /**
-     * Now in the user's initial time zone. This will be used to calculate the times of recurring 
-     * activities.
-     * @return
+     * Start time of scheduling, in the user's initial time zone. This will be used to calculate 
+     * the times of recurring activities.
      */
-    public DateTime getNow() {
-        return now;
+    public DateTime getStartsOn() {
+        return startsOn;
     }
     
     public int getMinimumPerSchedule() {
@@ -100,7 +99,7 @@ public final class ScheduleContext {
     
     @Override
     public int hashCode() {
-        return Objects.hash(initialTimeZone, endsOn, events, now, accountCreatedOn, minimumPerSchedule, criteriaContext);
+        return Objects.hash(initialTimeZone, endsOn, events, startsOn, accountCreatedOn, minimumPerSchedule, criteriaContext);
     }
 
     @Override
@@ -111,7 +110,7 @@ public final class ScheduleContext {
             return false;
         ScheduleContext other = (ScheduleContext) obj;
         return (Objects.equals(endsOn, other.endsOn) && Objects.equals(initialTimeZone, other.initialTimeZone) &&
-                Objects.equals(events, other.events) && Objects.equals(now, other.now) &&
+                Objects.equals(events, other.events) && Objects.equals(startsOn, other.startsOn) &&
                 Objects.equals(minimumPerSchedule, other.minimumPerSchedule) &&
                 Objects.equals(accountCreatedOn, other.accountCreatedOn) && 
                 Objects.equals(criteriaContext, other.criteriaContext));
@@ -119,7 +118,7 @@ public final class ScheduleContext {
 
     @Override
     public String toString() {
-        return "ScheduleContext [initialTimeZone=" + initialTimeZone + ", endsOn=" + endsOn + ", events=" + events + ", now=" + now
+        return "ScheduleContext [initialTimeZone=" + initialTimeZone + ", endsOn=" + endsOn + ", events=" + events + ", startsOn=" + startsOn
                 + ", accountCreatedOn=" + accountCreatedOn + ", minimumPerSchedule=" + minimumPerSchedule 
                 + ", criteriaContext=" + criteriaContext + "]";
     }
@@ -127,10 +126,10 @@ public final class ScheduleContext {
 
     public static class Builder {
         private DateTimeZone initialTimeZone;
+        private DateTime startsOn;
         private DateTime endsOn;
         private Map<String,DateTime> events;
         private int minimumPerSchedule;
-        private DateTime now;
         private DateTime accountCreatedOn;
         private CriteriaContext.Builder contextBuilder = new CriteriaContext.Builder();
         
@@ -176,8 +175,8 @@ public final class ScheduleContext {
             contextBuilder.withUserDataGroups(userDataGroups);
             return this;
         }
-        public Builder withNow(DateTime now) {
-            this.now = now;
+        public Builder withStartsOn(DateTime startsOn) {
+            this.startsOn = startsOn;
             return this;
         }
         public Builder withAccountCreatedOn(DateTime accountCreatedOn) {
@@ -192,7 +191,7 @@ public final class ScheduleContext {
             withInitialTimeZone(context.initialTimeZone);
             withEndsOn(context.endsOn);
             withEvents(context.events);
-            withNow(context.now);
+            withStartsOn(context.startsOn);
             withMinimumPerSchedule(context.minimumPerSchedule);
             withAccountCreatedOn(context.accountCreatedOn);
             contextBuilder.withContext(context.criteriaContext);
@@ -202,10 +201,10 @@ public final class ScheduleContext {
         public ScheduleContext build() {
             // pretty much everything else is optional. I would like healthCode to be required, but it's not:
             // we use these selection criteria to select subpopulations on sign up.
-            if (now == null) {
-                now = (initialTimeZone == null) ? DateTime.now() : DateTime.now(initialTimeZone);
+            if (startsOn == null) {
+                startsOn = (initialTimeZone == null) ? DateTime.now() : DateTime.now(initialTimeZone);
             }
-            return new ScheduleContext(initialTimeZone, endsOn, events, now, minimumPerSchedule, accountCreatedOn,
+            return new ScheduleContext(initialTimeZone, startsOn, endsOn, events, minimumPerSchedule, accountCreatedOn,
                     contextBuilder.build());
         }
     }

--- a/app/org/sagebionetworks/bridge/play/controllers/ScheduledActivityController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ScheduledActivityController.java
@@ -132,7 +132,7 @@ public class ScheduledActivityController extends BaseController {
                 .withUserAgent(request().getHeader(USER_AGENT))
                 .withLanguages(context.getCriteriaContext().getLanguages())
                 .withUserDataGroups(context.getCriteriaContext().getUserDataGroups())
-                .withActivitiesAccessedOn(context.getNow())
+                .withActivitiesAccessedOn(DateUtils.getCurrentDateTime())
                 .withTimeZone(context.getInitialTimeZone())
                 .withStudyIdentifier(context.getCriteriaContext().getStudyIdentifier()).build();
         cacheProvider.updateRequestInfo(requestInfo);

--- a/app/org/sagebionetworks/bridge/play/controllers/ScheduledActivityController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ScheduledActivityController.java
@@ -132,7 +132,7 @@ public class ScheduledActivityController extends BaseController {
                 .withUserAgent(request().getHeader(USER_AGENT))
                 .withLanguages(context.getCriteriaContext().getLanguages())
                 .withUserDataGroups(context.getCriteriaContext().getUserDataGroups())
-                .withActivitiesAccessedOn(DateUtils.getCurrentDateTime())
+                .withActivitiesAccessedOn(DateUtils.getCurrentDateTime().withZone(requestTimeZone))
                 .withTimeZone(context.getInitialTimeZone())
                 .withStudyIdentifier(context.getCriteriaContext().getStudyIdentifier()).build();
         cacheProvider.updateRequestInfo(requestInfo);

--- a/app/org/sagebionetworks/bridge/validators/ScheduleContextValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/ScheduleContextValidator.java
@@ -44,12 +44,12 @@ public class ScheduleContextValidator implements Validator {
             errors.rejectValue("accountCreatedOn", "is required");
         }
         // Very the ending timestamp is not invalid.
-        DateTime now = context.getNow();
+        DateTime startsOn = context.getStartsOn();
         if (context.getEndsOn() == null) {
             errors.rejectValue("endsOn", "is required");
-        } else if (context.getEndsOn().isBefore(now)) {
-            errors.rejectValue("endsOn", "must be after the time of the request");
-        } else if (context.getEndsOn().minusDays(MAX_EXPIRES_ON_DAYS).isAfter(now)) {
+        } else if (context.getEndsOn().isBefore(startsOn)) {
+            errors.rejectValue("endsOn", "must be after startsOn");
+        } else if (context.getEndsOn().minusDays(MAX_EXPIRES_ON_DAYS).isAfter(startsOn)) {
             errors.rejectValue("endsOn", "must be "+MAX_EXPIRES_ON_DAYS+" days or less");
         }
         if (context.getMinimumPerSchedule() < 0) {

--- a/test/org/sagebionetworks/bridge/TestConstants.java
+++ b/test/org/sagebionetworks/bridge/TestConstants.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge;
 
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.joda.time.DateTime;
@@ -69,4 +70,6 @@ public class TestConstants {
             .withSignedMostRecentConsent(false).build();
     
     public static final Set<String> USER_DATA_GROUPS = Sets.newHashSet("group1","group2");
+    
+    public static final LinkedHashSet<String> LANGUAGES = TestUtils.newLinkedHashSet("en","fr");
 }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDaoTest.java
@@ -187,7 +187,7 @@ public class DynamoScheduledActivityDaoTest {
         
         // Finish one of the activities, and save some data with it too.
         ScheduledActivity activity = savedActivities.get(1);
-        activity.setFinishedOn(context.getNow().getMillis());
+        activity.setFinishedOn(context.getStartsOn().getMillis());
         activity.setClientData(clientData);
         assertEquals("activity deleted", ScheduledActivityStatus.DELETED, activity.getStatus());
         activityDao.updateActivities(healthCode, Lists.newArrayList(activity));

--- a/test/org/sagebionetworks/bridge/models/schedules/ActivitySchedulerTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/ActivitySchedulerTest.java
@@ -393,7 +393,7 @@ public class ActivitySchedulerTest {
         // Going out 1 week into the future, with a day day expiration winow, the old task will be 
         // expired and the new task will not be generated. Without a minimum, nothing will be returned
         ScheduleContext noMinContext = getContext(PST, NOW.withZone(PST).plusDays(10));
-        noMinContext = new ScheduleContext.Builder().withContext(noMinContext).withNow(NOW.plusDays(10)).build();
+        noMinContext = new ScheduleContext.Builder().withContext(noMinContext).withStartsOn(NOW.plusDays(10)).build();
         
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, noMinContext);
 

--- a/test/org/sagebionetworks/bridge/models/schedules/ScheduleContextTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/ScheduleContextTest.java
@@ -47,7 +47,7 @@ public class ScheduleContextTest {
         ScheduleContext context = new ScheduleContext.Builder().withStudyIdentifier(TestConstants.TEST_STUDY).build();
         
         assertEquals(ClientInfo.UNKNOWN_CLIENT, context.getCriteriaContext().getClientInfo());
-        assertNotNull(context.getNow());
+        assertNotNull(context.getStartsOn());
         assertEquals(0, context.getMinimumPerSchedule());
     }
     
@@ -72,7 +72,7 @@ public class ScheduleContextTest {
                 .withEvents(events)
                 .withHealthCode("healthCode")
                 .withUserDataGroups(TestConstants.USER_DATA_GROUPS)
-                .withNow(now).build();
+                .withStartsOn(now).build();
         assertEquals(studyId, context.getCriteriaContext().getStudyIdentifier());
         assertEquals(clientInfo, context.getCriteriaContext().getClientInfo());
         assertEquals(PST, context.getInitialTimeZone());
@@ -81,7 +81,7 @@ public class ScheduleContextTest {
         assertEquals(3, context.getMinimumPerSchedule());
         assertEquals("healthCode", context.getCriteriaContext().getHealthCode());
         assertEquals(TestConstants.USER_DATA_GROUPS, context.getCriteriaContext().getUserDataGroups());
-        assertEquals(now, context.getNow());
+        assertEquals(now, context.getStartsOn());
 
         // and the other studyId setter
         context = new ScheduleContext.Builder().withStudyIdentifier("study-key").build();

--- a/test/org/sagebionetworks/bridge/models/schedules/ScheduleContextTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/ScheduleContextTest.java
@@ -56,8 +56,8 @@ public class ScheduleContextTest {
         ClientInfo clientInfo = ClientInfo.fromUserAgentCache("app/5");
         StudyIdentifier studyId = new StudyIdentifierImpl("study-key");
         DateTimeZone PST = DateTimeZone.forOffsetHours(-7);
+        DateTime startsOn = DateTime.now().minusHours(2);
         DateTime endsOn = DateTime.now();
-        DateTime now = DateTime.now();
         
         Map<String,DateTime> events = new HashMap<>();
         events.put("enrollment", DateTime.now());
@@ -67,12 +67,13 @@ public class ScheduleContextTest {
                 .withClientInfo(clientInfo)
                 .withStudyIdentifier(studyId)
                 .withInitialTimeZone(PST)
+                .withStartsOn(startsOn)
                 .withEndsOn(endsOn)
                 .withMinimumPerSchedule(3)
                 .withEvents(events)
                 .withHealthCode("healthCode")
-                .withUserDataGroups(TestConstants.USER_DATA_GROUPS)
-                .withStartsOn(now).build();
+                .withUserDataGroups(TestConstants.USER_DATA_GROUPS).build();
+        
         assertEquals(studyId, context.getCriteriaContext().getStudyIdentifier());
         assertEquals(clientInfo, context.getCriteriaContext().getClientInfo());
         assertEquals(PST, context.getInitialTimeZone());
@@ -81,11 +82,15 @@ public class ScheduleContextTest {
         assertEquals(3, context.getMinimumPerSchedule());
         assertEquals("healthCode", context.getCriteriaContext().getHealthCode());
         assertEquals(TestConstants.USER_DATA_GROUPS, context.getCriteriaContext().getUserDataGroups());
-        assertEquals(now, context.getStartsOn());
+        assertEquals(startsOn, context.getStartsOn());
 
         // and the other studyId setter
-        context = new ScheduleContext.Builder().withStudyIdentifier("study-key").build();
-        assertEquals(studyId, context.getCriteriaContext().getStudyIdentifier());
+        ScheduleContext context2 = new ScheduleContext.Builder().withStudyIdentifier("study-key").build();
+        assertEquals(studyId, context2.getCriteriaContext().getStudyIdentifier());
+        
+        // Test the withContext() method.
+        ScheduleContext context3 = new ScheduleContext.Builder().withContext(context).build();
+        assertEquals(context, context3);
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/play/controllers/ScheduledActivityControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ScheduledActivityControllerTest.java
@@ -62,7 +62,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ScheduledActivityControllerTest {

--- a/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceDuplicateTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceDuplicateTest.java
@@ -164,7 +164,7 @@ public class ScheduledActivityServiceDuplicateTest {
         
         contextBuilder = new ScheduleContext.Builder()
                 .withClientInfo(ClientInfo.fromUserAgentCache("Lilly/25 (iPhone Simulator; iPhone OS/9.3) BridgeSDK/12"))
-                .withNow(ACTIVITIES_LAST_RETRIEVED_ON)
+                .withStartsOn(ACTIVITIES_LAST_RETRIEVED_ON)
                 .withStudyIdentifier("test-study")
                 .withEndsOn(DateTime.now(MSK).plusDays(4))
                 .withHealthCode("d8bc3e0e-51b6-4ead-9b82-33a8fde88c6f")
@@ -357,7 +357,7 @@ public class ScheduledActivityServiceDuplicateTest {
     
     private void allWithinQueryWindow(List<ScheduledActivity> activities, ScheduleContext context) {
         for (ScheduledActivity act : activities) {
-            DateTime windowStart = context.getNow();
+            DateTime windowStart = context.getStartsOn();
             DateTime windowEnd = context.getEndsOn();
             
             assertTrue(act.getExpiresOn() == null || act.getExpiresOn().isAfter(windowStart));

--- a/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceMockTest.java
@@ -478,7 +478,7 @@ public class ScheduledActivityServiceMockTest {
     }
     
     private void executeComplexTestInTimeZone(int hourOfDay, DateTimeZone timeZone) throws Exception {
-        DateTime now = NOW.withZone(timeZone).withHourOfDay(hourOfDay);
+        DateTime startsOn = NOW.withZone(timeZone).withHourOfDay(hourOfDay);
         String json = TestUtils.createJson("{"+  
                 "'guid':'5fe9029e-beb6-4163-ac35-23d048deeefe',"+
                 "'label':'Voice Activity',"+
@@ -580,7 +580,7 @@ public class ScheduledActivityServiceMockTest {
             "}");
             
         Map<String,DateTime> events = Maps.newHashMap();
-        events.put("enrollment", now.withZone(DateTimeZone.UTC).minusDays(3));
+        events.put("enrollment", startsOn.withZone(DateTimeZone.UTC).minusDays(3));
         when(activityEventService.getActivityEventMap("AAA")).thenReturn(events);
         
         ClientInfo info = ClientInfo.fromUserAgentCache("Parkinson-QA/36 (iPhone 5S; iPhone OS/9.2.1) BridgeSDK/7");
@@ -593,12 +593,12 @@ public class ScheduledActivityServiceMockTest {
             .withClientInfo(info)
             .withStudyIdentifier("test-study")
             .withUserDataGroups(Sets.newHashSet("parkinson","test_user"))
-                .withEndsOn(now.plusDays(1).withHourOfDay(23).withMinuteOfHour(59).withSecondOfMinute(59))
+                .withEndsOn(startsOn.plusDays(1).withHourOfDay(23).withMinuteOfHour(59).withSecondOfMinute(59))
                 .withInitialTimeZone(timeZone)
             .withHealthCode("AAA")
             .withUserId(USER_ID)
-            .withNow(now)
-            .withAccountCreatedOn(now.minusDays(4))
+            .withStartsOn(startsOn)
+            .withAccountCreatedOn(startsOn.minusDays(4))
             .build();
         
         // Is a parkinson patient, gets 3 tasks (or 6 tasks late in the day, see BRIDGE-1603
@@ -774,7 +774,7 @@ public class ScheduledActivityServiceMockTest {
         DateTime enrollment = DateTime.parse("2017-02-20T01:00:00.000Z");
         DateTimeZone initialTimeZone = DateTimeZone.forOffsetHours(initialTZOffset);
         DateTimeZone requestTimeZone = DateTimeZone.forOffsetHours(requestTZOffset);
-        DateTime now = DateTime.parse("2017-04-06T17:10:10.000Z").withZone(requestTimeZone);
+        DateTime startsOn = DateTime.parse("2017-04-06T17:10:10.000Z").withZone(requestTimeZone);
         
         Map<String,DateTime> eventMap = Maps.newHashMap();
         eventMap.put("enrollment", enrollment);
@@ -790,10 +790,10 @@ public class ScheduledActivityServiceMockTest {
         ScheduleContext context = new ScheduleContext.Builder()
                 .withStudyIdentifier(TEST_STUDY)
                 .withUserId("userId")
-                .withNow(now)
+                .withStartsOn(startsOn)
                 .withAccountCreatedOn(enrollment)
                 .withInitialTimeZone(initialTimeZone)
-                .withEndsOn(now.plusDays(4).withZone(requestTimeZone))
+                .withEndsOn(startsOn.plusDays(4).withZone(requestTimeZone))
                 .withHealthCode("healthCode").build();
         
         List<ScheduledActivity> activities = service.getScheduledActivities(context);
@@ -849,7 +849,7 @@ public class ScheduledActivityServiceMockTest {
         events.put("enrollment", ENROLLMENT);
         
         return new ScheduleContext.Builder().withStudyIdentifier(TEST_STUDY).withInitialTimeZone(DateTimeZone.UTC)
-                .withNow(NOW)
+                .withStartsOn(NOW)
                 .withAccountCreatedOn(ENROLLMENT.minusHours(2)).withEndsOn(endsOn).withHealthCode(HEALTH_CODE)
                 .withUserId(USER_ID).withEvents(events).build();
     }

--- a/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceRecurringTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceRecurringTest.java
@@ -195,13 +195,13 @@ public class ScheduledActivityServiceRecurringTest {
         return getContext(now, EST, now.withZone(requestZone).plusDays(2));
     }
     
-    private ScheduleContext getContext(DateTime now, DateTimeZone persistedZone, DateTime endsOn) {
+    private ScheduleContext getContext(DateTime startsOn, DateTimeZone persistedZone, DateTime endsOn) {
         return new ScheduleContext.Builder()
             .withStudyIdentifier(study.getStudyIdentifier())
             .withClientInfo(ClientInfo.UNKNOWN_CLIENT)
             .withInitialTimeZone(persistedZone)
-            .withNow(now)
-            .withAccountCreatedOn(now)
+            .withAccountCreatedOn(startsOn)
+            .withStartsOn(startsOn)
             // Setting the endsOn value to the end of the day, as we do in the controller.
             .withEndsOn(endsOn.withHourOfDay(23).withMinuteOfHour(59).withSecondOfMinute(59))
             .withHealthCode(testUser.getHealthCode())

--- a/test/org/sagebionetworks/bridge/validators/ScheduleContextValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/ScheduleContextValidatorTest.java
@@ -55,7 +55,7 @@ public class ScheduleContextValidatorTest {
             Validate.nonEntityThrowingException(validator, context);
             fail("Should have thrown exception");
         } catch(BadRequestException e) {
-            assertTrue(e.getMessage().contains("endsOn must be after the time of the request"));
+            assertTrue(e.getMessage().contains("endsOn must be after startsOn"));
         }
     }
     


### PR DESCRIPTION
We're about to introduce a new endpoint (/v4/activities) that will allow the client to retrieve activities for an arbitrary date range. When we do this, the "now" value in the ScheduleContext will really be the "startsOn" value of the query, and only "now" by default in the v3 of the API. Just doing a rename here to separate this change from the functional changes that are coming.