### PR TITLE
BridgePF EC2 system metrics on new relic

### DIFF
--- a/dist/.ebextensions/newrelic-server.config
+++ b/dist/.ebextensions/newrelic-server.config
@@ -1,0 +1,12 @@
+packages:
+  yum:
+    newrelic-sysmond: []
+  rpm:
+    newrelic: http://yum.newrelic.com/pub/newrelic/el5/x86_64/newrelic-repo-5-3.noarch.rpm
+container_commands:
+  "01SetLicenseKey":
+    command: "nrsysmond-config --set license_key=$NEW_RELIC_LICENSE_KEY"
+  "02SetInstanceId":
+    command: "export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo hostname=$INSTANCE_ID && echo hostname=$INSTANCE_ID >> /etc/newrelic/nrsysmond.cfg"
+  "03StartMonitor":
+    command: "/etc/init.d/newrelic-sysmond start"


### PR DESCRIPTION
Use new relic insructions[1] to make BridgePF EC2 instances
report system metrics to our new relic service. The default
dashboard[2] contains CPU usage, load average, memory, network
and disk io metrics.

[1]
https://docs.newrelic.com/docs/servers/new-relic-servers-linux/installation-configuration/install-aws-elastic-beanstalk-new-relic-servers
[2] http://imgur.com/a/RjkwO