### PR TITLE
Rollback newrelic agent

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-ses" % "1.10.20",
   
   // New Relic
-  "com.newrelic.agent.java" % "newrelic-agent" % "3.39.1",
+  "com.newrelic.agent.java" % "newrelic-agent" % "3.32.0",
   // Dom4j, needed to resolve dependency conflicts for Hibernate
   "dom4j" % "dom4j" % "1.6.1",
   // MySQL JDBC connector


### PR DESCRIPTION
Chnage 85e5b04 updated the new relic agent to ver 3.39.1. However
in order to deploy the new agent the heroku JAVA_OPTS Env Var pointing
to the agent jar needs to be updated at the same time. There really isn't
a good way to deploy and update the Env var without incurring downtime
on heroku.  AWS provides a rolling update feature which will make this
possible.  We rollback the agent now and update after we move to
using AWS.