### PR TITLE
fix Spring wonkiness in Auth stuff

### DIFF
--- a/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
@@ -13,6 +13,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.dao.AccountDao;
@@ -42,6 +44,7 @@ import org.sagebionetworks.bridge.services.AccountWorkflowService;
 import org.sagebionetworks.bridge.services.HealthCodeService;
 
 /** Hibernate implementation of Account Dao. */
+@Component
 public class HibernateAccountDao implements AccountDao {
     private static final Logger LOG = LoggerFactory.getLogger(HibernateAccountDao.class);
 
@@ -50,16 +53,19 @@ public class HibernateAccountDao implements AccountDao {
     private HibernateHelper hibernateHelper;
 
     /** Service that handles email verification, password reset, etc. */
+    @Autowired
     public final void setAccountWorkflowService(AccountWorkflowService accountWorkflowService){
         this.accountWorkflowService = accountWorkflowService;
     }
 
     /** Health code service, because this DAO is expected to generate health codes for new accounts. */
+    @Autowired
     public final void setHealthCodeService(HealthCodeService healthCodeService) {
         this.healthCodeService = healthCodeService;
     }
 
     /** This makes interfacing with Hibernate easier. */
+    @Autowired
     public final void setHibernateHelper(HibernateHelper hibernateHelper) {
         this.hibernateHelper = hibernateHelper;
     }

--- a/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
@@ -96,18 +96,18 @@ public class AuthenticationController extends BaseController {
     }
 
     public Result requestResetPassword() throws Exception {
+        JsonNode json = requestToJSON(request());
         Email email = parseJson(request(), Email.class);
-        Study study = studyService.getStudy(email.getStudyIdentifier());
-        verifySupportedVersionOrThrowException(study);
+        Study study = getStudyOrThrowException(json);
         authenticationService.requestResetPassword(study, email);
 
         return okResult("If registered with the study, we'll email you instructions on how to change your password.");
     }
 
     public Result resetPassword() throws Exception {
+        JsonNode json = requestToJSON(request());
         PasswordReset passwordReset = parseJson(request(), PasswordReset.class);
-        Study study = studyService.getStudy(passwordReset.getStudyIdentifier());
-        verifySupportedVersionOrThrowException(study);
+        getStudyOrThrowException(json);
         authenticationService.resetPassword(passwordReset);
         return okResult("Password has been changed.");
     }
@@ -166,9 +166,6 @@ public class AuthenticationController extends BaseController {
      * study. As a fallback for existing clients, it also looks for the study information in the query string or
      * headers. If the study cannot be found in any of these places, it throws an exception, because the API will not
      * work correctly without it.
-     * 
-     * @param node
-     * @return
      */
     private Study getStudyOrThrowException(JsonNode node) {
         String studyId = getStudyStringOrThrowException(node);

--- a/app/org/sagebionetworks/bridge/services/AccountWorkflowService.java
+++ b/app/org/sagebionetworks/bridge/services/AccountWorkflowService.java
@@ -25,7 +25,10 @@ import org.sagebionetworks.bridge.services.email.BasicEmailProvider;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
+@Component
 public class AccountWorkflowService {
     
     private static final String PASSWORD_RESET_TOKEN_EXPIRED = "Password reset token has expired (or already been used).";
@@ -62,19 +65,23 @@ public class AccountWorkflowService {
     private AccountDao accountDao;
     
     private CacheProvider cacheProvider;
-    
+
+    @Autowired
     public final void setStudyService(StudyService studyService) {
         this.studyService = studyService;
     }
-    
+
+    @Autowired
     public final void setSendMailService(SendMailService sendMailService) {
         this.sendMailService = sendMailService;
     }
-    
+
+    @Autowired
     public final void setAccountDao(AccountDao accountDao) {
         this.accountDao = accountDao;
     }
-    
+
+    @Autowired
     public final void setCacheProvider(CacheProvider cacheProvider) {
         this.cacheProvider = cacheProvider;
     }


### PR DESCRIPTION
[Yesterday it worked.](https://github.com/Sage-Bionetworks/BridgePF/pull/1461)

Then, today, it stopped working.

Spring is weird like that.

This change refactors the Spring stuff around Auth to restore Autowiring, uses the Primary annotation to resolve ambiguity, and the Lazy annotation to resolve circular dependencies. This should allow us to autowire up everything in a simpler more reliable way.

While testing this, I discovered a test break. One of our recent changes accidentally changed it so requestResetPassword without a study now throws an NPE instead of a 404. I fixed AuthenticationController to use the getStudyOrThrowException() (same as signUp) and added unit tests.

Testing done:
* unit tests
* integ tests for both MySQL implementation and Stormpth implementation
* manually tested verify email, reset password, and email sign-in workflows for both MySQL implementation and Stormpath implementation