### PR TITLE
LimitExceededException should not be logged as an error

### DIFF
--- a/app/org/sagebionetworks/bridge/exceptions/LimitExceededException.java
+++ b/app/org/sagebionetworks/bridge/exceptions/LimitExceededException.java
@@ -4,6 +4,7 @@ package org.sagebionetworks.bridge.exceptions;
  * Requests have exceeded an allowable limit, either in time or in number. The message should explain what 
  * is being gated (e.g. too many requests to sign in via email; too many users enrolled in the study, etc.).
  */
+@NoStackTraceException
 @SuppressWarnings("serial")
 public class LimitExceededException extends BridgeServiceException {
     public LimitExceededException(String message) {


### PR DESCRIPTION
Testing done:
* Before implementing the fix, requested email sign in, observed ERROR and stack trace in the logs.
* After implementing fix, observed INFO and no stack trace in the logs.