### PR TITLE
add optimistic versioning to HibernateAccount

### DIFF
--- a/app/org/sagebionetworks/bridge/exceptions/ConcurrentModificationException.java
+++ b/app/org/sagebionetworks/bridge/exceptions/ConcurrentModificationException.java
@@ -27,7 +27,7 @@ public class ConcurrentModificationException extends BridgeServiceException {
     }
     
     public Class<? extends BridgeEntity> getEntityClass() {
-        return entity.getClass();
+        return entity != null ? entity.getClass() : null;
     }
     
     public BridgeEntity getEntity() {

--- a/app/org/sagebionetworks/bridge/hibernate/HibernateAccount.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateAccount.java
@@ -16,6 +16,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.MapKeyClass;
 import javax.persistence.MapKeyColumn;
 import javax.persistence.Table;
+import javax.persistence.Version;
 
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.models.accounts.AccountStatus;
@@ -45,6 +46,7 @@ public class HibernateAccount {
     private Long passwordModifiedOn;
     private Set<Roles> roles;
     private AccountStatus status;
+    private int version;
 
     /**
      * Account ID, used as a unique identifier for the account that doesn't leak email address (which is personally
@@ -247,5 +249,16 @@ public class HibernateAccount {
     /** @see #getStatus */
     public void setStatus(AccountStatus status) {
         this.status = status;
+    }
+
+    @Version
+    /** Version number, used by Hibernate to handle optimistic locking. */
+    public int getVersion() {
+        return version;
+    }
+
+    /** @see #getVersion */
+    public void setVersion(int version) {
+        this.version = version;
     }
 }

--- a/app/org/sagebionetworks/bridge/models/accounts/GenericAccount.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/GenericAccount.java
@@ -41,6 +41,7 @@ public class GenericAccount implements Account {
     private Set<Roles> roleSet = ImmutableSet.of();
     private AccountStatus status;
     private StudyIdentifier studyId;
+    private int version;
 
     /** {@inheritDoc} */
     @Override
@@ -235,5 +236,15 @@ public class GenericAccount implements Account {
     /** @see #getCreatedOn */
     public void setCreatedOn(DateTime createdOn) {
         this.createdOn = createdOn;
+    }
+
+    /** Version number, used by Hibernate to handle optimistic locking. */
+    public int getVersion() {
+        return version;
+    }
+
+    /** @see #getVersion */
+    public void setVersion(int version) {
+        this.version = version;
     }
 }

--- a/test/org/sagebionetworks/bridge/exceptions/ConcurrentModificationExceptionTest.java
+++ b/test/org/sagebionetworks/bridge/exceptions/ConcurrentModificationExceptionTest.java
@@ -1,0 +1,45 @@
+package org.sagebionetworks.bridge.exceptions;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.http.HttpStatus;
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.BridgeEntity;
+
+public class ConcurrentModificationExceptionTest {
+    private static final TestEntity DUMMY_ENTITY = new TestEntity();
+    private static final String ERROR_MESSAGE = "Something bad happened.";
+
+    @Test
+    public void serialization() {
+        ConcurrentModificationException ex = new ConcurrentModificationException(DUMMY_ENTITY, ERROR_MESSAGE);
+        JsonNode exNode = BridgeObjectMapper.get().valueToTree(ex);
+        assertTrue(exNode.has("entity"));
+        assertTrue(exNode.has("entityClass"));
+        assertEquals(ERROR_MESSAGE, exNode.get("message").textValue());
+        assertEquals(HttpStatus.SC_CONFLICT, exNode.get("statusCode").intValue());
+    }
+
+    @Test
+    public void serializationNullEntity() {
+        ConcurrentModificationException ex = new ConcurrentModificationException(ERROR_MESSAGE);
+        JsonNode exNode = BridgeObjectMapper.get().valueToTree(ex);
+        assertFalse(exNode.has("entity"));
+        assertFalse(exNode.has("entityClass"));
+        assertEquals(ERROR_MESSAGE, exNode.get("message").textValue());
+        assertEquals(HttpStatus.SC_CONFLICT, exNode.get("statusCode").intValue());
+    }
+
+    // Trivial class with a single getter. We need a concrete implementation of BridgeEntity, and Jackson requires that
+    // it be non-empty.
+    private static class TestEntity implements BridgeEntity {
+        public String getFoo() {
+            return "foo";
+        }
+    }
+}


### PR DESCRIPTION
This fixes https://sagebionetworks.jira.com/browse/BRIDGE-1898

If you make two simultaneous updates to the same account, or consent to two different subpops simultaneously, it's very possible that you'll hit a race condition and the "second one wins".

This adds optimistic versioning to HibernateAccount, which is handled mostly transparently by Hibernate. This way, if you make two simultaneous edits, the second one will throw a 409, alerting the end user that something bad happened.

Testing done:
* updated and ran unit tests
* no functional changes, but ran integ tests as a sanity check
* manually tested concurrent modification by injecting a 5 second wait into update, then testing various combinations like simultaneous consents, simultaneous edits, edit with a password change, etc