### PR TITLE
Tweaking some numbers in new external ID queries for better performance (as measured through use of the BSM).

### DIFF
--- a/conf/bridge-server.conf
+++ b/conf/bridge-server.conf
@@ -54,8 +54,8 @@ uat.external.id.add.limit = 100
 prod.external.id.add.limit = 100
 
 // capacity per second for rate limiting dynamo queries
-external.id.get.rate = 1
-prod.external.id.get.rate = 10
+external.id.get.rate = 5
+prod.external.id.get.rate = 30
 
 external.id.lock.duration = 30000
 


### PR DESCRIPTION
The performance now in the UI is similar to before. It uses some of the burst capacity of the DDB table, it is probably possible to get throughput exceptions if you hit this API very hard, and of course, this is a capacity regulator per machine, so requests would be hitting separate machines that are nevertheless consuming one pool of DDB capacity.