### PR TITLE
worker accounts can get health codes

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
@@ -155,8 +155,7 @@ public class ParticipantController extends BaseController {
 
         StudyParticipant participant = participantService.getParticipant(study, userId, true);
         
-        // Workers can never retrieve a health code. There's just no reason to leak it here.
-        ObjectWriter writer = StudyParticipant.API_NO_HEALTH_CODE_WRITER;
+        ObjectWriter writer = StudyParticipant.API_WITH_HEALTH_CODE_WRITER;
         String ser = writer.writeValueAsString(participant);
 
         return ok(ser).as(BridgeConstants.JSON_MIME_TYPE);

--- a/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
@@ -172,7 +172,7 @@ public class ParticipantControllerTest {
         summaries.add(SUMMARY);
         summaries.add(SUMMARY);
         summaries.add(SUMMARY);
-        PagedResourceList<AccountSummary> page = new PagedResourceList<AccountSummary>(summaries, 10, 20, 30).withFilter("emailFilter", "foo");
+        PagedResourceList<AccountSummary> page = new PagedResourceList<>(summaries, 10, 20, 30).withFilter("emailFilter", "foo");
         
         when(authService.getSession(eq(study), any())).thenReturn(session);
         
@@ -769,11 +769,11 @@ public class ParticipantControllerTest {
         
         Result result = controller.getParticipantForWorker(study.getIdentifier(), ID);
         assertEquals(200, result.status());
-        
-        StudyParticipant participant = BridgeObjectMapper.get().readValue(Helpers.contentAsString(result),
-                StudyParticipant.class);
-        assertNull(participant.getHealthCode());
-        assertEquals(ID, participant.getId());
+
+        JsonNode participantNode = BridgeObjectMapper.get().readTree(Helpers.contentAsString(result));
+        assertEquals("healthCode", participantNode.get("healthCode").textValue());
+        assertNull(participantNode.get("encryptedHealthCode"));
+        assertEquals(ID, participantNode.get("id").textValue());
     }
     
     private ForwardCursorPagedResourceList<ScheduledActivity> createActivityResultsV2() {


### PR DESCRIPTION
User Data Download needs health codes, so it can scour Synapse for user data. This small change exposes health code for getParticipantForWorker.