### PR TITLE
Retrieving the full survey which contains the elements we need to examine for constraint violations.

### DIFF
--- a/app/org/sagebionetworks/bridge/services/StudyService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyService.java
@@ -555,7 +555,8 @@ public class StudyService {
         for (Survey oneSurvey : allSurveys) {
             List<Survey> allVersionsOfSurvey = surveyService.getSurveyAllVersions(study.getStudyIdentifier(), oneSurvey.getGuid());
             for (Survey oneSurveyVersion : allVersionsOfSurvey) {
-                for (SurveyElement element : oneSurveyVersion.getElements()) {
+                Survey fullSurvey = surveyService.getSurvey(oneSurveyVersion);
+                for (SurveyElement element : fullSurvey.getElements()) {
                     if (element.getRules() != null) {
                         for (SurveyRule rule : element.getRules()) {
                             if (rule.getAssignDataGroup() != null && !dataGroups.contains(rule.getAssignDataGroup())) {

--- a/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
@@ -314,17 +314,23 @@ public class StudyServiceMockTest {
         study.getDataGroups().remove(dataGroup);
         
         DateTime createdOn = DateTime.now();
+
+        Survey partialSurvey = new TestSurvey(StudyServiceMockTest.class, false);
+        partialSurvey.setGuid("AAA-BBB-CCC");
+        partialSurvey.setCreatedOn(createdOn.getMillis());
+        partialSurvey.setElements(ImmutableList.of());
         
-        Survey survey = new TestSurvey(StudyServiceMockTest.class, false);
-        survey.setGuid("AAA-BBB-CCC");
-        survey.setCreatedOn(createdOn.getMillis());
-        survey.getElements().get(0).setRules(Lists.newArrayList(
+        Survey fullSurvey = new TestSurvey(StudyServiceMockTest.class, false);
+        fullSurvey.setGuid("AAA-BBB-CCC");
+        fullSurvey.setCreatedOn(createdOn.getMillis());
+        fullSurvey.getElements().get(0).setRules(Lists.newArrayList(
                 new SurveyRule.Builder().withAssignDataGroup(dataGroup).withOperator(Operator.ALWAYS).build()));
         
-        List<Survey> surveyList = Lists.newArrayList(survey);
+        List<Survey> surveyList = Lists.newArrayList(partialSurvey);
 
         when(surveyService.getAllSurveysMostRecentVersion(study.getStudyIdentifier())).thenReturn(surveyList);
-        when(surveyService.getSurveyAllVersions(study.getStudyIdentifier(), survey.getGuid())).thenReturn(surveyList);
+        when(surveyService.getSurveyAllVersions(study.getStudyIdentifier(), fullSurvey.getGuid())).thenReturn(surveyList);
+        when(surveyService.getSurvey(partialSurvey)).thenReturn(fullSurvey);
         
         try {
             service.updateStudy(study, true);


### PR DESCRIPTION
The list calls only return the survey object without the list of elements, which doesn't fail, but also never prevents data groups that are in use from being removed.