### PR TITLE
Add clientData to the user's account object and study participant model.

### DIFF
--- a/app/org/sagebionetworks/bridge/cache/CacheProvider.java
+++ b/app/org/sagebionetworks/bridge/cache/CacheProvider.java
@@ -8,7 +8,6 @@ import java.util.List;
 import javax.annotation.Resource;
 
 import org.sagebionetworks.bridge.BridgeConstants;
-import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.RequestInfo;
@@ -326,10 +325,12 @@ public class CacheProvider {
     }
     
     private void promptToStartRedisIfLocal(Throwable e) {
+        throw new RuntimeException(e);
+        /*
         if (BridgeConfigFactory.getConfig().isLocal()) {
             throw new BridgeServiceException(
                     "Cannot find cache service, have you started a Redis server? (original message: "
                     + e.getMessage() + ")");
-        }
+        }*/
     }
 }

--- a/app/org/sagebionetworks/bridge/cache/CacheProvider.java
+++ b/app/org/sagebionetworks/bridge/cache/CacheProvider.java
@@ -8,6 +8,7 @@ import java.util.List;
 import javax.annotation.Resource;
 
 import org.sagebionetworks.bridge.BridgeConstants;
+import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.RequestInfo;
@@ -325,12 +326,10 @@ public class CacheProvider {
     }
     
     private void promptToStartRedisIfLocal(Throwable e) {
-        throw new RuntimeException(e);
-        /*
         if (BridgeConfigFactory.getConfig().isLocal()) {
             throw new BridgeServiceException(
                     "Cannot find cache service, have you started a Redis server? (original message: "
                     + e.getMessage() + ")");
-        }*/
+        }
     }
 }

