### PR TITLE
Stop sharing deployment buckets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ deploy:
       prod: bridge-prod
   - provider: elasticbeanstalk
     skip_cleanup: true
-    bucket_name: org-sagebridge-bridgepf-deployment-develop
+    bucket_name: org-sagebridge-bridgepf-deployment-$TRAVIS_BRANCH
     zip_file: target/universal/bridgepf-0.1-SNAPSHOT.zip
     region: us-east-1
     app: BridgePF


### PR DESCRIPTION
To facilitate cloudformation deployments we want to use
separate resources for each elastic beanstalk environment.