### PR TITLE
Data group rules

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
@@ -208,11 +208,11 @@ public class DynamoSurveyDao implements SurveyDao {
             // that point they will either not be copied on top of element rules which exist, or both 
             // element and constraint rules will be empty, so it makes no difference.
             Constraints con = question.getConstraints();
-            if (BridgeUtils.isEmpty(question.getRules())) {
-                question.setRules( con.getRules() );
+            if (BridgeUtils.isEmpty(question.getAfterRules())) {
+                question.setAfterRules( con.getRules() );
             }
             // question rules take precedence once they exist.
-            con.setRules(question.getRules());
+            con.setRules(question.getAfterRules());
         }
     }
 

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyElement.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyElement.java
@@ -27,7 +27,8 @@ public class DynamoSurveyElement implements SurveyElement {
     private String type;
     private int order;
     private JsonNode data;
-    private List<SurveyRule> rules;
+    private List<SurveyRule> beforeRules;
+    private List<SurveyRule> afterRules;
 
     public DynamoSurveyElement() {
     }
@@ -93,15 +94,23 @@ public class DynamoSurveyElement implements SurveyElement {
      */
     @DynamoDBTypeConverted(converter = SurveyRuleListMarshaller.class)
     @DynamoDBAttribute
-    public List<SurveyRule> getRules() {
-        return (this.rules == null) ? null : ImmutableList.copyOf(this.rules);
+    public List<SurveyRule> getAfterRules() {
+        return (this.afterRules == null) ? null : ImmutableList.copyOf(this.afterRules);
     }
-    public void setRules(List<SurveyRule> rules) {
-        this.rules = rules;
+    public void setAfterRules(List<SurveyRule> afterRules) {
+        this.afterRules = afterRules;
+    }
+    @DynamoDBTypeConverted(converter = SurveyRuleListMarshaller.class)
+    @DynamoDBAttribute
+    public List<SurveyRule> getBeforeRules() {
+        return (this.beforeRules == null) ? null : ImmutableList.copyOf(this.beforeRules);
+    }
+    public void setBeforeRules(List<SurveyRule> beforeRules) {
+        this.beforeRules = beforeRules;
     }
     @Override
     public int hashCode() {
-        return Objects.hash(guid, identifier, order, surveyCompoundKey, type, rules);
+        return Objects.hash(guid, identifier, order, surveyCompoundKey, type, beforeRules, afterRules);
     }
 
     @Override
@@ -116,7 +125,8 @@ public class DynamoSurveyElement implements SurveyElement {
                 Objects.equals(order, this.order) &&
                 Objects.equals(surveyCompoundKey, this.surveyCompoundKey) &&
                 Objects.equals(type, other.type) &&
-                Objects.equals(rules, other.rules);
+                Objects.equals(afterRules, other.afterRules) &&
+                Objects.equals(beforeRules, other.beforeRules);
     }
     
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyElement.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyElement.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.bridge.dynamodb;
 
 import java.util.List;
-import java.util.Objects;
 
 import org.sagebionetworks.bridge.models.surveys.SurveyElement;
 import org.sagebionetworks.bridge.models.surveys.SurveyElementConstants;
@@ -108,25 +107,4 @@ public class DynamoSurveyElement implements SurveyElement {
     public void setBeforeRules(List<SurveyRule> beforeRules) {
         this.beforeRules = beforeRules;
     }
-    @Override
-    public int hashCode() {
-        return Objects.hash(guid, identifier, order, surveyCompoundKey, type, beforeRules, afterRules);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null || getClass() != obj.getClass())
-            return false;
-        DynamoSurveyElement other = (DynamoSurveyElement) obj;
-        return Objects.equals(guid, other.guid) &&
-                Objects.equals(identifier, other.identifier) &&
-                Objects.equals(order, this.order) &&
-                Objects.equals(surveyCompoundKey, this.surveyCompoundKey) &&
-                Objects.equals(type, other.type) &&
-                Objects.equals(afterRules, other.afterRules) &&
-                Objects.equals(beforeRules, other.beforeRules);
-    }
-    
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyInfoScreen.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyInfoScreen.java
@@ -29,6 +29,7 @@ public class DynamoSurveyInfoScreen extends DynamoSurveyElement implements Surve
         setIdentifier(entry.getIdentifier());
         setGuid(entry.getGuid());
         setData(entry.getData());
+        setBeforeRules(entry.getBeforeRules());
         setAfterRules(entry.getAfterRules());
     }
 

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyInfoScreen.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyInfoScreen.java
@@ -29,7 +29,7 @@ public class DynamoSurveyInfoScreen extends DynamoSurveyElement implements Surve
         setIdentifier(entry.getIdentifier());
         setGuid(entry.getGuid());
         setData(entry.getData());
-        setRules(entry.getRules());
+        setAfterRules(entry.getAfterRules());
     }
 
     @Override

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyInfoScreen.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyInfoScreen.java
@@ -25,6 +25,7 @@ public class DynamoSurveyInfoScreen extends DynamoSurveyElement implements Surve
     }
     
     public DynamoSurveyInfoScreen(SurveyElement entry) {
+        setSurveyCompoundKey(entry.getSurveyCompoundKey());
         setType(entry.getType());
         setIdentifier(entry.getIdentifier());
         setGuid(entry.getGuid());
@@ -97,48 +98,4 @@ public class DynamoSurveyInfoScreen extends DynamoSurveyElement implements Surve
         this.title = JsonUtils.asText(data, TITLE_PROPERTY);
         this.image = JsonUtils.asEntity(data, IMAGE_PROPERTY, Image.class);
     }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + ((prompt == null) ? 0 : prompt.hashCode());
-        result = prime * result + ((promptDetail == null) ? 0 : promptDetail.hashCode());
-        result = prime * result + ((title == null) ? 0 : title.hashCode());
-        result = prime * result + ((image == null) ? 0 : image.hashCode());
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (!super.equals(obj))
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        DynamoSurveyInfoScreen other = (DynamoSurveyInfoScreen) obj;
-        if (prompt == null) {
-            if (other.prompt != null)
-                return false;
-        } else if (!prompt.equals(other.prompt))
-            return false;
-        if (promptDetail == null) {
-            if (other.promptDetail != null)
-                return false;
-        } else if (!promptDetail.equals(other.promptDetail))
-            return false;
-        if (title == null) {
-            if (other.title != null)
-                return false;
-        } else if (!title.equals(other.title))
-            return false;
-        if (image == null) {
-            if (other.image != null)
-                return false;
-        } else if (!image.equals(other.image))
-            return false;
-        return true;
-    }
-
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyQuestion.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyQuestion.java
@@ -30,11 +30,12 @@ public class DynamoSurveyQuestion extends DynamoSurveyElement implements SurveyQ
     }
     
     public DynamoSurveyQuestion(SurveyElement entry) {
-        setType( entry.getType() );
-        setIdentifier( entry.getIdentifier() );
-        setGuid( entry.getGuid() );
-        setData( entry.getData() );
-        setAfterRules( entry.getAfterRules() );
+        setType(entry.getType());
+        setIdentifier(entry.getIdentifier());
+        setGuid(entry.getGuid());
+        setData(entry.getData());
+        setBeforeRules(entry.getBeforeRules());
+        setAfterRules(entry.getAfterRules());
     }
     
     @Override

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyQuestion.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyQuestion.java
@@ -34,7 +34,7 @@ public class DynamoSurveyQuestion extends DynamoSurveyElement implements SurveyQ
         setIdentifier( entry.getIdentifier() );
         setGuid( entry.getGuid() );
         setData( entry.getData() );
-        setRules( entry.getRules() );
+        setAfterRules( entry.getAfterRules() );
     }
     
     @Override

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyQuestion.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyQuestion.java
@@ -1,12 +1,13 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import java.util.Objects;
+import java.util.List;
 
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.json.JsonUtils;
 import org.sagebionetworks.bridge.models.surveys.Constraints;
 import org.sagebionetworks.bridge.models.surveys.SurveyElement;
 import org.sagebionetworks.bridge.models.surveys.SurveyQuestion;
+import org.sagebionetworks.bridge.models.surveys.SurveyRule;
 import org.sagebionetworks.bridge.models.surveys.UIHint;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
@@ -30,6 +31,7 @@ public class DynamoSurveyQuestion extends DynamoSurveyElement implements SurveyQ
     }
     
     public DynamoSurveyQuestion(SurveyElement entry) {
+        setSurveyCompoundKey(entry.getSurveyCompoundKey());
         setType(entry.getType());
         setIdentifier(entry.getIdentifier());
         setGuid(entry.getGuid());
@@ -117,34 +119,9 @@ public class DynamoSurveyQuestion extends DynamoSurveyElement implements SurveyQ
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + Objects.hashCode(constraints);
-        result = prime * result + Objects.hashCode(hint);
-        result = prime * result + Objects.hashCode(prompt);
-        result = prime * result + Objects.hashCode(promptDetail);
-        result = prime * result + Objects.hashCode(fireEvent);
-        return result;
-    }
-    
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        } else if (obj == null || getClass() != obj.getClass()) {
-            return false;
-        }
-        final DynamoSurveyQuestion that = (DynamoSurveyQuestion) obj;
-        return Objects.equals(constraints, that.constraints) && Objects.equals(hint, that.hint)
-            && Objects.equals(prompt, that.prompt) && Objects.equals(fireEvent, that.fireEvent)
-            && Objects.equals(promptDetail, that.promptDetail);
-    }
-
-    @Override
     public String toString() {
-        return String.format("DynamoSurveyQuestion [hint=%s, prompt=%s, promptDetail=%s, fireEvent=%s, constraints=%s]", 
-            hint, prompt, promptDetail, fireEvent, constraints);
+        return String.format("DynamoSurveyQuestion [surveyCompoundKey=%s, guid=%s, identifier=%s, type=%s, order=%s, beforeRules=%s, afterRules=%s, hint=%s, prompt=%s, promptDetail=%s, fireEvent=%s, constraints=%s]", 
+            getSurveyCompoundKey(), getGuid(), getIdentifier(), getType(), getOrder(), getBeforeRules(), getAfterRules(), hint, prompt, promptDetail, fireEvent, constraints);
     }
 
 }

