### PR TITLE
Add data group rule

### DIFF
--- a/app/org/sagebionetworks/bridge/models/surveys/SurveyRule.java
+++ b/app/org/sagebionetworks/bridge/models/surveys/SurveyRule.java
@@ -6,6 +6,20 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
+/**
+ * <p>
+ * Survey rules allow some logic to be embedded in a survey. The value of a rule is compared (in the manner indicated by
+ * the operator) to the user's answer to a question after the user has given an answer, and an action is taken. This can
+ * include declining to answer the question ("de" operator) or always doing the given action ("always operator).
+ * </p>
+ * 
+ * <p>
+ * The rules in a survey come in two categories: <em>navigation rules</em> (skipTo, endSurvey) immediately end the
+ * evaluation of rules in favor of navigating to a new context; while <em>state rules</em> (assignDataGroup) change the
+ * state of the participant, but rules should continue to be evaluated.
+ * </p>
+ * 
+ */
 @JsonDeserialize(builder=SurveyRule.Builder.class)
 public final class SurveyRule {
 
@@ -24,12 +38,15 @@ public final class SurveyRule {
     private final Object value;
     private final String skipToTarget;
     private final Boolean endSurvey;
+    private final String assignDataGroup;
     
-    private SurveyRule(Operator operator, Object value, String skipToTarget, Boolean endSurvey) {
+    private SurveyRule(Operator operator, Object value, String skipToTarget, Boolean endSurvey,
+            String assignDataGroup) {
         this.operator = operator;
         this.value = value;
         this.skipToTarget = skipToTarget;
         this.endSurvey = endSurvey;
+        this.assignDataGroup = assignDataGroup;
     }
     public Operator getOperator() {
         return operator;
@@ -38,17 +55,36 @@ public final class SurveyRule {
     public Object getValue() {
         return value;
     }
+    /**
+     * If the rule condition is true, advanced to the question or information screen indicated by the 
+     * identifier. Do not evaluate further rules in the list of rules. The identifier must be later 
+     * in the list of survey questions (you cannot backtrack). If the rule is false, continue 
+     * evaluating rules or continue with the next question it the study.
+     */
     @JsonProperty("skipTo")
     public String getSkipToTarget() {
         return skipToTarget;
     }
+    /**
+     * If the rule condition is true, stop evaluating rules and end the survey immediately. Existing 
+     * survey answers should be sent to the survey. If the rule is false, continue evaluating rules or 
+     * continue with the next question it the study.
+     */
     public Boolean getEndSurvey() {
         return endSurvey;
+    }
+    /**
+     * If the rule condition is true, add this data group to the participant's data groups. Otherwise, 
+     * remove this data group from the participant's data groups. Continue evaluating the rules after 
+     * this rule (do not end evaluation, this is not a navigation rule).
+     */
+    public String getAssignDataGroup() {
+        return assignDataGroup;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(operator, value, skipToTarget, endSurvey);
+        return Objects.hash(operator, value, skipToTarget, endSurvey, assignDataGroup);
     }
 
     @Override
@@ -61,13 +97,14 @@ public final class SurveyRule {
         return Objects.equals(skipToTarget, other.skipToTarget) &&
                Objects.equals(operator, other.operator) &&
                Objects.equals(value, other.value) &&
-               Objects.equals(endSurvey, other.endSurvey);
+               Objects.equals(endSurvey, other.endSurvey) &&
+               Objects.equals(assignDataGroup, other.assignDataGroup);
     }
 
     @Override
     public String toString() {
         return "SurveyRule [operator=" + operator + ", value=" + value + ", skipToTarget=" + skipToTarget
-                + ", endSurvey=" + endSurvey + "]";
+                + ", endSurvey=" + endSurvey + ", assignDataGroup=" + assignDataGroup + "]";
     }
 
     public static class Builder {
@@ -75,6 +112,7 @@ public final class SurveyRule {
         private Object value;
         private String skipToTarget;
         private Boolean endSurvey;
+        private String assignDataGroup;
 
         public Builder withOperator(SurveyRule.Operator operator) {
             this.operator = operator;
@@ -95,8 +133,12 @@ public final class SurveyRule {
             }
             return this;
         }
+        public Builder withAssignDataGroup(String dataGroup) {
+            this.assignDataGroup = dataGroup;
+            return this;
+        }
         public SurveyRule build() {
-            return new SurveyRule(operator, value, skipToTarget, endSurvey);
+            return new SurveyRule(operator, value, skipToTarget, endSurvey, assignDataGroup);
         }
     }
     

--- a/app/org/sagebionetworks/bridge/services/StudyService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyService.java
@@ -549,8 +549,8 @@ public class StudyService {
             }
         }
         
-        // Check all versions of all surveys (that aren't deleted) and throws a constraint violation if any contain a rule, 
-        // referencing a data group, that has been removed from the study.
+        // Check all versions of all surveys (that aren't deleted) and throw a constraint violation if any survey 
+        // contains a rule, that references a data group, that has been removed from the study.
         List<Survey> allSurveys = surveyService.getAllSurveysMostRecentVersion(study.getStudyIdentifier());
         for (Survey oneSurvey : allSurveys) {
             List<Survey> allVersionsOfSurvey = surveyService.getSurveyAllVersions(study.getStudyIdentifier(), oneSurvey.getGuid());

--- a/test/org/sagebionetworks/bridge/models/surveys/SurveyRuleTest.java
+++ b/test/org/sagebionetworks/bridge/models/surveys/SurveyRuleTest.java
@@ -77,5 +77,21 @@ public class SurveyRuleTest {
         
         SurveyRule deser = BridgeObjectMapper.get().treeToValue(node, SurveyRule.class);
         assertEquals(alwaysRule, deser);
-    }    
+    }
+    
+    @Test
+    public void canSerializeAssignDataGroupRule() throws Exception {
+        SurveyRule dataGroupRule = new SurveyRule.Builder().withValue("foo").withOperator(Operator.EQ)
+                .withAssignDataGroup("bar").build();
+        
+        JsonNode node = BridgeObjectMapper.get().valueToTree(dataGroupRule);
+        assertEquals("eq", node.get("operator").asText());
+        assertEquals("foo", node.get("value").asText());
+        assertNull(node.get("skipTo"));
+        assertEquals("bar", node.get("assignDataGroup").asText());
+        assertEquals("SurveyRule", node.get("type").asText());
+        
+        SurveyRule deser = BridgeObjectMapper.get().treeToValue(node, SurveyRule.class);
+        assertEquals(dataGroupRule, deser);
+    }
 }

--- a/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
@@ -35,7 +35,6 @@ import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.cache.ViewCache;
-import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
 import org.sagebionetworks.bridge.dynamodb.DynamoSurvey;
 import org.sagebionetworks.bridge.exceptions.ConsentRequiredException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
@@ -47,6 +46,7 @@ import org.sagebionetworks.bridge.models.ResourceList;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
+import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
@@ -132,7 +132,7 @@ public class SurveyControllerTest {
         viewCache.setCacheProvider(provider);
         
         studyService = mock(StudyService.class);
-        DynamoStudy study = new DynamoStudy();
+        Study study = Study.create();
         doReturn(study).when(studyService).getStudy(any(StudyIdentifier.class));
         
         controller = spy(new SurveyController());

--- a/test/org/sagebionetworks/bridge/validators/SurveySaveValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/SurveySaveValidatorTest.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge.validators;
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
 
 import java.util.List;
+import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
 import org.joda.time.DateTime;
@@ -35,9 +36,12 @@ import org.sagebionetworks.bridge.models.surveys.UIHint;
 import org.sagebionetworks.bridge.upload.UploadUtil;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 @SuppressWarnings({ "rawtypes", "unchecked" })
 public class SurveySaveValidatorTest {
+    
+    private static final Set<String> STUDY_DATA_GROUPS = Sets.newHashSet("foo", "baz");
 
     private Survey survey;
 
@@ -45,10 +49,11 @@ public class SurveySaveValidatorTest {
 
     @Before
     public void before() {
+        
         survey = new TestSurvey(SurveySaveValidatorTest.class, true);
         // because this is set by the service before validation
         survey.setGuid("AAA");
-        validator = new SurveySaveValidator();
+        validator = new SurveySaveValidator(STUDY_DATA_GROUPS);
     }
 
     private SurveyInfoScreen createSurveyInfoScreen() {
@@ -405,7 +410,7 @@ public class SurveySaveValidatorTest {
         survey.getElements().add(info);
 
         assertValidatorMessage(validator, survey, "elements[0].constraints.rules[0]",
-                "cannot have a skipTo target and an endSurvey property");
+                "must have one and only one action: skipTo, endSurvey, or assignDataGroup");
     }
 
     @Test
@@ -431,7 +436,7 @@ public class SurveySaveValidatorTest {
         survey.getElements().add(question);
 
         assertValidatorMessage(validator, survey, "elements[0].constraints.rules[0]",
-                "must have a skipTo target or an endSurvey property");
+                "must have one and only one action: skipTo, endSurvey, or assignDataGroup");
     }
 
     @Test
@@ -507,7 +512,7 @@ public class SurveySaveValidatorTest {
         survey.getElements().add(info);
 
         assertValidatorMessage(validator, survey, "elements[0].rules[0]",
-                "cannot have a skipTo target and an endSurvey property");
+                "must have one and only one action: skipTo, endSurvey, or assignDataGroup");
     }
 
     @Test
@@ -534,7 +539,7 @@ public class SurveySaveValidatorTest {
         survey.getElements().add(question);
 
         assertValidatorMessage(validator, survey, "elements[0].rules[0]",
-                "must have a skipTo target or an endSurvey property");
+                "must have one and only one action: skipTo, endSurvey, or assignDataGroup");
     }
 
     @Test
@@ -882,5 +887,39 @@ public class SurveySaveValidatorTest {
         
         assertValidatorMessage(validator, survey, "elements[0].rules[0]",
                 "only valid with the 'always' operator");
+    }
+    
+    @Test
+    public void validatesAssignDataGroupMustAppearAlone() {
+        survey = new TestSurvey(SurveySaveValidatorTest.class, false);
+
+        // The integer question is after the high_bp question. Create a rule that would backgtrack, verify it
+        // doesn't validate.
+        SurveyQuestion question = ((TestSurvey) survey).getIntegerQuestion();
+        
+        String targetId = ((TestSurvey) survey).getStringQuestion().getIdentifier();
+
+        SurveyRule rule = new SurveyRule.Builder().withOperator(SurveyRule.Operator.EQ).withValue(1)
+                .withSkipToTarget(targetId).withAssignDataGroup("dataGroup").build();
+        question.setRules(Lists.newArrayList(rule));
+
+        assertValidatorMessage(validator, survey, "elements[4].rules[0]",
+                "must have one and only one action: skipTo, endSurvey, or assignDataGroup");
+    }
+    
+    @Test
+    public void validateAssignDataGroupAssignsRealDataGroup() {
+        survey = new TestSurvey(SurveySaveValidatorTest.class, false);
+
+        // The integer question is after the high_bp question. Create a rule that would backgtrack, verify it
+        // doesn't validate.
+        SurveyQuestion question = ((TestSurvey) survey).getIntegerQuestion();
+        
+        SurveyRule rule = new SurveyRule.Builder().withOperator(SurveyRule.Operator.EQ).withValue(1)
+                .withAssignDataGroup("bar").build();
+        question.setRules(Lists.newArrayList(rule));
+
+        assertValidatorMessage(validator, survey, "elements[4].rules[0]",
+                "has a data group 'bar' that is not a valid data group: baz, foo");
     }
 }

--- a/test/org/sagebionetworks/bridge/validators/SurveySaveValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/SurveySaveValidatorTest.java
@@ -893,8 +893,6 @@ public class SurveySaveValidatorTest {
     public void validatesAssignDataGroupMustAppearAlone() {
         survey = new TestSurvey(SurveySaveValidatorTest.class, false);
 
-        // The integer question is after the high_bp question. Create a rule that would backgtrack, verify it
-        // doesn't validate.
         SurveyQuestion question = ((TestSurvey) survey).getIntegerQuestion();
         
         String targetId = ((TestSurvey) survey).getStringQuestion().getIdentifier();
@@ -911,8 +909,6 @@ public class SurveySaveValidatorTest {
     public void validateAssignDataGroupAssignsRealDataGroup() {
         survey = new TestSurvey(SurveySaveValidatorTest.class, false);
 
-        // The integer question is after the high_bp question. Create a rule that would backgtrack, verify it
-        // doesn't validate.
         SurveyQuestion question = ((TestSurvey) survey).getIntegerQuestion();
         
         SurveyRule rule = new SurveyRule.Builder().withOperator(SurveyRule.Operator.EQ).withValue(1)


### PR DESCRIPTION
This builds on the prior PR to add an "ALWAYS" operator to survey rules. That PR should be merged first. This rule specifies a condition under which a user should be tagged with a data group.