### PR TITLE
Ability to set a limit on the number of accounts created in a study

### DIFF
--- a/app/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/app/org/sagebionetworks/bridge/BridgeConstants.java
@@ -11,10 +11,7 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 
 public class BridgeConstants {
-    public static final int MAX_USERS_IN_EVAL_STUDY = 15;
-    
-    public static final String MAX_USERS_ERROR = "While study is in evaluation mode, it may not exceed "
-            + MAX_USERS_IN_EVAL_STUDY + " accounts.";
+    public static final String MAX_USERS_ERROR = "While study is in evaluation mode, it may not exceed %s accounts.";
     
     // Study ID for the test study, used in local tests and most integ tests.
     public static final String API_STUDY_ID_STRING = "api";

--- a/app/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/app/org/sagebionetworks/bridge/BridgeConstants.java
@@ -11,6 +11,11 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 
 public class BridgeConstants {
+    public static final int MAX_USERS_IN_EVAL_STUDY = 15;
+    
+    public static final String MAX_USERS_ERROR = "While study is in evaluation mode, it may not exceed "
+            + MAX_USERS_IN_EVAL_STUDY + " accounts.";
+    
     // Study ID for the test study, used in local tests and most integ tests.
     public static final String API_STUDY_ID_STRING = "api";
     public static final StudyIdentifier API_STUDY_ID = new StudyIdentifierImpl(API_STUDY_ID_STRING);

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
@@ -37,6 +37,7 @@ public final class DynamoStudy implements Study {
     private boolean usesCustomExportSchedule;
     private String consentNotificationEmail;
     private int minAgeOfConsent;
+    private int accountLimit;
     private Long version;
     private boolean active;
     private Set<String> profileAttributes;
@@ -52,7 +53,6 @@ public final class DynamoStudy implements Study {
     private boolean externalIdValidationEnabled;
     private boolean emailSignInEnabled;
     private boolean externalIdRequiredOnSignup;
-    private boolean evaluationStudy;
     private Map<String, Integer> minSupportedAppVersions;
     private Map<String, String> pushNotificationARNs;
     private boolean disableExport;
@@ -406,13 +406,13 @@ public final class DynamoStudy implements Study {
     }
     
     @Override
-    public boolean isEvaluationStudy() {
-        return evaluationStudy;
+    public int getAccountLimit() {
+        return accountLimit;
     };
     
     @Override
-    public void setEvaluationStudy(boolean evaluationStudy) {
-        this.evaluationStudy = evaluationStudy;
+    public void setAccountLimit(int accountLimit) {
+        this.accountLimit = accountLimit;
     }
 
     @Override
@@ -423,7 +423,7 @@ public final class DynamoStudy implements Study {
                 healthCodeExportEnabled, emailVerificationEnabled, externalIdValidationEnabled,
                 externalIdRequiredOnSignup, minSupportedAppVersions, synapseDataAccessTeamId, synapseProjectId,
                 usesCustomExportSchedule, pushNotificationARNs, disableExport, emailSignInTemplate,
-                emailSignInEnabled, evaluationStudy);
+                emailSignInEnabled, accountLimit);
     }
 
     @Override
@@ -460,7 +460,7 @@ public final class DynamoStudy implements Study {
                 && Objects.equals(disableExport, other.disableExport)
                 && Objects.equals(emailSignInTemplate, other.emailSignInTemplate)
                 && Objects.equals(emailSignInEnabled, other.emailSignInEnabled)
-                && Objects.equals(evaluationStudy, other.evaluationStudy);
+                && Objects.equals(accountLimit, other.accountLimit);
     }
 
     @Override
@@ -472,14 +472,14 @@ public final class DynamoStudy implements Study {
                         + "dataGroups=%s, passwordPolicy=%s, verifyEmailTemplate=%s, resetPasswordTemplate=%s, "
                         + "strictUploadValidationEnabled=%s, healthCodeExportEnabled=%s, emailVerificationEnabled=%s, "
                         + "externalIdValidationEnabled=%s, externalIdRequiredOnSignup=%s, minSupportedAppVersions=%s, "
-                        + "usesCustomExportSchedule=%s, pushNotificationARNs=%s], "
-                        + "disableExport=%s, emailSignInTemplate=%s, emailSignInEnabled=%s, evaluationStudy=%s]",
+                        + "usesCustomExportSchedule=%s, pushNotificationARNs=%s, disableExport=%s, "
+                        + "emailSignInTemplate=%s, emailSignInEnabled=%s, accountLimit=%s]",
                 name, active, sponsorName, identifier, stormpathHref, minAgeOfConsent, supportEmail,
                 synapseDataAccessTeamId, synapseProjectId, technicalEmail, consentNotificationEmail, version,
                 profileAttributes, taskIdentifiers, dataGroups, passwordPolicy, verifyEmailTemplate,
                 resetPasswordTemplate, strictUploadValidationEnabled, healthCodeExportEnabled, emailVerificationEnabled,
                 externalIdValidationEnabled, externalIdRequiredOnSignup, minSupportedAppVersions,
                 usesCustomExportSchedule, pushNotificationARNs, disableExport, emailSignInTemplate,
-                emailSignInEnabled, evaluationStudy);
+                emailSignInEnabled, accountLimit);
     }
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
@@ -52,6 +52,7 @@ public final class DynamoStudy implements Study {
     private boolean externalIdValidationEnabled;
     private boolean emailSignInEnabled;
     private boolean externalIdRequiredOnSignup;
+    private boolean evaluationStudy;
     private Map<String, Integer> minSupportedAppVersions;
     private Map<String, String> pushNotificationARNs;
     private boolean disableExport;
@@ -403,6 +404,16 @@ public final class DynamoStudy implements Study {
     public void setExternalIdRequiredOnSignup(boolean externalIdRequiredOnSignup) {
         this.externalIdRequiredOnSignup = externalIdRequiredOnSignup;
     }
+    
+    @Override
+    public boolean isEvaluationStudy() {
+        return evaluationStudy;
+    };
+    
+    @Override
+    public void setEvaluationStudy(boolean evaluationStudy) {
+        this.evaluationStudy = evaluationStudy;
+    }
 
     @Override
     public int hashCode() {
@@ -412,7 +423,7 @@ public final class DynamoStudy implements Study {
                 healthCodeExportEnabled, emailVerificationEnabled, externalIdValidationEnabled,
                 externalIdRequiredOnSignup, minSupportedAppVersions, synapseDataAccessTeamId, synapseProjectId,
                 usesCustomExportSchedule, pushNotificationARNs, disableExport, emailSignInTemplate,
-                emailSignInEnabled);
+                emailSignInEnabled, evaluationStudy);
     }
 
     @Override
@@ -448,7 +459,8 @@ public final class DynamoStudy implements Study {
                 && Objects.equals(pushNotificationARNs, other.pushNotificationARNs)
                 && Objects.equals(disableExport, other.disableExport)
                 && Objects.equals(emailSignInTemplate, other.emailSignInTemplate)
-                && Objects.equals(emailSignInEnabled, other.emailSignInEnabled);
+                && Objects.equals(emailSignInEnabled, other.emailSignInEnabled)
+                && Objects.equals(evaluationStudy, other.evaluationStudy);
     }
 
     @Override
@@ -461,13 +473,13 @@ public final class DynamoStudy implements Study {
                         + "strictUploadValidationEnabled=%s, healthCodeExportEnabled=%s, emailVerificationEnabled=%s, "
                         + "externalIdValidationEnabled=%s, externalIdRequiredOnSignup=%s, minSupportedAppVersions=%s, "
                         + "usesCustomExportSchedule=%s, pushNotificationARNs=%s], "
-                        + "disableExport=%s, emailSignInTemplate=%s, emailSignInEnabled=%s]",
+                        + "disableExport=%s, emailSignInTemplate=%s, emailSignInEnabled=%s, evaluationStudy=%s]",
                 name, active, sponsorName, identifier, stormpathHref, minAgeOfConsent, supportEmail,
                 synapseDataAccessTeamId, synapseProjectId, technicalEmail, consentNotificationEmail, version,
                 profileAttributes, taskIdentifiers, dataGroups, passwordPolicy, verifyEmailTemplate,
                 resetPasswordTemplate, strictUploadValidationEnabled, healthCodeExportEnabled, emailVerificationEnabled,
                 externalIdValidationEnabled, externalIdRequiredOnSignup, minSupportedAppVersions,
                 usesCustomExportSchedule, pushNotificationARNs, disableExport, emailSignInTemplate,
-                emailSignInEnabled);
+                emailSignInEnabled, evaluationStudy);
     }
 }