--- a/app/org/sagebionetworks/bridge/models/surveys/SurveyElement.java
+++ b/app/org/sagebionetworks/bridge/models/surveys/SurveyElement.java
@@ -17,7 +17,8 @@ public interface SurveyElement {
     public static final String IMAGE_PROPERTY = "image";
     public static final String PROMPT_DETAIL_PROPERTY = "promptDetail";
     public static final String PROMPT_PROPERTY = "prompt";
-    public static final String RULES_PROPERTY = "rules";
+    public static final String BEFORE_RULES_PROPERTY = "beforeRules";
+    public static final String AFTER_RULES_PROPERTY = "afterRules";
     public static final String TITLE_PROPERTY = "title";
     public static final String TYPE_PROPERTY = "type";    
     public static final String UI_HINTS_PROPERTY = "uiHint";
@@ -42,8 +43,11 @@ public interface SurveyElement {
     JsonNode getData();
     void setData(JsonNode data);
     
-    List<SurveyRule> getRules();
-    void setRules(List<SurveyRule> rules);
+    List<SurveyRule> getBeforeRules();
+    void setBeforeRules(List<SurveyRule> beforeRules);
+    
+    List<SurveyRule> getAfterRules();
+    void setAfterRules(List<SurveyRule> afterRules);
     
 }
 

--- a/app/org/sagebionetworks/bridge/models/surveys/SurveyElement.java
+++ b/app/org/sagebionetworks/bridge/models/surveys/SurveyElement.java
@@ -10,18 +10,18 @@ import org.sagebionetworks.bridge.json.JsonNodeToSurveyElementConverter;
 @JsonDeserialize(converter = JsonNodeToSurveyElementConverter.class)
 public interface SurveyElement {
 
-    public static final String CONSTRAINTS_PROPERTY = "constraints";
-    public static final String FIRE_EVENT_PROPERTY = "fireEvent";
-    public static final String GUID_PROPERTY = "guid";
-    public static final String IDENTIFIER_PROPERTY = "identifier";
-    public static final String IMAGE_PROPERTY = "image";
-    public static final String PROMPT_DETAIL_PROPERTY = "promptDetail";
-    public static final String PROMPT_PROPERTY = "prompt";
-    public static final String BEFORE_RULES_PROPERTY = "beforeRules";
-    public static final String AFTER_RULES_PROPERTY = "afterRules";
-    public static final String TITLE_PROPERTY = "title";
-    public static final String TYPE_PROPERTY = "type";    
-    public static final String UI_HINTS_PROPERTY = "uiHint";
+    String CONSTRAINTS_PROPERTY = "constraints";
+    String FIRE_EVENT_PROPERTY = "fireEvent";
+    String GUID_PROPERTY = "guid";
+    String IDENTIFIER_PROPERTY = "identifier";
+    String IMAGE_PROPERTY = "image";
+    String PROMPT_DETAIL_PROPERTY = "promptDetail";
+    String PROMPT_PROPERTY = "prompt";
+    String BEFORE_RULES_PROPERTY = "beforeRules";
+    String AFTER_RULES_PROPERTY = "afterRules";
+    String TITLE_PROPERTY = "title";
+    String TYPE_PROPERTY = "type";    
+    String UI_HINTS_PROPERTY = "uiHint";
     
     String getSurveyCompoundKey();
     void setSurveyCompoundKey(String surveyCompoundKey);

--- a/app/org/sagebionetworks/bridge/models/surveys/SurveyInfoScreen.java
+++ b/app/org/sagebionetworks/bridge/models/surveys/SurveyInfoScreen.java
@@ -24,7 +24,8 @@ public interface SurveyInfoScreen extends SurveyElement {
         question.setPromptDetail(JsonUtils.asText(node, PROMPT_DETAIL_PROPERTY));
         question.setTitle(JsonUtils.asText(node, TITLE_PROPERTY));
         question.setImage(JsonUtils.asEntity(node, IMAGE_PROPERTY, Image.class));
-        question.setRules(JsonUtils.asEntityList(node, RULES_PROPERTY, SurveyRule.class));
+        question.setBeforeRules(JsonUtils.asEntityList(node, BEFORE_RULES_PROPERTY, SurveyRule.class));
+        question.setAfterRules(JsonUtils.asEntityList(node, AFTER_RULES_PROPERTY, SurveyRule.class));
         return question;
     }
     

--- a/app/org/sagebionetworks/bridge/models/surveys/SurveyQuestion.java
+++ b/app/org/sagebionetworks/bridge/models/surveys/SurveyQuestion.java
@@ -24,7 +24,8 @@ public interface SurveyQuestion extends SurveyElement {
         question.setPromptDetail(JsonUtils.asText(node, PROMPT_DETAIL_PROPERTY));
         question.setFireEvent(JsonUtils.asBoolean(node, FIRE_EVENT_PROPERTY));
         question.setUiHint(JsonUtils.asEntity(node, UI_HINTS_PROPERTY, UIHint.class));
-        question.setRules(JsonUtils.asEntityList(node, RULES_PROPERTY, SurveyRule.class));
+        question.setBeforeRules(JsonUtils.asEntityList(node, BEFORE_RULES_PROPERTY, SurveyRule.class));
+        question.setAfterRules(JsonUtils.asEntityList(node, AFTER_RULES_PROPERTY, SurveyRule.class));
         question.setConstraints(JsonUtils.asConstraints(node, CONSTRAINTS_PROPERTY));
         return question;
     }

--- a/app/org/sagebionetworks/bridge/models/surveys/SurveyRule.java
+++ b/app/org/sagebionetworks/bridge/models/surveys/SurveyRule.java
@@ -171,21 +171,15 @@ public final class SurveyRule {
             return this;
         }
         public Builder withEndSurvey(Boolean endSurvey) {
-            if (Boolean.TRUE.equals(endSurvey)) {
-                this.endSurvey = endSurvey;    
-            }
+            this.endSurvey = (Boolean.TRUE.equals(endSurvey)) ? Boolean.TRUE : null;
             return this;
         }
         public Builder withDisplayIf(Boolean displayIf) {
-            if (Boolean.TRUE.equals(displayIf)) {
-                this.displayIf = displayIf;
-            }
+            this.displayIf = (Boolean.TRUE.equals(displayIf)) ? Boolean.TRUE : null;
             return this;
         }
         public Builder withDisplayUnless(Boolean displayUnless) {
-            if (Boolean.TRUE.equals(displayUnless)) {
-                this.displayUnless = displayUnless;
-            }
+            this.displayUnless = (Boolean.TRUE.equals(displayUnless)) ? Boolean.TRUE : null;
             return this;
         }
         public Builder withAssignDataGroup(String dataGroup) {

--- a/app/org/sagebionetworks/bridge/models/surveys/SurveyRule.java
+++ b/app/org/sagebionetworks/bridge/models/surveys/SurveyRule.java
@@ -1,6 +1,8 @@
 package org.sagebionetworks.bridge.models.surveys;
 
+import java.util.EnumSet;
 import java.util.Objects;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -31,22 +33,34 @@ public final class SurveyRule {
         LE,    // less than or equal to
         GE,    // greater than or equal to
         DE,    // declined to answer
-        ALWAYS // always apply this rule
+        ALWAYS,// always apply this rule
+        ANY,   // at least one is contained in set
+        ALL    // all are contained in set
     }
+    
+    public static final EnumSet<SurveyRule.Operator> SET_OPERATORS = EnumSet.of(Operator.ANY, Operator.ALL);
+    
+    public static final EnumSet<SurveyRule.Operator> NULL_VALUE_OPERATORS = EnumSet.of(Operator.DE, Operator.ALWAYS);
     
     private final Operator operator;
     private final Object value;
     private final String skipToTarget;
     private final Boolean endSurvey;
+    private final Boolean displayIf;
+    private final Boolean displayUnless;
     private final String assignDataGroup;
+    private final Set<String> dataGroups;
     
     private SurveyRule(Operator operator, Object value, String skipToTarget, Boolean endSurvey,
-            String assignDataGroup) {
+            String assignDataGroup, Set<String> dataGroups, Boolean displayIf, Boolean displayUnless) {
         this.operator = operator;
         this.value = value;
         this.skipToTarget = skipToTarget;
         this.endSurvey = endSurvey;
         this.assignDataGroup = assignDataGroup;
+        this.dataGroups = dataGroups;
+        this.displayIf = displayIf;
+        this.displayUnless = displayUnless;
     }
     public Operator getOperator() {
         return operator;
@@ -81,10 +95,31 @@ public final class SurveyRule {
     public String getAssignDataGroup() {
         return assignDataGroup;
     }
-
+    /**
+     * The data groups that will be tested against the user's assigned data groups, using the appropriate
+     * set operator (any contained, all contained). 
+     */
+    public Set<String> getDataGroups() {
+        return dataGroups;
+    }
+    /**
+     * If an expression is true, display the current screen. This action only makes sense in the rules 
+     * before a question executes, and it does not stop evaluation of further rules in the list. 
+     */
+    public Boolean getDisplayIf() {
+        return displayIf;
+    }
+    /**
+     * Unless an expression is true, display the current screen. This action only makes sense in the 
+     * rules before a question executes, and it does not stop evaluation of further rules in the list. 
+     */
+    public Boolean getDisplayUnless() {
+        return displayUnless;
+    }
+    
     @Override
     public int hashCode() {
-        return Objects.hash(operator, value, skipToTarget, endSurvey, assignDataGroup);
+        return Objects.hash(operator, value, skipToTarget, endSurvey, assignDataGroup, dataGroups);
     }
 
     @Override
@@ -98,13 +133,15 @@ public final class SurveyRule {
                Objects.equals(operator, other.operator) &&
                Objects.equals(value, other.value) &&
                Objects.equals(endSurvey, other.endSurvey) &&
-               Objects.equals(assignDataGroup, other.assignDataGroup);
+               Objects.equals(assignDataGroup, other.assignDataGroup) &&
+               Objects.equals(dataGroups, other.dataGroups);
     }
 
     @Override
     public String toString() {
         return "SurveyRule [operator=" + operator + ", value=" + value + ", skipToTarget=" + skipToTarget
-                + ", endSurvey=" + endSurvey + ", assignDataGroup=" + assignDataGroup + "]";
+                + ", endSurvey=" + endSurvey + ", assignDataGroup=" + assignDataGroup + ", dataGroups=" + 
+                dataGroups + "]";
     }
 
     public static class Builder {
@@ -112,7 +149,10 @@ public final class SurveyRule {
         private Object value;
         private String skipToTarget;
         private Boolean endSurvey;
+        private Boolean displayIf;
+        private Boolean displayUnless;
         private String assignDataGroup;
+        private Set<String> dataGroups;
 
         public Builder withOperator(SurveyRule.Operator operator) {
             this.operator = operator;
@@ -133,12 +173,29 @@ public final class SurveyRule {
             }
             return this;
         }
+        public Builder withDisplayIf(Boolean displayIf) {
+            if (Boolean.TRUE.equals(displayIf)) {
+                this.displayIf = displayIf;
+            }
+            return this;
+        }
+        public Builder withDisplayUnless(Boolean displayUnless) {
+            if (Boolean.TRUE.equals(displayUnless)) {
+                this.displayUnless = displayUnless;
+            }
+            return this;
+        }
         public Builder withAssignDataGroup(String dataGroup) {
             this.assignDataGroup = dataGroup;
             return this;
         }
+        public Builder withDataGroups(Set<String> dataGroups) {
+            this.dataGroups = dataGroups;
+            return this;
+        }
         public SurveyRule build() {
-            return new SurveyRule(operator, value, skipToTarget, endSurvey, assignDataGroup);
+            return new SurveyRule(operator, value, skipToTarget, endSurvey, assignDataGroup, dataGroups, displayIf,
+                    displayUnless);
         }
     }
     

--- a/app/org/sagebionetworks/bridge/models/surveys/SurveyRule.java
+++ b/app/org/sagebionetworks/bridge/models/surveys/SurveyRule.java
@@ -119,7 +119,8 @@ public final class SurveyRule {
     
     @Override
     public int hashCode() {
-        return Objects.hash(operator, value, skipToTarget, endSurvey, assignDataGroup, dataGroups);
+        return Objects.hash(operator, value, skipToTarget, endSurvey, assignDataGroup, dataGroups, displayIf,
+                displayUnless);
     }
 
     @Override
@@ -134,14 +135,16 @@ public final class SurveyRule {
                Objects.equals(value, other.value) &&
                Objects.equals(endSurvey, other.endSurvey) &&
                Objects.equals(assignDataGroup, other.assignDataGroup) &&
-               Objects.equals(dataGroups, other.dataGroups);
+               Objects.equals(dataGroups, other.dataGroups) &&
+               Objects.equals(displayIf, other.displayIf) &&
+               Objects.equals(displayUnless, other.displayUnless);
     }
 
     @Override
     public String toString() {
         return "SurveyRule [operator=" + operator + ", value=" + value + ", skipToTarget=" + skipToTarget
                 + ", endSurvey=" + endSurvey + ", assignDataGroup=" + assignDataGroup + ", dataGroups=" + 
-                dataGroups + "]";
+                dataGroups + ", displayIf=" + displayIf + ", displayUnless=" + displayUnless + "]";
     }
 
     public static class Builder {

--- a/app/org/sagebionetworks/bridge/validators/SurveySaveValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/SurveySaveValidator.java
@@ -187,7 +187,7 @@ public class SurveySaveValidator implements Validator {
                 SurveyRule rule = rules.get(j);
                 if (rule.getOperator() != SurveyRule.Operator.ALWAYS) {
                     errors.pushNestedPath(propertyPath);
-                    errors.rejectValue(fieldName+"["+j+"]", "only valid with the 'always' operator");
+                    errors.rejectValue(fieldName+"["+j+"].operator", "only 'always' operator is valid for info screen rules");
                     errors.popNestedPath();
                 }
             }
@@ -207,28 +207,32 @@ public class SurveySaveValidator implements Validator {
                     errors.rejectValue(fieldPath, "must have one and only one action");
                 }
                 if (assignedDataGroupDoesNotExist(rule)) {
-                    errors.rejectValue(fieldPath, "has a data group '" + rule.getAssignDataGroup()
+                    errors.rejectValue(fieldPath + ".assignDataGroup", "has a data group '" + rule.getAssignDataGroup()
                             + "' that is not a valid data group: " + COMMA_SPACE_JOINER.join(dataGroups));            
                 }
                 if (afterRuleControlsDisplay(fieldPath, rule)) {
-                    errors.rejectValue(fieldPath, "specifies display after screen has been shown");
+                    if (rule.getDisplayIf() == Boolean.TRUE) {
+                        errors.rejectValue(fieldPath + ".displayIf", "specifies display after screen has been shown");    
+                    } else if (rule.getDisplayUnless() == Boolean.TRUE) {
+                        errors.rejectValue(fieldPath + ".displayUnless", "specifies display after screen has been shown");
+                    }
                 }
                 if (skipToBackReferencesQuestion(alreadySeenIdentifiers, rule)) {
-                    errors.rejectValue(fieldPath, "back references question " + rule.getSkipToTarget());
+                    errors.rejectValue(fieldPath + ".skipTo", "back references question " + rule.getSkipToTarget());
                 }
                 // Split rules by their operator, the operators determines what data is being tested. 
                 // Only validate fields that are relevant for the operator, ignore the other.
                 if (SurveyRule.SET_OPERATORS.contains(rule.getOperator())) {
                     // tests against data groups
                     if (isEmpty(rule.getDataGroups())) {
-                        errors.rejectValue(fieldPath, "should define one or more data groups");
+                        errors.rejectValue(fieldPath + ".dataGroups", "should define one or more data groups");
                     } else if (!dataGroups.containsAll(rule.getDataGroups())) {
-                        errors.rejectValue(fieldPath,
-                            "contains dataGroups '" + COMMA_SPACE_JOINER.join(rule.getDataGroups())
+                        errors.rejectValue(fieldPath + ".dataGroups",
+                            "contains data groups '" + COMMA_SPACE_JOINER.join(rule.getDataGroups())
                                     + "' that are not valid data groups: " + COMMA_SPACE_JOINER.join(dataGroups));
                     }
                 } else if (valueMissingForOperator(rule)) {
-                    errors.rejectValue(fieldPath, "is required");
+                    errors.rejectValue(fieldPath + ".value", "is required");
                 }
                 errors.popNestedPath();
             }
@@ -281,7 +285,7 @@ public class SurveySaveValidator implements Validator {
                 if (rule.getSkipToTarget() != null) {
                     if (!skipToBackReferencesQuestion(alreadySeenIdentifiers, rule)) {
                         errors.pushNestedPath(propertyPath);
-                        errors.rejectValue(fieldName+"["+j+"]", "has a skipTo identifier that doesn't exist: " + rule.getSkipToTarget());
+                        errors.rejectValue(fieldName+"["+j+"].skipTo", "identifier doesn't exist: " + rule.getSkipToTarget());
                         errors.popNestedPath();
                     }
                 }

--- a/app/org/sagebionetworks/bridge/validators/SurveySaveValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/SurveySaveValidator.java
@@ -143,6 +143,13 @@ public class SurveySaveValidator implements Validator {
         
         for (int i=0; i < elements.size(); i++) {
             SurveyElement element = elements.get(i);
+            
+            if (element.getBeforeRules() != null) {
+                for (int j=0; j < element.getBeforeRules().size(); j++) {
+                    SurveyRule rule = element.getBeforeRules().get(j);
+                    validateOneRuleSet(errors, rule, alreadySeenIdentifiers, "elements["+i+"]", "beforeRules["+j+"]");
+                }
+            }
             if (element.getAfterRules() != null) {
                 for (int j=0; j < element.getAfterRules().size(); j++) {
                     SurveyRule rule = element.getAfterRules().get(j);
@@ -155,20 +162,22 @@ public class SurveySaveValidator implements Validator {
                     for (int j=0; j < question.getConstraints().getRules().size(); j++) {
                         SurveyRule rule = question.getConstraints().getRules().get(j);
                         validateOneRuleSet(errors, rule, alreadySeenIdentifiers,
-                                "elements[" + i + "].constraints", "afterRules[" + j + "]");
+                                "elements[" + i + "].constraints", "rules[" + j + "]");
                     }
                 }
             } else if (element instanceof SurveyInfoScreen) {
                 // The only operator that makes sense on an information screen is ALWAYS, since there 
                 // is no value to test against.
+                if (element.getBeforeRules() != null) {
+                    for (int j=0; j < element.getBeforeRules().size(); j++) {
+                        SurveyRule rule = element.getBeforeRules().get(j);
+                        validateOnRuleSetInInfoScreen(errors, rule, "elements["+i+"]", "beforeRules["+j+"]");
+                    }
+                }
                 if (element.getAfterRules() != null) {
                     for (int j=0; j < element.getAfterRules().size(); j++) {
                         SurveyRule rule = element.getAfterRules().get(j);
-                        if (rule.getOperator() != SurveyRule.Operator.ALWAYS) {
-                            errors.pushNestedPath("elements["+i+"]");
-                            errors.rejectValue("afterRules["+j+"]", "only valid with the 'always' operator");
-                            errors.popNestedPath();
-                        }
+                        validateOnRuleSetInInfoScreen(errors, rule, "elements["+i+"]", "afterRules["+j+"]");
                     }
                 }
             }
@@ -178,6 +187,12 @@ public class SurveySaveValidator implements Validator {
         // Now verify that all skipToTarget identifiers actually exist
         for (int i=0; i < elements.size(); i++) {
             SurveyElement element = elements.get(i);
+            if (element.getBeforeRules() != null) {
+                for (int j=0; j < element.getBeforeRules().size(); j++) {
+                    SurveyRule rule = element.getBeforeRules().get(j);
+                    validateSkipToTargetExists(errors, rule, alreadySeenIdentifiers, "elements["+i+"]", "beforeRules["+j+"]");
+                }
+            }
             if (element.getAfterRules() != null) {
                 for (int j=0; j < element.getAfterRules().size(); j++) {
                     SurveyRule rule = element.getAfterRules().get(j);
@@ -194,6 +209,14 @@ public class SurveySaveValidator implements Validator {
                     }
                 }
             }
+        }
+    }
+
+    private void validateOnRuleSetInInfoScreen(Errors errors, SurveyRule rule, String propertyPath, String fieldPath) {
+        if (rule.getOperator() != SurveyRule.Operator.ALWAYS) {
+            errors.pushNestedPath(propertyPath);
+            errors.rejectValue(fieldPath, "only valid with the 'always' operator");
+            errors.popNestedPath();
         }
     }
     

--- a/app/org/sagebionetworks/bridge/validators/SurveySaveValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/SurveySaveValidator.java
@@ -143,10 +143,10 @@ public class SurveySaveValidator implements Validator {
         
         for (int i=0; i < elements.size(); i++) {
             SurveyElement element = elements.get(i);
-            if (element.getRules() != null) {
-                for (int j=0; j < element.getRules().size(); j++) {
-                    SurveyRule rule = element.getRules().get(j);
-                    validateOneRuleSet(errors, rule, alreadySeenIdentifiers, "elements["+i+"]", "rules["+j+"]");
+            if (element.getAfterRules() != null) {
+                for (int j=0; j < element.getAfterRules().size(); j++) {
+                    SurveyRule rule = element.getAfterRules().get(j);
+                    validateOneRuleSet(errors, rule, alreadySeenIdentifiers, "elements["+i+"]", "afterRules["+j+"]");
                 }
             }
             if (element instanceof SurveyQuestion) {
@@ -155,18 +155,18 @@ public class SurveySaveValidator implements Validator {
                     for (int j=0; j < question.getConstraints().getRules().size(); j++) {
                         SurveyRule rule = question.getConstraints().getRules().get(j);
                         validateOneRuleSet(errors, rule, alreadySeenIdentifiers,
-                                "elements[" + i + "].constraints", "rules[" + j + "]");
+                                "elements[" + i + "].constraints", "afterRules[" + j + "]");
                     }
                 }
             } else if (element instanceof SurveyInfoScreen) {
                 // The only operator that makes sense on an information screen is ALWAYS, since there 
                 // is no value to test against.
-                if (element.getRules() != null) {
-                    for (int j=0; j < element.getRules().size(); j++) {
-                        SurveyRule rule = element.getRules().get(j);
+                if (element.getAfterRules() != null) {
+                    for (int j=0; j < element.getAfterRules().size(); j++) {
+                        SurveyRule rule = element.getAfterRules().get(j);
                         if (rule.getOperator() != SurveyRule.Operator.ALWAYS) {
                             errors.pushNestedPath("elements["+i+"]");
-                            errors.rejectValue("rules["+j+"]", "only valid with the 'always' operator");
+                            errors.rejectValue("afterRules["+j+"]", "only valid with the 'always' operator");
                             errors.popNestedPath();
                         }
                     }
@@ -178,10 +178,10 @@ public class SurveySaveValidator implements Validator {
         // Now verify that all skipToTarget identifiers actually exist
         for (int i=0; i < elements.size(); i++) {
             SurveyElement element = elements.get(i);
-            if (element.getRules() != null) {
-                for (int j=0; j < element.getRules().size(); j++) {
-                    SurveyRule rule = element.getRules().get(j);
-                    validateSkipToTargetExists(errors, rule, alreadySeenIdentifiers, "elements["+i+"]", "rules["+j+"]");
+            if (element.getAfterRules() != null) {
+                for (int j=0; j < element.getAfterRules().size(); j++) {
+                    SurveyRule rule = element.getAfterRules().get(j);
+                    validateSkipToTargetExists(errors, rule, alreadySeenIdentifiers, "elements["+i+"]", "afterRules["+j+"]");
                 }
             }
             if (element instanceof SurveyQuestion) {

--- a/app/org/sagebionetworks/bridge/validators/SurveySaveValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/SurveySaveValidator.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.bridge.validators;
 
+import static org.sagebionetworks.bridge.BridgeUtils.isEmpty;
+import static org.sagebionetworks.bridge.BridgeUtils.COMMA_SPACE_JOINER;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.sagebionetworks.bridge.models.surveys.SurveyElementConstants.SURVEY_INFO_SCREEN_TYPE;
 import static org.sagebionetworks.bridge.models.surveys.SurveyElementConstants.SURVEY_QUESTION_TYPE;
@@ -19,7 +21,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
-import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.models.surveys.Constraints;
 import org.sagebionetworks.bridge.models.surveys.DateConstraints;
 import org.sagebionetworks.bridge.models.surveys.DateTimeConstraints;
@@ -154,8 +155,7 @@ public class SurveySaveValidator implements Validator {
                 validateOneRuleSet(errors, question.getConstraints().getRules(), alreadySeenIdentifiers,
                         propertyPath+".constraints", "rules");
             } else if (element instanceof SurveyInfoScreen) {
-                // The only operator that makes sense on an information screen is ALWAYS, since there 
-                // is no value to test against.
+                // There are some additional constraints for information screens.
                 validateOnRuleSetInInfoScreen(errors, element.getBeforeRules(), propertyPath, "beforeRules");
                 validateOnRuleSetInInfoScreen(errors, element.getAfterRules(), propertyPath, "afterRules");
             }
@@ -202,30 +202,66 @@ public class SurveySaveValidator implements Validator {
                 String fieldPath = fieldName+"["+j+"]";
                 
                 errors.pushNestedPath(propertyPath);
-                int actionCount = 0;
-                if (rule.getSkipToTarget() != null) {
-                    actionCount++;
+                
+                if (!hasOneAction(rule)) {
+                    errors.rejectValue(fieldPath, "must have one and only one action");
                 }
-                if (rule.getEndSurvey() != null) {
-                    actionCount++;
-                }
-                if (rule.getAssignDataGroup() != null) {
-                    actionCount++;
-                }
-                if (actionCount != 1) {
-                    errors.rejectValue(fieldPath, "must have one and only one action: skipTo, endSurvey, or assignDataGroup");
-                }
-                if (rule.getAssignDataGroup() != null && !dataGroups.contains(rule.getAssignDataGroup())) {
+                if (assignedDataGroupDoesNotExist(rule)) {
                     errors.rejectValue(fieldPath, "has a data group '" + rule.getAssignDataGroup()
-                            + "' that is not a valid data group: " + BridgeUtils.COMMA_SPACE_JOINER.join(dataGroups));            
+                            + "' that is not a valid data group: " + COMMA_SPACE_JOINER.join(dataGroups));            
                 }
-                // Otherwise we can assume there's a skipToTarget, start checking that by looking for back references.
-                if (alreadySeenIdentifiers.contains(rule.getSkipToTarget())) {
+                if (skipToBackReferencesQuestion(alreadySeenIdentifiers, rule)) {
                     errors.rejectValue(fieldPath, "back references question " + rule.getSkipToTarget());
+                }
+                // Split rules by their operator, the operators determines what data is being tested. 
+                // Only validate rules for fields that are relevant for the operator, ignore the other.
+                if (SurveyRule.SET_OPERATORS.contains(rule.getOperator())) {
+                    // tests against data groups
+                    if (isEmpty(rule.getDataGroups())) {
+                        errors.rejectValue(fieldPath, "should define one or more data groups");
+                    } else if (!dataGroups.containsAll(rule.getDataGroups())) {
+                        errors.rejectValue(fieldPath,
+                            "contains dataGroups '" + COMMA_SPACE_JOINER.join(rule.getDataGroups())
+                                    + "' that are not valid data groups: " + COMMA_SPACE_JOINER.join(dataGroups));
+                    }
+                } else if (valueMissingForOperator(rule)) {
+                    errors.rejectValue(fieldPath, "is required");
                 }
                 errors.popNestedPath();
             }
         }
+    }
+
+    private boolean valueMissingForOperator(SurveyRule rule) {
+        return !SurveyRule.NULL_VALUE_OPERATORS.contains(rule.getOperator()) && rule.getValue() == null;
+    }
+
+    private boolean skipToBackReferencesQuestion(Set<String> alreadySeenIdentifiers, SurveyRule rule) {
+        return rule.getSkipToTarget() != null && alreadySeenIdentifiers.contains(rule.getSkipToTarget());
+    }
+
+    private boolean assignedDataGroupDoesNotExist(SurveyRule rule) {
+        return rule.getAssignDataGroup() != null && !dataGroups.contains(rule.getAssignDataGroup());
+    }
+
+    private boolean hasOneAction(SurveyRule rule) {
+        int actionCount = 0;
+        if (rule.getSkipToTarget() != null) {
+            actionCount++;
+        }
+        if (rule.getEndSurvey() != null) {
+            actionCount++;
+        }
+        if (rule.getAssignDataGroup() != null) {
+            actionCount++;
+        }
+        if (rule.getDisplayIf() != null) {
+            actionCount++;
+        }
+        if (rule.getDisplayUnless() != null) {
+            actionCount++;
+        }
+        return actionCount == 1;
     }
     
     private void validateSkipToTargetExists(Errors errors, List<SurveyRule> rules, Set<String> alreadySeenIdentifiers,
@@ -235,7 +271,7 @@ public class SurveySaveValidator implements Validator {
                 SurveyRule rule = rules.get(j);
                 
                 if (rule.getSkipToTarget() != null) {
-                    if (!alreadySeenIdentifiers.contains(rule.getSkipToTarget())) {
+                    if (!skipToBackReferencesQuestion(alreadySeenIdentifiers, rule)) {
                         errors.pushNestedPath(propertyPath);
                         errors.rejectValue(fieldName+"["+j+"]", "has a skipTo identifier that doesn't exist: " + rule.getSkipToTarget());
                         errors.popNestedPath();

--- a/app/org/sagebionetworks/bridge/validators/SurveySaveValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/SurveySaveValidator.java
@@ -210,11 +210,14 @@ public class SurveySaveValidator implements Validator {
                     errors.rejectValue(fieldPath, "has a data group '" + rule.getAssignDataGroup()
                             + "' that is not a valid data group: " + COMMA_SPACE_JOINER.join(dataGroups));            
                 }
+                if (afterRuleControlsDisplay(fieldPath, rule)) {
+                    errors.rejectValue(fieldPath, "specifies display after screen has been shown");
+                }
                 if (skipToBackReferencesQuestion(alreadySeenIdentifiers, rule)) {
                     errors.rejectValue(fieldPath, "back references question " + rule.getSkipToTarget());
                 }
                 // Split rules by their operator, the operators determines what data is being tested. 
-                // Only validate rules for fields that are relevant for the operator, ignore the other.
+                // Only validate fields that are relevant for the operator, ignore the other.
                 if (SurveyRule.SET_OPERATORS.contains(rule.getOperator())) {
                     // tests against data groups
                     if (isEmpty(rule.getDataGroups())) {
@@ -232,6 +235,11 @@ public class SurveySaveValidator implements Validator {
         }
     }
 
+    private boolean afterRuleControlsDisplay(String propertyPath, SurveyRule rule) {
+        return propertyPath.startsWith("afterRules") && 
+            (rule.getDisplayIf() == Boolean.TRUE || rule.getDisplayUnless() == Boolean.TRUE);
+    }
+    
     private boolean valueMissingForOperator(SurveyRule rule) {
         return !SurveyRule.NULL_VALUE_OPERATORS.contains(rule.getOperator()) && rule.getValue() == null;
     }

--- a/app/org/sagebionetworks/bridge/validators/SurveySaveValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/SurveySaveValidator.java
@@ -156,8 +156,8 @@ public class SurveySaveValidator implements Validator {
                         propertyPath+".constraints", "rules");
             } else if (element instanceof SurveyInfoScreen) {
                 // There are some additional constraints for information screens.
-                validateOnRuleSetInInfoScreen(errors, element.getBeforeRules(), propertyPath, "beforeRules");
-                validateOnRuleSetInInfoScreen(errors, element.getAfterRules(), propertyPath, "afterRules");
+                validateOneRuleSetInInfoScreen(errors, element.getBeforeRules(), propertyPath, "beforeRules");
+                validateOneRuleSetInInfoScreen(errors, element.getAfterRules(), propertyPath, "afterRules");
             }
             alreadySeenIdentifiers.add(element.getIdentifier());
         }        
@@ -181,7 +181,7 @@ public class SurveySaveValidator implements Validator {
         }
     }
 
-    private void validateOnRuleSetInInfoScreen(Errors errors, List<SurveyRule> rules, String propertyPath, String fieldName) {
+    private void validateOneRuleSetInInfoScreen(Errors errors, List<SurveyRule> rules, String propertyPath, String fieldName) {
         if (rules != null) {
             for (int j=0; j < rules.size(); j++) {
                 SurveyRule rule = rules.get(j);

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -115,7 +115,6 @@ public class TestUtils {
             Validate.entityThrowingException(validator, object);
             fail("Should have thrown exception");
         } catch(InvalidEntityException e) {
-            System.out.println(e);
             assertEquals(fieldNameAsLabel+error, e.getErrors().get(fieldName).get(0));
         }
     }

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -115,6 +115,7 @@ public class TestUtils {
             Validate.entityThrowingException(validator, object);
             fail("Should have thrown exception");
         } catch(InvalidEntityException e) {
+            System.out.println(e);
             assertEquals(fieldNameAsLabel+error, e.getErrors().get(fieldName).get(0));
         }
     }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoTest.java
@@ -638,7 +638,7 @@ public class DynamoSurveyDaoTest {
         infoScreen.setIdentifier("info_screen");
         infoScreen.setPromptDetail("Be honest: do you have high blood pressue?");
         infoScreen.setGuid(UUID.randomUUID().toString());
-        infoScreen.setRules(ImmutableList.of(rule));
+        infoScreen.setAfterRules(ImmutableList.of(rule));
         
         // Element rules override anything set in constraints, once they exist.
         SurveyQuestion question = SurveyQuestion.create();
@@ -653,7 +653,7 @@ public class DynamoSurveyDaoTest {
         question.setUiHint(UIHint.CHECKBOX);
         question.setConstraints(ic);
         question.setGuid(UUID.randomUUID().toString());
-        question.setRules(ImmutableList.of(rule));
+        question.setAfterRules(ImmutableList.of(rule));
         
         survey.getElements().add(migrateQuestion);
         survey.getElements().add(infoScreen);
@@ -664,52 +664,52 @@ public class DynamoSurveyDaoTest {
         
         // Migrated question has been moved up
         SurveyElement element1 = createdSurvey.getElements().get(0);
-        assertEquals(rule, element1.getRules().get(0));
-        assertEquals(1, element1.getRules().size());
+        assertEquals(rule, element1.getAfterRules().get(0));
+        assertEquals(1, element1.getAfterRules().size());
         assertEquals(rule, ((SurveyQuestion)element1).getConstraints().getRules().get(0));
         assertEquals(1, ((SurveyQuestion)element1).getConstraints().getRules().size());
         // Info screen has rule
-        assertEquals(rule, createdSurvey.getElements().get(1).getRules().get(0));
-        assertEquals(1, createdSurvey.getElements().get(1).getRules().size());
+        assertEquals(rule, createdSurvey.getElements().get(1).getAfterRules().get(0));
+        assertEquals(1, createdSurvey.getElements().get(1).getAfterRules().size());
         // Normal question has been moved down, overwriting existing
-        assertEquals(rule, createdSurvey.getElements().get(2).getRules().get(0));
-        assertEquals(1, createdSurvey.getElements().get(2).getRules().size());
+        assertEquals(rule, createdSurvey.getElements().get(2).getAfterRules().get(0));
+        assertEquals(1, createdSurvey.getElements().get(2).getAfterRules().size());
         
         SurveyQuestion savedQuestion = (SurveyQuestion)createdSurvey.getElements().get(2);
-        assertEquals(rule, savedQuestion.getRules().get(0));
-        assertEquals(1, savedQuestion.getRules().size());
+        assertEquals(rule, savedQuestion.getAfterRules().get(0));
+        assertEquals(1, savedQuestion.getAfterRules().size());
         
         // But if there's a rule on the element and not the constraints, it is not removed. 
         // Constraints are updated.
-        Survey survey2 = updateRules(createdSurvey, ImmutableList.of(rule), ImmutableList.of());
+        Survey survey2 = updateAfterRules(createdSurvey, ImmutableList.of(rule), ImmutableList.of());
         SurveyElement element2 = survey2.getElements().get(0);
-        assertEquals(1, element2.getRules().size());
+        assertEquals(1, element2.getAfterRules().size());
         assertEquals(1, ((SurveyQuestion)element2).getConstraints().getRules().size());
         
         // Setting both to no rules will clear them.
-        Survey survey3 = updateRules(survey2, ImmutableList.of(), ImmutableList.of());
+        Survey survey3 = updateAfterRules(survey2, ImmutableList.of(), ImmutableList.of());
         SurveyElement element3 = survey3.getElements().get(0);
-        assertEquals(0, element3.getRules().size());
+        assertEquals(0, element3.getAfterRules().size());
         assertEquals(0, ((SurveyQuestion)element3).getConstraints().getRules().size());
         
         // null rules list in question, non-null non-empty rules list in constraints
         // (this is a variant of the migration case, the rule will be migrated) 
-        Survey survey4 = updateRules(survey3, null, ImmutableList.of(rule));
+        Survey survey4 = updateAfterRules(survey3, null, ImmutableList.of(rule));
         SurveyElement element4 = survey4.getElements().get(0);
-        assertEquals(1, element4.getRules().size());
+        assertEquals(1, element4.getAfterRules().size());
         assertEquals(1, ((SurveyQuestion)element4).getConstraints().getRules().size());
         
         // empty rules list in question, non-null non-empty rules in constraints
         // (this is a variant of the migration case, the rule will be migrated) 
-        Survey survey5 = updateRules(survey4, ImmutableList.of(), ImmutableList.of(rule));
+        Survey survey5 = updateAfterRules(survey4, ImmutableList.of(), ImmutableList.of(rule));
         SurveyElement element5 = survey5.getElements().get(0);
-        assertEquals(1, element5.getRules().size());
+        assertEquals(1, element5.getAfterRules().size());
         assertEquals(1, ((SurveyQuestion)element5).getConstraints().getRules().size());
     }
     
-    private Survey updateRules(Survey survey, List<SurveyRule> inElement, List<SurveyRule> inConstraints) {
+    private Survey updateAfterRules(Survey survey, List<SurveyRule> inElement, List<SurveyRule> inConstraints) {
         SurveyElement element = survey.getElements().get(0);
-        element.setRules(inElement);
+        element.setAfterRules(inElement);
         ((SurveyQuestion)element).getConstraints().setRules(inConstraints);
         Survey keys = surveyDao.updateSurvey(survey);
         return surveyDao.getSurvey(keys);

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyInfoScreenTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyInfoScreenTest.java
@@ -39,7 +39,9 @@ public class DynamoSurveyInfoScreenTest {
         assertEquals("guid", copy.getGuid());
         assertEquals("identifier", copy.getIdentifier());
         assertEquals("SurveyInfoScreen", copy.getType());
+        assertEquals(1, copy.getBeforeRules().size());
         assertEquals(beforeRule, copy.getBeforeRules().get(0));
+        assertEquals(1, copy.getAfterRules().size());
         assertEquals(afterRule, copy.getAfterRules().get(0));
     }
 }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyInfoScreenTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyInfoScreenTest.java
@@ -1,0 +1,45 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.models.surveys.Image;
+import org.sagebionetworks.bridge.models.surveys.SurveyInfoScreen;
+import org.sagebionetworks.bridge.models.surveys.SurveyRule;
+import org.sagebionetworks.bridge.models.surveys.SurveyRule.Operator;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
+public class DynamoSurveyInfoScreenTest {
+    
+    @Test
+    public void copyConstructor() {
+        SurveyInfoScreen screen = SurveyInfoScreen.create();
+        screen.setPrompt("prompt");
+        screen.setPromptDetail("promptDetail");
+        screen.setTitle("title");
+        screen.setImage(new Image("sourceUrl", 100, 100));
+        screen.setSurveyCompoundKey("surveyCompoundKey");
+        screen.setGuid("guid");
+        screen.setIdentifier("identifier");
+        screen.setType("SurveyInfoScreen");
+        SurveyRule beforeRule = new SurveyRule.Builder().withDisplayUnless(true).withDataGroups(Sets.newHashSet("foo")).build();
+        SurveyRule afterRule = new SurveyRule.Builder().withOperator(Operator.ALWAYS).withEndSurvey(true).build();
+        screen.setBeforeRules(Lists.newArrayList(beforeRule));
+        screen.setAfterRules(Lists.newArrayList(afterRule));
+
+        SurveyInfoScreen copy = new DynamoSurveyInfoScreen(screen);
+        assertEquals("prompt", copy.getPrompt());
+        assertEquals("promptDetail", copy.getPromptDetail());
+        assertEquals("title", copy.getTitle());
+        assertEquals(screen.getImage(), copy.getImage());
+        assertEquals("surveyCompoundKey", copy.getSurveyCompoundKey());
+        assertEquals("guid", copy.getGuid());
+        assertEquals("identifier", copy.getIdentifier());
+        assertEquals("SurveyInfoScreen", copy.getType());
+        assertEquals(beforeRule, copy.getBeforeRules().get(0));
+        assertEquals(afterRule, copy.getAfterRules().get(0));
+    }
+}

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyQuestionTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyQuestionTest.java
@@ -45,6 +45,10 @@ public class DynamoSurveyQuestionTest {
         assertEquals("guid", copy.getGuid());
         assertEquals("identifier", copy.getIdentifier());
         assertEquals("SurveyQuestion", copy.getType());
+        assertEquals(1, copy.getBeforeRules().size());
+        assertEquals(question.getBeforeRules().get(0), copy.getBeforeRules().get(0));
+        assertEquals(1, copy.getAfterRules().size());
+        assertEquals(question.getAfterRules().get(0), copy.getAfterRules().get(0));
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyQuestionTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyQuestionTest.java
@@ -1,17 +1,52 @@
 package org.sagebionetworks.bridge.dynamodb;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.joda.time.DateTime;
 import org.junit.Test;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.surveys.IntegerConstraints;
 import org.sagebionetworks.bridge.models.surveys.SurveyQuestion;
+import org.sagebionetworks.bridge.models.surveys.SurveyRule;
 import org.sagebionetworks.bridge.models.surveys.UIHint;
 import org.sagebionetworks.bridge.models.surveys.Unit;
+import org.sagebionetworks.bridge.models.surveys.SurveyRule.Operator;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 public class DynamoSurveyQuestionTest {
-
+    
+    @Test
+    public void copyConstructor() {
+        SurveyQuestion question = SurveyQuestion.create();
+        question.setPrompt("prompt");
+        question.setPromptDetail("promptDetail");
+        question.setFireEvent(true);
+        question.setUiHint(UIHint.COMBOBOX);
+        question.setConstraints(new IntegerConstraints());
+        question.setSurveyCompoundKey("surveyCompoundKey");
+        question.setGuid("guid");
+        question.setIdentifier("identifier");
+        question.setType("SurveyQuestion");
+        SurveyRule beforeRule = new SurveyRule.Builder().withDisplayUnless(true).withDataGroups(Sets.newHashSet("foo")).build();
+        SurveyRule afterRule = new SurveyRule.Builder().withOperator(Operator.ALWAYS).withEndSurvey(true).build();
+        question.setBeforeRules(Lists.newArrayList(beforeRule));
+        question.setAfterRules(Lists.newArrayList(afterRule));
+    
+        SurveyQuestion copy = new DynamoSurveyQuestion(question);
+        assertEquals("prompt", copy.getPrompt());
+        assertEquals("promptDetail", copy.getPromptDetail());
+        assertTrue(copy.getFireEvent());
+        assertEquals(UIHint.COMBOBOX, copy.getUiHint());
+        assertTrue(copy.getConstraints() instanceof IntegerConstraints);
+        assertEquals("surveyCompoundKey", copy.getSurveyCompoundKey());
+        assertEquals("guid", copy.getGuid());
+        assertEquals("identifier", copy.getIdentifier());
+        assertEquals("SurveyQuestion", copy.getType());
+    }
+    
     @Test
     public void canSerialize() throws Exception {
         DateTime date = DateTime.parse("2015-10-10T10:10:10.000Z");

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyTest.java
@@ -57,12 +57,12 @@ public class DynamoSurveyTest {
         screen.setPrompt("This is the prompt");
         screen.setPromptDetail("This is further explanation of the prompt.");
         screen.setImage(new Image("http://foo.bar", 100, 100));
-        screen.setRules(Lists.newArrayList(rule));
+        screen.setAfterRules(Lists.newArrayList(rule));
         survey.getElements().add(screen);
         
         // and add a rule as well to a survey question
         SurveyElement dateQuestion = (SurveyElement)TestSurvey.selectBy(survey, DataType.DATE);
-        dateQuestion.setRules(Lists.newArrayList(rule));
+        dateQuestion.setAfterRules(Lists.newArrayList(rule));
 
         // Convert to JSON.
         JsonNode jsonNode = BridgeObjectMapper.get().convertValue(survey, JsonNode.class);
@@ -122,7 +122,7 @@ public class DynamoSurveyTest {
         DateConstraints dc = (DateConstraints)convertedDateQuestion.getConstraints();
         assertNotNull("Earliest date exists", dc.getEarliestValue());
         assertNotNull("Latest date exists", dc.getLatestValue());
-        assertEquals(rule, convertedDateQuestion.getRules().get(0));
+        assertEquals(rule, convertedDateQuestion.getAfterRules().get(0));
 
         DateTimeConstraints dtc = (DateTimeConstraints) TestSurvey.selectBy(convertedSurvey, DataType.DATETIME).getConstraints();
         assertNotNull("Earliest date exists", dtc.getEarliestValue());
@@ -137,7 +137,7 @@ public class DynamoSurveyTest {
         assertEquals("name", ic.getRules().get(1).getSkipToTarget());
         
         SurveyInfoScreen retrievedScreen = (SurveyInfoScreen)convertedSurvey.getElements().get(convertedSurvey.getElements().size()-1);
-        assertEquals(rule, retrievedScreen.getRules().get(0));
+        assertEquals(rule, retrievedScreen.getAfterRules().get(0));
     }
 
     @Test

--- a/test/org/sagebionetworks/bridge/models/surveys/SurveyElementTest.java
+++ b/test/org/sagebionetworks/bridge/models/surveys/SurveyElementTest.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 import org.junit.Test;
 
+import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoSurveyInfoScreen;
 import org.sagebionetworks.bridge.dynamodb.DynamoSurveyQuestion;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
@@ -26,19 +27,16 @@ public class SurveyElementTest {
     
     @Test
     public void serializeSurveyQuestion() throws Exception {
-        
         // start with JSON
-        String jsonText = "{" +
-                "   \"fireEvent\":false," +
-                "   \"guid\":\"test-guid\"," +
-                "   \"identifier\":\"test-survey-question\"," +
-                "   \"prompt\":\"Is this a survey question?\"," +
-                "   \"promptDetail\":\"Details about question\"," +
-                "   \"beforeRules\":[{\"operator\":\"eq\",\"value\":10,\"assignDataGroup\":\"foo\"}],"+
-                "   \"afterRules\":[{\"operator\":\"always\",\"endSurvey\":true}],"+
-                "   \"type\":\"SurveyQuestion\"," +
-                "   \"uiHint\":\"textfield\"" +
-                "}";
+        String jsonText = TestUtils.createJson("{'fireEvent':false," +
+                "'guid':'test-guid'," +
+                "'identifier':'test-survey-question'," +
+                "'prompt':'Is this a survey question?'," +
+                "'promptDetail':'Details about question'," +
+                "'beforeRules':[{'operator':'eq','value':10,'assignDataGroup':'foo'}],"+
+                "'afterRules':[{'operator':'always','endSurvey':true}],"+
+                "'type':'SurveyQuestion'," +
+                "'uiHint':'textfield'}");
 
         // convert to POJO
         DynamoSurveyQuestion question = (DynamoSurveyQuestion) BridgeObjectMapper.get().readValue(jsonText,
@@ -88,22 +86,19 @@ public class SurveyElementTest {
     @Test
     public void serializeSurveyInfoScreen() throws Exception {
         // start with JSON
-        
-        String jsonText = "{" +
-                "   \"guid\":\"test-guid\"," +
-                "   \"identifier\":\"test-survey-info-screen\"," +
-                "   \"image\":{" +
-                "       \"source\":\"http://www.example.com/test.png\"," +
-                "       \"width\":200," +
-                "       \"height\":150" +
-                "   }," +
-                "   \"prompt\":\"This is the survey info\"," +
-                "   \"beforeRules\":[{\"operator\":\"eq\",\"value\":10,\"assignDataGroup\":\"foo\"}],"+
-                "   \"afterRules\":[{\"operator\":\"always\",\"endSurvey\":true}],"+
-                "   \"promptDetail\":\"More info\"," +
-                "   \"title\":\"Survey Info\"," +
-                "   \"type\":\"SurveyInfoScreen\"" +
-                "}";
+        String jsonText = TestUtils.createJson("{'guid':'test-guid'," +
+                "'identifier':'test-survey-info-screen'," +
+                "'image':{" +
+                "    'source':'http://www.example.com/test.png'," +
+                "    'width':200," +
+                "    'height':150" +
+                "}," +
+                "'prompt':'This is the survey info'," +
+                "'beforeRules':[{'operator':'eq','value':10,'assignDataGroup':'foo'}],"+
+                "'afterRules':[{'operator':'always','endSurvey':true}],"+
+                "'promptDetail':'More info'," +
+                "'title':'Survey Info'," +
+                "'type':'SurveyInfoScreen'}");
 
         // convert to POJO
         DynamoSurveyInfoScreen infoScreen = (DynamoSurveyInfoScreen) BridgeObjectMapper.get().readValue(jsonText,
@@ -148,13 +143,11 @@ public class SurveyElementTest {
     @Test(expected = InvalidEntityException.class)
     public void serializeInvalidSurveyElementType() throws Exception {
         // start with JSON
-        String jsonText = "{\n" +
-                "   \"guid\":\"bad-guid\",\n" +
-                "   \"identifier\":\"bad-survey-element\",\n" +
-                "   \"prompt\":\"Is this valid?\",\n" +
-                "   \"promptDetail\":\"Details about validity\",\n" +
-                "   \"type\":\"SurveyEggplant\"\n" +
-                "}";
+        String jsonText = TestUtils.createJson("{'guid': 'bad-guid'," +
+                "'identifier': 'bad-survey-element'," +
+                "'prompt': 'Is this valid?'," +
+                "'promptDetail': 'Details about validity'," +
+                "'type': 'SurveyEggplant'}");
 
         // convert to POJO
         BridgeObjectMapper.get().readValue(jsonText, SurveyElement.class);

--- a/test/org/sagebionetworks/bridge/models/surveys/SurveyElementTest.java
+++ b/test/org/sagebionetworks/bridge/models/surveys/SurveyElementTest.java
@@ -18,8 +18,15 @@ import org.sagebionetworks.bridge.models.surveys.SurveyRule.Operator;
 
 @SuppressWarnings("unchecked")
 public class SurveyElementTest {
+    
+    private static final SurveyRule BEFORE_RULE = new SurveyRule.Builder().withOperator(Operator.EQ).withValue(10)
+            .withAssignDataGroup("foo").build();
+    private static final SurveyRule AFTER_RULE = new SurveyRule.Builder().withEndSurvey(true)
+            .withOperator(Operator.ALWAYS).build();
+    
     @Test
     public void serializeSurveyQuestion() throws Exception {
+        
         // start with JSON
         String jsonText = "{" +
                 "   \"fireEvent\":false," +
@@ -27,7 +34,8 @@ public class SurveyElementTest {
                 "   \"identifier\":\"test-survey-question\"," +
                 "   \"prompt\":\"Is this a survey question?\"," +
                 "   \"promptDetail\":\"Details about question\"," +
-                "   \"rules\":[{\"operator\":\"always\",\"endSurvey\":true}],"+
+                "   \"beforeRules\":[{\"operator\":\"eq\",\"value\":10,\"assignDataGroup\":\"foo\"}],"+
+                "   \"afterRules\":[{\"operator\":\"always\",\"endSurvey\":true}],"+
                 "   \"type\":\"SurveyQuestion\"," +
                 "   \"uiHint\":\"textfield\"" +
                 "}";
@@ -46,13 +54,16 @@ public class SurveyElementTest {
         assertNull(question.getSurveyCompoundKey());
         assertEquals("SurveyQuestion", question.getType());
         assertEquals(UIHint.TEXTFIELD, question.getUiHint());
+        
+        assertEquals(BEFORE_RULE, question.getBeforeRules().get(0));
+        assertEquals(AFTER_RULE, question.getAfterRules().get(0));
 
         // convert back to JSON
         String convertedJson = BridgeObjectMapper.get().writeValueAsString(question);
 
         // then convert to a map so we can validate the raw JSON
         Map<String, Object> jsonMap = BridgeObjectMapper.get().readValue(convertedJson, JsonUtils.TYPE_REF_RAW_MAP);
-        assertEquals(8, jsonMap.size());
+        assertEquals(9, jsonMap.size());
         assertFalse((boolean) jsonMap.get("fireEvent"));
         assertEquals("test-guid", jsonMap.get("guid"));
         assertEquals("test-survey-question", jsonMap.get("identifier"));
@@ -63,7 +74,6 @@ public class SurveyElementTest {
         
         SurveyQuestion deserQuestion = BridgeObjectMapper.get().readValue(convertedJson, SurveyQuestion.class);
         
-        SurveyRule rule = new SurveyRule.Builder().withEndSurvey(true).withOperator(Operator.ALWAYS).build();
         assertFalse(deserQuestion.getFireEvent());
         assertEquals("test-guid", deserQuestion.getGuid());
         assertEquals("test-survey-question", deserQuestion.getIdentifier());
@@ -71,7 +81,8 @@ public class SurveyElementTest {
         assertEquals("Details about question", deserQuestion.getPromptDetail());
         assertEquals("SurveyQuestion", deserQuestion.getType());
         assertEquals(UIHint.TEXTFIELD, deserQuestion.getUiHint());
-        assertEquals(rule, deserQuestion.getRules().get(0));
+        assertEquals(BEFORE_RULE, deserQuestion.getBeforeRules().get(0));
+        assertEquals(AFTER_RULE, deserQuestion.getAfterRules().get(0));
     }
 
     @Test
@@ -87,7 +98,8 @@ public class SurveyElementTest {
                 "       \"height\":150" +
                 "   }," +
                 "   \"prompt\":\"This is the survey info\"," +
-                "   \"rules\":[{\"operator\":\"always\",\"endSurvey\":true}],"+
+                "   \"beforeRules\":[{\"operator\":\"eq\",\"value\":10,\"assignDataGroup\":\"foo\"}],"+
+                "   \"afterRules\":[{\"operator\":\"always\",\"endSurvey\":true}],"+
                 "   \"promptDetail\":\"More info\"," +
                 "   \"title\":\"Survey Info\"," +
                 "   \"type\":\"SurveyInfoScreen\"" +
@@ -105,8 +117,8 @@ public class SurveyElementTest {
         assertNull(infoScreen.getSurveyCompoundKey());
         assertEquals("Survey Info", infoScreen.getTitle());
         assertEquals("SurveyInfoScreen", infoScreen.getType());
-        SurveyRule rule = new SurveyRule.Builder().withEndSurvey(true).withOperator(Operator.ALWAYS).build();
-        assertEquals(rule, infoScreen.getRules().get(0));
+        assertEquals(BEFORE_RULE, infoScreen.getBeforeRules().get(0));
+        assertEquals(AFTER_RULE, infoScreen.getAfterRules().get(0));
 
         assertEquals("http://www.example.com/test.png", infoScreen.getImage().getSource());
         assertEquals(200, infoScreen.getImage().getWidth());
@@ -117,7 +129,7 @@ public class SurveyElementTest {
 
         // then convert to a map so we can validate the raw JSON
         Map<String, Object> jsonMap = BridgeObjectMapper.get().readValue(convertedJson, JsonUtils.TYPE_REF_RAW_MAP);
-        assertEquals(8, jsonMap.size());
+        assertEquals(9, jsonMap.size());
         assertEquals("test-guid", jsonMap.get("guid"));
         assertEquals("test-survey-info-screen", jsonMap.get("identifier"));
         assertEquals("This is the survey info", jsonMap.get("prompt"));

--- a/test/org/sagebionetworks/bridge/models/surveys/SurveyRuleTest.java
+++ b/test/org/sagebionetworks/bridge/models/surveys/SurveyRuleTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.TreeSet;
+
 import org.junit.Test;
 
 import org.sagebionetworks.bridge.TestUtils;
@@ -39,11 +41,11 @@ public class SurveyRuleTest {
                 .withSkipToTarget("test").withEndSurvey(Boolean.FALSE).build();
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(skipToRule);
-        assertEquals("eq", node.get("operator").asText());
-        assertEquals("value", node.get("value").asText());
-        assertEquals("test", node.get("skipTo").asText());
+        assertEquals("eq", node.get("operator").textValue());
+        assertEquals("value", node.get("value").textValue());
+        assertEquals("test", node.get("skipTo").textValue());
         assertNull(node.get("endSurvey"));
-        assertEquals("SurveyRule", node.get("type").asText());
+        assertEquals("SurveyRule", node.get("type").textValue());
         
         SurveyRule deser = BridgeObjectMapper.get().treeToValue(node, SurveyRule.class);
         assertEquals(skipToRule, deser);
@@ -55,11 +57,11 @@ public class SurveyRuleTest {
                 .withEndSurvey(Boolean.TRUE).build();
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(endRule);
-        assertEquals("eq", node.get("operator").asText());
-        assertEquals("value", node.get("value").asText());
+        assertEquals("eq", node.get("operator").textValue());
+        assertEquals("value", node.get("value").textValue());
         assertNull(node.get("skipTo"));
-        assertTrue(node.get("endSurvey").asBoolean());
-        assertEquals("SurveyRule", node.get("type").asText());
+        assertTrue(node.get("endSurvey").booleanValue());
+        assertEquals("SurveyRule", node.get("type").textValue());
         
         SurveyRule deser = BridgeObjectMapper.get().treeToValue(node, SurveyRule.class);
         assertEquals(endRule, deser);
@@ -70,11 +72,11 @@ public class SurveyRuleTest {
         SurveyRule alwaysRule = new SurveyRule.Builder().withOperator(Operator.ALWAYS).withEndSurvey(true).build();
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(alwaysRule);
-        assertEquals("always", node.get("operator").asText());
+        assertEquals("always", node.get("operator").textValue());
         assertNull(node.get("value"));
         assertNull(node.get("skipTo"));
-        assertTrue(node.get("endSurvey").asBoolean());
-        assertEquals("SurveyRule", node.get("type").asText());
+        assertTrue(node.get("endSurvey").booleanValue());
+        assertEquals("SurveyRule", node.get("type").textValue());
         
         SurveyRule deser = BridgeObjectMapper.get().treeToValue(node, SurveyRule.class);
         assertEquals(alwaysRule, deser);
@@ -86,11 +88,11 @@ public class SurveyRuleTest {
                 .withAssignDataGroup("bar").build();
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(dataGroupRule);
-        assertEquals("eq", node.get("operator").asText());
-        assertEquals("foo", node.get("value").asText());
+        assertEquals("eq", node.get("operator").textValue());
+        assertEquals("foo", node.get("value").textValue());
         assertNull(node.get("skipTo"));
-        assertEquals("bar", node.get("assignDataGroup").asText());
-        assertEquals("SurveyRule", node.get("type").asText());
+        assertEquals("bar", node.get("assignDataGroup").textValue());
+        assertEquals("SurveyRule", node.get("type").textValue());
         
         SurveyRule deser = BridgeObjectMapper.get().treeToValue(node, SurveyRule.class);
         assertEquals(dataGroupRule, deser);
@@ -98,14 +100,18 @@ public class SurveyRuleTest {
     
     @Test
     public void canSerializeDisplayIf() throws Exception {
+        TreeSet<String> displayGroups = new TreeSet<>();
+        displayGroups.add("bar");
+        displayGroups.add("foo");
         SurveyRule displayIf = new SurveyRule.Builder().withOperator(Operator.ANY)
-                .withDataGroups(Sets.newHashSet("foo")).withDisplayIf(Boolean.TRUE).build();
+                .withDataGroups(displayGroups).withDisplayIf(Boolean.TRUE).build();
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(displayIf);
-        assertEquals("any", node.get("operator").asText());
-        assertEquals("foo", node.get("dataGroups").get(0).asText());
-        assertTrue(node.get("displayIf").asBoolean());
-        assertEquals("SurveyRule", node.get("type").asText());
+        assertEquals("any", node.get("operator").textValue());
+        assertEquals("bar", node.get("dataGroups").get(0).textValue());
+        assertEquals("foo", node.get("dataGroups").get(1).textValue());
+        assertTrue(node.get("displayIf").booleanValue());
+        assertEquals("SurveyRule", node.get("type").textValue());
         
         SurveyRule deser = BridgeObjectMapper.get().treeToValue(node, SurveyRule.class);
         assertEquals(displayIf, deser);
@@ -117,10 +123,10 @@ public class SurveyRuleTest {
                 .withDataGroups(Sets.newHashSet("foo")).withDisplayUnless(Boolean.TRUE).build();
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(displayIf);
-        assertEquals("any", node.get("operator").asText());
-        assertEquals("foo", node.get("dataGroups").get(0).asText());
-        assertTrue(node.get("displayUnless").asBoolean());
-        assertEquals("SurveyRule", node.get("type").asText());
+        assertEquals("any", node.get("operator").textValue());
+        assertEquals("foo", node.get("dataGroups").get(0).textValue());
+        assertTrue(node.get("displayUnless").booleanValue());
+        assertEquals("SurveyRule", node.get("type").textValue());
         
         SurveyRule deser = BridgeObjectMapper.get().treeToValue(node, SurveyRule.class);
         assertEquals(displayIf, deser);

--- a/test/org/sagebionetworks/bridge/models/surveys/SurveyRuleTest.java
+++ b/test/org/sagebionetworks/bridge/models/surveys/SurveyRuleTest.java
@@ -139,4 +139,14 @@ public class SurveyRuleTest {
         assertNull(node.get("displayUnless"));
         assertNull(node.get("endSurvey"));
     }
+    
+    @Test
+    public void settingBooleanActionToFalseNullifiesIt() {
+        SurveyRule.Builder builder = new SurveyRule.Builder().withDisplayIf(true).withDisplayUnless(true).withEndSurvey(true);
+        
+        SurveyRule rule = builder.withDisplayIf(false).withDisplayUnless(false).withEndSurvey(false).build();
+        assertNull(rule.getDisplayIf());
+        assertNull(rule.getDisplayUnless());
+        assertNull(rule.getEndSurvey());
+    }
 }

--- a/test/org/sagebionetworks/bridge/validators/SurveySaveValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/SurveySaveValidatorTest.java
@@ -409,7 +409,7 @@ public class SurveySaveValidatorTest {
         info.setIdentifier("theend");
         survey.getElements().add(info);
 
-        assertValidatorMessage(validator, survey, "elements[0].constraints.rules[0]",
+        assertValidatorMessage(validator, survey, "elements[0].constraints.afterRules[0]",
                 "must have one and only one action: skipTo, endSurvey, or assignDataGroup");
     }
 
@@ -435,7 +435,7 @@ public class SurveySaveValidatorTest {
         question.setConstraints(constraints);
         survey.getElements().add(question);
 
-        assertValidatorMessage(validator, survey, "elements[0].constraints.rules[0]",
+        assertValidatorMessage(validator, survey, "elements[0].constraints.afterRules[0]",
                 "must have one and only one action: skipTo, endSurvey, or assignDataGroup");
     }
 
@@ -466,7 +466,7 @@ public class SurveySaveValidatorTest {
         question.setUiHint(UIHint.TEXTFIELD);
         question.setPrompt("Prompt");
         question.setConstraints(constraints);
-        question.setRules(Lists.newArrayList(
+        question.setAfterRules(Lists.newArrayList(
                 new SurveyRule.Builder().withOperator(Operator.EQ).withValue("No").withSkipToTarget("theend").build()));
 
         SurveyInfoScreen info = new DynamoSurveyInfoScreen();
@@ -501,7 +501,7 @@ public class SurveySaveValidatorTest {
         question.setUiHint(UIHint.TEXTFIELD);
         question.setPrompt("Prompt");
         question.setConstraints(constraints);
-        question.setRules(Lists.newArrayList(rule));
+        question.setAfterRules(Lists.newArrayList(rule));
         
         survey.getElements().add(question);
 
@@ -511,7 +511,7 @@ public class SurveySaveValidatorTest {
         info.setIdentifier("theend");
         survey.getElements().add(info);
 
-        assertValidatorMessage(validator, survey, "elements[0].rules[0]",
+        assertValidatorMessage(validator, survey, "elements[0].afterRules[0]",
                 "must have one and only one action: skipTo, endSurvey, or assignDataGroup");
     }
 
@@ -534,11 +534,11 @@ public class SurveySaveValidatorTest {
         question.setUiHint(UIHint.TEXTFIELD);
         question.setPrompt("Prompt");
         question.setConstraints(constraints);
-        question.setRules(Lists.newArrayList(rule));
+        question.setAfterRules(Lists.newArrayList(rule));
         
         survey.getElements().add(question);
 
-        assertValidatorMessage(validator, survey, "elements[0].rules[0]",
+        assertValidatorMessage(validator, survey, "elements[0].afterRules[0]",
                 "must have one and only one action: skipTo, endSurvey, or assignDataGroup");
     }
 
@@ -795,7 +795,7 @@ public class SurveySaveValidatorTest {
                 .withSkipToTarget("high_bp").build();
         question.getConstraints().setRules(Lists.newArrayList(rule));
 
-        assertValidatorMessage(validator, survey, "elements[4].constraints.rules[0]", "back references question high_bp");
+        assertValidatorMessage(validator, survey, "elements[4].constraints.afterRules[0]", "back references question high_bp");
     }
 
     @Test
@@ -837,9 +837,9 @@ public class SurveySaveValidatorTest {
 
         SurveyRule rule = new SurveyRule.Builder().withOperator(SurveyRule.Operator.EQ).withValue(1)
                 .withSkipToTarget("high_bp").build();
-        question.setRules(Lists.newArrayList(rule));
+        question.setAfterRules(Lists.newArrayList(rule));
 
-        assertValidatorMessage(validator, survey, "elements[4].rules[0]", "back references question high_bp");
+        assertValidatorMessage(validator, survey, "elements[4].afterRules[0]", "back references question high_bp");
     }
 
     @Test
@@ -850,7 +850,7 @@ public class SurveySaveValidatorTest {
         SurveyQuestion question = ((TestSurvey) survey).getIntegerQuestion();
         SurveyRule rule = new SurveyRule.Builder().withOperator(SurveyRule.Operator.EQ).withValue(1)
                 .withEndSurvey(Boolean.TRUE).build();
-        question.setRules(Lists.newArrayList(rule));
+        question.setAfterRules(Lists.newArrayList(rule));
 
         Validate.entityThrowingException(validator, survey);
     }
@@ -865,9 +865,9 @@ public class SurveySaveValidatorTest {
 
         SurveyRule rule = new SurveyRule.Builder().withOperator(SurveyRule.Operator.EQ).withValue(1)
                 .withSkipToTarget("this_does_not_exist").build();
-        question.setRules(Lists.newArrayList(rule));
+        question.setAfterRules(Lists.newArrayList(rule));
 
-        assertValidatorMessage(validator, survey, "elements[4].rules[0]",
+        assertValidatorMessage(validator, survey, "elements[4].afterRules[0]",
                 "has a skipTo identifier that doesn't exist: this_does_not_exist");
     }
     
@@ -881,11 +881,11 @@ public class SurveySaveValidatorTest {
         info.setPromptDetail("prompt detail");
         info.setIdentifier("identifier");
         info.setGuid("guid");
-        info.setRules(Lists.newArrayList(
+        info.setAfterRules(Lists.newArrayList(
                 new SurveyRule.Builder().withValue("foo").withOperator(Operator.EQ).withEndSurvey(true).build()));
         survey.setElements(Lists.newArrayList(info));
         
-        assertValidatorMessage(validator, survey, "elements[0].rules[0]",
+        assertValidatorMessage(validator, survey, "elements[0].afterRules[0]",
                 "only valid with the 'always' operator");
     }
     
@@ -899,9 +899,9 @@ public class SurveySaveValidatorTest {
 
         SurveyRule rule = new SurveyRule.Builder().withOperator(SurveyRule.Operator.EQ).withValue(1)
                 .withSkipToTarget(targetId).withAssignDataGroup("dataGroup").build();
-        question.setRules(Lists.newArrayList(rule));
+        question.setAfterRules(Lists.newArrayList(rule));
 
-        assertValidatorMessage(validator, survey, "elements[4].rules[0]",
+        assertValidatorMessage(validator, survey, "elements[4].afterRules[0]",
                 "must have one and only one action: skipTo, endSurvey, or assignDataGroup");
     }
     
@@ -913,9 +913,9 @@ public class SurveySaveValidatorTest {
         
         SurveyRule rule = new SurveyRule.Builder().withOperator(SurveyRule.Operator.EQ).withValue(1)
                 .withAssignDataGroup("bar").build();
-        question.setRules(Lists.newArrayList(rule));
+        question.setAfterRules(Lists.newArrayList(rule));
 
-        assertValidatorMessage(validator, survey, "elements[4].rules[0]",
+        assertValidatorMessage(validator, survey, "elements[4].afterRules[0]",
                 "has a data group 'bar' that is not a valid data group: baz, foo");
     }
 }

--- a/test/org/sagebionetworks/bridge/validators/SurveySaveValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/SurveySaveValidatorTest.java
@@ -409,7 +409,7 @@ public class SurveySaveValidatorTest {
         info.setIdentifier("theend");
         survey.getElements().add(info);
 
-        assertValidatorMessage(validator, survey, "elements[0].constraints.afterRules[0]",
+        assertValidatorMessage(validator, survey, "elements[0].constraints.rules[0]",
                 "must have one and only one action: skipTo, endSurvey, or assignDataGroup");
     }
 
@@ -435,7 +435,7 @@ public class SurveySaveValidatorTest {
         question.setConstraints(constraints);
         survey.getElements().add(question);
 
-        assertValidatorMessage(validator, survey, "elements[0].constraints.afterRules[0]",
+        assertValidatorMessage(validator, survey, "elements[0].constraints.rules[0]",
                 "must have one and only one action: skipTo, endSurvey, or assignDataGroup");
     }
 
@@ -795,7 +795,7 @@ public class SurveySaveValidatorTest {
                 .withSkipToTarget("high_bp").build();
         question.getConstraints().setRules(Lists.newArrayList(rule));
 
-        assertValidatorMessage(validator, survey, "elements[4].constraints.afterRules[0]", "back references question high_bp");
+        assertValidatorMessage(validator, survey, "elements[4].constraints.rules[0]", "back references question high_bp");
     }
 
     @Test
@@ -917,5 +917,23 @@ public class SurveySaveValidatorTest {
 
         assertValidatorMessage(validator, survey, "elements[4].afterRules[0]",
                 "has a data group 'bar' that is not a valid data group: baz, foo");
+    }
+    
+    @Test
+    public void beforeRulesAreValidated() {
+        survey = new TestSurvey(SurveySaveValidatorTest.class, false);
+
+        SurveyRule invalidSkipTo = new SurveyRule.Builder().withOperator(SurveyRule.Operator.EQ).withValue(1).withSkipToTarget("some-nonsense").build();
+        SurveyRule tooManyActions = new SurveyRule.Builder().withOperator(SurveyRule.Operator.LE).withValue(1).withSkipToTarget("nonsense").withEndSurvey(true).build();
+
+        SurveyQuestion question = ((TestSurvey) survey).getIntegerQuestion();
+        question.setBeforeRules(Lists.newArrayList(invalidSkipTo, tooManyActions));
+        
+        survey.setElements(Lists.newArrayList(question));
+        
+        assertValidatorMessage(validator, survey, "elements[0].beforeRules[0]",
+                "has a skipTo identifier that doesn't exist: some-nonsense");
+        assertValidatorMessage(validator, survey, "elements[0].beforeRules[1]",
+                "must have one and only one action: skipTo, endSurvey, or assignDataGroup");
     }
 }

--- a/test/org/sagebionetworks/bridge/validators/SurveySaveValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/SurveySaveValidatorTest.java
@@ -410,7 +410,7 @@ public class SurveySaveValidatorTest {
         survey.getElements().add(info);
 
         assertValidatorMessage(validator, survey, "elements[0].constraints.rules[0]",
-                "must have one and only one action: skipTo, endSurvey, or assignDataGroup");
+                "must have one and only one action");
     }
 
     @Test
@@ -436,7 +436,7 @@ public class SurveySaveValidatorTest {
         survey.getElements().add(question);
 
         assertValidatorMessage(validator, survey, "elements[0].constraints.rules[0]",
-                "must have one and only one action: skipTo, endSurvey, or assignDataGroup");
+                "must have one and only one action");
     }
 
     @Test
@@ -512,7 +512,7 @@ public class SurveySaveValidatorTest {
         survey.getElements().add(info);
 
         assertValidatorMessage(validator, survey, "elements[0].afterRules[0]",
-                "must have one and only one action: skipTo, endSurvey, or assignDataGroup");
+                "must have one and only one action");
     }
 
     @Test
@@ -539,7 +539,7 @@ public class SurveySaveValidatorTest {
         survey.getElements().add(question);
 
         assertValidatorMessage(validator, survey, "elements[0].afterRules[0]",
-                "must have one and only one action: skipTo, endSurvey, or assignDataGroup");
+                "must have one and only one action");
     }
 
     @Test
@@ -898,11 +898,11 @@ public class SurveySaveValidatorTest {
         String targetId = ((TestSurvey) survey).getStringQuestion().getIdentifier();
 
         SurveyRule rule = new SurveyRule.Builder().withOperator(SurveyRule.Operator.EQ).withValue(1)
-                .withSkipToTarget(targetId).withAssignDataGroup("dataGroup").build();
+                .withSkipToTarget(targetId).withAssignDataGroup("baz").build();
         question.setAfterRules(Lists.newArrayList(rule));
 
         assertValidatorMessage(validator, survey, "elements[4].afterRules[0]",
-                "must have one and only one action: skipTo, endSurvey, or assignDataGroup");
+                "must have one and only one action");
     }
     
     @Test
@@ -934,6 +934,6 @@ public class SurveySaveValidatorTest {
         assertValidatorMessage(validator, survey, "elements[0].beforeRules[0]",
                 "has a skipTo identifier that doesn't exist: some-nonsense");
         assertValidatorMessage(validator, survey, "elements[0].beforeRules[1]",
-                "must have one and only one action: skipTo, endSurvey, or assignDataGroup");
+                "must have one and only one action");
     }
 }

--- a/test/org/sagebionetworks/bridge/validators/SurveySaveValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/SurveySaveValidatorTest.java
@@ -936,4 +936,24 @@ public class SurveySaveValidatorTest {
         assertValidatorMessage(validator, survey, "elements[0].beforeRules[1]",
                 "must have one and only one action");
     }
+    
+    @Test
+    public void cannotSetDisplayRuleAfterScreenDisplayed() {
+        survey = new TestSurvey(SurveySaveValidatorTest.class, false);
+        
+        // Most rules work in most places, but these specifically refer to the current screen and 
+        // must be evaluated before the screen is displayed in "after rules" is not useful.
+        SurveyRule displayIf = new SurveyRule.Builder().withOperator(SurveyRule.Operator.EQ).withValue(1).withDisplayIf(true).build();
+        SurveyRule displayUnless = new SurveyRule.Builder().withOperator(SurveyRule.Operator.LE).withValue(1).withDisplayUnless(true).build();
+        
+        SurveyQuestion question = ((TestSurvey) survey).getIntegerQuestion();
+        question.setAfterRules(Lists.newArrayList(displayIf, displayUnless));
+        
+        survey.setElements(Lists.newArrayList(question));
+        
+        assertValidatorMessage(validator, survey, "elements[0].afterRules[0]",
+                "specifies display after screen has been shown");
+        assertValidatorMessage(validator, survey, "elements[0].afterRules[1]",
+                "specifies display after screen has been shown");
+    }
 }


### PR DESCRIPTION
Splits element rules into a before and after set.
Add two new actions for before sets: displayIf and displayUnless
Add the ability to specify data groups to test against (rather than the answer to a question);
Add two new set operators, "any" and "all", specifically for testing against data groups
Update validation rules
