### PR TITLE
Disable email until verified

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
@@ -15,7 +15,6 @@ import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.PublishedSurveyException;
 import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolder;
-import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.surveys.Survey;

--- a/app/org/sagebionetworks/bridge/exceptions/InvalidEntityException.java
+++ b/app/org/sagebionetworks/bridge/exceptions/InvalidEntityException.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.http.HttpStatus;
-import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.models.BridgeEntity;
 
 @NoStackTraceException

--- a/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
@@ -98,9 +98,8 @@ public class AuthenticationController extends BaseController {
     }
 
     public Result requestResetPassword() throws Exception {
-        JsonNode json = requestToJSON(request());
         Email email = parseJson(request(), Email.class);
-        Study study = getStudyOrThrowException(json);
+        Study study = studyService.getStudy(email.getStudyIdentifier());
         authenticationService.requestResetPassword(study, email);
         return okResult("If registered with the study, we'll email you instructions on how to change your password.");
     }

--- a/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
@@ -22,8 +22,6 @@ import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.accounts.UserSessionInfo;
 import org.sagebionetworks.bridge.models.studies.Study;
-import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
-import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.springframework.stereotype.Controller;
 
 import play.mvc.BodyParser;
@@ -92,20 +90,24 @@ public class AuthenticationController extends BaseController {
     public Result resendEmailVerification() throws Exception {
         JsonNode json = requestToJSON(request());
         Email email = parseJson(request(), Email.class);
-        StudyIdentifier studyIdentifier = getStudyIdentifierOrThrowException(json);
-        authenticationService.resendEmailVerification(studyIdentifier, email);
+        Study study = getStudyOrThrowException(json);
+        authenticationService.resendEmailVerification(study.getStudyIdentifier(), email);
         return okResult("If registered with the study, we'll email you instructions on how to verify your account.");
     }
 
     public Result requestResetPassword() throws Exception {
         Email email = parseJson(request(), Email.class);
         Study study = studyService.getStudy(email.getStudyIdentifier());
+        verifySupportedVersionOrThrowException(study);
         authenticationService.requestResetPassword(study, email);
+
         return okResult("If registered with the study, we'll email you instructions on how to change your password.");
     }
 
     public Result resetPassword() throws Exception {
         PasswordReset passwordReset = parseJson(request(), PasswordReset.class);
+        Study study = studyService.getStudy(passwordReset.getStudyIdentifier());
+        verifySupportedVersionOrThrowException(study);
         authenticationService.resetPassword(passwordReset);
         return okResult("Password has been changed.");
     }
@@ -173,11 +175,6 @@ public class AuthenticationController extends BaseController {
         Study study = studyService.getStudy(studyId);
         verifySupportedVersionOrThrowException(study);
         return study;
-    }
-
-    private StudyIdentifier getStudyIdentifierOrThrowException(JsonNode node) {
-        String studyId = getStudyStringOrThrowException(node);
-        return new StudyIdentifierImpl(studyId);
     }
 
     private String getStudyStringOrThrowException(JsonNode node) {

--- a/app/org/sagebionetworks/bridge/services/ConsentService.java
+++ b/app/org/sagebionetworks/bridge/services/ConsentService.java
@@ -10,8 +10,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Resource;
-
 import org.apache.commons.io.IOUtils;
 
 import org.sagebionetworks.bridge.dao.AccountDao;

--- a/app/org/sagebionetworks/bridge/services/EmailVerificationService.java
+++ b/app/org/sagebionetworks/bridge/services/EmailVerificationService.java
@@ -47,7 +47,7 @@ public class EmailVerificationService {
         this.cacheProvider = cacheProvider;
     }
     
-    protected String getVerifiedAddressKey(String emailAddress) {
+    private String getVerifiedAddressKey(String emailAddress) {
         return emailAddress + KEY_POSTFIX;
     }
     

--- a/app/org/sagebionetworks/bridge/services/EmailVerificationService.java
+++ b/app/org/sagebionetworks/bridge/services/EmailVerificationService.java
@@ -31,6 +31,8 @@ public class EmailVerificationService {
 
     private static final Logger LOG = LoggerFactory.getLogger(EmailVerificationService.class);
     
+    private static final int VERIFIED_EMAIL_CACHE_IN_SECONDS = 60*5;
+    
     private static final String KEY_POSTFIX = ":emailVerificationStatus";
     
     private AmazonSimpleEmailServiceClient sesClient;
@@ -45,13 +47,13 @@ public class EmailVerificationService {
         this.cacheProvider = cacheProvider;
     }
     
-    private String getVerifiedAddressKey(String emailAddress) {
+    protected String getVerifiedAddressKey(String emailAddress) {
         return emailAddress + KEY_POSTFIX;
     }
     
     private EmailVerificationStatus cacheAndReturn(String emailAddress, EmailVerificationStatus status) {
         String key = getVerifiedAddressKey(emailAddress);
-        cacheProvider.setString(key, status.name(), 60*60*24);
+        cacheProvider.setString(key, status.name(), VERIFIED_EMAIL_CACHE_IN_SECONDS);
         return status;
     }
     

--- a/app/org/sagebionetworks/bridge/services/email/BasicEmailProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/BasicEmailProvider.java
@@ -14,28 +14,20 @@ import org.sagebionetworks.bridge.models.studies.EmailTemplate;
 import org.sagebionetworks.bridge.models.studies.Study;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
-public class BasicEmailProvider implements MimeTypeEmailProvider {
+public class BasicEmailProvider extends MimeTypeEmailProvider {
 
-    private final Study study;
     private final Set<String> recipientEmails;
     private final Map<String,String> tokenMap;
     private final EmailTemplate template;
     
     private BasicEmailProvider(Study study, Map<String,String> tokenMap, Set<String> recipientEmails, EmailTemplate template) {
-        this.study = study;
+        super(study);
         this.recipientEmails = recipientEmails;
         this.tokenMap = tokenMap;
         this.template = template;
-    }
-    public String getPlainSenderEmail() {
-        return study.getSupportEmail();
-    }
-    public Study getStudy() {
-        return study;
     }
     public Set<String> getRecipientEmails() {
         return recipientEmails;
@@ -49,7 +41,7 @@ public class BasicEmailProvider implements MimeTypeEmailProvider {
     
     @Override
     public MimeTypeEmail getMimeTypeEmail() throws MessagingException {
-        tokenMap.putAll(BridgeUtils.studyTemplateVariables(study));
+        tokenMap.putAll(BridgeUtils.studyTemplateVariables(getStudy()));
         tokenMap.put("host", BridgeConfigFactory.getConfig().getHostnameWithPostfix("webservices"));
         
         final MimeTypeEmailBuilder emailBuilder = new MimeTypeEmailBuilder();
@@ -57,9 +49,7 @@ public class BasicEmailProvider implements MimeTypeEmailProvider {
         final String formattedSubject = BridgeUtils.resolveTemplate(template.getSubject(), tokenMap);
         emailBuilder.withSubject(formattedSubject);
 
-        Set<String> senderEmails = BridgeUtils.commaListToOrderedSet(study.getSupportEmail());
-        String senderEmail = Iterables.getFirst(senderEmails, null);
-        final String sendFromEmail = String.format("%s <%s>", study.getName(), senderEmail);
+        final String sendFromEmail = getFormattedSenderEmail();
         emailBuilder.withSender(sendFromEmail);
 
         for (String recipientEmail : recipientEmails) {

--- a/app/org/sagebionetworks/bridge/services/email/BasicEmailProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/BasicEmailProvider.java
@@ -31,6 +31,9 @@ public class BasicEmailProvider implements MimeTypeEmailProvider {
         this.tokenMap = tokenMap;
         this.template = template;
     }
+    public String getPlainSenderEmail() {
+        return study.getSupportEmail();
+    }
     public Study getStudy() {
         return study;
     }

--- a/app/org/sagebionetworks/bridge/services/email/ConsentEmailProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/ConsentEmailProvider.java
@@ -59,6 +59,11 @@ public class ConsentEmailProvider implements MimeTypeEmailProvider {
     }
 
     @Override
+    public String getPlainSenderEmail() {
+        return study.getSupportEmail();
+    }
+    
+    @Override
     public MimeTypeEmail getMimeTypeEmail() throws MessagingException {
         MimeTypeEmailBuilder builder = new MimeTypeEmailBuilder();
 

--- a/app/org/sagebionetworks/bridge/services/email/MimeTypeEmailProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/MimeTypeEmailProvider.java
@@ -18,14 +18,19 @@ public abstract class MimeTypeEmailProvider {
     }
     
     /**
-     * Get the sender email address without any further formatting. So for example, if the provider formats the sender
-     * email as <code>"Study Name" &lt;email@email.com&gtl</code>, This method should return only
-     * <code>email@email.com</code>.
+     * Get the sender email address without any further formatting. For example, if the provider formats the sender
+     * email as <code>"Study Name" &lt;email@email.com&gtl</code>, This method returns only <code>email@email.com</code>.
      */
     public String getPlainSenderEmail() {
         Set<String> senderEmails = BridgeUtils.commaListToOrderedSet(getStudy().getSupportEmail());
         return Iterables.getFirst(senderEmails, null);
     }
+    
+    /**
+     * Get the sender email address as formatted for an email. For example, if the provider's email address is
+     * <code>email@email.com</code>, this method would return something like
+     * <code>"Study Name" &lt;email@email.com&gtl</code>.
+     */
     public String getFormattedSenderEmail() {
         String senderEmail = getPlainSenderEmail();
         return String.format("%s <%s>", getStudy().getName(), senderEmail);

--- a/app/org/sagebionetworks/bridge/services/email/MimeTypeEmailProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/MimeTypeEmailProvider.java
@@ -1,16 +1,39 @@
 package org.sagebionetworks.bridge.services.email;
 
+import java.util.Set;
+
 import javax.mail.MessagingException;
 
-public interface MimeTypeEmailProvider {
+import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.models.studies.Study;
 
+import com.google.common.collect.Iterables;
+
+public abstract class MimeTypeEmailProvider {
+
+    private Study study;
+    
+    MimeTypeEmailProvider(Study study) {
+        this.study = study;
+    }
+    
     /**
      * Get the sender email address without any further formatting. So for example, if the provider formats the sender
      * email as <code>"Study Name" &lt;email@email.com&gtl</code>, This method should return only
      * <code>email@email.com</code>.
      */
-    String getPlainSenderEmail();
+    public String getPlainSenderEmail() {
+        Set<String> senderEmails = BridgeUtils.commaListToOrderedSet(getStudy().getSupportEmail());
+        return Iterables.getFirst(senderEmails, null);
+    }
+    public String getFormattedSenderEmail() {
+        String senderEmail = getPlainSenderEmail();
+        return String.format("%s <%s>", getStudy().getName(), senderEmail);
+    }
+    public Study getStudy() {
+        return study;
+    }
     
-    MimeTypeEmail getMimeTypeEmail() throws MessagingException;
+    public abstract MimeTypeEmail getMimeTypeEmail() throws MessagingException;
     
 }

--- a/app/org/sagebionetworks/bridge/services/email/MimeTypeEmailProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/MimeTypeEmailProvider.java
@@ -4,6 +4,11 @@ import javax.mail.MessagingException;
 
 public interface MimeTypeEmailProvider {
 
+    /**
+     * Get the sender email address without any further formatting. So for example, if the provider formats the sender
+     * email as <code>"Study Name" &lt;email@email.com&gtl</code>, This method should return only
+     * <code>email@email.com</code>.
+     */
     String getPlainSenderEmail();
     
     MimeTypeEmail getMimeTypeEmail() throws MessagingException;

--- a/app/org/sagebionetworks/bridge/services/email/MimeTypeEmailProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/MimeTypeEmailProvider.java
@@ -13,7 +13,7 @@ public abstract class MimeTypeEmailProvider {
 
     private Study study;
     
-    MimeTypeEmailProvider(Study study) {
+    protected MimeTypeEmailProvider(Study study) {
         this.study = study;
     }
     

--- a/app/org/sagebionetworks/bridge/services/email/MimeTypeEmailProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/MimeTypeEmailProvider.java
@@ -4,6 +4,8 @@ import javax.mail.MessagingException;
 
 public interface MimeTypeEmailProvider {
 
+    String getPlainSenderEmail();
+    
     MimeTypeEmail getMimeTypeEmail() throws MessagingException;
     
 }

--- a/app/org/sagebionetworks/bridge/services/email/WithdrawConsentEmailProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/WithdrawConsentEmailProvider.java
@@ -17,42 +17,36 @@ import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.Withdrawal;
 import org.sagebionetworks.bridge.models.studies.Study;
 
-public class WithdrawConsentEmailProvider implements MimeTypeEmailProvider {
+public class WithdrawConsentEmailProvider extends MimeTypeEmailProvider {
     
     private static final DateTimeFormatter FORMATTER = DateTimeFormat.forPattern("MMMM d, yyyy");
     private static final String CONSENT_EMAIL_SUBJECT = "Notification of consent withdrawal for %s";
     private static final String SUB_TYPE_HTML = "html";
 
-    private Study study;
     private String externalId;
     private Account account;
     private Withdrawal withdrawal;
     private long withdrewOn;
     
     public WithdrawConsentEmailProvider(Study study, String externalId, Account account, Withdrawal withdrawal, long withdrewOn) {
-        this.study = study;
+        super(study);
         this.externalId = externalId;
         this.account = account;
         this.withdrawal = withdrawal;
         this.withdrewOn = withdrewOn;
-    }
-
-    @Override
-    public String getPlainSenderEmail() {
-        return study.getSupportEmail();
     }
     
     @Override
     public MimeTypeEmail getMimeTypeEmail() throws MessagingException {
         MimeTypeEmailBuilder builder = new MimeTypeEmailBuilder();
 
-        String subject = String.format(CONSENT_EMAIL_SUBJECT, study.getName());
+        String subject = String.format(CONSENT_EMAIL_SUBJECT, getStudy().getName());
         builder.withSubject(subject);
 
-        final String sendFromEmail = String.format("%s <%s>", study.getName(), study.getSupportEmail());
+        final String sendFromEmail = getFormattedSenderEmail();
         builder.withSender(sendFromEmail);
 
-        Set<String> emailAddresses = BridgeUtils.commaListToOrderedSet(study.getConsentNotificationEmail());
+        Set<String> emailAddresses = BridgeUtils.commaListToOrderedSet(getStudy().getConsentNotificationEmail());
         builder.withRecipients(emailAddresses);
 
         String content = String.format("<p>User %s withdrew from the study on %s. </p>", 

--- a/app/org/sagebionetworks/bridge/services/email/WithdrawConsentEmailProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/WithdrawConsentEmailProvider.java
@@ -36,6 +36,11 @@ public class WithdrawConsentEmailProvider implements MimeTypeEmailProvider {
         this.withdrawal = withdrawal;
         this.withdrewOn = withdrewOn;
     }
+
+    @Override
+    public String getPlainSenderEmail() {
+        return study.getSupportEmail();
+    }
     
     @Override
     public MimeTypeEmail getMimeTypeEmail() throws MessagingException {

--- a/test/org/sagebionetworks/bridge/play/interceptors/ExceptionInterceptorTest.java
+++ b/test/org/sagebionetworks/bridge/play/interceptors/ExceptionInterceptorTest.java
@@ -185,12 +185,11 @@ public class ExceptionInterceptorTest {
             Result result = (Result)interceptor.invoke(invocation);
             JsonNode node = new ObjectMapper().readTree(contentAsString(result));
             
-            assertEquals(6, node.size());
+            assertEquals(5, node.size());
             assertEquals("identifier is required", node.get("errors").get("identifier").get(0).asText());
             assertEquals("InvalidEntityException", node.get("type").asText());
             assertNotNull(node.get("entity"));
             assertNotNull(node.get("errors"));
-            assertNotNull(node.get("entityClass"));
 
             assertStatusCode(400, result, node);
         }

--- a/test/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
@@ -3,8 +3,6 @@ package org.sagebionetworks.bridge.services;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/test/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
@@ -40,6 +40,8 @@ import org.sagebionetworks.bridge.services.email.MimeTypeEmailProvider;
 @RunWith(MockitoJUnitRunner.class)
 public class AccountWorkflowServiceTest {
     
+    private static final String SUPPORT_EMAIL = "support@support.com";
+
     private static final String SPTOKEN = "sptoken";
 
     @Mock
@@ -77,7 +79,7 @@ public class AccountWorkflowServiceTest {
         study = Study.create();
         study.setIdentifier(TEST_STUDY_IDENTIFIER);
         study.setName("This study name");
-        study.setSupportEmail("support@support.com");
+        study.setSupportEmail(SUPPORT_EMAIL);
         study.setVerifyEmailTemplate(verifyEmailTemplate);
         study.setResetPasswordTemplate(resetPasswordTemplate);
         

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
@@ -49,6 +49,7 @@ import com.google.common.collect.Iterables;
 @RunWith(MockitoJUnitRunner.class)
 public class AuthenticationServiceMockTest {
     
+    private static final String SUPPORT_EMAIL = "support@support.com";
     private static final String STUDY_ID = "test-study";
     private static final String CACHE_KEY = "email@email.com:test-study:signInRequest";
     private static final String RECIPIENT_EMAIL = "email@email.com";
@@ -105,7 +106,7 @@ public class AuthenticationServiceMockTest {
         study.setIdentifier(STUDY_ID);
         study.setEmailSignInEnabled(true);
         study.setEmailSignInTemplate(new EmailTemplate("subject","body",MimeType.TEXT));
-        study.setSupportEmail("sender@sender.com");
+        study.setSupportEmail(SUPPORT_EMAIL);
         study.setName("Sender");
         
         account = new SimpleAccount();

--- a/test/org/sagebionetworks/bridge/services/EmailVerificationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/EmailVerificationServiceTest.java
@@ -206,7 +206,7 @@ public class EmailVerificationServiceTest {
         
         assertTrue(service.isVerified(EMAIL_ADDRESS));
         
-        verify(cacheProvider).setString(eq(service.getVerifiedAddressKey(EMAIL_ADDRESS)),
+        verify(cacheProvider).setString(eq(EMAIL_ADDRESS_KEY),
                 eq("VERIFIED"), anyInt());
     }
     
@@ -216,7 +216,7 @@ public class EmailVerificationServiceTest {
         
         assertFalse(service.isVerified(EMAIL_ADDRESS));
         
-        verify(cacheProvider).setString(eq(service.getVerifiedAddressKey(EMAIL_ADDRESS)),
+        verify(cacheProvider).setString(eq(EMAIL_ADDRESS_KEY),
                 eq("PENDING"), anyInt());
     }
     
@@ -226,7 +226,7 @@ public class EmailVerificationServiceTest {
         
         assertFalse(service.isVerified(EMAIL_ADDRESS));
         
-        verify(cacheProvider).setString(eq(service.getVerifiedAddressKey(EMAIL_ADDRESS)),
+        verify(cacheProvider).setString(eq(EMAIL_ADDRESS_KEY),
                 eq("UNVERIFIED"), anyInt());
     }
 

--- a/test/org/sagebionetworks/bridge/services/EmailVerificationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/EmailVerificationServiceTest.java
@@ -1,7 +1,12 @@
 package org.sagebionetworks.bridge.services;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -13,7 +18,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
+
+import org.sagebionetworks.bridge.cache.CacheProvider;
 
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient;
 import com.amazonaws.services.simpleemail.model.GetIdentityVerificationAttributesRequest;
@@ -27,130 +35,187 @@ public class EmailVerificationServiceTest {
 
     private static final String EMAIL_ADDRESS = "foo@foo.com";
     
+    private static final String EMAIL_ADDRESS_KEY = EMAIL_ADDRESS + ":emailVerificationStatus";
+
     @Mock
     private AmazonSimpleEmailServiceClient sesClient;
     @Mock
     private GetIdentityVerificationAttributesResult result;
     @Mock
     private IdentityVerificationAttributes attributes;
-
+    @Mock
+    private CacheProvider cacheProvider;
+    @Spy
     private EmailVerificationService service;
-    
+
     private ArgumentCaptor<GetIdentityVerificationAttributesRequest> getCaptor;
-    
+
     @Before
     public void before() {
-        service = new EmailVerificationService();
         service.setAmazonSimpleEmailServiceClient(sesClient);
+        service.setCacheProvider(cacheProvider);
     }
 
     private void mockSession(String status) {
         getCaptor = ArgumentCaptor.forClass(GetIdentityVerificationAttributesRequest.class);
-                
-        Map<String,IdentityVerificationAttributes> map = Maps.newHashMap();
+
+        Map<String, IdentityVerificationAttributes> map = Maps.newHashMap();
         map.put(EMAIL_ADDRESS, attributes);
         when(result.getVerificationAttributes()).thenReturn(map);
         when(attributes.getVerificationStatus()).thenReturn(status); // aka unverified
         when(sesClient.getIdentityVerificationAttributes(any())).thenReturn(result);
     }
-    
+
     @Test
     public void verifiedEmailTakesNoAction() {
         mockSession("Success");
 
         EmailVerificationStatus status = service.verifyEmailAddress(EMAIL_ADDRESS);
-        
+
         assertEquals(EmailVerificationStatus.VERIFIED, status);
         verify(sesClient, never()).verifyEmailIdentity(any());
         verify(sesClient).getIdentityVerificationAttributes(getCaptor.capture());
         assertEquals(EMAIL_ADDRESS, getCaptor.getValue().getIdentities().get(0));
+
+        verify(cacheProvider).setString(eq(EMAIL_ADDRESS_KEY), eq("VERIFIED"), anyInt());
     }
-    
+
     @Test
     public void ifUnverifiedAttemptsToResendVerification() {
         mockSession("Failure");
 
         EmailVerificationStatus status = service.verifyEmailAddress(EMAIL_ADDRESS);
-        
+
         assertEquals(EmailVerificationStatus.PENDING, status);
         verify(sesClient).verifyEmailIdentity(any());
         verify(sesClient).getIdentityVerificationAttributes(getCaptor.capture());
         assertEquals(EMAIL_ADDRESS, getCaptor.getValue().getIdentities().get(0));
+
+        verify(cacheProvider).setString(eq(EMAIL_ADDRESS_KEY), eq("UNVERIFIED"), anyInt());
     }
-    
+
     @Test
     public void emailDoesntExistRequestVerification() {
-        ArgumentCaptor<VerifyEmailIdentityRequest> verifyCaptor = ArgumentCaptor.forClass(VerifyEmailIdentityRequest.class);
+        ArgumentCaptor<VerifyEmailIdentityRequest> verifyCaptor = ArgumentCaptor
+                .forClass(VerifyEmailIdentityRequest.class);
         mockSession(null);
-        
+
         EmailVerificationStatus status = service.verifyEmailAddress(EMAIL_ADDRESS);
-        
+
         assertEquals(EmailVerificationStatus.PENDING, status);
         verify(sesClient).verifyEmailIdentity(verifyCaptor.capture());
         verify(sesClient).getIdentityVerificationAttributes(getCaptor.capture());
         assertEquals(EMAIL_ADDRESS, verifyCaptor.getValue().getEmailAddress());
         assertEquals(EMAIL_ADDRESS, getCaptor.getValue().getIdentities().get(0));
+        
+        verify(cacheProvider).setString(eq(EMAIL_ADDRESS_KEY), eq("PENDING"), anyInt());
     }
 
     @Test
     public void canResendRegardlessOfStatus() {
-        ArgumentCaptor<VerifyEmailIdentityRequest> verifyCaptor = ArgumentCaptor.forClass(VerifyEmailIdentityRequest.class);
+        ArgumentCaptor<VerifyEmailIdentityRequest> verifyCaptor = ArgumentCaptor
+                .forClass(VerifyEmailIdentityRequest.class);
         mockSession("Success");
-        
+
         EmailVerificationStatus status = service.sendVerifyEmailRequest(EMAIL_ADDRESS);
-        
+
         assertEquals(EmailVerificationStatus.PENDING, status);
         verify(sesClient).verifyEmailIdentity(verifyCaptor.capture());
         assertEquals(EMAIL_ADDRESS, verifyCaptor.getValue().getEmailAddress());
+        
+        verify(cacheProvider).setString(eq(EMAIL_ADDRESS_KEY), eq("PENDING"), anyInt());
     }
-    
+
     @Test
     public void getEmailStatus() {
         mockSession("Success");
-        
+
         EmailVerificationStatus status = service.getEmailStatus(EMAIL_ADDRESS);
-        
+
         verify(sesClient).getIdentityVerificationAttributes(any());
         assertEquals(EmailVerificationStatus.VERIFIED, status);
+        verify(cacheProvider).setString(eq(EMAIL_ADDRESS_KEY), eq("VERIFIED"), anyInt());
     }
-    
+
     @Test
     public void getEmailStatusAttributesNull() {
         getCaptor = ArgumentCaptor.forClass(GetIdentityVerificationAttributesRequest.class);
-        
-        Map<String,IdentityVerificationAttributes> map = Maps.newHashMap();
+
+        Map<String, IdentityVerificationAttributes> map = Maps.newHashMap();
         map.put(EMAIL_ADDRESS, attributes);
         when(result.getVerificationAttributes()).thenReturn(null);
         when(sesClient.getIdentityVerificationAttributes(any())).thenReturn(result);
-        
+
         EmailVerificationStatus status = service.getEmailStatus(EMAIL_ADDRESS);
-        
+
         verify(sesClient).getIdentityVerificationAttributes(any());
         assertEquals(EmailVerificationStatus.UNVERIFIED, status);
+        
+        verify(cacheProvider).setString(eq(EMAIL_ADDRESS_KEY), eq("UNVERIFIED"), anyInt());        
     }
-    
+
     @Test
     public void getEmailStatusVerificationStatusNull() {
         getCaptor = ArgumentCaptor.forClass(GetIdentityVerificationAttributesRequest.class);
-        
-        Map<String,IdentityVerificationAttributes> map = Maps.newHashMap();
+
+        Map<String, IdentityVerificationAttributes> map = Maps.newHashMap();
         map.put(EMAIL_ADDRESS, attributes);
         when(result.getVerificationAttributes()).thenReturn(map);
         when(attributes.getVerificationStatus()).thenReturn(null);
         when(sesClient.getIdentityVerificationAttributes(any())).thenReturn(result);
-        
+
         EmailVerificationStatus status = service.getEmailStatus(EMAIL_ADDRESS);
-        
+
         verify(sesClient).getIdentityVerificationAttributes(any());
         assertEquals(EmailVerificationStatus.UNVERIFIED, status);
+        
+        verify(cacheProvider).setString(eq(EMAIL_ADDRESS_KEY), eq("UNVERIFIED"), anyInt());        
     }
-    
+
     @Test
     public void sendVerifyEmailRequest() {
         mockSession("Success");
         service.sendVerifyEmailRequest(EMAIL_ADDRESS);
-        
+
         verify(sesClient).verifyEmailIdentity(any());
+        
+        verify(cacheProvider).setString(eq(EMAIL_ADDRESS_KEY), eq("PENDING"), anyInt());        
+    }
+    
+    @Test
+    public void isVerifiedAndCached() throws Exception {
+        when(cacheProvider.getString(EMAIL_ADDRESS_KEY)).thenReturn("VERIFIED");
+        assertTrue(service.isVerified(EMAIL_ADDRESS));
+    }
+
+    @Test
+    public void isPendingAndCached() throws Exception {
+        when(cacheProvider.getString(EMAIL_ADDRESS_KEY)).thenReturn("PENDING");
+        assertFalse(service.isVerified(EMAIL_ADDRESS));
+    }
+    
+    @Test
+    public void isUnverifiedAndCached() throws Exception {
+        when(cacheProvider.getString(EMAIL_ADDRESS_KEY)).thenReturn("UNVERIFIED");
+        assertFalse(service.isVerified(EMAIL_ADDRESS));
+    }
+    
+    @Test
+    public void isVerifiedUncached() {
+        doReturn(EmailVerificationStatus.VERIFIED).when(service).getEmailStatus(EMAIL_ADDRESS);
+        assertTrue(service.isVerified(EMAIL_ADDRESS));
+    }
+    
+    @Test
+    public void isPendingUncached() {
+        doReturn(EmailVerificationStatus.PENDING).when(service).getEmailStatus(EMAIL_ADDRESS);
+        assertFalse(service.isVerified(EMAIL_ADDRESS));
+    }
+
+    @Test
+    public void isUnverifiedUncached() {
+        doReturn(EmailVerificationStatus.UNVERIFIED).when(service).getEmailStatus(EMAIL_ADDRESS);
+        assertFalse(service.isVerified(EMAIL_ADDRESS));
     }
 
 }

--- a/test/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceTest.java
@@ -28,6 +28,8 @@ public class SendMailViaAmazonServiceTest {
     
     private SendMailViaAmazonService service;
     
+    private Study study;
+    
     @Mock
     private AmazonSimpleEmailServiceClient emailClient;
     
@@ -39,6 +41,10 @@ public class SendMailViaAmazonServiceTest {
     
     @Before
     public void before() {
+        study = Study.create();
+        study.setName("Name");
+        study.setSupportEmail(SUPPORT_EMAIL);
+        
         service = new SendMailViaAmazonService();
         service.setEmailClient(emailClient);
         service.setEmailVerificationService(emailVerificationService);
@@ -49,8 +55,8 @@ public class SendMailViaAmazonServiceTest {
         when(emailVerificationService.isVerified(SUPPORT_EMAIL)).thenReturn(false);
         
         BasicEmailProvider provider = new BasicEmailProvider.Builder()
-                .withStudy(Study.create())
-                .withRecipientEmail(SUPPORT_EMAIL)
+                .withStudy(study)
+                .withRecipientEmail(RECIPIENT_EMAIL)
                 .withEmailTemplate(new EmailTemplate("subject", "body", MimeType.HTML))
                 .build();
         try {
@@ -65,10 +71,6 @@ public class SendMailViaAmazonServiceTest {
     public void verifiedEmailWorks() {
         when(emailClient.sendRawEmail(any())).thenReturn(result);
         when(emailVerificationService.isVerified(SUPPORT_EMAIL)).thenReturn(true);
-        
-        Study study = Study.create();
-        study.setName("Name");
-        study.setSupportEmail(SUPPORT_EMAIL);
         
         BasicEmailProvider provider = new BasicEmailProvider.Builder()
                 .withStudy(study)

--- a/test/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceTest.java
@@ -1,0 +1,77 @@
+package org.sagebionetworks.bridge.services;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
+import org.sagebionetworks.bridge.models.studies.EmailTemplate;
+import org.sagebionetworks.bridge.models.studies.MimeType;
+import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.services.email.BasicEmailProvider;
+
+import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient;
+import com.amazonaws.services.simpleemail.model.SendRawEmailResult;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SendMailViaAmazonServiceTest {
+
+    private static final String EMAIL = "email@email.com";
+    
+    private SendMailViaAmazonService service;
+    
+    @Mock
+    private AmazonSimpleEmailServiceClient emailClient;
+    
+    @Mock
+    private EmailVerificationService emailVerificationService;
+    
+    @Mock
+    private SendRawEmailResult result;
+    
+    @Before
+    public void before() {
+        service = new SendMailViaAmazonService();
+        service.setSupportEmail(EMAIL);
+        service.setEmailClient(emailClient);
+        service.setEmailVerificationService(emailVerificationService);
+    }
+    
+    @Test
+    public void unverifiedEmailThrowsException() {
+        //when(emailClient.sendRawEmail(any())).thenReturn(result);
+        when(emailVerificationService.isVerified(EMAIL)).thenReturn(false);
+        
+        BasicEmailProvider provider = new BasicEmailProvider.Builder()
+                .withStudy(Study.create())
+                .withRecipientEmail(EMAIL)
+                .withEmailTemplate(new EmailTemplate("subject", "body", MimeType.HTML))
+                .build();
+        try {
+            service.sendEmail(provider);
+            fail("Should have thrown exception");
+        } catch(BridgeServiceException e) {
+            assertEquals(SendMailViaAmazonService.UNVERIFIED_EMAIL_ERROR, e.getMessage());
+        }
+    }
+    
+    @Test
+    public void verifiedEmailWorks() {
+        when(emailClient.sendRawEmail(any())).thenReturn(result);
+        when(emailVerificationService.isVerified(EMAIL)).thenReturn(true);
+        
+        BasicEmailProvider provider = new BasicEmailProvider.Builder()
+                .withStudy(Study.create())
+                .withRecipientEmail(EMAIL)
+                .withEmailTemplate(new EmailTemplate("subject", "body", MimeType.HTML))
+                .build();
+        service.sendEmail(provider);
+    }
+}

--- a/test/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceTest.java
@@ -23,7 +23,8 @@ import com.amazonaws.services.simpleemail.model.SendRawEmailResult;
 @RunWith(MockitoJUnitRunner.class)
 public class SendMailViaAmazonServiceTest {
 
-    private static final String EMAIL = "email@email.com";
+    private static final String SUPPORT_EMAIL = "email@email.com";
+    private static final String RECIPIENT_EMAIL = "recipient@recipient.com";
     
     private SendMailViaAmazonService service;
     
@@ -39,19 +40,17 @@ public class SendMailViaAmazonServiceTest {
     @Before
     public void before() {
         service = new SendMailViaAmazonService();
-        service.setSupportEmail(EMAIL);
         service.setEmailClient(emailClient);
         service.setEmailVerificationService(emailVerificationService);
     }
     
     @Test
     public void unverifiedEmailThrowsException() {
-        //when(emailClient.sendRawEmail(any())).thenReturn(result);
-        when(emailVerificationService.isVerified(EMAIL)).thenReturn(false);
+        when(emailVerificationService.isVerified(SUPPORT_EMAIL)).thenReturn(false);
         
         BasicEmailProvider provider = new BasicEmailProvider.Builder()
                 .withStudy(Study.create())
-                .withRecipientEmail(EMAIL)
+                .withRecipientEmail(SUPPORT_EMAIL)
                 .withEmailTemplate(new EmailTemplate("subject", "body", MimeType.HTML))
                 .build();
         try {
@@ -65,11 +64,15 @@ public class SendMailViaAmazonServiceTest {
     @Test
     public void verifiedEmailWorks() {
         when(emailClient.sendRawEmail(any())).thenReturn(result);
-        when(emailVerificationService.isVerified(EMAIL)).thenReturn(true);
+        when(emailVerificationService.isVerified(SUPPORT_EMAIL)).thenReturn(true);
+        
+        Study study = Study.create();
+        study.setName("Name");
+        study.setSupportEmail(SUPPORT_EMAIL);
         
         BasicEmailProvider provider = new BasicEmailProvider.Builder()
-                .withStudy(Study.create())
-                .withRecipientEmail(EMAIL)
+                .withStudy(study)
+                .withRecipientEmail(RECIPIENT_EMAIL)
                 .withEmailTemplate(new EmailTemplate("subject", "body", MimeType.HTML))
                 .build();
         service.sendEmail(provider);

--- a/test/org/sagebionetworks/bridge/services/email/MimeTypeEmailProviderTest.java
+++ b/test/org/sagebionetworks/bridge/services/email/MimeTypeEmailProviderTest.java
@@ -1,0 +1,44 @@
+package org.sagebionetworks.bridge.services.email;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.mail.MessagingException;
+
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.models.studies.Study;
+
+public class MimeTypeEmailProviderTest {
+    static class MimeTypeEmailProviderImpl extends MimeTypeEmailProvider {
+        public MimeTypeEmailProviderImpl(Study study) {
+            super(study);
+        }
+        public MimeTypeEmail getMimeTypeEmail() throws MessagingException {
+            return null;
+        }
+    }
+    
+    @Test
+    public void works() {
+        Study study = Study.create();
+        study.setName("Very Useful Study 🐶");
+        study.setSupportEmail("support@support.com");
+        
+        MimeTypeEmailProvider provider = new MimeTypeEmailProviderImpl(study);
+        
+        assertEquals("support@support.com", provider.getPlainSenderEmail());
+        assertEquals("Very Useful Study 🐶 <support@support.com>", provider.getFormattedSenderEmail());
+    }
+    
+    @Test
+    public void worksWithMultipleAddresses() {
+        Study study = Study.create();
+        study.setName("Very Useful Study 🐶");
+        study.setSupportEmail("support@support.com,email@email.com");
+        
+        MimeTypeEmailProvider provider = new MimeTypeEmailProviderImpl(study);
+        
+        assertEquals("support@support.com", provider.getPlainSenderEmail());
+        assertEquals("Very Useful Study 🐶 <support@support.com>", provider.getFormattedSenderEmail());
+    }
+}

--- a/test/org/sagebionetworks/bridge/validators/SurveyPublishValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/SurveyPublishValidatorTest.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.bridge.validators;
 
-import static org.junit.Assert.*;
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
 
 import java.util.List;
@@ -42,6 +41,7 @@ public class SurveyPublishValidatorTest {
 
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void multiValueWithNoEnumeration() {
         List<SurveyQuestionOption>[] testCases = new List[] { null, ImmutableList.of() };


### PR DESCRIPTION
- SendMailService no longer has a default email address that it uses to send email, this is always provided by the MimeTypeEmailProvider;
- if the email is not verified by SES, throw an error;
- cache whether or not support email is verified by SES in Redis
- default system email is still in our configuration and we can still use it to send certain emails if we want them to be from us, but we must now explicitly provide it in the MimeTypeEmailProvider we use