### PR TITLE
Prevent survey element guids from being duplicates during validation.

### DIFF
--- a/app/org/sagebionetworks/bridge/validators/SurveyPublishValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/SurveyPublishValidator.java
@@ -30,6 +30,7 @@ public class SurveyPublishValidator implements Validator {
         Survey survey = (Survey) target;
         // Validate that no identifier has been duplicated.
         Set<String> foundIdentifiers = Sets.newHashSet();
+        Set<String> foundGuids = Sets.newHashSet();
         for (int i = 0; i < survey.getElements().size(); i++) {
             SurveyElement element = survey.getElements().get(i);
             errors.pushNestedPath("elements["+i+"]");
@@ -40,7 +41,13 @@ public class SurveyPublishValidator implements Validator {
             if (foundIdentifiers.contains(element.getIdentifier())) {
                 errors.rejectValue("identifier", "exists in an earlier survey element");
             }
+            if (element.getGuid() != null && foundGuids.contains(element.getGuid())) {
+                errors.rejectValue("guid", "exists in an earlier survey element");
+            }
             foundIdentifiers.add(element.getIdentifier());
+            if (element.getGuid() != null) {
+                foundGuids.add(element.getGuid());    
+            }
             errors.popNestedPath();
         }
     }

--- a/app/org/sagebionetworks/bridge/validators/SurveySaveValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/SurveySaveValidator.java
@@ -69,6 +69,7 @@ public class SurveySaveValidator implements Validator {
 
         // Validate that no identifier has been duplicated.
         Set<String> foundIdentifiers = Sets.newHashSet();
+        Set<String> foundGuids = Sets.newHashSet();
         for (int i=0; i < survey.getElements().size(); i++) {
             SurveyElement element = survey.getElements().get(i);
             errors.pushNestedPath("elements["+i+"]");
@@ -80,7 +81,13 @@ public class SurveySaveValidator implements Validator {
             if (foundIdentifiers.contains(element.getIdentifier())) {
                 errors.rejectValue("identifier", "exists in an earlier survey element");
             }
+            if (element.getGuid() != null && foundGuids.contains(element.getGuid())) {
+                errors.rejectValue("guid", "exists in an earlier survey element");
+            }
             foundIdentifiers.add(element.getIdentifier());
+            if (element.getGuid() != null) {
+                foundGuids.add(element.getGuid());    
+            }
             errors.popNestedPath();
         }
         // You can get all sorts of NPEs if survey is not valid and you look at the rules.

--- a/test/org/sagebionetworks/bridge/validators/SurveyPublishValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/SurveyPublishValidatorTest.java
@@ -54,5 +54,21 @@ public class SurveyPublishValidatorTest {
                     "must have non-null, non-empty choices list");
         }
     }
+    
+    @Test
+    public void validateGuidsNotDuplicates() {
+        survey = new TestSurvey(SurveySaveValidatorTest.class, false);
+        survey.getElements().get(0).setGuid(survey.getElements().get(1).getGuid());
+        
+        assertValidatorMessage(validator, survey, "elements[1].guid", "exists in an earlier survey element");
+    }
+    
+    @Test
+    public void validateIdentifiersNotDuplicates() {
+        survey = new TestSurvey(SurveySaveValidatorTest.class, false);
+        survey.getElements().get(0).setIdentifier(survey.getElements().get(1).getIdentifier());
+        
+        assertValidatorMessage(validator, survey, "elements[1].identifier", "exists in an earlier survey element");
+    }
 
 }

--- a/test/org/sagebionetworks/bridge/validators/SurveySaveValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/SurveySaveValidatorTest.java
@@ -1048,6 +1048,22 @@ public class SurveySaveValidatorTest {
         assertValidatorMessage(validator, survey, "elements[0].beforeRules[0]", "must have one and only one action");
     }
     
+    @Test
+    public void validateGuidsNotDuplicates() {
+        survey = new TestSurvey(SurveySaveValidatorTest.class, false);
+        survey.getElements().get(0).setGuid(survey.getElements().get(1).getGuid());
+        
+        assertValidatorMessage(validator, survey, "elements[1].guid", "exists in an earlier survey element");
+    }
+    
+    @Test
+    public void validateIdentifiersNotDuplicates() {
+        survey = new TestSurvey(SurveySaveValidatorTest.class, false);
+        survey.getElements().get(0).setIdentifier(survey.getElements().get(1).getIdentifier());
+        
+        assertValidatorMessage(validator, survey, "elements[1].identifier", "exists in an earlier survey element");
+    }
+    
     private Survey updateSurveyWithBeforeRulesInOneQuestion(SurveyRule... rules) {
         survey = new TestSurvey(SurveySaveValidatorTest.class, false);
         


### PR DESCRIPTION
The editor had a bug where copied elements maintained the same GUID and we allowed this to be saved on the server. These should be unique and stable. Adding validation to prevent saving/publishing surveys with elements that have duplicated GUIDs.

(Also fixed in the UI.)