### PR TITLE
For scheduled activity history calls, support offsetKey as well as offsetBy

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/ScheduledActivityDao.java
+++ b/app/org/sagebionetworks/bridge/dao/ScheduledActivityDao.java
@@ -15,7 +15,7 @@ public interface ScheduledActivityDao {
      */
     ForwardCursorPagedResourceList<ScheduledActivity> getActivityHistoryV2(String healthCode,
             String activityGuid, DateTime scheduledOnStart, DateTime scheduledOnEnd, DateTimeZone timezone,
-            String offsetBy, int pageSize);
+            String offsetKey, int pageSize);
     
     /**
      * Load an individual activity.

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -319,7 +319,7 @@ public class ParticipantService {
     }
 
     public ForwardCursorPagedResourceList<ScheduledActivity> getActivityHistory(Study study, String userId,
-            String activityGuid, DateTime scheduledOnStart, DateTime scheduledOnEnd, String offsetBy, int pageSize) {
+            String activityGuid, DateTime scheduledOnStart, DateTime scheduledOnEnd, String offsetKey, int pageSize) {
         checkNotNull(study);
         checkArgument(isNotBlank(activityGuid));
         checkArgument(isNotBlank(userId));
@@ -327,7 +327,7 @@ public class ParticipantService {
         Account account = getAccountThrowingException(study, userId);
 
         return scheduledActivityService.getActivityHistory(account.getHealthCode(), activityGuid, scheduledOnStart,
-                scheduledOnEnd, offsetBy, pageSize);
+                scheduledOnEnd, offsetKey, pageSize);
     }
 
     public void deleteActivities(Study study, String userId) {

--- a/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
+++ b/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
@@ -121,7 +121,7 @@ public class ScheduledActivityService {
     }
 
     public ForwardCursorPagedResourceList<ScheduledActivity> getActivityHistory(String healthCode,
-            String activityGuid, DateTime scheduledOnStart, DateTime scheduledOnEnd, String offsetBy,
+            String activityGuid, DateTime scheduledOnStart, DateTime scheduledOnEnd, String offsetKey,
             int pageSize) {
         checkArgument(isNotBlank(healthCode));
         checkArgument(isNotBlank(activityGuid));
@@ -146,7 +146,7 @@ public class ScheduledActivityService {
         }
 
         return activityDao.getActivityHistoryV2(
-                healthCode, activityGuid, scheduledOnStart, scheduledOnEnd, timezone, offsetBy, pageSize);
+                healthCode, activityGuid, scheduledOnStart, scheduledOnEnd, timezone, offsetKey, pageSize);
     }
     
     // This needs to be exposed for tests because although we can fix a point of time for tests, we cannot

--- a/conf/routes
+++ b/conf/routes
@@ -33,7 +33,7 @@ POST   /v3/participants/:userId                              @org.sagebionetwork
 GET    /v3/participants/:userId/uploads                      @org.sagebionetworks.bridge.play.controllers.ParticipantController.getUploads(userId: String, startTime: String ?= null, endTime: String ?= null, pageSize: Integer ?= null, offsetKey: String ?= null)
 GET    /v3/participants/:userId/requestInfo                  @org.sagebionetworks.bridge.play.controllers.ParticipantController.getRequestInfo(userId: String)
 DELETE /v3/participants/:userId/activities                   @org.sagebionetworks.bridge.play.controllers.ParticipantController.deleteActivities(userId: String)
-GET    /v3/participants/:userId/activities/:activityGuid     @org.sagebionetworks.bridge.play.controllers.ParticipantController.getActivityHistoryV2(userId: String, activityGuid: String, scheduledOnStart: String ?= null, scheduledOnEnd: String ?= null, offsetBy: String ?= null, pageSize: String ?= null)
+GET    /v3/participants/:userId/activities/:activityGuid     @org.sagebionetworks.bridge.play.controllers.ParticipantController.getActivityHistoryV2(userId: String, activityGuid: String, scheduledOnStart: String ?= null, scheduledOnEnd: String ?= null, offsetBy: String ?= null, offsetKey: String ?= null, pageSize: String ?= null)
 GET    /v3/participants/:userId/notifications                @org.sagebionetworks.bridge.play.controllers.ParticipantController.getNotificationRegistrations(userId: String)
 POST   /v3/participants/:userId/sendNotification             @org.sagebionetworks.bridge.play.controllers.ParticipantController.sendNotification(userId: String)
 POST   /v3/participants/:userId/signOut                      @org.sagebionetworks.bridge.play.controllers.ParticipantController.signOut(userId: String)
@@ -141,7 +141,7 @@ GET    /v3/tasks                    @org.sagebionetworks.bridge.play.controllers
 POST   /v3/tasks                    @org.sagebionetworks.bridge.play.controllers.ScheduledActivityController.updateScheduledActivities()
 GET    /v3/activities               @org.sagebionetworks.bridge.play.controllers.ScheduledActivityController.getScheduledActivities(until: String ?= null, offset: String ?= null, daysAhead: String ?= null, minimumPerSchedule: String ?= null)
 POST   /v3/activities               @org.sagebionetworks.bridge.play.controllers.ScheduledActivityController.updateScheduledActivities()
-GET    /v3/activities/:activityGuid @org.sagebionetworks.bridge.play.controllers.ScheduledActivityController.getActivityHistory(activityGuid: String, scheduledOnStart: String ?= null, scheduledOnEnd: String ?= null, offsetBy: String ?= null, pageSize: String ?= null)
+GET    /v3/activities/:activityGuid @org.sagebionetworks.bridge.play.controllers.ScheduledActivityController.getActivityHistory(activityGuid: String, scheduledOnStart: String ?= null, scheduledOnEnd: String ?= null, offsetBy: String ?= null, offsetKey ?= null, pageSize: String ?= null)
 GET    /v4/activities               @org.sagebionetworks.bridge.play.controllers.ScheduledActivityController.getScheduledActivitiesByDateRange(startTime: String ?= null, endTime: String ?= null)
 POST   /v4/activities               @org.sagebionetworks.bridge.play.controllers.ScheduledActivityController.updateScheduledActivities()
 


### PR DESCRIPTION
In removing ScheduledActivityList, we are moving from offsetBy to offsetKey (which is the correct parameter for this call). Support both parameters during the transition period.

The only client that really uses this is the Bridge Study Manager, but I want the parameters to be correct in the Java SDK, so it needs to be changed as well.

This is the LAST of the pagination changes, promise!