### PR TITLE
Adding a description of password requirements to the password reset page. 

### DIFF
--- a/app/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/app/org/sagebionetworks/bridge/BridgeUtils.java
@@ -357,7 +357,7 @@ public class BridgeUtils {
                 phrases.add("one number");
             }
             if (policy.isSymbolRequired()) {
-                phrases.add("one symoblic character");
+                phrases.add("one symbolic character");
             }
             for (int i=0; i < phrases.size(); i++) {
                 if (i == phrases.size()-1) {

--- a/app/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/app/org/sagebionetworks/bridge/BridgeUtils.java
@@ -357,7 +357,8 @@ public class BridgeUtils {
                 phrases.add("one number");
             }
             if (policy.isSymbolRequired()) {
-                phrases.add("one symbolic character");
+                // !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~
+                phrases.add("one symbolic character (non-alphanumerics like #$%&@)");
             }
             for (int i=0; i < phrases.size(); i++) {
                 if (i == phrases.size()-1) {

--- a/app/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/app/org/sagebionetworks/bridge/BridgeUtils.java
@@ -8,6 +8,7 @@ import static org.springframework.util.StringUtils.commaDelimitedListToSet;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.security.SecureRandom;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -25,6 +26,7 @@ import org.joda.time.DateTime;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.json.BridgeTypeName;
+import org.sagebionetworks.bridge.models.studies.PasswordPolicy;
 import org.sagebionetworks.bridge.models.studies.Study;
 
 import org.springframework.core.annotation.AnnotationUtils;
@@ -337,6 +339,37 @@ public class BridgeUtils {
             }
         }
         return encoded;
+    }
+    
+    public static String passwordPolicyDescription(PasswordPolicy policy) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Password must be ").append(policy.getMinLength()).append(" or more characters");
+        if (policy.isLowerCaseRequired() || policy.isNumericRequired() || policy.isSymbolRequired() || policy.isUpperCaseRequired()) {
+            sb.append(", and must contain at least ");
+            List<String> phrases = new ArrayList<>();
+            if (policy.isLowerCaseRequired()) {
+                phrases.add("one lower-case letter");
+            }
+            if (policy.isUpperCaseRequired()) {
+                phrases.add("one upper-case letter");
+            }
+            if (policy.isNumericRequired()) {
+                phrases.add("one number");
+            }
+            if (policy.isSymbolRequired()) {
+                phrases.add("one symoblic character");
+            }
+            for (int i=0; i < phrases.size(); i++) {
+                if (i == phrases.size()-1) {
+                    sb.append(", and ");
+                } else if (i > 0) {
+                    sb.append(", ");
+                }
+                sb.append(phrases.get(i));
+            }
+        }
+        sb.append(".");
+        return sb.toString();
     }
 
 }

--- a/app/org/sagebionetworks/bridge/play/controllers/ApplicationController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ApplicationController.java
@@ -4,6 +4,7 @@ import static org.sagebionetworks.bridge.BridgeConstants.ASSETS_HOST;
 
 import org.apache.commons.lang3.StringEscapeUtils;
 
+import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
@@ -33,8 +34,10 @@ public class ApplicationController extends BaseController {
 
     public Result resetPassword(String studyId) {
         Study study = studyService.getStudy(studyId);
+        String passwordDescription = BridgeUtils.passwordPolicyDescription(study.getPasswordPolicy());
         return ok(views.html.resetPassword.render(ASSETS_HOST, ASSETS_BUILD,
-                StringEscapeUtils.escapeHtml4(study.getName()), study.getSupportEmail()));
+            StringEscapeUtils.escapeHtml4(study.getName()), study.getSupportEmail(), 
+            passwordDescription));
     }
     
     public Result startSession(String studyId, String email, String token) {

--- a/app/views/resetPassword.scala.html
+++ b/app/views/resetPassword.scala.html
@@ -1,4 +1,4 @@
-@(assetsHost: String, assetsBuild: String, studyName: String, studySupportEmail: String)
+@(assetsHost: String, assetsBuild: String, studyName: String, studySupportEmail: String, passwordDescription: String)
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -29,6 +29,9 @@
 		
 		<div style="margin-top:10px">
 			<input id="submit" type="submit" value="Reset Password"/>
+		</div>
+		<div style="margin-top:10px">
+			@passwordDescription
 		</div>
 	</form>
 </div>

--- a/test/org/sagebionetworks/bridge/BridgeUtilsTest.java
+++ b/test/org/sagebionetworks/bridge/BridgeUtilsTest.java
@@ -17,6 +17,7 @@ import org.joda.time.DateTime;
 import org.junit.Test;
 
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
+import org.sagebionetworks.bridge.models.studies.PasswordPolicy;
 import org.sagebionetworks.bridge.models.studies.Study;
 
 import com.google.common.collect.Lists;
@@ -334,6 +335,17 @@ public class BridgeUtilsTest {
     @Test
     public void encodeURIComponentNoEscaping() {
         assertEquals("foo-bar", BridgeUtils.encodeURIComponent("foo-bar"));
+    }
+    
+    @Test
+    public void passwordPolicyDescription() {
+        PasswordPolicy policy = new PasswordPolicy(8, false, true, false, true);
+        String description = BridgeUtils.passwordPolicyDescription(policy);
+        assertEquals("Password must be 8 or more characters, and must contain at least one upper-case letter, and one symoblic character.", description);
+        
+        policy = new PasswordPolicy(2, false, false, false, false);
+        description = BridgeUtils.passwordPolicyDescription(policy);
+        assertEquals("Password must be 2 or more characters.", description);
     }
     
     // assertEquals with two sets doesn't verify the order is the same... hence this test method.

--- a/test/org/sagebionetworks/bridge/BridgeUtilsTest.java
+++ b/test/org/sagebionetworks/bridge/BridgeUtilsTest.java
@@ -341,7 +341,7 @@ public class BridgeUtilsTest {
     public void passwordPolicyDescription() {
         PasswordPolicy policy = new PasswordPolicy(8, false, true, false, true);
         String description = BridgeUtils.passwordPolicyDescription(policy);
-        assertEquals("Password must be 8 or more characters, and must contain at least one upper-case letter, and one symoblic character.", description);
+        assertEquals("Password must be 8 or more characters, and must contain at least one upper-case letter, and one symbolic character.", description);
         
         policy = new PasswordPolicy(2, false, false, false, false);
         description = BridgeUtils.passwordPolicyDescription(policy);

--- a/test/org/sagebionetworks/bridge/BridgeUtilsTest.java
+++ b/test/org/sagebionetworks/bridge/BridgeUtilsTest.java
@@ -341,7 +341,7 @@ public class BridgeUtilsTest {
     public void passwordPolicyDescription() {
         PasswordPolicy policy = new PasswordPolicy(8, false, true, false, true);
         String description = BridgeUtils.passwordPolicyDescription(policy);
-        assertEquals("Password must be 8 or more characters, and must contain at least one upper-case letter, and one symbolic character.", description);
+        assertEquals("Password must be 8 or more characters, and must contain at least one upper-case letter, and one symbolic character (non-alphanumerics like #$%&@).", description);
         
         policy = new PasswordPolicy(2, false, false, false, false);
         description = BridgeUtils.passwordPolicyDescription(policy);

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -25,8 +24,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.Mockito;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 


### PR DESCRIPTION
We can add this description elsewhere if needed. We could tell them that the password has to be a maximum of 999 characters, but this makes for a very hostile techie message and I'm not aware that humans create passwords in the hundreds of characters. Or any password managers either.