--- a/app/org/sagebionetworks/bridge/models/studies/Study.java
+++ b/app/org/sagebionetworks/bridge/models/studies/Study.java
@@ -95,6 +95,13 @@ public interface Study extends BridgeEntity, StudyIdentifier {
     void setSynapseProjectId(String projectId);
 
     /**
+     * This study is for evaluation purposes. We limit the total number of accounts that can be 
+     * created in an evaluation study. 
+     */
+    boolean isEvaluationStudy();
+    void setEvaluationStudy(boolean isEvaluationStudy);
+    
+    /**
      * The email address for a technical contact who can coordinate with the Bridge Server team on 
      * issues related either to client development or hand-offs of the study data through the 
      * Bridge server. This can be a comma-separated list of email addresses.

--- a/app/org/sagebionetworks/bridge/models/studies/Study.java
+++ b/app/org/sagebionetworks/bridge/models/studies/Study.java
@@ -95,11 +95,13 @@ public interface Study extends BridgeEntity, StudyIdentifier {
     void setSynapseProjectId(String projectId);
 
     /**
-     * This study is for evaluation purposes. We limit the total number of accounts that can be 
-     * created in an evaluation study. 
+     * Set a limit on the number of accounts that can be created for this study. This is intended 
+     * to establish evaluation studies with limited accounts or enrollment. The value should be 
+     * set to 0 for production studies (there is a runtime cost to enforcing this limit). If 
+     * value is zero, no limit is enforced.
      */
-    boolean isEvaluationStudy();
-    void setEvaluationStudy(boolean isEvaluationStudy);
+    int getAccountLimit();
+    void setAccountLimit(int accountLimit);
     
     /**
      * The email address for a technical contact who can coordinate with the Bridge Server team on 

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.dao.AccountDao;
@@ -35,6 +36,7 @@ import org.sagebionetworks.bridge.dao.ParticipantOption.SharingScope;
 import org.sagebionetworks.bridge.dao.ScheduledActivityDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
+import org.sagebionetworks.bridge.exceptions.LimitExceededException;
 import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.ForwardCursorPagedResourceList;
@@ -228,6 +230,10 @@ public class ParticipantService {
         checkNotNull(study);
         checkNotNull(callerRoles);
         checkNotNull(participant);
+        
+        if (study.isEvaluationStudy()) {
+            throwExceptionIfLimitMetOrExceeded(study);
+        }
 
         Validate.entityThrowingException(new StudyParticipantValidator(study, true), participant);
         
@@ -265,6 +271,14 @@ public class ParticipantService {
         }
         accountDao.updateAccount(account);
         optionsService.setAllOptions(study.getStudyIdentifier(), account.getHealthCode(), options);
+    }
+
+    private void throwExceptionIfLimitMetOrExceeded(Study study) {
+        PagedResourceList<AccountSummary> summaries = getPagedAccountSummaries(study, 0,
+                BridgeConstants.MAX_USERS_IN_EVAL_STUDY, null, null, null);
+        if (summaries.getTotal() >= BridgeConstants.MAX_USERS_IN_EVAL_STUDY) {
+            throw new LimitExceededException(BridgeConstants.MAX_USERS_ERROR);
+        }
     }
 
     private void updateAccountOptionsAndRoles(Study study, Set<Roles> callerRoles,

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -231,7 +231,7 @@ public class ParticipantService {
         checkNotNull(callerRoles);
         checkNotNull(participant);
         
-        if (study.isEvaluationStudy()) {
+        if (study.getAccountLimit() > 0) {
             throwExceptionIfLimitMetOrExceeded(study);
         }
 
@@ -274,10 +274,12 @@ public class ParticipantService {
     }
 
     private void throwExceptionIfLimitMetOrExceeded(Study study) {
+        // It's sufficient to get one record because the total for this query is all the records that 
+        // match in the database. 
         PagedResourceList<AccountSummary> summaries = getPagedAccountSummaries(study, 0,
-                BridgeConstants.MAX_USERS_IN_EVAL_STUDY, null, null, null);
-        if (summaries.getTotal() >= BridgeConstants.MAX_USERS_IN_EVAL_STUDY) {
-            throw new LimitExceededException(BridgeConstants.MAX_USERS_ERROR);
+                BridgeConstants.API_MINIMUM_PAGE_SIZE, null, null, null);
+        if (summaries.getTotal() >= study.getAccountLimit()) {
+            throw new LimitExceededException(String.format(BridgeConstants.MAX_USERS_ERROR, study.getAccountLimit()));
         }
     }
 

--- a/app/org/sagebionetworks/bridge/services/StudyService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyService.java
@@ -429,7 +429,7 @@ public class StudyService {
             study.setExternalIdValidationEnabled(originalStudy.isExternalIdValidationEnabled());
             study.setExternalIdRequiredOnSignup(originalStudy.isExternalIdRequiredOnSignup());
             study.setEmailSignInEnabled(originalStudy.isEmailSignInEnabled());
-            study.setEvaluationStudy(originalStudy.isEvaluationStudy());
+            study.setAccountLimit(originalStudy.getAccountLimit());
         }
 
         // prevent anyone changing active to false -- it should be done by deactivateStudy() method

--- a/app/org/sagebionetworks/bridge/services/StudyService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyService.java
@@ -417,8 +417,8 @@ public class StudyService {
         
         checkViolationConstraints(study);
         
-        // And this cannot be set unless you're an administrator. Regardless of what the
-        // developer set, set these back to the original study.
+        // A number of fields can only be set by an administrator. We set these to their existing values if the 
+        // caller is not an admin.
         if (!isAdminUpdate) {
             // prevent non-admins update a deactivated study
             if (!originalStudy.isActive()) {
@@ -429,6 +429,7 @@ public class StudyService {
             study.setExternalIdValidationEnabled(originalStudy.isExternalIdValidationEnabled());
             study.setExternalIdRequiredOnSignup(originalStudy.isExternalIdRequiredOnSignup());
             study.setEmailSignInEnabled(originalStudy.isEmailSignInEnabled());
+            study.setEvaluationStudy(originalStudy.isEvaluationStudy());
         }
 
         // prevent anyone changing active to false -- it should be done by deactivateStudy() method

--- a/app/org/sagebionetworks/bridge/validators/StudyValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/StudyValidator.java
@@ -88,6 +88,9 @@ public class StudyValidator implements Validator {
         if (study.getMinAgeOfConsent() < 0) {
             errors.rejectValue("minAgeOfConsent", "must be zero (no minimum age of consent) or higher");
         }
+        if (study.getAccountLimit() < 0) {
+            errors.rejectValue("accountLimit", "must be zero (no limit set) or higher");
+        }
         validateTemplate(errors, study.getVerifyEmailTemplate(), "verifyEmailTemplate");
         validateTemplate(errors, study.getResetPasswordTemplate(), "resetPasswordTemplate");
         

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -394,7 +394,7 @@ public class TestUtils {
         study.setExternalIdRequiredOnSignup(true);
         study.setActive(true);
         study.setDisableExport(false);
-        study.setEvaluationStudy(true);
+        study.setAccountLimit(0);
         study.setPushNotificationARNs(pushNotificationARNs);
         return study;
     }

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -394,6 +394,7 @@ public class TestUtils {
         study.setExternalIdRequiredOnSignup(true);
         study.setActive(true);
         study.setDisableExport(false);
+        study.setEvaluationStudy(true);
         study.setPushNotificationARNs(pushNotificationARNs);
         return study;
     }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
@@ -77,6 +77,7 @@ public class DynamoStudyTest {
         assertTrue(node.get("externalIdValidationEnabled").asBoolean());
         assertTrue(node.get("externalIdRequiredOnSignup").asBoolean());
         assertTrue(node.get("emailSignInEnabled").asBoolean());
+        assertTrue(node.get("evaluationStudy").asBoolean());
         assertFalse(node.get("disableExport").asBoolean());
         assertEqualsAndNotNull("Study", node.get("type").asText());
         assertEqualsAndNotNull(study.getPushNotificationARNs().get(OperatingSystem.IOS),

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
@@ -25,7 +25,6 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 /**
  * Main functionality we want to verify in this test is that study can be serialized with all values, 
  * but filtered in the API to exclude read-only studies when exposed to researchers.
- *
  */
 public class DynamoStudyTest {
     
@@ -77,7 +76,7 @@ public class DynamoStudyTest {
         assertTrue(node.get("externalIdValidationEnabled").asBoolean());
         assertTrue(node.get("externalIdRequiredOnSignup").asBoolean());
         assertTrue(node.get("emailSignInEnabled").asBoolean());
-        assertTrue(node.get("evaluationStudy").asBoolean());
+        assertEquals(0, node.get("accountLimit").asInt());
         assertFalse(node.get("disableExport").asBoolean());
         assertEqualsAndNotNull("Study", node.get("type").asText());
         assertEqualsAndNotNull(study.getPushNotificationARNs().get(OperatingSystem.IOS),

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -38,6 +38,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.TestUtils;
@@ -52,9 +53,12 @@ import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
+import org.sagebionetworks.bridge.exceptions.LimitExceededException;
 import org.sagebionetworks.bridge.models.CriteriaContext;
+import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountStatus;
+import org.sagebionetworks.bridge.models.accounts.AccountSummary;
 import org.sagebionetworks.bridge.models.accounts.Email;
 import org.sagebionetworks.bridge.models.accounts.ExternalIdentifier;
 import org.sagebionetworks.bridge.models.accounts.IdentifierHolder;
@@ -163,6 +167,9 @@ public class ParticipantServiceTest {
     @Mock
     private ScheduledActivityService scheduledActivityService;
     
+    @Mock
+    private PagedResourceList<AccountSummary> accountSummaries;
+    
     @Captor
     ArgumentCaptor<StudyParticipant> participantCaptor;
     
@@ -194,6 +201,7 @@ public class ParticipantServiceTest {
     public void before() {
         STUDY.setExternalIdValidationEnabled(false);
         STUDY.setExternalIdRequiredOnSignup(false);
+        STUDY.setEvaluationStudy(false);
         participantService = new ParticipantService();
         participantService.setAccountDao(accountDao);
         participantService.setParticipantOptionsService(optionsService);
@@ -849,6 +857,37 @@ public class ParticipantServiceTest {
         // Submitting same value again with validation does nothing
         verify(externalIdService).assignExternalId(STUDY, EXTERNAL_ID, HEALTH_CODE);
         verifyNotSetAsOption();
+    }
+
+    @Test
+    public void limitNotExceededException() {
+        mockHealthCodeAndAccountRetrieval();
+        STUDY.setEvaluationStudy(true);
+        when(accountSummaries.getTotal()).thenReturn(BridgeConstants.MAX_USERS_IN_EVAL_STUDY-1);
+        when(accountDao.getPagedAccountSummaries(STUDY, 0, BridgeConstants.MAX_USERS_IN_EVAL_STUDY, null, null, null))
+                .thenReturn(accountSummaries);
+        
+        participantService.createParticipant(STUDY,  CALLER_ROLES, PARTICIPANT, false);
+    }
+    
+    @Test(expected = LimitExceededException.class)
+    public void throwLimitExceededExactlyException() {
+        STUDY.setEvaluationStudy(true);
+        when(accountSummaries.getTotal()).thenReturn(BridgeConstants.MAX_USERS_IN_EVAL_STUDY);
+        when(accountDao.getPagedAccountSummaries(STUDY, 0, BridgeConstants.MAX_USERS_IN_EVAL_STUDY, null, null, null))
+                .thenReturn(accountSummaries);
+        
+        participantService.createParticipant(STUDY,  CALLER_ROLES, PARTICIPANT, false);
+    }
+    
+    @Test(expected = LimitExceededException.class)
+    public void throwLimitExceededException() {
+        STUDY.setEvaluationStudy(true);
+        when(accountSummaries.getTotal()).thenReturn(BridgeConstants.MAX_USERS_IN_EVAL_STUDY+3);
+        when(accountDao.getPagedAccountSummaries(STUDY, 0, BridgeConstants.MAX_USERS_IN_EVAL_STUDY, null, null, null))
+                .thenReturn(accountSummaries);
+        
+        participantService.createParticipant(STUDY,  CALLER_ROLES, PARTICIPANT, false);
     }
     
     private void verifyStatusCreate(Set<Roles> callerRoles) {

--- a/test/org/sagebionetworks/bridge/services/StudyServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceTest.java
@@ -289,6 +289,7 @@ public class StudyServiceTest {
         study.setStrictUploadValidationEnabled(false);
         study.setEmailVerificationEnabled(false);
         study.setEmailSignInEnabled(true);
+        study.setEvaluationStudy(true);
         
         study = studyService.createStudy(study);
         // These are set to the defaults.
@@ -298,6 +299,7 @@ public class StudyServiceTest {
         assertTrue(study.isStrictUploadValidationEnabled());
         assertTrue(study.isEmailVerificationEnabled());
         assertFalse(study.isEmailSignInEnabled());
+        assertTrue(study.isEvaluationStudy());
         
         // Researchers cannot change theseOkay, now that these are set, researchers cannot change them. Except setting active 
         // to false, which is a logical delete that throws a BadRequestException
@@ -306,6 +308,7 @@ public class StudyServiceTest {
         study.setExternalIdValidationEnabled(false);
         study.setExternalIdRequiredOnSignup(false);
         study.setEmailSignInEnabled(true);
+        study.setEvaluationStudy(false);
         study = studyService.updateStudy(study, false); // nope
         
         // These have not changed:
@@ -314,6 +317,7 @@ public class StudyServiceTest {
         assertTrue(study.isExternalIdValidationEnabled());
         assertTrue(study.isExternalIdRequiredOnSignup());
         assertFalse(study.isEmailSignInEnabled());
+        assertTrue(study.isEvaluationStudy());
         
         // But administrators can change these
         study.setHealthCodeExportEnabled(false);
@@ -321,6 +325,7 @@ public class StudyServiceTest {
         study.setExternalIdValidationEnabled(false);
         study.setExternalIdRequiredOnSignup(false);
         study.setEmailSignInEnabled(true);
+        study.setEvaluationStudy(false);
         study = studyService.updateStudy(study, true); // yep
         
         assertFalse(study.isHealthCodeExportEnabled());
@@ -328,6 +333,7 @@ public class StudyServiceTest {
         assertFalse(study.isExternalIdValidationEnabled());
         assertFalse(study.isExternalIdRequiredOnSignup());
         assertTrue(study.isEmailSignInEnabled());
+        assertFalse(study.isEvaluationStudy());
     }
     
     @Test(expected=InvalidEntityException.class)

--- a/test/org/sagebionetworks/bridge/services/StudyServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceTest.java
@@ -289,7 +289,7 @@ public class StudyServiceTest {
         study.setStrictUploadValidationEnabled(false);
         study.setEmailVerificationEnabled(false);
         study.setEmailSignInEnabled(true);
-        study.setEvaluationStudy(true);
+        study.setAccountLimit(15);
         
         study = studyService.createStudy(study);
         // These are set to the defaults.
@@ -299,7 +299,7 @@ public class StudyServiceTest {
         assertTrue(study.isStrictUploadValidationEnabled());
         assertTrue(study.isEmailVerificationEnabled());
         assertFalse(study.isEmailSignInEnabled());
-        assertTrue(study.isEvaluationStudy());
+        assertEquals(15, study.getAccountLimit());
         
         // Researchers cannot change theseOkay, now that these are set, researchers cannot change them. Except setting active 
         // to false, which is a logical delete that throws a BadRequestException
@@ -308,7 +308,7 @@ public class StudyServiceTest {
         study.setExternalIdValidationEnabled(false);
         study.setExternalIdRequiredOnSignup(false);
         study.setEmailSignInEnabled(true);
-        study.setEvaluationStudy(false);
+        study.setAccountLimit(0);
         study = studyService.updateStudy(study, false); // nope
         
         // These have not changed:
@@ -317,7 +317,7 @@ public class StudyServiceTest {
         assertTrue(study.isExternalIdValidationEnabled());
         assertTrue(study.isExternalIdRequiredOnSignup());
         assertFalse(study.isEmailSignInEnabled());
-        assertTrue(study.isEvaluationStudy());
+        assertEquals(15, study.getAccountLimit());
         
         // But administrators can change these
         study.setHealthCodeExportEnabled(false);
@@ -325,7 +325,7 @@ public class StudyServiceTest {
         study.setExternalIdValidationEnabled(false);
         study.setExternalIdRequiredOnSignup(false);
         study.setEmailSignInEnabled(true);
-        study.setEvaluationStudy(false);
+        study.setAccountLimit(0);
         study = studyService.updateStudy(study, true); // yep
         
         assertFalse(study.isHealthCodeExportEnabled());
@@ -333,7 +333,7 @@ public class StudyServiceTest {
         assertFalse(study.isExternalIdValidationEnabled());
         assertFalse(study.isExternalIdRequiredOnSignup());
         assertTrue(study.isEmailSignInEnabled());
-        assertFalse(study.isEvaluationStudy());
+        assertEquals(0, study.getAccountLimit());
     }
     
     @Test(expected=InvalidEntityException.class)

--- a/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
@@ -233,6 +233,12 @@ public class StudyValidatorTest {
     }
     
     @Test
+    public void cannotSetAccountLimitLessThanZero() {
+        study.setAccountLimit(-100);
+        assertCorrectMessage(study, "accountLimit", "accountLimit must be zero (no limit set) or higher");
+    }
+    
+    @Test
     public void shortListOfDataGroupsOK() {
         study.setDataGroups(Sets.newHashSet("beta_users", "production_users", "testers", "internal"));
         Validate.entityThrowingException(StudyValidator.INSTANCE, study);


### PR DESCRIPTION
Intended as a feature to create studies for evaluation before we've established business terms. Exact number of accounts is configurable, enforcing limit has a runtime cost.