### PR TITLE
Set the time when creating a persistent task so that it can be finished multiple times in one day.

### DIFF
--- a/app/org/sagebionetworks/bridge/models/schedules/PersistentActivityScheduler.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/PersistentActivityScheduler.java
@@ -3,7 +3,6 @@ package org.sagebionetworks.bridge.models.schedules;
 import java.util.List;
 
 import org.joda.time.DateTime;
-import org.joda.time.LocalTime;
 
 import com.google.common.collect.Lists;
 
@@ -15,6 +14,10 @@ public class PersistentActivityScheduler extends ActivityScheduler {
     
     @Override
     public List<ScheduledActivity> getScheduledActivities(SchedulePlan plan, ScheduleContext context) {
+        // similar to a safety check in ActivityScheduler.getScheduledTimeBasedOnEvent
+        if (schedule.getEventId() == null) {
+            schedule.setEventId("enrollment");
+        }
         List<ScheduledActivity> scheduledActivities = Lists.newArrayList();
         for (Activity activity : schedule.getActivities()) {
 
@@ -22,17 +25,13 @@ public class PersistentActivityScheduler extends ActivityScheduler {
             // activity whenever that activity is finished. This is implicit and does not need to be configured 
             // when creating a schedule. It's clearer if you don't include this "finished" event, though it 
             // won't break anything if a user does include it in the eventId.
-            
-            // similar to a safety check in ActivityScheduler.getScheduledTimeBasedOnEvent
-            if (schedule.getEventId() == null) {
-                schedule.setEventId("enrollment");
-            }
             String finishedId = "activity:"+activity.getGuid()+":finished";
             DateTime scheduledTime = getFirstEventDateTime(context, finishedId+"," + schedule.getEventId());
-            
+
             if (scheduledTime != null) {
+                DateTime localDateTime = scheduledTime.withZone(context.getInitialTimeZone());
                 addScheduledActivityAtTimeForOneActivity(scheduledActivities, plan, context,
-                        scheduledTime.toLocalDate(), LocalTime.MIDNIGHT, activity);
+                        localDateTime.toLocalDate(), localDateTime.toLocalTime(), activity);
             }
         }
         return scheduledActivities;

--- a/test/org/sagebionetworks/bridge/models/schedules/PersistentActivitySchedulerTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/PersistentActivitySchedulerTest.java
@@ -56,14 +56,14 @@ public class PersistentActivitySchedulerTest {
     public void scheduleWithMultipleActivitiesWorks() {
         schedule.getActivities().add(TestUtils.getActivity1());
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusDays(1)));
-        assertDates(scheduledActivities, "2015-03-23 00:00", "2015-03-23 00:00");
+        assertDates(scheduledActivities, "2015-03-23 10:00", "2015-03-23 10:00");
     }
     
     @Test
     public void scheduleWorks() {
         // enrollment "2015-03-23T10:00:00Z"
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusDays(1)));
-        assertDates(scheduledActivities, "2015-03-23 00:00");
+        assertDates(scheduledActivities, "2015-03-23 10:00");
     }
     @Test
     public void startsOnScheduleWorks() {
@@ -83,7 +83,7 @@ public class PersistentActivitySchedulerTest {
         
         schedule.setEndsOn("2015-04-23T13:40:00Z");
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(1)));
-        assertDates(scheduledActivities, "2015-03-23 00:00");
+        assertDates(scheduledActivities, "2015-03-23 10:00");
     }
     @Test
     public void startEndsOnScheduleWorks() {
@@ -94,7 +94,7 @@ public class PersistentActivitySchedulerTest {
         
         // Should get one activity
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(1)));
-        assertDates(scheduledActivities, "2015-03-23 00:00");
+        assertDates(scheduledActivities, "2015-03-23 10:00");
     }
     @Test
     public void sequenceOfEventsWorks() {
@@ -107,12 +107,12 @@ public class PersistentActivitySchedulerTest {
         // Once that occurs, a task is issued for "right now"
         events.put("survey:AAA:finished", asDT("2015-04-10 11:40"));
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(1)));
-        assertDates(scheduledActivities, "2015-04-10 00:00");
+        assertDates(scheduledActivities, "2015-04-10 11:40");
         
         // and it's reissued any time that task itself is completed.
         events.put("activity:"+schedule.getActivities().get(0).getGuid()+":finished", asDT("2015-04-12 09:40"));
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(2)));
-        assertDates(scheduledActivities, "2015-04-12 00:00");
+        assertDates(scheduledActivities, "2015-04-12 09:40");
     }
     @Test
     public void originalPersistentScheduleStructureStillWorks() {

--- a/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceDuplicateTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceDuplicateTest.java
@@ -350,7 +350,7 @@ public class ScheduledActivityServiceDuplicateTest {
         // It's adjusted, magically it's still 6/30 I haven't figured out why yet.
         List<ScheduledActivity> list = filterByLabel(activities, "Do Persistent Activity");
         assertEquals(1, list.size());
-        assertEquals("21e97935-6d64-4cd5-ae70-653caad7b2f9:2016-06-30T00:00:00.000", list.get(0).getGuid());
+        assertEquals("21e97935-6d64-4cd5-ae70-653caad7b2f9:2016-06-30T12:43:07.951", list.get(0).getGuid());
         // This one hasn't been started, obviously
         assertNull(filterByLabel(activities, "Training Session 1").get(0).getStartedOn());
     }


### PR DESCRIPTION
This behavior is complicated so I wrote an integration test that verifies this works, accounting for the way the scheduling service works alongside the scheduler.