### PR TITLE
admins can get and update participants

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
@@ -4,6 +4,7 @@ import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.NO_CALLER_ROLES;
 import static org.sagebionetworks.bridge.BridgeUtils.getDateTimeOrDefault;
 import static org.sagebionetworks.bridge.BridgeUtils.getIntOrDefault;
+import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.Roles.WORKER;
 
@@ -135,7 +136,7 @@ public class ParticipantController extends BaseController {
     }
     
     public Result getParticipant(String userId) throws Exception {
-        UserSession session = getAuthenticatedSession(RESEARCHER);
+        UserSession session = getAuthenticatedSession(ADMIN, RESEARCHER);
         Study study = studyService.getStudy(session.getStudyIdentifier());
 
         StudyParticipant participant = participantService.getParticipant(study, userId, true);
@@ -176,7 +177,7 @@ public class ParticipantController extends BaseController {
     }
     
     public Result updateParticipant(String userId) {
-        UserSession session = getAuthenticatedSession(RESEARCHER);
+        UserSession session = getAuthenticatedSession(ADMIN, RESEARCHER);
         Study study = studyService.getStudy(session.getStudyIdentifier());
 
         StudyParticipant participant = parseJson(request(), StudyParticipant.class);


### PR DESCRIPTION
We recently made a change so that only admins can set the email verification status directly. However, admins can't actually get or update users. This breaks some integration tests (specifically, the one where we mark a user as *not* verified to test that unverified users can't log in). This also makes it so that we have no way of manually marking a user as verified.

This fixes that by adding admin access to get and update participants.