### PR TITLE
Survey rule changes

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
@@ -202,7 +202,7 @@ public class DynamoSurveyDao implements SurveyDao {
     private void reconcileRules(SurveyElement element) {
         if (element instanceof SurveyQuestion) {
             SurveyQuestion question = (SurveyQuestion)element;
-            if (BridgeUtils.isEmpty(question.getRules())) {
+            if (question.getRules() == null) {
                 // if question rules don't exist, the constraint rules are used
                 List<SurveyRule> rules = question.getConstraints().getRules();
                 question.setRules(rules);

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
@@ -20,6 +20,8 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.surveys.Survey;
 import org.sagebionetworks.bridge.models.surveys.SurveyElement;
 import org.sagebionetworks.bridge.models.surveys.SurveyElementFactory;
+import org.sagebionetworks.bridge.models.surveys.SurveyQuestion;
+import org.sagebionetworks.bridge.models.surveys.SurveyRule;
 import org.sagebionetworks.bridge.models.upload.UploadSchema;
 import org.sagebionetworks.bridge.services.UploadSchemaService;
 
@@ -182,9 +184,31 @@ public class DynamoSurveyDao implements SurveyDao {
 
             List<SurveyElement> elements = Lists.newArrayList();
             for (DynamoSurveyElement element : page.getResults()) {
-                elements.add(SurveyElementFactory.fromDynamoEntity(element));
+                SurveyElement surveyElement = SurveyElementFactory.fromDynamoEntity(element);
+                reconcileRules(surveyElement);
+                elements.add(surveyElement);
             }
             survey.setElements(elements);
+        }
+    }
+    
+    /**
+     * Rules began as part of constraints, but constraints are only applied to questions. To apply
+     * rules like "always end the survey after this screen," rules are being moved to be a property 
+     * of SurveyElement. In the interim, existing surveys copy constraint rules to the element if 
+     * the element's rules are empty. Once there are element rules, they take precedence over anything
+     * set in the constraints going forward.
+     */
+    private void reconcileRules(SurveyElement element) {
+        if (element instanceof SurveyQuestion) {
+            SurveyQuestion question = (SurveyQuestion)element;
+            if (BridgeUtils.isEmpty(question.getRules())) {
+                // if question rules don't exist, the constraint rules are used
+                List<SurveyRule> rules = question.getConstraints().getRules();
+                question.setRules(rules);
+            }
+            // question rules take precedence once they exist.
+            question.getConstraints().setRules(question.getRules());
         }
     }
 
@@ -387,6 +411,7 @@ public class DynamoSurveyDao implements SurveyDao {
             if (element.getGuid() == null) {
                 element.setGuid(BridgeUtils.generateGuid());
             }
+            reconcileRules(element);
             dynamoElements.add((DynamoSurveyElement)element);
         }
         

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyElement.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyElement.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -16,6 +15,7 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTypeConverted;
 import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableList;
 
 @DynamoDBTable(tableName = SurveyElementConstants.SURVEY_ELEMENT_TYPE)
 @JsonFilter("filter")
@@ -27,7 +27,7 @@ public class DynamoSurveyElement implements SurveyElement {
     private String type;
     private int order;
     private JsonNode data;
-    private List<SurveyRule> rules = new ArrayList<>();
+    private List<SurveyRule> rules;
 
     public DynamoSurveyElement() {
     }
@@ -86,10 +86,15 @@ public class DynamoSurveyElement implements SurveyElement {
     public void setData(JsonNode data) {
         this.data = data;
     }
+    /**
+     * For backwards compatibility purposes, a null property here is different than an 
+     * empty list. A null value indicates we have never moved the rules from the constraints 
+     * and persisted them as a property of the element; an empty list is a valid value. 
+     */
     @DynamoDBTypeConverted(converter = SurveyRuleListMarshaller.class)
     @DynamoDBAttribute
     public List<SurveyRule> getRules() {
-        return this.rules;
+        return (this.rules == null) ? null : ImmutableList.copyOf(this.rules);
     }
     public void setRules(List<SurveyRule> rules) {
         this.rules = rules;

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyElement.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyElement.java
@@ -1,7 +1,12 @@
 package org.sagebionetworks.bridge.dynamodb;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
 import org.sagebionetworks.bridge.models.surveys.SurveyElement;
 import org.sagebionetworks.bridge.models.surveys.SurveyElementConstants;
+import org.sagebionetworks.bridge.models.surveys.SurveyRule;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
@@ -22,6 +27,7 @@ public class DynamoSurveyElement implements SurveyElement {
     private String type;
     private int order;
     private JsonNode data;
+    private List<SurveyRule> rules = new ArrayList<>();
 
     public DynamoSurveyElement() {
     }
@@ -80,51 +86,32 @@ public class DynamoSurveyElement implements SurveyElement {
     public void setData(JsonNode data) {
         this.data = data;
     }
-
+    @DynamoDBTypeConverted(converter = SurveyRuleListMarshaller.class)
+    @DynamoDBAttribute
+    public List<SurveyRule> getRules() {
+        return this.rules;
+    }
+    public void setRules(List<SurveyRule> rules) {
+        this.rules = rules;
+    }
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((guid == null) ? 0 : guid.hashCode());
-        result = prime * result + ((identifier == null) ? 0 : identifier.hashCode());
-        result = prime * result + order;
-        result = prime * result + ((surveyCompoundKey == null) ? 0 : surveyCompoundKey.hashCode());
-        result = prime * result + ((type == null) ? 0 : type.hashCode());
-        return result;
+        return Objects.hash(guid, identifier, order, surveyCompoundKey, type, rules);
     }
 
     @Override
     public boolean equals(Object obj) {
         if (this == obj)
             return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
+        if (obj == null || getClass() != obj.getClass())
             return false;
         DynamoSurveyElement other = (DynamoSurveyElement) obj;
-        if (guid == null) {
-            if (other.guid != null)
-                return false;
-        } else if (!guid.equals(other.guid))
-            return false;
-        if (identifier == null) {
-            if (other.identifier != null)
-                return false;
-        } else if (!identifier.equals(other.identifier))
-            return false;
-        if (order != other.order)
-            return false;
-        if (surveyCompoundKey == null) {
-            if (other.surveyCompoundKey != null)
-                return false;
-        } else if (!surveyCompoundKey.equals(other.surveyCompoundKey))
-            return false;
-        if (type == null) {
-            if (other.type != null)
-                return false;
-        } else if (!type.equals(other.type))
-            return false;
-        return true;
+        return Objects.equals(guid, other.guid) &&
+                Objects.equals(identifier, other.identifier) &&
+                Objects.equals(order, this.order) &&
+                Objects.equals(surveyCompoundKey, this.surveyCompoundKey) &&
+                Objects.equals(type, other.type) &&
+                Objects.equals(rules, other.rules);
     }
     
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyInfoScreen.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyInfoScreen.java
@@ -14,26 +14,6 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class DynamoSurveyInfoScreen extends DynamoSurveyElement implements SurveyInfoScreen {
-
-    private static final String PROMPT_PROPERTY = "prompt";
-    private static final String IDENTIFIER_PROPERTY = "identifier";
-    private static final String GUID_PROPERTY = "guid";
-    private static final String PROMPT_DETAIL_PROPERTY = "promptDetail";
-    private static final String TYPE_PROPERTY = "type";
-    private static final String TITLE_PROPERTY = "title";
-    private static final String IMAGE_PROPERTY = "image";
-    
-    public static DynamoSurveyInfoScreen fromJson(JsonNode node) {
-        DynamoSurveyInfoScreen question = new DynamoSurveyInfoScreen();
-        question.setType( JsonUtils.asText(node, TYPE_PROPERTY) );
-        question.setIdentifier( JsonUtils.asText(node, IDENTIFIER_PROPERTY) );
-        question.setGuid( JsonUtils.asText(node, GUID_PROPERTY) );
-        question.setPrompt(JsonUtils.asText(node, PROMPT_PROPERTY));
-        question.setPromptDetail(JsonUtils.asText(node, PROMPT_DETAIL_PROPERTY));
-        question.setTitle(JsonUtils.asText(node, TITLE_PROPERTY));
-        question.setImage(JsonUtils.asEntity(node, IMAGE_PROPERTY, Image.class));
-        return question;
-    }
     
     private String prompt;
     private String promptDetail;

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyInfoScreen.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyInfoScreen.java
@@ -49,6 +49,7 @@ public class DynamoSurveyInfoScreen extends DynamoSurveyElement implements Surve
         setIdentifier(entry.getIdentifier());
         setGuid(entry.getGuid());
         setData(entry.getData());
+        setRules(entry.getRules());
     }
 
     @Override

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyQuestion.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyQuestion.java
@@ -56,6 +56,7 @@ public class DynamoSurveyQuestion extends DynamoSurveyElement implements SurveyQ
         setIdentifier( entry.getIdentifier() );
         setGuid( entry.getGuid() );
         setData( entry.getData() );
+        setRules( entry.getRules() );
     }
     
     @Override

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyQuestion.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyQuestion.java
@@ -18,28 +18,6 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class DynamoSurveyQuestion extends DynamoSurveyElement implements SurveyQuestion {
-    
-    private static final String CONSTRAINTS_PROPERTY = "constraints";
-    private static final String UI_HINTS_PROPERTY = "uiHint";
-    private static final String PROMPT_PROPERTY = "prompt";
-    private static final String PROMPT_DETAIL_PROPERTY = "promptDetail";
-    private static final String FIRE_EVENT_PROPERTY = "fireEvent";
-    private static final String IDENTIFIER_PROPERTY = "identifier";
-    private static final String GUID_PROPERTY = "guid";
-    private static final String TYPE_PROPERTY = "type";
-    
-    public static SurveyQuestion fromJson(JsonNode node) {
-        DynamoSurveyQuestion question = new DynamoSurveyQuestion();
-        question.setType( JsonUtils.asText(node, TYPE_PROPERTY) );
-        question.setIdentifier( JsonUtils.asText(node, IDENTIFIER_PROPERTY) );
-        question.setGuid( JsonUtils.asText(node, GUID_PROPERTY) );
-        question.setPrompt(JsonUtils.asText(node, PROMPT_PROPERTY));
-        question.setPromptDetail(JsonUtils.asText(node, PROMPT_DETAIL_PROPERTY));
-        question.setFireEvent(JsonUtils.asBoolean(node, FIRE_EVENT_PROPERTY));
-        question.setUiHint(JsonUtils.asEntity(node, UI_HINTS_PROPERTY, UIHint.class));
-        question.setConstraints(JsonUtils.asConstraints(node, CONSTRAINTS_PROPERTY));
-        return question;
-    }
 
     private String prompt;
     private String promptDetail;

--- a/app/org/sagebionetworks/bridge/dynamodb/SurveyRuleListMarshaller.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/SurveyRuleListMarshaller.java
@@ -1,0 +1,20 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import java.util.List;
+
+import org.sagebionetworks.bridge.models.surveys.SurveyRule;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+public class SurveyRuleListMarshaller extends ListMarshaller<SurveyRule> {
+
+    private static final TypeReference<List<SurveyRule>> STRING_LIST_TYPE =
+            new TypeReference<List<SurveyRule>>() {};
+
+    /** {@inheritDoc} */
+    @Override
+    public TypeReference<List<SurveyRule>> getTypeReference() {
+        return STRING_LIST_TYPE;
+    }
+
+}

--- a/app/org/sagebionetworks/bridge/models/surveys/SurveyElement.java
+++ b/app/org/sagebionetworks/bridge/models/surveys/SurveyElement.java
@@ -3,6 +3,8 @@ package org.sagebionetworks.bridge.models.surveys;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
+import java.util.List;
+
 import org.sagebionetworks.bridge.json.JsonNodeToSurveyElementConverter;
 
 @JsonDeserialize(converter = JsonNodeToSurveyElementConverter.class)
@@ -27,6 +29,9 @@ public interface SurveyElement {
     
     JsonNode getData();
     void setData(JsonNode data);
+    
+    List<SurveyRule> getRules();
+    void setRules(List<SurveyRule> rules);
     
 }
 

--- a/app/org/sagebionetworks/bridge/models/surveys/SurveyElement.java
+++ b/app/org/sagebionetworks/bridge/models/surveys/SurveyElement.java
@@ -10,6 +10,18 @@ import org.sagebionetworks.bridge.json.JsonNodeToSurveyElementConverter;
 @JsonDeserialize(converter = JsonNodeToSurveyElementConverter.class)
 public interface SurveyElement {
 
+    public static final String CONSTRAINTS_PROPERTY = "constraints";
+    public static final String FIRE_EVENT_PROPERTY = "fireEvent";
+    public static final String GUID_PROPERTY = "guid";
+    public static final String IDENTIFIER_PROPERTY = "identifier";
+    public static final String IMAGE_PROPERTY = "image";
+    public static final String PROMPT_DETAIL_PROPERTY = "promptDetail";
+    public static final String PROMPT_PROPERTY = "prompt";
+    public static final String RULES_PROPERTY = "rules";
+    public static final String TITLE_PROPERTY = "title";
+    public static final String TYPE_PROPERTY = "type";    
+    public static final String UI_HINTS_PROPERTY = "uiHint";
+    
     String getSurveyCompoundKey();
     void setSurveyCompoundKey(String surveyCompoundKey);
 

--- a/app/org/sagebionetworks/bridge/models/surveys/SurveyElementFactory.java
+++ b/app/org/sagebionetworks/bridge/models/surveys/SurveyElementFactory.java
@@ -19,9 +19,9 @@ public class SurveyElementFactory {
     public static SurveyElement fromJson(JsonNode node) {
         String type = JsonUtils.asText(node, "type");
         if (SURVEY_QUESTION_TYPE.equals(type)) {
-            return DynamoSurveyQuestion.fromJson(node);
+            return SurveyQuestion.fromJson(node);
         } else if (SURVEY_INFO_SCREEN_TYPE.equals(type)) {
-            return DynamoSurveyInfoScreen.fromJson(node);
+            return SurveyInfoScreen.fromJson(node);
         } else {
             throw new InvalidEntityException("Survey element type '"+type+"' not recognized.");
         }

--- a/app/org/sagebionetworks/bridge/models/surveys/SurveyInfoScreen.java
+++ b/app/org/sagebionetworks/bridge/models/surveys/SurveyInfoScreen.java
@@ -2,7 +2,9 @@ package org.sagebionetworks.bridge.models.surveys;
 
 import org.sagebionetworks.bridge.dynamodb.DynamoSurveyInfoScreen;
 import org.sagebionetworks.bridge.json.BridgeTypeName;
+import org.sagebionetworks.bridge.json.JsonUtils;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize(as=DynamoSurveyInfoScreen.class)
@@ -11,6 +13,19 @@ public interface SurveyInfoScreen extends SurveyElement {
     /** Convenience method for creating an instance using a concrete implementation. */
     static SurveyInfoScreen create() {
         return new DynamoSurveyInfoScreen();
+    }
+    
+    static DynamoSurveyInfoScreen fromJson(JsonNode node) {
+        DynamoSurveyInfoScreen question = new DynamoSurveyInfoScreen();
+        question.setType( JsonUtils.asText(node, TYPE_PROPERTY) );
+        question.setIdentifier( JsonUtils.asText(node, IDENTIFIER_PROPERTY) );
+        question.setGuid( JsonUtils.asText(node, GUID_PROPERTY) );
+        question.setPrompt(JsonUtils.asText(node, PROMPT_PROPERTY));
+        question.setPromptDetail(JsonUtils.asText(node, PROMPT_DETAIL_PROPERTY));
+        question.setTitle(JsonUtils.asText(node, TITLE_PROPERTY));
+        question.setImage(JsonUtils.asEntity(node, IMAGE_PROPERTY, Image.class));
+        question.setRules(JsonUtils.asEntityList(node, RULES_PROPERTY, SurveyRule.class));
+        return question;
     }
     
     String getTitle();

--- a/app/org/sagebionetworks/bridge/models/surveys/SurveyInfoScreen.java
+++ b/app/org/sagebionetworks/bridge/models/surveys/SurveyInfoScreen.java
@@ -1,12 +1,11 @@
 package org.sagebionetworks.bridge.models.surveys;
 
 import org.sagebionetworks.bridge.dynamodb.DynamoSurveyInfoScreen;
-import org.sagebionetworks.bridge.dynamodb.DynamoSurveyQuestion;
 import org.sagebionetworks.bridge.json.BridgeTypeName;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-@JsonDeserialize(as=DynamoSurveyQuestion.class)
+@JsonDeserialize(as=DynamoSurveyInfoScreen.class)
 @BridgeTypeName("SurveyInfoScreen")
 public interface SurveyInfoScreen extends SurveyElement {
     /** Convenience method for creating an instance using a concrete implementation. */

--- a/app/org/sagebionetworks/bridge/models/surveys/SurveyQuestion.java
+++ b/app/org/sagebionetworks/bridge/models/surveys/SurveyQuestion.java
@@ -2,7 +2,9 @@ package org.sagebionetworks.bridge.models.surveys;
 
 import org.sagebionetworks.bridge.dynamodb.DynamoSurveyQuestion;
 import org.sagebionetworks.bridge.json.BridgeTypeName;
+import org.sagebionetworks.bridge.json.JsonUtils;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize(as = DynamoSurveyQuestion.class)
@@ -12,7 +14,21 @@ public interface SurveyQuestion extends SurveyElement {
     static SurveyQuestion create() {
         return new DynamoSurveyQuestion();
     }
-
+    
+    static SurveyQuestion fromJson(JsonNode node) {
+        DynamoSurveyQuestion question = new DynamoSurveyQuestion();
+        question.setType( JsonUtils.asText(node, TYPE_PROPERTY) );
+        question.setIdentifier( JsonUtils.asText(node, IDENTIFIER_PROPERTY) );
+        question.setGuid( JsonUtils.asText(node, GUID_PROPERTY) );
+        question.setPrompt(JsonUtils.asText(node, PROMPT_PROPERTY));
+        question.setPromptDetail(JsonUtils.asText(node, PROMPT_DETAIL_PROPERTY));
+        question.setFireEvent(JsonUtils.asBoolean(node, FIRE_EVENT_PROPERTY));
+        question.setUiHint(JsonUtils.asEntity(node, UI_HINTS_PROPERTY, UIHint.class));
+        question.setRules(JsonUtils.asEntityList(node, RULES_PROPERTY, SurveyRule.class));
+        question.setConstraints(JsonUtils.asConstraints(node, CONSTRAINTS_PROPERTY));
+        return question;
+    }
+    
     String getPrompt();
 
     void setPrompt(String prompt);

--- a/app/org/sagebionetworks/bridge/models/surveys/SurveyRule.java
+++ b/app/org/sagebionetworks/bridge/models/surveys/SurveyRule.java
@@ -10,13 +10,14 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 public final class SurveyRule {
 
     public enum Operator {
-        EQ, // equal to
-        NE, // not equal to
-        LT, // less than
-        GT, // greater than
-        LE, // less than or equal to
-        GE, // greater than or equal to
-        DE  // declined to answer
+        EQ,    // equal to
+        NE,    // not equal to
+        LT,    // less than
+        GT,    // greater than
+        LE,    // less than or equal to
+        GE,    // greater than or equal to
+        DE,    // declined to answer
+        ALWAYS // always apply this rule
     }
     
     private final Operator operator;

--- a/app/org/sagebionetworks/bridge/validators/SurveyPublishValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/SurveyPublishValidator.java
@@ -25,7 +25,8 @@ public class SurveyPublishValidator implements Validator {
         return Survey.class.isAssignableFrom(clazz);
     }
 
-    @Override public void validate(Object target, Errors errors) {
+    @Override 
+    public void validate(Object target, Errors errors) {
         Survey survey = (Survey) target;
         // Validate that no identifier has been duplicated.
         Set<String> foundIdentifiers = Sets.newHashSet();

--- a/app/org/sagebionetworks/bridge/validators/SurveySaveValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/SurveySaveValidator.java
@@ -136,26 +136,32 @@ public class SurveySaveValidator implements Validator {
         
         for (int i=0; i < elements.size(); i++) {
             SurveyElement element = elements.get(i);
-            for (int j=0; j < element.getRules().size(); j++) {
-                SurveyRule rule = element.getRules().get(j);
-                validateOneRuleSet(errors, rule, alreadySeenIdentifiers, "elements["+i+"]", "rules["+j+"]");
+            if (element.getRules() != null) {
+                for (int j=0; j < element.getRules().size(); j++) {
+                    SurveyRule rule = element.getRules().get(j);
+                    validateOneRuleSet(errors, rule, alreadySeenIdentifiers, "elements["+i+"]", "rules["+j+"]");
+                }
             }
             if (element instanceof SurveyQuestion) {
                 SurveyQuestion question = (SurveyQuestion)element;
-                for (int j=0; j < question.getConstraints().getRules().size(); j++) {
-                    SurveyRule rule = question.getConstraints().getRules().get(j);
-                    validateOneRuleSet(errors, rule, alreadySeenIdentifiers,
-                            "elements[" + i + "].constraints", "rules[" + j + "]");
+                if (question.getConstraints().getRules() != null) {
+                    for (int j=0; j < question.getConstraints().getRules().size(); j++) {
+                        SurveyRule rule = question.getConstraints().getRules().get(j);
+                        validateOneRuleSet(errors, rule, alreadySeenIdentifiers,
+                                "elements[" + i + "].constraints", "rules[" + j + "]");
+                    }
                 }
             } else if (element instanceof SurveyInfoScreen) {
                 // The only operator that makes sense on an information screen is ALWAYS, since there 
                 // is no value to test against.
-                for (int j=0; j < element.getRules().size(); j++) {
-                    SurveyRule rule = element.getRules().get(j);
-                    if (rule.getOperator() != SurveyRule.Operator.ALWAYS) {
-                        errors.pushNestedPath("elements["+i+"]");
-                        errors.rejectValue("rules["+j+"]", "only valid with the 'always' operator");
-                        errors.popNestedPath();
+                if (element.getRules() != null) {
+                    for (int j=0; j < element.getRules().size(); j++) {
+                        SurveyRule rule = element.getRules().get(j);
+                        if (rule.getOperator() != SurveyRule.Operator.ALWAYS) {
+                            errors.pushNestedPath("elements["+i+"]");
+                            errors.rejectValue("rules["+j+"]", "only valid with the 'always' operator");
+                            errors.popNestedPath();
+                        }
                     }
                 }
             }
@@ -165,16 +171,20 @@ public class SurveySaveValidator implements Validator {
         // Now verify that all skipToTarget identifiers actually exist
         for (int i=0; i < elements.size(); i++) {
             SurveyElement element = elements.get(i);
-            for (int j=0; j < element.getRules().size(); j++) {
-                SurveyRule rule = element.getRules().get(j);
-                validateSkipToTargetExists(errors, rule, alreadySeenIdentifiers, "elements["+i+"]", "rules["+j+"]");
+            if (element.getRules() != null) {
+                for (int j=0; j < element.getRules().size(); j++) {
+                    SurveyRule rule = element.getRules().get(j);
+                    validateSkipToTargetExists(errors, rule, alreadySeenIdentifiers, "elements["+i+"]", "rules["+j+"]");
+                }
             }
             if (element instanceof SurveyQuestion) {
                 SurveyQuestion question = (SurveyQuestion)element;
-                for (int j=0; j < question.getConstraints().getRules().size(); j++) {
-                    // This validation only applies to skipTo target rules.
-                    SurveyRule rule = question.getConstraints().getRules().get(j);
-                    validateSkipToTargetExists(errors, rule, alreadySeenIdentifiers, "elements["+i+"].constraints", "rules["+j+"]");
+                if (question.getConstraints().getRules() != null) {
+                    for (int j=0; j < question.getConstraints().getRules().size(); j++) {
+                        // This validation only applies to skipTo target rules.
+                        SurveyRule rule = question.getConstraints().getRules().get(j);
+                        validateSkipToTargetExists(errors, rule, alreadySeenIdentifiers, "elements["+i+"].constraints", "rules["+j+"]");
+                    }
                 }
             }
         }

--- a/app/org/sagebionetworks/bridge/validators/SurveySaveValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/SurveySaveValidator.java
@@ -130,49 +130,86 @@ public class SurveySaveValidator implements Validator {
             errors.popNestedPath();
         }
     }
+
     private void validateRules(Errors errors, List<SurveyElement> elements) {
-        // Should not try and back-track in the survey.
         Set<String> alreadySeenIdentifiers = Sets.newHashSet();
+        
         for (int i=0; i < elements.size(); i++) {
             SurveyElement element = elements.get(i);
+            for (int j=0; j < element.getRules().size(); j++) {
+                SurveyRule rule = element.getRules().get(j);
+                validateOneRuleSet(errors, rule, alreadySeenIdentifiers, "elements["+i+"]", "rules["+j+"]");
+            }
             if (element instanceof SurveyQuestion) {
-                for (SurveyRule rule : ((SurveyQuestion)element).getConstraints().getRules()) {
-                    errors.pushNestedPath("elements["+i+"]");
-                    // Validate the rule either has a skipTo target, or an endSurvey = TRUE, but not both.
-                    if (rule.getSkipToTarget() != null && rule.getEndSurvey() != null) {
-                        errors.rejectValue("rule", "cannot have a skipTo target and an endSurvey property");
+                SurveyQuestion question = (SurveyQuestion)element;
+                for (int j=0; j < question.getConstraints().getRules().size(); j++) {
+                    SurveyRule rule = question.getConstraints().getRules().get(j);
+                    validateOneRuleSet(errors, rule, alreadySeenIdentifiers,
+                            "elements[" + i + "].constraints", "rules[" + j + "]");
+                }
+            } else if (element instanceof SurveyInfoScreen) {
+                // The only operator that makes sense on an information screen is ALWAYS, since there 
+                // is no value to test against.
+                for (int j=0; j < element.getRules().size(); j++) {
+                    SurveyRule rule = element.getRules().get(j);
+                    if (rule.getOperator() != SurveyRule.Operator.ALWAYS) {
+                        errors.pushNestedPath("elements["+i+"]");
+                        errors.rejectValue("rules["+j+"]", "only valid with the 'always' operator");
+                        errors.popNestedPath();
                     }
-                    // But must have either a skipTo target or an endSurvey property
-                    else if (rule.getSkipToTarget() == null && rule.getEndSurvey() == null) {
-                        errors.rejectValue("rule", "must have a skipTo target or an endSurvey property");
-                    }
-                    // Otherwise we can assume there's a skipToTarget, start checking that by looking for back references.
-                    else if (alreadySeenIdentifiers.contains(rule.getSkipToTarget())) {
-                        errors.rejectValue("rule", "back references question " + rule.getSkipToTarget());
-                    }
-                    errors.popNestedPath();
                 }
             }
             alreadySeenIdentifiers.add(element.getIdentifier());
-        }
+        }        
+        
         // Now verify that all skipToTarget identifiers actually exist
         for (int i=0; i < elements.size(); i++) {
             SurveyElement element = elements.get(i);
+            for (int j=0; j < element.getRules().size(); j++) {
+                SurveyRule rule = element.getRules().get(j);
+                validateSkipToTargetExists(errors, rule, alreadySeenIdentifiers, "elements["+i+"]", "rules["+j+"]");
+            }
             if (element instanceof SurveyQuestion) {
-                for (SurveyRule rule : ((SurveyQuestion)element).getConstraints().getRules()) {
+                SurveyQuestion question = (SurveyQuestion)element;
+                for (int j=0; j < question.getConstraints().getRules().size(); j++) {
                     // This validation only applies to skipTo target rules.
-                    if (rule.getSkipToTarget() != null) {
-                        if (!alreadySeenIdentifiers.contains(rule.getSkipToTarget())) {
-                            errors.pushNestedPath("elements["+i+"]");
-                            errors.rejectValue("rule", "has a skipTo identifier that doesn't exist: " + rule.getSkipToTarget());
-                            errors.popNestedPath();
-                        }
-                    }
+                    SurveyRule rule = question.getConstraints().getRules().get(j);
+                    validateSkipToTargetExists(errors, rule, alreadySeenIdentifiers, "elements["+i+"].constraints", "rules["+j+"]");
                 }
             }
         }
-
     }
+    
+    private void validateSkipToTargetExists(Errors errors, SurveyRule rule, Set<String> alreadySeenIdentifiers,
+            String propertyPath, String fieldPath) {
+        
+        if (rule.getSkipToTarget() != null) {
+            if (!alreadySeenIdentifiers.contains(rule.getSkipToTarget())) {
+                errors.pushNestedPath(propertyPath);
+                errors.rejectValue(fieldPath, "has a skipTo identifier that doesn't exist: " + rule.getSkipToTarget());
+                errors.popNestedPath();
+            }
+        }
+    }
+
+    private void validateOneRuleSet(Errors errors, SurveyRule rule, Set<String> alreadySeenIdentifiers,
+            String propertyPath, String fieldPath) {
+        // Validate the rule either has a skipTo target, or an endSurvey = TRUE, but not both.
+        errors.pushNestedPath(propertyPath);
+        if (rule.getSkipToTarget() != null && rule.getEndSurvey() != null) {
+            errors.rejectValue(fieldPath, "cannot have a skipTo target and an endSurvey property");
+        }
+        // But must have either a skipTo target or an endSurvey property
+        else if (rule.getSkipToTarget() == null && rule.getEndSurvey() == null) {
+            errors.rejectValue(fieldPath, "must have a skipTo target or an endSurvey property");
+        }
+        // Otherwise we can assume there's a skipToTarget, start checking that by looking for back references.
+        else if (alreadySeenIdentifiers.contains(rule.getSkipToTarget())) {
+            errors.rejectValue(fieldPath, "back references question " + rule.getSkipToTarget());
+        }
+        errors.popNestedPath();
+    }
+    
     private void doValidateConstraints(SurveyQuestion question, Constraints con, Errors errors) {
         if (con.getDataType() == null) {
             errors.rejectValue("dataType", "is required");
@@ -304,7 +341,7 @@ public class SurveySaveValidator implements Validator {
             if (min == null) {
                 errors.rejectValue("minValue", "is required for " + hint.name().toLowerCase());
             }
-            if (max == null){
+            if (max == null) {
                 errors.rejectValue("maxValue", "is required for " + hint.name().toLowerCase());
             }
         }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoTest.java
@@ -14,6 +14,8 @@ import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
+
 import javax.annotation.Resource;
 
 import com.google.common.collect.ImmutableList;
@@ -37,10 +39,14 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.surveys.BooleanConstraints;
 import org.sagebionetworks.bridge.models.surveys.DateConstraints;
+import org.sagebionetworks.bridge.models.surveys.IntegerConstraints;
 import org.sagebionetworks.bridge.models.surveys.Survey;
+import org.sagebionetworks.bridge.models.surveys.SurveyInfoScreen;
 import org.sagebionetworks.bridge.models.surveys.SurveyQuestion;
+import org.sagebionetworks.bridge.models.surveys.SurveyRule;
 import org.sagebionetworks.bridge.models.surveys.TestSurvey;
 import org.sagebionetworks.bridge.models.surveys.UIHint;
+import org.sagebionetworks.bridge.models.surveys.SurveyRule.Operator;
 import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
 import org.sagebionetworks.bridge.models.upload.UploadFieldType;
 import org.sagebionetworks.bridge.models.upload.UploadSchema;
@@ -601,6 +607,72 @@ public class DynamoSurveyDaoTest {
         } catch(EntityNotFoundException e) {
             // expected exception
         }
+    }
+    
+    @Test
+    public void rulesMovedToSurveyElementInBackwardsCompatibleManner() throws Exception {
+        Survey survey = Survey.create();
+        survey.setGuid(UUID.randomUUID().toString());
+        survey.setName("Rules test");
+        survey.setIdentifier(TestUtils.randomName(DynamoSurveyDaoTest.class));
+        survey.setStudyIdentifier(TEST_STUDY_IDENTIFIER);
+        
+        SurveyRule rule = new SurveyRule.Builder().withOperator(Operator.DE).withEndSurvey(true).build();
+        
+        // This question needs to copy rules from constraints to the element
+        SurveyQuestion migrateQuestion = SurveyQuestion.create();
+        BooleanConstraints c = new BooleanConstraints();
+        c.getRules().add(rule);
+        migrateQuestion.setPrompt("Do you have high blood pressure?");
+        migrateQuestion.setIdentifier("migrate_question");
+        migrateQuestion.setPromptDetail("Be honest: do you have high blood pressue?");
+        migrateQuestion.setUiHint(UIHint.CHECKBOX);
+        migrateQuestion.setConstraints(c);
+        migrateQuestion.setGuid(UUID.randomUUID().toString());
+        
+        // Information screens can now take rules
+        SurveyInfoScreen infoScreen = SurveyInfoScreen.create();
+        infoScreen.setPrompt("Do you have high blood pressure?");
+        infoScreen.setIdentifier("info_screen");
+        infoScreen.setPromptDetail("Be honest: do you have high blood pressue?");
+        infoScreen.setGuid(UUID.randomUUID().toString());
+        infoScreen.getRules().add(rule);
+        
+        // Element rules override anything set in constraints, once they exist.
+        SurveyQuestion question = SurveyQuestion.create();
+        IntegerConstraints ic = new IntegerConstraints();
+        // This rule will be overridden by the rules in the element itself, which now takes precedences
+        SurveyRule obsoleteRule = new SurveyRule.Builder().withOperator(Operator.EQ).withValue(10).withEndSurvey(true)
+                .build();
+        ic.getRules().add(obsoleteRule);
+        question.setPrompt("Do you have high blood pressure?");
+        question.setIdentifier("migrate_question");
+        question.setPromptDetail("Be honest: do you have high blood pressue?");
+        question.setUiHint(UIHint.CHECKBOX);
+        question.setConstraints(ic);
+        question.setGuid(UUID.randomUUID().toString());
+        question.getRules().add(rule);
+        
+        survey.getElements().add(migrateQuestion);
+        survey.getElements().add(infoScreen);
+        survey.getElements().add(question);
+        
+        Survey keys = createSurvey(survey);
+        Survey createdSurvey = surveyDao.getSurvey(keys);
+        
+        // Migrated question has been moved up
+        assertEquals(rule, createdSurvey.getElements().get(0).getRules().get(0));
+        assertEquals(1, createdSurvey.getElements().get(0).getRules().size());
+        // Info screen has rule
+        assertEquals(rule, createdSurvey.getElements().get(1).getRules().get(0));
+        assertEquals(1, createdSurvey.getElements().get(1).getRules().size());
+        // Normal question has been moved down, overwriting existing
+        assertEquals(rule, createdSurvey.getElements().get(2).getRules().get(0));
+        assertEquals(1, createdSurvey.getElements().get(2).getRules().size());
+        
+        SurveyQuestion savedQuestion = (SurveyQuestion)createdSurvey.getElements().get(2);
+        assertEquals(rule, savedQuestion.getRules().get(0));
+        assertEquals(1, savedQuestion.getRules().size());
     }
     
     private static void assertContainsAllKeys(Set<GuidCreatedOnVersionHolderImpl> expected, List<Survey> actual) {

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoTest.java
@@ -636,7 +636,7 @@ public class DynamoSurveyDaoTest {
         infoScreen.setIdentifier("info_screen");
         infoScreen.setPromptDetail("Be honest: do you have high blood pressue?");
         infoScreen.setGuid(UUID.randomUUID().toString());
-        infoScreen.getRules().add(rule);
+        infoScreen.setRules(ImmutableList.of(rule));
         
         // Element rules override anything set in constraints, once they exist.
         SurveyQuestion question = SurveyQuestion.create();
@@ -651,7 +651,7 @@ public class DynamoSurveyDaoTest {
         question.setUiHint(UIHint.CHECKBOX);
         question.setConstraints(ic);
         question.setGuid(UUID.randomUUID().toString());
-        question.getRules().add(rule);
+        question.setRules(ImmutableList.of(rule));
         
         survey.getElements().add(migrateQuestion);
         survey.getElements().add(infoScreen);

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyQuestionTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyQuestionTest.java
@@ -6,6 +6,7 @@ import org.joda.time.DateTime;
 import org.junit.Test;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.surveys.IntegerConstraints;
+import org.sagebionetworks.bridge.models.surveys.SurveyQuestion;
 import org.sagebionetworks.bridge.models.surveys.UIHint;
 import org.sagebionetworks.bridge.models.surveys.Unit;
 
@@ -35,7 +36,7 @@ public class DynamoSurveyQuestionTest {
         String string = BridgeObjectMapper.get().writeValueAsString(question);
         assertEquals("{\"surveyCompoundKey\":\"AAA:1444471810000\",\"guid\":\"AAA\",\"identifier\":\"identifier\",\"type\":\"type\",\"prompt\":\"Prompt\",\"promptDetail\":\"Prompt Detail\",\"fireEvent\":false,\"constraints\":{\"rules\":[],\"dataType\":\"integer\",\"unit\":\"days\",\"minValue\":2.0,\"maxValue\":6.0,\"step\":2.0,\"type\":\"IntegerConstraints\"},\"uiHint\":\"checkbox\"}", string);
 
-        DynamoSurveyQuestion question2 = (DynamoSurveyQuestion)DynamoSurveyQuestion.fromJson(BridgeObjectMapper.get().readTree(string));
+        SurveyQuestion question2 = (SurveyQuestion)SurveyQuestion.fromJson(BridgeObjectMapper.get().readTree(string));
         assertEquals(question.getPromptDetail(), question2.getPromptDetail());
         assertEquals(question.getPrompt(), question2.getPrompt());
         assertEquals(question.getIdentifier(), question2.getIdentifier());

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoUploadDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoUploadDaoMockTest.java
@@ -44,7 +44,6 @@ import com.amazonaws.services.dynamodbv2.document.ItemCollection;
 import com.amazonaws.services.dynamodbv2.document.QueryOutcome;
 import com.amazonaws.services.dynamodbv2.document.internal.IteratorSupport;
 import com.amazonaws.services.dynamodbv2.document.spec.QuerySpec;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.QueryResult;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;

--- a/test/org/sagebionetworks/bridge/models/surveys/SurveyElementTest.java
+++ b/test/org/sagebionetworks/bridge/models/surveys/SurveyElementTest.java
@@ -14,20 +14,22 @@ import org.sagebionetworks.bridge.dynamodb.DynamoSurveyQuestion;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.json.JsonUtils;
+import org.sagebionetworks.bridge.models.surveys.SurveyRule.Operator;
 
 @SuppressWarnings("unchecked")
 public class SurveyElementTest {
     @Test
     public void serializeSurveyQuestion() throws Exception {
         // start with JSON
-        String jsonText = "{\n" +
-                "   \"fireEvent\":false,\n" +
-                "   \"guid\":\"test-guid\",\n" +
-                "   \"identifier\":\"test-survey-question\",\n" +
-                "   \"prompt\":\"Is this a survey question?\",\n" +
-                "   \"promptDetail\":\"Details about question\",\n" +
-                "   \"type\":\"SurveyQuestion\",\n" +
-                "   \"uiHint\":\"textfield\"\n" +
+        String jsonText = "{" +
+                "   \"fireEvent\":false," +
+                "   \"guid\":\"test-guid\"," +
+                "   \"identifier\":\"test-survey-question\"," +
+                "   \"prompt\":\"Is this a survey question?\"," +
+                "   \"promptDetail\":\"Details about question\"," +
+                "   \"rules\":[{\"operator\":\"always\",\"endSurvey\":true}],"+
+                "   \"type\":\"SurveyQuestion\"," +
+                "   \"uiHint\":\"textfield\"" +
                 "}";
 
         // convert to POJO
@@ -50,7 +52,7 @@ public class SurveyElementTest {
 
         // then convert to a map so we can validate the raw JSON
         Map<String, Object> jsonMap = BridgeObjectMapper.get().readValue(convertedJson, JsonUtils.TYPE_REF_RAW_MAP);
-        assertEquals(7, jsonMap.size());
+        assertEquals(8, jsonMap.size());
         assertFalse((boolean) jsonMap.get("fireEvent"));
         assertEquals("test-guid", jsonMap.get("guid"));
         assertEquals("test-survey-question", jsonMap.get("identifier"));
@@ -58,23 +60,37 @@ public class SurveyElementTest {
         assertEquals("Details about question", jsonMap.get("promptDetail"));
         assertEquals("SurveyQuestion", jsonMap.get("type"));
         assertEquals("textfield", jsonMap.get("uiHint"));
+        
+        SurveyQuestion deserQuestion = BridgeObjectMapper.get().readValue(convertedJson, SurveyQuestion.class);
+        
+        SurveyRule rule = new SurveyRule.Builder().withEndSurvey(true).withOperator(Operator.ALWAYS).build();
+        assertFalse(deserQuestion.getFireEvent());
+        assertEquals("test-guid", deserQuestion.getGuid());
+        assertEquals("test-survey-question", deserQuestion.getIdentifier());
+        assertEquals("Is this a survey question?", deserQuestion.getPrompt());
+        assertEquals("Details about question", deserQuestion.getPromptDetail());
+        assertEquals("SurveyQuestion", deserQuestion.getType());
+        assertEquals(UIHint.TEXTFIELD, deserQuestion.getUiHint());
+        assertEquals(rule, deserQuestion.getRules().get(0));
     }
 
     @Test
     public void serializeSurveyInfoScreen() throws Exception {
         // start with JSON
-        String jsonText = "{\n" +
-                "   \"guid\":\"test-guid\",\n" +
-                "   \"identifier\":\"test-survey-info-screen\",\n" +
-                "   \"image\":{\n" +
-                "       \"source\":\"http://www.example.com/test.png\",\n" +
-                "       \"width\":200,\n" +
-                "       \"height\":150\n" +
-                "   },\n" +
-                "   \"prompt\":\"This is the survey info\",\n" +
-                "   \"promptDetail\":\"More info\",\n" +
-                "   \"title\":\"Survey Info\",\n" +
-                "   \"type\":\"SurveyInfoScreen\"\n" +
+        
+        String jsonText = "{" +
+                "   \"guid\":\"test-guid\"," +
+                "   \"identifier\":\"test-survey-info-screen\"," +
+                "   \"image\":{" +
+                "       \"source\":\"http://www.example.com/test.png\"," +
+                "       \"width\":200," +
+                "       \"height\":150" +
+                "   }," +
+                "   \"prompt\":\"This is the survey info\"," +
+                "   \"rules\":[{\"operator\":\"always\",\"endSurvey\":true}],"+
+                "   \"promptDetail\":\"More info\"," +
+                "   \"title\":\"Survey Info\"," +
+                "   \"type\":\"SurveyInfoScreen\"" +
                 "}";
 
         // convert to POJO
@@ -89,6 +105,8 @@ public class SurveyElementTest {
         assertNull(infoScreen.getSurveyCompoundKey());
         assertEquals("Survey Info", infoScreen.getTitle());
         assertEquals("SurveyInfoScreen", infoScreen.getType());
+        SurveyRule rule = new SurveyRule.Builder().withEndSurvey(true).withOperator(Operator.ALWAYS).build();
+        assertEquals(rule, infoScreen.getRules().get(0));
 
         assertEquals("http://www.example.com/test.png", infoScreen.getImage().getSource());
         assertEquals(200, infoScreen.getImage().getWidth());
@@ -99,7 +117,7 @@ public class SurveyElementTest {
 
         // then convert to a map so we can validate the raw JSON
         Map<String, Object> jsonMap = BridgeObjectMapper.get().readValue(convertedJson, JsonUtils.TYPE_REF_RAW_MAP);
-        assertEquals(7, jsonMap.size());
+        assertEquals(8, jsonMap.size());
         assertEquals("test-guid", jsonMap.get("guid"));
         assertEquals("test-survey-info-screen", jsonMap.get("identifier"));
         assertEquals("This is the survey info", jsonMap.get("prompt"));

--- a/test/org/sagebionetworks/bridge/models/surveys/SurveyRuleTest.java
+++ b/test/org/sagebionetworks/bridge/models/surveys/SurveyRuleTest.java
@@ -63,4 +63,19 @@ public class SurveyRuleTest {
         SurveyRule deser = BridgeObjectMapper.get().treeToValue(node, SurveyRule.class);
         assertEquals(endRule, deser);
     }
+    
+    @Test
+    public void canSerializeAlwaysRule() throws Exception {
+        SurveyRule alwaysRule = new SurveyRule.Builder().withOperator(Operator.ALWAYS).withEndSurvey(true).build();
+        
+        JsonNode node = BridgeObjectMapper.get().valueToTree(alwaysRule);
+        assertEquals("always", node.get("operator").asText());
+        assertNull(node.get("value"));
+        assertNull(node.get("skipTo"));
+        assertTrue(node.get("endSurvey").asBoolean());
+        assertEquals("SurveyRule", node.get("type").asText());
+        
+        SurveyRule deser = BridgeObjectMapper.get().treeToValue(node, SurveyRule.class);
+        assertEquals(alwaysRule, deser);
+    }    
 }

--- a/test/org/sagebionetworks/bridge/validators/SurveySaveValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/SurveySaveValidatorTest.java
@@ -461,8 +461,8 @@ public class SurveySaveValidatorTest {
         question.setUiHint(UIHint.TEXTFIELD);
         question.setPrompt("Prompt");
         question.setConstraints(constraints);
-        question.getRules().add(
-                new SurveyRule.Builder().withOperator(Operator.EQ).withValue("No").withSkipToTarget("theend").build());
+        question.setRules(Lists.newArrayList(
+                new SurveyRule.Builder().withOperator(Operator.EQ).withValue("No").withSkipToTarget("theend").build()));
 
         SurveyInfoScreen info = new DynamoSurveyInfoScreen();
         info.setTitle("Title");
@@ -496,7 +496,7 @@ public class SurveySaveValidatorTest {
         question.setUiHint(UIHint.TEXTFIELD);
         question.setPrompt("Prompt");
         question.setConstraints(constraints);
-        question.getRules().add(rule);
+        question.setRules(Lists.newArrayList(rule));
         
         survey.getElements().add(question);
 
@@ -529,7 +529,7 @@ public class SurveySaveValidatorTest {
         question.setUiHint(UIHint.TEXTFIELD);
         question.setPrompt("Prompt");
         question.setConstraints(constraints);
-        question.getRules().add(rule);
+        question.setRules(Lists.newArrayList(rule));
         
         survey.getElements().add(question);
 
@@ -876,8 +876,8 @@ public class SurveySaveValidatorTest {
         info.setPromptDetail("prompt detail");
         info.setIdentifier("identifier");
         info.setGuid("guid");
-        info.getRules()
-                .add(new SurveyRule.Builder().withValue("foo").withOperator(Operator.EQ).withEndSurvey(true).build());
+        info.setRules(Lists.newArrayList(
+                new SurveyRule.Builder().withValue("foo").withOperator(Operator.EQ).withEndSurvey(true).build()));
         survey.setElements(Lists.newArrayList(info));
         
         assertValidatorMessage(validator, survey, "elements[0].rules[0]",


### PR DESCRIPTION
- rules moved from constraints to element, both questions and information screens, in a backwards compatible manner
- adjusted survey validation appropriately (only some rules applicable to info screens).
- added the "always" operator. Always do this rule... doesn't matter what the answer to the question, or if there's any answer at all (even declined);