--- a/app/org/sagebionetworks/bridge/hibernate/HibernateAccount.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateAccount.java
@@ -49,12 +49,12 @@ public class HibernateAccount {
     private int version;
     private String clientData;
 
-    HibernateAccount() {}
+    public HibernateAccount() {}
     
     /**
      * Constructor to load information for the AccountSummary object.
      */
-    HibernateAccount(Long createdOn, String studyId, String firstName, String lastName, String email, String id,
+    public HibernateAccount(Long createdOn, String studyId, String firstName, String lastName, String email, String id,
             AccountStatus status) {
         this.createdOn = createdOn;
         this.studyId = studyId;

--- a/app/org/sagebionetworks/bridge/hibernate/HibernateAccount.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateAccount.java
@@ -49,10 +49,15 @@ public class HibernateAccount {
     private int version;
     private String clientData;
 
+    /**
+     * No args constructor, required and used by Hibernate for full object initialization.
+     */
     public HibernateAccount() {}
     
     /**
-     * Constructor to load information for the AccountSummary object.
+     * Constructor to load information for the AccountSummary object. Could not find a way to 
+     * construct this object with just the indicated fields using a select clause, without also 
+     * specifying a constructor.
      */
     public HibernateAccount(Long createdOn, String studyId, String firstName, String lastName, String email, String id,
             AccountStatus status) {

--- a/app/org/sagebionetworks/bridge/hibernate/HibernateAccount.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateAccount.java
@@ -47,6 +47,23 @@ public class HibernateAccount {
     private Set<Roles> roles;
     private AccountStatus status;
     private int version;
+    private String clientData;
+
+    HibernateAccount() {}
+    
+    /**
+     * Constructor to load information for the AccountSummary object.
+     */
+    HibernateAccount(Long createdOn, String studyId, String firstName, String lastName, String email, String id,
+            AccountStatus status) {
+        this.createdOn = createdOn;
+        this.studyId = studyId;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.email = email;
+        this.id = id;
+        this.status = status;
+    }
 
     /**
      * Account ID, used as a unique identifier for the account that doesn't leak email address (which is personally
@@ -250,7 +267,18 @@ public class HibernateAccount {
     public void setStatus(AccountStatus status) {
         this.status = status;
     }
-
+    
+    /** @see #getClientData */
+    @Column(columnDefinition = "mediumtext", name = "clientData", nullable = true)
+    public String getClientData() {
+        return clientData;
+    }
+    
+    /** The serialized content of clientData JSON. */
+    public void setClientData(String clientData) {
+        this.clientData = clientData;
+    }
+    
     @Version
     /** Version number, used by Hibernate to handle optimistic locking. */
     public int getVersion() {

--- a/app/org/sagebionetworks/bridge/models/accounts/Account.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/Account.java
@@ -12,6 +12,8 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 /**
  * Encryption of account values is handled transparently by the account implementation. 
  * All values are set and retrieved in clear text.
@@ -80,4 +82,11 @@ public interface Account extends BridgeEntity {
     String getId();
     
     DateTime getCreatedOn();
+    
+    /**
+     * Arbitrary JsonNode data that can be persisted by the client application for a specific user. Like other account data, 
+     * this can include PII, and can be up to 16MB when serialized (however, we expect data of 1MB or less to be normal usage). 
+     */
+    JsonNode getClientData();
+    void setClientData(JsonNode clientData);
 }

--- a/app/org/sagebionetworks/bridge/models/accounts/GenericAccount.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/GenericAccount.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -41,6 +42,7 @@ public class GenericAccount implements Account {
     private Set<Roles> roleSet = ImmutableSet.of();
     private AccountStatus status;
     private StudyIdentifier studyId;
+    private JsonNode clientData;
     private int version;
 
     /** {@inheritDoc} */
@@ -236,6 +238,17 @@ public class GenericAccount implements Account {
     /** @see #getCreatedOn */
     public void setCreatedOn(DateTime createdOn) {
         this.createdOn = createdOn;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public JsonNode getClientData() {
+        return clientData;
+    }
+
+    /** @see #getCreatedOn */
+    public void setClientData(JsonNode clientData) {
+        this.clientData = clientData;
     }
 
     /** Version number, used by Hibernate to handle optimistic locking. */

--- a/app/org/sagebionetworks/bridge/models/accounts/StudyParticipant.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/StudyParticipant.java
@@ -327,7 +327,7 @@ public final class StudyParticipant implements BridgeEntity {
             return this;
         }
         public Builder withEncryptedHealthCode(String encHealthCode) {
-            withEncryptedHealthCode((encHealthCode == null) ? null : ENCRYPTOR.decrypt(encHealthCode));
+            withHealthCode((encHealthCode == null) ? null : ENCRYPTOR.decrypt(encHealthCode));
             return this;
         }
         public Builder withAttributes(Map<String,String> attributes) {

--- a/app/org/sagebionetworks/bridge/models/accounts/StudyParticipant.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/StudyParticipant.java
@@ -233,58 +233,58 @@ public final class StudyParticipant implements BridgeEntity {
         }
         public Builder copyFieldsOf(StudyParticipant participant, Set<String> fieldNames) {
             if (fieldNames.contains("firstName")) {
-                this.firstName = participant.getFirstName();    
+                withFirstName(participant.getFirstName());    
             }
             if (fieldNames.contains("lastName")) {
-                this.lastName = participant.getLastName();    
+                withLastName(participant.getLastName());    
             }
             if (fieldNames.contains("email")) {
-                this.email = participant.getEmail();
+                withEmail(participant.getEmail());
             }
             if (fieldNames.contains("externalId")) {
-                this.externalId = participant.getExternalId();    
+                withExternalId(participant.getExternalId());    
             }
             if (fieldNames.contains("password")) {
-                this.password = participant.getPassword();    
+                withPassword(participant.getPassword());    
             }
             if (fieldNames.contains("sharingScope")) {
-                this.sharingScope = participant.getSharingScope();
+                withSharingScope(participant.getSharingScope());
             }
             if (fieldNames.contains("notifyByEmail")) {
-                this.notifyByEmail = participant.isNotifyByEmail();    
+                withNotifyByEmail(participant.isNotifyByEmail());    
             }
             if (fieldNames.contains("healthCode")) {
-                this.healthCode = participant.getHealthCode();    
+                withHealthCode(participant.getHealthCode());    
             }
             if (fieldNames.contains("dataGroups")) {
-                this.dataGroups = participant.getDataGroups();    
+                withDataGroups(participant.getDataGroups());    
             }
             if (fieldNames.contains("attributes")) {
-                this.attributes = participant.getAttributes();    
+                withAttributes(participant.getAttributes());    
             }
             if (fieldNames.contains("consentHistories")) {
-                this.consentHistories = participant.getConsentHistories();    
+                withConsentHistories(participant.getConsentHistories());    
             }
             if (fieldNames.contains("roles")) {
-                this.roles = participant.getRoles();    
+                withRoles(participant.getRoles());    
             }
             if (fieldNames.contains("languages")) {
-                this.languages = participant.getLanguages();    
+                withLanguages(participant.getLanguages());    
             }
             if (fieldNames.contains("status")){
-                this.status = participant.getStatus();    
+                withStatus(participant.getStatus());    
             }
             if (fieldNames.contains("createdOn")) {
-                this.createdOn = participant.getCreatedOn();    
+                withCreatedOn(participant.getCreatedOn());    
             }
             if (fieldNames.contains("id")) {
-                this.id = participant.getId();    
+                withId(participant.getId());    
             }
             if (fieldNames.contains("timeZone")) {
-                this.timeZone = participant.getTimeZone();    
+                withTimeZone(participant.getTimeZone());    
             }
             if (fieldNames.contains("clientData")) {
-                this.clientData = participant.getClientData();
+                withClientData(participant.getClientData());
             }
             return this;
         }
@@ -327,7 +327,7 @@ public final class StudyParticipant implements BridgeEntity {
             return this;
         }
         public Builder withEncryptedHealthCode(String encHealthCode) {
-            this.healthCode = (encHealthCode == null) ? null : ENCRYPTOR.decrypt(encHealthCode);
+            withEncryptedHealthCode((encHealthCode == null) ? null : ENCRYPTOR.decrypt(encHealthCode));
             return this;
         }
         public Builder withAttributes(Map<String,String> attributes) {

--- a/app/org/sagebionetworks/bridge/models/accounts/StudyParticipant.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/StudyParticipant.java
@@ -19,6 +19,7 @@ import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.BridgeEntity;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
@@ -67,11 +68,13 @@ public final class StudyParticipant implements BridgeEntity {
     private final DateTime createdOn;
     private final String id;
     private final DateTimeZone timeZone;
+    private final JsonNode clientData;
     
     private StudyParticipant(String firstName, String lastName, String email, String externalId, String password,
             SharingScope sharingScope, Boolean notifyByEmail, Set<String> dataGroups, String healthCode,
             Map<String, String> attributes, Map<String, List<UserConsentHistory>> consentHistories, Set<Roles> roles,
-            LinkedHashSet<String> languages, AccountStatus status, DateTime createdOn, String id, DateTimeZone timeZone) {
+            LinkedHashSet<String> languages, AccountStatus status, DateTime createdOn, String id, DateTimeZone timeZone,
+            JsonNode clientData) {
         
         ImmutableMap.Builder<String, List<UserConsentHistory>> immutableConsentsBuilder = new ImmutableMap.Builder<>();
         if (consentHistories != null) {
@@ -100,6 +103,7 @@ public final class StudyParticipant implements BridgeEntity {
         this.createdOn = createdOn;
         this.id = id;
         this.timeZone = timeZone;
+        this.clientData = clientData;
     }
     
     public String getFirstName() {
@@ -156,12 +160,15 @@ public final class StudyParticipant implements BridgeEntity {
     public DateTimeZone getTimeZone() {
         return timeZone;
     }
+    public JsonNode getClientData() {
+        return clientData;
+    }
     
     @Override
     public int hashCode() {
         return Objects.hash(attributes, consentHistories, createdOn, dataGroups, email, 
                 externalId, firstName, healthCode, id, languages, lastName, notifyByEmail, 
-                password, roles, sharingScope, status, timeZone);
+                password, roles, sharingScope, status, timeZone, clientData);
     }
 
     @Override
@@ -179,7 +186,8 @@ public final class StudyParticipant implements BridgeEntity {
                 && Objects.equals(lastName, other.lastName) && Objects.equals(notifyByEmail, other.notifyByEmail)
                 && Objects.equals(password, other.password) && Objects.equals(roles, other.roles)
                 && Objects.equals(sharingScope, other.sharingScope) && Objects.equals(status, other.status)
-                && Objects.equals(timeZone, other.timeZone);
+                && Objects.equals(timeZone, other.timeZone)
+                && Objects.equals(clientData, other.clientData);
     }
 
     public static class Builder {
@@ -200,6 +208,7 @@ public final class StudyParticipant implements BridgeEntity {
         private DateTime createdOn;
         private String id;
         private DateTimeZone timeZone;
+        private JsonNode clientData;
         
         public Builder copyOf(StudyParticipant participant) {
             this.firstName = participant.getFirstName();
@@ -219,6 +228,7 @@ public final class StudyParticipant implements BridgeEntity {
             this.createdOn = participant.getCreatedOn();
             this.id = participant.getId();
             this.timeZone = participant.getTimeZone();
+            this.clientData = participant.getClientData();
             return this;
         }
         public Builder copyFieldsOf(StudyParticipant participant, Set<String> fieldNames) {
@@ -272,6 +282,9 @@ public final class StudyParticipant implements BridgeEntity {
             }
             if (fieldNames.contains("timeZone")) {
                 this.timeZone = participant.getTimeZone();    
+            }
+            if (fieldNames.contains("clientData")) {
+                this.clientData = participant.getClientData();
             }
             return this;
         }
@@ -357,11 +370,15 @@ public final class StudyParticipant implements BridgeEntity {
             this.timeZone = timeZone;
             return this;
         }
+        public Builder withClientData(JsonNode clientData) {
+            this.clientData = clientData;
+            return this;
+        }
         
         public StudyParticipant build() {
             return new StudyParticipant(firstName, lastName, email, externalId, password, sharingScope, notifyByEmail,
                     dataGroups, healthCode, attributes, consentHistories, roles,
-                    languages, status, createdOn, id, timeZone);
+                    languages, status, createdOn, id, timeZone, clientData);
         }
     }
 

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -185,6 +185,7 @@ public class ParticipantService {
         builder.withRoles(account.getRoles());
         builder.withId(account.getId());
         builder.withHealthCode(account.getHealthCode());
+        builder.withClientData(account.getClientData());
 
         Map<String, String> attributes = Maps.newHashMap();
         for (String attribute : study.getUserProfileAttributes()) {
@@ -307,6 +308,7 @@ public class ParticipantService {
 
         account.setFirstName(participant.getFirstName());
         account.setLastName(participant.getLastName());
+        account.setClientData(participant.getClientData());
         for (String attribute : study.getUserProfileAttributes()) {
             String value = participant.getAttributes().get(attribute);
             account.setAttribute(attribute, value);

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -18,6 +18,7 @@ import java.util.Set;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -455,9 +456,19 @@ public class TestUtils {
         return schedule;
     }
     
-    public static JsonNode getClientData() throws Exception {
-        String json = TestUtils.createJson("{'booleanFlag':true,'stringValue':'testString','intValue':4}");
-        return BridgeObjectMapper.get().readTree(json);
+    public static JsonNode getClientData() {
+        try {
+            String json = TestUtils.createJson("{'booleanFlag':true,'stringValue':'testString','intValue':4}");
+            return BridgeObjectMapper.get().readTree(json);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+    public static JsonNode getOtherClientData() {
+        JsonNode clientData = TestUtils.getClientData();
+        ((ObjectNode)clientData).put("newField", "newValue");
+        return clientData;
     }
     
     public static Set<String> getFieldNamesSet(JsonNode node) {

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityTest.java
@@ -23,7 +23,6 @@ import org.sagebionetworks.bridge.models.schedules.ScheduledActivity;
 import org.sagebionetworks.bridge.models.schedules.ScheduledActivityStatus;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Lists;
 
 public class DynamoScheduledActivityTest {
@@ -31,13 +30,7 @@ public class DynamoScheduledActivityTest {
     @Test
     public void equalsHashCode() throws Exception {
         EqualsVerifier.forClass(DynamoScheduledActivity.class).suppress(Warning.NONFINAL_FIELDS).allFieldsShouldBeUsed()
-                .withPrefabValues(JsonNode.class, TestUtils.getClientData(), getOtherClientData()).verify();
-    }
-
-    private JsonNode getOtherClientData() throws Exception {
-        JsonNode clientData = TestUtils.getClientData();
-        ((ObjectNode)clientData).put("newField", "newValue");
-        return clientData;
+                .withPrefabValues(JsonNode.class, TestUtils.getClientData(), TestUtils.getOtherClientData()).verify();
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
+++ b/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
@@ -30,6 +30,7 @@ import org.mockito.ArgumentCaptor;
 
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.exceptions.AccountDisabledException;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.exceptions.ConcurrentModificationException;
@@ -98,7 +99,7 @@ public class HibernateAccountDaoTest {
         dao.setAccountWorkflowService(mockAccountWorkflowService);
         dao.setHealthCodeService(mockHealthCodeService);
         dao.setHibernateHelper(mockHibernateHelper);
-
+        
         when(mockHealthCodeService.createMapping(TestConstants.TEST_STUDY)).thenReturn(new HealthIdImpl(HEALTH_ID,
                 HEALTH_CODE));
     }
@@ -668,9 +669,11 @@ public class HibernateAccountDaoTest {
         assertEquals("email2@example.com", accountSummaryList.get(1).getEmail());
 
         // verify hibernate calls
-        String expectedQueryString = "from HibernateAccount where studyId='" + TestConstants.TEST_STUDY_IDENTIFIER +
-                "'";
-        verify(mockHibernateHelper).queryGet(expectedQueryString, 10, 5, HibernateAccount.class);
+        String expectedQueryString = "from HibernateAccount where studyId='" + 
+                TestConstants.TEST_STUDY_IDENTIFIER + "'";
+        String expectedGetQueryString = HibernateAccountDao.ACCOUNT_SUMMARY_QUERY_PREFIX + expectedQueryString;
+        
+        verify(mockHibernateHelper).queryGet(expectedGetQueryString, 10, 5, HibernateAccount.class);
         verify(mockHibernateHelper).queryCount(expectedQueryString);
     }
 
@@ -698,10 +701,11 @@ public class HibernateAccountDaoTest {
         assertEquals(endDate.toString(), paramsMap.get("endTime"));
 
         // verify hibernate calls
-        String expectedQueryString = "from HibernateAccount where studyId='" + TestConstants.TEST_STUDY_IDENTIFIER +
-                "' and email like '%" + EMAIL + "%' and createdOn >= " + startDate.getMillis() + " and createdOn <= " +
-                endDate.getMillis();
-        verify(mockHibernateHelper).queryGet(expectedQueryString, 10, 5, HibernateAccount.class);
+        String expectedQueryString = "from HibernateAccount where studyId='" + 
+                TestConstants.TEST_STUDY_IDENTIFIER + "' and email like '%" + EMAIL + "%' and createdOn >= " + 
+                startDate.getMillis() + " and createdOn <= " + endDate.getMillis();
+        String expectedGetQueryString = HibernateAccountDao.ACCOUNT_SUMMARY_QUERY_PREFIX + expectedQueryString;
+        verify(mockHibernateHelper).queryGet(expectedGetQueryString, 10, 5, HibernateAccount.class);
         verify(mockHibernateHelper).queryCount(expectedQueryString);
     }
 
@@ -734,7 +738,7 @@ public class HibernateAccountDaoTest {
     }
 
     @Test
-    public void marshallSuccess() {
+    public void marshallSuccess() throws Exception {
         // create a fully populated GenericAccount
         GenericAccount genericAccount = new GenericAccount();
         genericAccount.setId(ACCOUNT_ID);
@@ -749,6 +753,7 @@ public class HibernateAccountDaoTest {
         genericAccount.setPasswordHash(DUMMY_PASSWORD_HASH);
         genericAccount.setRoles(EnumSet.of(Roles.DEVELOPER, Roles.TEST_USERS));
         genericAccount.setStatus(AccountStatus.ENABLED);
+        genericAccount.setClientData(TestUtils.getClientData());
         genericAccount.setVersion(VERSION);
 
         // populate attributes
@@ -791,6 +796,7 @@ public class HibernateAccountDaoTest {
         assertEquals(DUMMY_PASSWORD_HASH, hibernateAccount.getPasswordHash());
         assertEquals(EnumSet.of(Roles.DEVELOPER, Roles.TEST_USERS), hibernateAccount.getRoles());
         assertEquals(AccountStatus.ENABLED, hibernateAccount.getStatus());
+        assertEquals(TestUtils.getClientData().toString(), hibernateAccount.getClientData());
         assertEquals(VERSION, hibernateAccount.getVersion());
 
         // validate attributes
@@ -829,7 +835,7 @@ public class HibernateAccountDaoTest {
     }
 
     @Test
-    public void unmarshallSuccess() {
+    public void unmarshallSuccess() throws Exception {
         // create a fully populated HibernateAccount
         HibernateAccount hibernateAccount = new HibernateAccount();
         hibernateAccount.setId(ACCOUNT_ID);
@@ -844,6 +850,7 @@ public class HibernateAccountDaoTest {
         hibernateAccount.setPasswordHash(DUMMY_PASSWORD_HASH);
         hibernateAccount.setRoles(EnumSet.of(Roles.DEVELOPER, Roles.TEST_USERS));
         hibernateAccount.setStatus(AccountStatus.ENABLED);
+        hibernateAccount.setClientData(TestUtils.getClientData().toString());
         hibernateAccount.setVersion(VERSION);
 
         // populate attributes
@@ -903,6 +910,7 @@ public class HibernateAccountDaoTest {
         assertEquals(DUMMY_PASSWORD_HASH, genericAccount.getPasswordHash());
         assertEquals(EnumSet.of(Roles.DEVELOPER, Roles.TEST_USERS), genericAccount.getRoles());
         assertEquals(AccountStatus.ENABLED, genericAccount.getStatus());
+        assertEquals(TestUtils.getClientData(), genericAccount.getClientData());
         assertEquals(VERSION, genericAccount.getVersion());
 
         // createdOn is stored as a long, so just compare epoch milliseconds.

--- a/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
+++ b/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
@@ -738,7 +738,7 @@ public class HibernateAccountDaoTest {
     }
 
     @Test
-    public void marshallSuccess() throws Exception {
+    public void marshallSuccess() {
         // create a fully populated GenericAccount
         GenericAccount genericAccount = new GenericAccount();
         genericAccount.setId(ACCOUNT_ID);
@@ -835,7 +835,7 @@ public class HibernateAccountDaoTest {
     }
 
     @Test
-    public void unmarshallSuccess() throws Exception {
+    public void unmarshallSuccess() {
         // create a fully populated HibernateAccount
         HibernateAccount hibernateAccount = new HibernateAccount();
         hibernateAccount.setId(ACCOUNT_ID);

--- a/test/org/sagebionetworks/bridge/hibernate/HibernateAccountTest.java
+++ b/test/org/sagebionetworks/bridge/hibernate/HibernateAccountTest.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import org.junit.Test;
 
 import org.sagebionetworks.bridge.Roles;
+import org.sagebionetworks.bridge.models.accounts.AccountStatus;
 
 public class HibernateAccountTest {
     @Test
@@ -114,5 +115,19 @@ public class HibernateAccountTest {
         // Similarly, putting values to the set reflect through.
         gettedRoleSet2.add(Roles.RESEARCHER);
         assertEquals(EnumSet.of(Roles.RESEARCHER), account.getRoles());
+    }
+    
+    @Test
+    public void accountSummaryConstructor() {
+        HibernateAccount account = new HibernateAccount(new Long(123), "studyId", "firstName", "lastName", "email",
+                "id", AccountStatus.UNVERIFIED);
+
+        assertEquals(new Long(123), account.getCreatedOn());
+        assertEquals("studyId", account.getStudyId());
+        assertEquals("firstName", account.getFirstName());
+        assertEquals("lastName", account.getLastName());
+        assertEquals("email", account.getEmail());
+        assertEquals("id", account.getId());
+        assertEquals(AccountStatus.UNVERIFIED, account.getStatus());
     }
 }

--- a/test/org/sagebionetworks/bridge/models/accounts/StudyParticipantTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/StudyParticipantTest.java
@@ -199,10 +199,6 @@ public class StudyParticipantTest {
         assertCopyField("healthCode", (builder)-> verify(builder).withHealthCode(any()));
     }
     @Test
-    public void canCopyGetEncryptedHealthCode() {
-        assertCopyField("encryptedHealthCode", (builder)-> verify(builder).withEncryptedHealthCode(any()));
-    }
-    @Test
     public void canCopyGetAttributes() {
         assertCopyField("attributes", (builder)-> verify(builder).withAttributes(any()));
     }
@@ -239,17 +235,6 @@ public class StudyParticipantTest {
         assertCopyField("clientData", (builder)-> verify(builder).withClientData(any()));
     }
     
-    private void assertCopyField(String fieldName, Consumer<StudyParticipant.Builder> predicate) {
-        StudyParticipant participant = makeParticipant().build();
-        StudyParticipant.Builder builder = spy(StudyParticipant.Builder.class);
-        
-        builder.copyFieldsOf(participant, Sets.newHashSet(fieldName));
-        
-        verify(builder).copyFieldsOf(participant, Sets.newHashSet(fieldName));
-        predicate.accept(builder);
-        verifyNoMoreInteractions(builder);
-    }
-    
     @Test
     public void testNullResiliency() {
         // We don't remove nulls from the collections, at least not when reading them.
@@ -284,6 +269,17 @@ public class StudyParticipantTest {
         assertEquals("password", participant.getPassword());
     }    
 
+    private void assertCopyField(String fieldName, Consumer<StudyParticipant.Builder> predicate) {
+        StudyParticipant participant = makeParticipant().build();
+        StudyParticipant.Builder builder = spy(StudyParticipant.Builder.class);
+        Set<String> fieldsToCopy = Sets.newHashSet(fieldName);
+        
+        builder.copyFieldsOf(participant, fieldsToCopy);
+        verify(builder).copyFieldsOf(participant, fieldsToCopy);
+        predicate.accept(builder);
+        verifyNoMoreInteractions(builder);
+    }
+    
     private StudyParticipant createParticipantWithHealthCodes() throws Exception {
         StudyParticipant.Builder builder = makeParticipant();
         builder.withHealthCode(null).withEncryptedHealthCode(TestConstants.ENCRYPTED_HEALTH_CODE);
@@ -309,6 +305,7 @@ public class StudyParticipantTest {
                 .withCreatedOn(CREATED_ON)
                 .withId(ACCOUNT_ID)
                 .withStatus(AccountStatus.ENABLED)
+                .withClientData(clientData)
                 .withTimeZone(TIME_ZONE);
         
         Map<String,List<UserConsentHistory>> historiesMap = Maps.newHashMap();

--- a/test/org/sagebionetworks/bridge/models/accounts/StudyParticipantTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/StudyParticipantTest.java
@@ -145,7 +145,7 @@ public class StudyParticipantTest {
     }
 
     @Test
-    public void canCopy() throws Exception {
+    public void canCopy() {
         StudyParticipant participant = makeParticipant().build();
         StudyParticipant copy = new StudyParticipant.Builder().copyOf(participant).build();
         
@@ -209,7 +209,7 @@ public class StudyParticipantTest {
         return builder.build();
     }
 
-    private StudyParticipant.Builder makeParticipant() throws Exception {
+    private StudyParticipant.Builder makeParticipant() {
         JsonNode clientData = TestUtils.getClientData();
         
         StudyParticipant.Builder builder = new StudyParticipant.Builder()

--- a/test/org/sagebionetworks/bridge/models/accounts/StudyParticipantTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/StudyParticipantTest.java
@@ -44,8 +44,9 @@ public class StudyParticipantTest {
             .put("C", "D").build();
     
     @Test
-    public void hashEquals() {
-        EqualsVerifier.forClass(StudyParticipant.class).allFieldsShouldBeUsed().verify();
+    public void hashEquals() throws Exception {
+        EqualsVerifier.forClass(StudyParticipant.class).allFieldsShouldBeUsed()
+                .withPrefabValues(JsonNode.class, TestUtils.getClientData(), TestUtils.getOtherClientData()).verify();
     }
     
     @Test
@@ -69,6 +70,11 @@ public class StudyParticipantTest {
         assertEquals(ACCOUNT_ID, node.get("id").asText());
         assertEquals("+04:00", node.get("timeZone").asText());
         assertEquals("StudyParticipant", node.get("type").asText());
+        
+        JsonNode clientData = node.get("clientData");
+        assertTrue(clientData.get("booleanFlag").booleanValue());
+        assertEquals("testString", clientData.get("stringValue").asText());
+        assertEquals(4, clientData.get("intValue").intValue());
 
         Set<String> roleNames = Sets.newHashSet(
                 Roles.ADMIN.name().toLowerCase(), Roles.WORKER.name().toLowerCase());
@@ -87,7 +93,7 @@ public class StudyParticipantTest {
 
         assertEquals("B", node.get("attributes").get("A").asText());
         assertEquals("D", node.get("attributes").get("C").asText());
-        assertEquals(18, node.size());
+        assertEquals(19, node.size());
         
         StudyParticipant deserParticipant = BridgeObjectMapper.get().readValue(node.toString(), StudyParticipant.class);
         assertEquals("firstName", deserParticipant.getFirstName());
@@ -139,7 +145,7 @@ public class StudyParticipantTest {
     }
 
     @Test
-    public void canCopy() {
+    public void canCopy() throws Exception {
         StudyParticipant participant = makeParticipant().build();
         StudyParticipant copy = new StudyParticipant.Builder().copyOf(participant).build();
         
@@ -157,6 +163,7 @@ public class StudyParticipantTest {
         assertEquals(CREATED_ON, copy.getCreatedOn());
         assertEquals(AccountStatus.ENABLED, copy.getStatus());
         assertEquals(ACCOUNT_ID, copy.getId());
+        assertEquals(TestUtils.getClientData(), copy.getClientData());
         
         // And they are equal in the Java sense
         assertEquals(copy, participant);
@@ -196,13 +203,15 @@ public class StudyParticipantTest {
         assertEquals("password", participant.getPassword());
     }    
 
-    private StudyParticipant createParticipantWithHealthCodes() {
+    private StudyParticipant createParticipantWithHealthCodes() throws Exception {
         StudyParticipant.Builder builder = makeParticipant();
         builder.withHealthCode(null).withEncryptedHealthCode(TestConstants.ENCRYPTED_HEALTH_CODE);
         return builder.build();
     }
 
-    private StudyParticipant.Builder makeParticipant() {
+    private StudyParticipant.Builder makeParticipant() throws Exception {
+        JsonNode clientData = TestUtils.getClientData();
+        
         StudyParticipant.Builder builder = new StudyParticipant.Builder()
                 .withFirstName("firstName")
                 .withLastName("lastName")
@@ -219,7 +228,8 @@ public class StudyParticipantTest {
                 .withCreatedOn(CREATED_ON)
                 .withId(ACCOUNT_ID)
                 .withStatus(AccountStatus.ENABLED)
-                .withTimeZone(TIME_ZONE);
+                .withTimeZone(TIME_ZONE)
+                .withClientData(clientData);
         
         Map<String,List<UserConsentHistory>> historiesMap = Maps.newHashMap();
         

--- a/test/org/sagebionetworks/bridge/models/accounts/StudyParticipantTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/StudyParticipantTest.java
@@ -4,11 +4,16 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -170,6 +175,82 @@ public class StudyParticipantTest {
     }
     
     @Test
+    public void canCopyGetFirstName() {
+        assertCopyField("firstName", (builder)-> verify(builder).withFirstName(any()));
+    }
+    @Test
+    public void canCopyGetLastName() {
+        assertCopyField("lastName", (builder)-> verify(builder).withLastName(any()));
+    }
+    @Test
+    public void canCopyGetSharingScope() {
+        assertCopyField("sharingScope", (builder)-> verify(builder).withSharingScope(any()));
+    }
+    @Test
+    public void canCopyIsNotifyByEmail() {
+        assertCopyField("notifyByEmail", (builder)-> verify(builder).withNotifyByEmail(any()));
+    }
+    @Test
+    public void canCopyGetDataGroups() {
+        assertCopyField("dataGroups", (builder)-> verify(builder).withDataGroups(any()));
+    }
+    @Test
+    public void canCopyGetHealthCode() {
+        assertCopyField("healthCode", (builder)-> verify(builder).withHealthCode(any()));
+    }
+    @Test
+    public void canCopyGetEncryptedHealthCode() {
+        assertCopyField("encryptedHealthCode", (builder)-> verify(builder).withEncryptedHealthCode(any()));
+    }
+    @Test
+    public void canCopyGetAttributes() {
+        assertCopyField("attributes", (builder)-> verify(builder).withAttributes(any()));
+    }
+    @Test
+    public void canCopyGetConsentHistories() {
+        assertCopyField("consentHistories", (builder)-> verify(builder).withConsentHistories(any()));
+    }
+    @Test
+    public void canCopyGetRoles() {
+        assertCopyField("roles", (builder)-> verify(builder).withRoles(any()));
+    }
+    @Test
+    public void canCopyGetLanguages() {
+        assertCopyField("languages", (builder)-> verify(builder).withLanguages(any()));
+    }
+    @Test
+    public void canCopyGetStatus() {
+        assertCopyField("status", (builder)-> verify(builder).withStatus(any()));
+    }
+    @Test
+    public void canCopyGetCreatedOn() {
+        assertCopyField("createdOn", (builder)-> verify(builder).withCreatedOn(any()));
+    }
+    @Test
+    public void canCopyGetId() {
+        assertCopyField("id", (builder)-> verify(builder).withId(any()));
+    }
+    @Test
+    public void canCopyGetTimeZone() {
+        assertCopyField("timeZone", (builder)-> verify(builder).withTimeZone(any()));
+    }
+    @Test
+    public void canCopyGetClientData() {
+        assertCopyField("clientData", (builder)-> verify(builder).withClientData(any()));
+    }
+    
+    private void assertCopyField(String fieldName, Consumer<StudyParticipant.Builder> predicate) {
+        StudyParticipant participant = makeParticipant().build();
+        StudyParticipant.Builder builder = spy(StudyParticipant.Builder.class);
+        
+        builder.copyFieldsOf(participant, Sets.newHashSet(fieldName));
+        
+        verify(builder).copyFieldsOf(participant, Sets.newHashSet(fieldName));
+        predicate.accept(builder);
+        verifyNoMoreInteractions(builder);
+    }
+    
+    @Test
     public void testNullResiliency() {
         // We don't remove nulls from the collections, at least not when reading them.
         StudyParticipant participant = new StudyParticipant.Builder()
@@ -228,8 +309,7 @@ public class StudyParticipantTest {
                 .withCreatedOn(CREATED_ON)
                 .withId(ACCOUNT_ID)
                 .withStatus(AccountStatus.ENABLED)
-                .withTimeZone(TIME_ZONE)
-                .withClientData(clientData);
+                .withTimeZone(TIME_ZONE);
         
         Map<String,List<UserConsentHistory>> historiesMap = Maps.newHashMap();
         

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -377,6 +377,10 @@ public class ParticipantServiceTest {
         when(account.getStatus()).thenReturn(AccountStatus.DISABLED);
         when(account.getCreatedOn()).thenReturn(createdOn);
         when(account.getAttribute("attr2")).thenReturn("anAttribute2");
+        List<ConsentSignature> sigs1 = Lists.newArrayList(new ConsentSignature.Builder()
+                .withName("Name 1").withBirthdate("1980-01-01").build());
+        when(account.getConsentSignatureHistory(SubpopulationGuid.create("guid1"))).thenReturn(sigs1);
+        when(account.getClientData()).thenReturn(TestUtils.getClientData());
         
         mockHealthCodeAndAccountRetrieval();
         
@@ -394,11 +398,6 @@ public class ParticipantServiceTest {
         subpopulations.add(subpop2);
         when(subpopService.getSubpopulations(STUDY.getStudyIdentifier())).thenReturn(subpopulations);
 
-        List<ConsentSignature> sigs1 = Lists.newArrayList(new ConsentSignature.Builder()
-                .withName("Name 1").withBirthdate("1980-01-01").build());
-        when(account.getConsentSignatureHistory(SubpopulationGuid.create("guid1"))).thenReturn(sigs1);
-        when(account.getClientData()).thenReturn(TestUtils.getClientData());
-        
         when(subpopService.getSubpopulation(STUDY.getStudyIdentifier(), SubpopulationGuid.create("guid1"))).thenReturn(subpop1);
         when(subpopService.getSubpopulation(STUDY.getStudyIdentifier(), SubpopulationGuid.create("guid2"))).thenReturn(subpop2);
         
@@ -692,6 +691,7 @@ public class ParticipantServiceTest {
         doReturn(lookup).when(optionsService).getOptions(HEALTH_CODE);
         doReturn(EMAIL).when(account).getEmail();
         doReturn(HEALTH_CODE).when(account).getHealthCode();
+        doReturn(TestUtils.getClientData()).when(account).getClientData();
         
         StudyParticipant participant = participantService.getParticipant(STUDY, account, false);
         
@@ -700,6 +700,7 @@ public class ParticipantServiceTest {
         // Other fields exist too, but getParticipant() is tested in its entirety earlier in this test.
         assertEquals(EMAIL, participant.getEmail());
         assertEquals(ID, participant.getId());
+        assertEquals(TestUtils.getClientData(), participant.getClientData());
     }
 
     // Contrived test case for a case that never happens, but somehow does.

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -127,7 +127,8 @@ public class ParticipantServiceTest {
             .withLanguages(USER_LANGUAGES)
             .withStatus(AccountStatus.DISABLED)
             .withExternalId(EXTERNAL_ID)
-            .withTimeZone(USER_TIME_ZONE).build();
+            .withTimeZone(USER_TIME_ZONE)
+            .withClientData(TestUtils.getClientData()).build();
     
     private static final DateTime START_DATE = DateTime.now();
     private static final DateTime END_DATE = START_DATE.plusDays(1);
@@ -261,6 +262,7 @@ public class ParticipantServiceTest {
         verify(account).setLastName(LAST_NAME);
         verify(account).setAttribute(PHONE, "123456789");
         verify(account).setRoles(USER_ROLES);
+        verify(account).setClientData(TestUtils.getClientData());
         // Not called on create
         verify(account, never()).setStatus(AccountStatus.DISABLED);
         
@@ -395,6 +397,7 @@ public class ParticipantServiceTest {
         List<ConsentSignature> sigs1 = Lists.newArrayList(new ConsentSignature.Builder()
                 .withName("Name 1").withBirthdate("1980-01-01").build());
         when(account.getConsentSignatureHistory(SubpopulationGuid.create("guid1"))).thenReturn(sigs1);
+        when(account.getClientData()).thenReturn(TestUtils.getClientData());
         
         when(subpopService.getSubpopulation(STUDY.getStudyIdentifier(), SubpopulationGuid.create("guid1"))).thenReturn(subpop1);
         when(subpopService.getSubpopulation(STUDY.getStudyIdentifier(), SubpopulationGuid.create("guid2"))).thenReturn(subpop2);
@@ -423,6 +426,7 @@ public class ParticipantServiceTest {
         assertEquals(createdOn, participant.getCreatedOn());
         assertEquals(USER_TIME_ZONE, participant.getTimeZone());
         assertEquals(USER_LANGUAGES, participant.getLanguages());
+        assertEquals(TestUtils.getClientData(), participant.getClientData());
         
         assertNull(participant.getAttributes().get("attr1"));
         assertEquals("anAttribute2", participant.getAttributes().get("attr2"));
@@ -491,6 +495,7 @@ public class ParticipantServiceTest {
         verify(account).setFirstName(FIRST_NAME);
         verify(account).setLastName(LAST_NAME);
         verify(account).setAttribute(PHONE, "123456789");
+        verify(account).setClientData(TestUtils.getClientData());
     }
     
     @Test(expected = InvalidEntityException.class)


### PR DESCRIPTION
NOTE: Existing tables need to be updated:
    `ALTER TABLE bridgepf.Accounts MODIFY clientData MEDIUMTEXT;`

This adds a large string to the account table for whatever arbitrary JSON the client wants to store on the server. It cherry picks the columns we need for AccountSummary so this doesn't effect the performance of listing accounts.

NOTE: I'll merge this when I'm in the office. I don't have access to the RDS passwords (no vpn at home) to update the dev DB before merging this.