### PR TITLE
Increase Upload Limits

### DIFF
--- a/app/org/sagebionetworks/bridge/validators/UploadValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/UploadValidator.java
@@ -11,7 +11,7 @@ import org.springframework.validation.Validator;
 @Component
 public class UploadValidator implements Validator {
 
-    private static final long MAX_UPLOAD_SIZE = 10L * 1000L * 1000L; // 10 MB
+    private static final long MAX_UPLOAD_SIZE = 20L * 1000L * 1000L; // 20 MB
 
     @Override
     public boolean supports(Class<?> clazz) {

--- a/conf/bridge-server.conf
+++ b/conf/bridge-server.conf
@@ -105,8 +105,8 @@ prod.upload.cms.priv.bucket = org-sagebridge-upload-cms-priv-prod
 # Studies in this comma-separated list ignore upload dedupe logic
 upload.dupe.study.whitelist = api
 
-// Maximum 25 MB per zip entry
-max.zip.entry.size = 25000000
+// Maximum 50 MB per zip entry
+max.zip.entry.size = 50000000
 // Maximum 100 zip entries per archive
 max.num.zip.entries = 100
 

--- a/test/org/sagebionetworks/bridge/validators/UploadValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/UploadValidatorTest.java
@@ -85,7 +85,7 @@ public class UploadValidatorTest {
             ObjectNode node = JsonNodeFactory.instance.objectNode();
             node.put("name", this.getClass().getSimpleName());
             node.put("contentType", "text/plain");
-            node.put("contentLength", 11000000L);
+            node.put("contentLength", 21000000L);
             node.put("contentMd5", Base64.encodeBase64String(DigestUtils.md5(message)));
             UploadRequest uploadRequest = UploadRequest.fromJson(node);
             


### PR DESCRIPTION
We have a 25mb/file limit in place to protect against zip bomb attacks. However, JourneyPRO has a task that uploads very large JSON files (~30mb), which hits this limit. They've already done as much as they can to reduce the file size, but there's not much more they can do.

This increases the per-file limit to 50mb and the total (zipped) archive limit to 20mb.