### PR TITLE
Deploy to AWS Elastic beanstalk uat environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,3 +50,15 @@ deploy:
     access_key_id: AKIAIG6T67NMROEIMC7A
     secret_access_key:
       secure: WygEvdxSQNZpJnPtmk8GDK6ueHUO0tissYQU3rV3ZCQLNjPwPSYxuqEwno2zP07XPQBxzD2TTZRKQYY5q3st14wdkoaKyiEo97VF5kitQCHK6aCs2L9MUPfL6SjhE2KFzJVDdSJzAYQcxoSPps5mqqcvceYYPhgVg3sUriK7c10=
+  - provider: elasticbeanstalk
+    skip_cleanup: true
+    bucket_name: org-sagebridge-deployment-uat
+    zip_file: target/universal/bridgepf-0.1-SNAPSHOT.zip
+    region: us-east-1
+    app: BridgePF
+    env: BridgePF-uat
+    on:
+      branch: uat
+    access_key_id: AKIAIG6T67NMROEIMC7A
+    secret_access_key:
+      secure: WygEvdxSQNZpJnPtmk8GDK6ueHUO0tissYQU3rV3ZCQLNjPwPSYxuqEwno2zP07XPQBxzD2TTZRKQYY5q3st14wdkoaKyiEo97VF5kitQCHK6aCs2L9MUPfL6SjhE2KFzJVDdSJzAYQcxoSPps5mqqcvceYYPhgVg3sUriK7c10=

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,25 +40,15 @@ deploy:
       prod: bridge-prod
   - provider: elasticbeanstalk
     skip_cleanup: true
-    bucket_name: org-sagebridge-deployment-dev
+    bucket_name: elasticbeanstalk-us-east-1-649232250620
     zip_file: target/universal/bridgepf-0.1-SNAPSHOT.zip
     region: us-east-1
     app: BridgePF
-    env: BridgePF-dev
+    env:
+      develop: BridgePF-dev
+      uat: BridgePF-uat
     on:
-      branch: develop
-    access_key_id: AKIAIG6T67NMROEIMC7A
-    secret_access_key:
-      secure: WygEvdxSQNZpJnPtmk8GDK6ueHUO0tissYQU3rV3ZCQLNjPwPSYxuqEwno2zP07XPQBxzD2TTZRKQYY5q3st14wdkoaKyiEo97VF5kitQCHK6aCs2L9MUPfL6SjhE2KFzJVDdSJzAYQcxoSPps5mqqcvceYYPhgVg3sUriK7c10=
-  - provider: elasticbeanstalk
-    skip_cleanup: true
-    bucket_name: org-sagebridge-deployment-uat
-    zip_file: target/universal/bridgepf-0.1-SNAPSHOT.zip
-    region: us-east-1
-    app: BridgePF
-    env: BridgePF-uat
-    on:
-      branch: uat
+      all_branches: true
     access_key_id: AKIAIG6T67NMROEIMC7A
     secret_access_key:
       secure: WygEvdxSQNZpJnPtmk8GDK6ueHUO0tissYQU3rV3ZCQLNjPwPSYxuqEwno2zP07XPQBxzD2TTZRKQYY5q3st14wdkoaKyiEo97VF5kitQCHK6aCs2L9MUPfL6SjhE2KFzJVDdSJzAYQcxoSPps5mqqcvceYYPhgVg3sUriK7c10=

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ deploy:
       prod: bridge-prod
   - provider: elasticbeanstalk
     skip_cleanup: true
-    bucket_name: elasticbeanstalk-us-east-1-649232250620
+    bucket_name: org.sagebridge.bridgepf.deploy
     zip_file: target/universal/bridgepf-0.1-SNAPSHOT.zip
     region: us-east-1
     app: BridgePF


### PR DESCRIPTION
This change allows travis to deploy BridgePF to AWS EB
BridgePF/BridgePF-uat environment.