### PR TITLE
Returning timestamps used to retrieve activities...

### DIFF
--- a/app/org/sagebionetworks/bridge/models/DateTimeRangeResourceList.java
+++ b/app/org/sagebionetworks/bridge/models/DateTimeRangeResourceList.java
@@ -4,8 +4,11 @@ import java.util.List;
 
 import org.joda.time.DateTime;
 
+import org.sagebionetworks.bridge.json.DateTimeSerializer;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 public class DateTimeRangeResourceList<T> {
     private final List<T> items;
@@ -25,9 +28,11 @@ public class DateTimeRangeResourceList<T> {
     public int getTotal() {
         return items.size();
     }
+    @JsonSerialize(using = DateTimeSerializer.class)
     public DateTime getStartTime() {
         return startTime;
     }
+    @JsonSerialize(using = DateTimeSerializer.class)
     public DateTime getEndTime() {
         return endTime;
     }

--- a/app/org/sagebionetworks/bridge/play/controllers/ScheduledActivityController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ScheduledActivityController.java
@@ -15,6 +15,7 @@ import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.dao.ParticipantOption;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.json.DateUtils;
+import org.sagebionetworks.bridge.models.DateTimeRangeResourceList;
 import org.sagebionetworks.bridge.models.ForwardCursorPagedResourceList;
 import org.sagebionetworks.bridge.models.RequestInfo;
 import org.sagebionetworks.bridge.models.ResourceList;
@@ -88,14 +89,15 @@ public class ScheduledActivityController extends BaseController {
         if (!startsOn.getZone().equals(endsOn.getZone())) {
             throw new BadRequestException(AMBIGUOUS_TIMEZONE_ERROR);
         }
+        DateTime startsOnInclusive = startsOn.minusMillis(1);
 
         DateTimeZone requestTimeZone = startsOn.getZone();
-        ScheduleContext context = getScheduledActivitiesInternal(session, requestTimeZone, startsOn, endsOn, 0);
+        ScheduleContext context = getScheduledActivitiesInternal(session, requestTimeZone, startsOnInclusive, endsOn, 0);
 
         List<ScheduledActivity> scheduledActivities = scheduledActivityService.getScheduledActivitiesV4(context);
         
-        return ok(ScheduledActivity.SCHEDULED_ACTIVITY_WRITER
-                .writeValueAsString(new ResourceList<ScheduledActivity>(scheduledActivities)));
+        return ok(ScheduledActivity.SCHEDULED_ACTIVITY_WRITER.writeValueAsString(
+                new DateTimeRangeResourceList<ScheduledActivity>(scheduledActivities, startsOn, endsOn)));
     }
 
     public Result updateScheduledActivities() throws Exception {

--- a/test/org/sagebionetworks/bridge/json/JodaDateTimeDeserializerTest.java
+++ b/test/org/sagebionetworks/bridge/json/JodaDateTimeDeserializerTest.java
@@ -23,5 +23,6 @@ public class JodaDateTimeDeserializerTest {
         // execute and validate
         DateTime result = new JodaDateTimeDeserializer().deserialize(mockJP, null);
         assertEquals(expectedMillis, result.getMillis());
+        assertEquals("2014-02-12T16:07:00.000-08:00", result.toString());
     }
 }

--- a/test/org/sagebionetworks/bridge/models/DateTimeRangeResourceListTest.java
+++ b/test/org/sagebionetworks/bridge/models/DateTimeRangeResourceListTest.java
@@ -15,12 +15,12 @@ public class DateTimeRangeResourceListTest {
     @Test
     public void canSerialize() throws Exception {
         DateTimeRangeResourceList<String> list = new DateTimeRangeResourceList<>(
-                Lists.newArrayList("1", "2", "3"), DateTime.parse("2016-02-03T10:10:10.000Z"),
-                DateTime.parse("2016-02-23T14:14:14.000Z"));
+                Lists.newArrayList("1", "2", "3"), DateTime.parse("2016-02-03T10:10:10.000-08:00"),
+                DateTime.parse("2016-02-23T14:14:14.000-08:00"));
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(list);
-        assertEquals("2016-02-03T10:10:10.000Z", node.get("startTime").asText());
-        assertEquals("2016-02-23T14:14:14.000Z", node.get("endTime").asText());
+        assertEquals("2016-02-03T10:10:10.000-08:00", node.get("startTime").asText());
+        assertEquals("2016-02-23T14:14:14.000-08:00", node.get("endTime").asText());
         assertEquals(3, node.get("total").asInt());
         assertEquals("DateTimeRangeResourceList", node.get("type").asText());
         assertEquals("1", node.get("items").get(0).asText());


### PR DESCRIPTION
...and adjusting the start time by one millisecond so the range is start (inclusive) to end (exclusive).