### PR TITLE
don't log session when decrypting healthcode fails

### DIFF
--- a/app/org/sagebionetworks/bridge/cache/CacheProvider.java
+++ b/app/org/sagebionetworks/bridge/cache/CacheProvider.java
@@ -174,7 +174,7 @@ public class CacheProvider {
                 throw new BridgeServiceException("Error parsing JSON for session " + sessionToken);
             }
         } catch (Throwable e) {
-            //promptToStartRedisIfLocal(e);
+            promptToStartRedisIfLocal(e);
             throw new BridgeServiceException(e);
         }
     }

--- a/app/org/sagebionetworks/bridge/cache/CacheProvider.java
+++ b/app/org/sagebionetworks/bridge/cache/CacheProvider.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge.cache;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.io.IOException;
 import java.util.List;
 
 import javax.annotation.Resource;
@@ -164,16 +165,23 @@ public class CacheProvider {
             if (ser == null) {
                 return null;
             }
-            return bridgeObjectMapper.readValue(ser, UserSession.class);
+            try {
+                return bridgeObjectMapper.readValue(ser, UserSession.class);
+            } catch (IOException ex) {
+                // Because StudyParticipant.Builder.withEncryptedHealthCode() can throw, and because of the way
+                // Jackson's BuilderBasedDeserializer, the error message actually contains the JSON. To prevent leaking
+                // personal identifying info, we should squelch the error message and replace it with our own.
+                throw new BridgeServiceException("Error parsing JSON for session " + sessionToken);
+            }
         } catch (Throwable e) {
-            promptToStartRedisIfLocal(e);
+            //promptToStartRedisIfLocal(e);
             throw new BridgeServiceException(e);
         }
     }
 
     public UserSession getUserSessionByUserId(final String userId) {
         checkNotNull(userId);
-        String sessionToken = null;
+        String sessionToken;
         try {
             final String userKey = RedisKey.USER_SESSION.getRedisKey(userId);
             sessionToken = getWithFallback(userKey, false);


### PR DESCRIPTION
See https://sagebionetworks.jira.com/browse/BRIDGE-1927. When we fail to decrypt the healthcode, we end up logging the session and all the personal identifying info into the logs. This is bad.

This is a quick fix to address that. A more long-term fix might be a custom deserializer for sessions, or encrypting/decrypting the whole session object as a separate step from the JSON parsing.

Testing done:
* Started Bridge Server with a different bridge.healthcode.redis.key. Signed in to create session.
* Restarted Bridge Server with the original bridge.healthcode.redis.key. (This is using the original code, but with promptToStartRedisIfLocal() commented out, so I can see the full stack trace.) Signed in. Verified the session is written to the logs.
* Made the code change. Restarted Bridge Server. Signed in. Verified the session is no longer written to the logs.