### PR TITLE
Synchronous Health Data API

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataRecord.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataRecord.java
@@ -27,12 +27,14 @@ import com.fasterxml.jackson.datatype.joda.deser.LocalDateDeserializer;
 @DynamoDBTable(tableName = "HealthDataRecord3")
 @JsonFilter("filter")
 public class DynamoHealthDataRecord implements HealthDataRecord {
+    private String appVersion;
     private Long createdOn;
     private String createdOnTimeZone;
     private JsonNode data;
     private String healthCode;
     private String id;
     private JsonNode metadata;
+    private String phoneInfo;
     private String schemaId;
     private int schemaRevision;
     private String studyId;
@@ -44,6 +46,18 @@ public class DynamoHealthDataRecord implements HealthDataRecord {
     private Set<String> userDataGroups;
     private Long version;
     private ExporterStatus synapseExporterStatus;
+
+    /** {@inheritDoc} */
+    @Override
+    public String getAppVersion() {
+        return appVersion;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setAppVersion(String appVersion) {
+        this.appVersion = appVersion;
+    }
 
     /** {@inheritDoc} */
     @DynamoDBIndexRangeKey(attributeName = "createdOn", globalSecondaryIndexName = "healthCode-createdOn-index")
@@ -122,6 +136,18 @@ public class DynamoHealthDataRecord implements HealthDataRecord {
     @Override
     public void setMetadata(JsonNode metadata) {
         this.metadata = metadata;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getPhoneInfo() {
+        return phoneInfo;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setPhoneInfo(String phoneInfo) {
+        this.phoneInfo = phoneInfo;
     }
 
     /** {@inheritDoc} */

--- a/app/org/sagebionetworks/bridge/models/Metrics.java
+++ b/app/org/sagebionetworks/bridge/models/Metrics.java
@@ -53,6 +53,11 @@ public class Metrics {
         json.put("end", DateUtils.getCurrentISODateTime());
     }
 
+    /** Record ID, used for synchronous health data submission API. */
+    public void setRecordId(String recordId) {
+        put("record_id", recordId);
+    }
+
     public void setRequestId(String requestId) {
         checkArgument(isNotBlank(requestId), "Request ID cannot be blank.");
         json.put("request_id", requestId);
@@ -94,20 +99,12 @@ public class Metrics {
         put("session_id", sessionId);
     }
 
-    public void setSpToken(String spToken) {
-        put("sp_token", spToken);
-    }
-
     public void setUploadId(String uploadId) {
         put("upload_id", uploadId);
     }
 
     public void setUploadSize(long uploadSize) {
         json.put("upload_size", uploadSize);
-    }
-
-    public void setSharingOption(String sharingOption) {
-        put("sharing_option", sharingOption);
     }
 
     private void put(final String field, final String value) {

--- a/app/org/sagebionetworks/bridge/models/healthdata/HealthDataRecord.java
+++ b/app/org/sagebionetworks/bridge/models/healthdata/HealthDataRecord.java
@@ -37,6 +37,14 @@ public interface HealthDataRecord extends BridgeEntity {
     }
 
     /**
+     * App version, as reported by the app. Generally in the form "version 1.0.0, build 2". Must be 48 chars or less.
+     */
+    String getAppVersion();
+
+    /** @see #getAppVersion */
+    void setAppVersion(String appVersion);
+
+    /**
      * The timestamp at which this health data was created (recorded on the client), in milliseconds since 1970-01-01
      * (start of epoch).
      */
@@ -74,6 +82,12 @@ public interface HealthDataRecord extends BridgeEntity {
 
     /** @see #getMetadata */
     void setMetadata(JsonNode metadata);
+
+    /** Phone info, for example "iPhone9,3" or "iPhone 5c (GSM)". Must be 48 chars or less. */
+    String getPhoneInfo();
+
+    /** @see #getPhoneInfo */
+    void setPhoneInfo(String phoneInfo);
 
     /** Schema ID of the health data. */
     String getSchemaId();

--- a/app/org/sagebionetworks/bridge/models/healthdata/HealthDataSubmission.java
+++ b/app/org/sagebionetworks/bridge/models/healthdata/HealthDataSubmission.java
@@ -1,0 +1,120 @@
+package org.sagebionetworks.bridge.models.healthdata;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.joda.time.DateTime;
+
+import org.sagebionetworks.bridge.json.DateTimeDeserializer;
+import org.sagebionetworks.bridge.json.DateTimeSerializer;
+import org.sagebionetworks.bridge.models.BridgeEntity;
+
+/** Health data submitted by the user. */
+@JsonDeserialize(builder = HealthDataSubmission.Builder.class)
+public class HealthDataSubmission implements BridgeEntity {
+    private final String appVersion;
+    private final DateTime createdOn;
+    private final JsonNode data;
+    private final String phoneInfo;
+    private final String schemaId;
+    private final int schemaRevision;
+
+    /** Private constructor. To construct, use builder. */
+    private HealthDataSubmission(String appVersion, DateTime createdOn, JsonNode data, String phoneInfo,
+            String schemaId, int schemaRevision) {
+        this.appVersion = appVersion;
+        this.createdOn = createdOn;
+        this.data = data;
+        this.phoneInfo = phoneInfo;
+        this.schemaId = schemaId;
+        this.schemaRevision = schemaRevision;
+    }
+
+    /**
+     * App version, as reported by the app. Generally in the form "version 1.0.0, build 2". Must be 48 chars or less.
+     */
+    public String getAppVersion() {
+        return appVersion;
+    }
+
+    /** When the health data was created, as reported by the app. */
+    @JsonSerialize(using = DateTimeSerializer.class)
+    public DateTime getCreatedOn() {
+        return createdOn;
+    }
+
+    /** Health data, as key-value pairs corresponding to the schema fields. */
+    public JsonNode getData() {
+        return data;
+    }
+
+    /** Phone info, for example "iPhone9,3" or "iPhone 5c (GSM)". Must be 48 chars or less. */
+    public String getPhoneInfo() {
+        return phoneInfo;
+    }
+
+    /** Schema ID with which to process this health data. */
+    public String getSchemaId() {
+        return schemaId;
+    }
+
+    /** Schema revision with which to process this health data. */
+    public int getSchemaRevision() {
+        return schemaRevision;
+    }
+
+    /** Builder for health data submission. */
+    public static class Builder {
+        private String appVersion;
+        private DateTime createdOn;
+        private JsonNode data;
+        private String phoneInfo;
+        private String schemaId;
+        private int schemaRevision;
+
+        /** @see HealthDataSubmission#getAppVersion */
+        public Builder withAppVersion(String appVersion) {
+            this.appVersion = appVersion;
+            return this;
+        }
+
+        /** @see HealthDataSubmission#getCreatedOn */
+        @JsonDeserialize(using = DateTimeDeserializer.class)
+        public Builder withCreatedOn(DateTime createdOn) {
+            this.createdOn = createdOn;
+            return this;
+        }
+
+        /** @see HealthDataSubmission#getData */
+        public Builder withData(JsonNode data) {
+            this.data = data;
+            return this;
+        }
+
+        /** @see HealthDataSubmission#getPhoneInfo */
+        public Builder withPhoneInfo(String phoneInfo) {
+            this.phoneInfo = phoneInfo;
+            return this;
+        }
+
+        /** @see HealthDataSubmission#getSchemaId */
+        public Builder withSchemaId(String schemaId) {
+            this.schemaId = schemaId;
+            return this;
+        }
+
+        /** @see HealthDataSubmission#getSchemaRevision */
+        public Builder withSchemaRevision(int schemaRevision) {
+            this.schemaRevision = schemaRevision;
+            return this;
+        }
+
+        /**
+         * Builds but does not validate the HealthDataSubmission. HealthDataSubmission is validated by
+         * HealthDataSubmissionValidator.
+         */
+        public HealthDataSubmission build() {
+            return new HealthDataSubmission(appVersion, createdOn, data, phoneInfo, schemaId, schemaRevision);
+        }
+    }
+}

--- a/app/org/sagebionetworks/bridge/play/controllers/HealthDataController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/HealthDataController.java
@@ -1,6 +1,13 @@
 package org.sagebionetworks.bridge.play.controllers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.sagebionetworks.bridge.json.DateUtils;
+import org.sagebionetworks.bridge.models.Metrics;
+import org.sagebionetworks.bridge.models.RequestInfo;
+import org.sagebionetworks.bridge.models.accounts.UserSession;
+import org.sagebionetworks.bridge.models.healthdata.HealthDataRecord;
+import org.sagebionetworks.bridge.models.healthdata.HealthDataSubmission;
 import org.sagebionetworks.bridge.models.healthdata.RecordExportStatusRequest;
 import org.sagebionetworks.bridge.services.HealthDataService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +26,33 @@ public class HealthDataController extends BaseController {
     @Autowired
     final void setHealthDataService(HealthDataService healthDataService) {
         this.healthDataService = healthDataService;
+    }
+
+    /**
+     * API to allow consented users to submit health data in a synchronous API, instead of using the asynchronous
+     * upload API. This is most beneficial for small data sets, like simple surveys. This API returns the health data
+     * record produced from this submission, which includes the record ID.
+     */
+    public Result submitHealthData() throws JsonProcessingException {
+        // Submit health data.
+        UserSession session = getAuthenticatedAndConsentedSession();
+        HealthDataSubmission healthDataSubmission = parseJson(request(), HealthDataSubmission.class);
+        HealthDataRecord savedRecord = healthDataService.submitHealthData(session.getStudyIdentifier(),
+                session.getParticipant(), healthDataSubmission);
+
+        // Write record ID into the metrics, for logging and diagnostics.
+        Metrics metrics = getMetrics();
+        if (metrics != null) {
+            metrics.setRecordId(savedRecord.getId());
+        }
+
+        // Record upload time to user's request info. This allows us to track the last time the user submitted.
+        RequestInfo requestInfo = getRequestInfoBuilder(session).withUploadedOn(DateUtils.getCurrentDateTime())
+                .build();
+        cacheProvider.updateRequestInfo(requestInfo);
+
+        // Return the record produced by this submission. Filter out Health Code, of course.
+        return created(HealthDataRecord.PUBLIC_RECORD_WRITER.writeValueAsString(savedRecord));
     }
 
     public Result updateRecordsStatus() throws JsonProcessingException{

--- a/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2.java
+++ b/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2.java
@@ -146,8 +146,10 @@ public class IosSchemaValidationHandler2 implements UploadValidationHandler {
         ObjectNode dataMap = BridgeObjectMapper.get().createObjectNode();
         record.setData(dataMap);
 
-        // Use info.json verbatim is the metadata.
+        // Use info.json verbatim is the metadata. Transcribe appVersion and phoneInfo from info.json into record.
         JsonNode infoJson = getInfoJsonFile(context, uploadId, jsonDataMap);
+        record.setAppVersion(JsonUtils.asText(infoJson, UploadUtil.FIELD_APP_VERSION));
+        record.setPhoneInfo(JsonUtils.asText(infoJson, UploadUtil.FIELD_PHONE_INFO));
         record.setMetadata(infoJson);
 
         // validate and normalize filenames

--- a/app/org/sagebionetworks/bridge/upload/StrictValidationHandler.java
+++ b/app/org/sagebionetworks/bridge/upload/StrictValidationHandler.java
@@ -121,7 +121,7 @@ public class StrictValidationHandler implements UploadValidationHandler {
 
         // log warning
         String combinedErrorMessage = "Strict upload validation error in study " + context.getStudy().getIdentifier()
-                + ", schema " + schemaId + "-v" + schemaRev + ", upload " + context.getUpload().getUploadId() + ": " +
+                + ", schema " + schemaId + "-v" + schemaRev + ", upload " + context.getUploadId() + ": " +
                 ERROR_MESSAGE_JOINER.join(errorList);
         logger.warn(combinedErrorMessage);
 

--- a/app/org/sagebionetworks/bridge/upload/TranscribeConsentHandler.java
+++ b/app/org/sagebionetworks/bridge/upload/TranscribeConsentHandler.java
@@ -27,7 +27,7 @@ public class TranscribeConsentHandler implements UploadValidationHandler {
     @Override
     public void handle(@Nonnull UploadValidationContext context) {
         // read sharing scope from options service
-        ParticipantOptionsLookup lookup = optionsService.getOptions(context.getUpload().getHealthCode());
+        ParticipantOptionsLookup lookup = optionsService.getOptions(context.getHealthCode());
 
         // Get sharing scope (defaults to NO_SHARING)
         SharingScope userSharingScope = lookup.getEnum(SHARING_SCOPE, SharingScope.class);

--- a/app/org/sagebionetworks/bridge/upload/UploadArtifactsHandler.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadArtifactsHandler.java
@@ -39,7 +39,7 @@ public class UploadArtifactsHandler implements UploadValidationHandler {
 
     @Override
     public void handle(@Nonnull UploadValidationContext context) {
-        String uploadId = context.getUpload().getUploadId();
+        String uploadId = context.getUploadId();
 
         // step 1: upload health data record
         HealthDataRecord record = context.getHealthDataRecord();

--- a/app/org/sagebionetworks/bridge/upload/UploadUtil.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadUtil.java
@@ -33,6 +33,11 @@ import org.sagebionetworks.bridge.schema.SchemaUtils;
 public class UploadUtil {
     private static final Logger logger = LoggerFactory.getLogger(UploadUtil.class);
 
+    // Common field names
+    public static final String FIELD_APP_VERSION = "appVersion";
+    public static final String FIELD_PHONE_INFO = "phoneInfo";
+
+    // Regex patterns and strings for validation.
     private static final Pattern FIELD_NAME_MULTIPLE_SPECIAL_CHARS_PATTERN = Pattern.compile("[\\-\\._ ]{2,}");
     private static final Pattern FIELD_NAME_SPECIAL_CHARS_PATTERN = Pattern.compile("[\\-\\._ ]");
     private static final Pattern FIELD_NAME_VALID_CHARS_PATTERN = Pattern.compile("[a-zA-Z0-9\\-\\._ ]+");

--- a/app/org/sagebionetworks/bridge/upload/UploadValidationContext.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadValidationContext.java
@@ -13,6 +13,7 @@ import com.google.common.collect.ImmutableList;
 
 /** This class encapsulates data read and generated during the process of upload validation. */
 public class UploadValidationContext {
+    private String healthCode;
     private StudyIdentifier study;
     private Upload upload;
     private boolean success = true;
@@ -25,6 +26,16 @@ public class UploadValidationContext {
     private HealthDataRecord healthDataRecord;
     private Map<String, byte[]> attachmentsByFieldName;
     private String recordId;
+
+    /** Health code of the user contributing the health data. */
+    public String getHealthCode() {
+        return healthCode;
+    }
+
+    /** @see #getHealthCode */
+    public void setHealthCode(String healthCode) {
+        this.healthCode = healthCode;
+    }
 
     /**
      * This is the study that the upload lives in and is validated against. This is made available by the upload
@@ -50,6 +61,14 @@ public class UploadValidationContext {
     /** @see #getUpload */
     public void setUpload(Upload upload) {
         this.upload = upload;
+    }
+
+    /**
+     * Helper method which returns the upload ID. Returns null if there is no upload. This is generally used of the
+     * health data is created through the synchronous API instead of the upload API.
+     */
+    public String getUploadId() {
+        return upload != null ? upload.getUploadId() : null;
     }
 
     /**
@@ -185,6 +204,7 @@ public class UploadValidationContext {
      */
     public UploadValidationContext shallowCopy() {
         UploadValidationContext copy = new UploadValidationContext();
+        copy.healthCode = this.healthCode;
         copy.study = this.study;
         copy.upload = this.upload;
         copy.success = this.success;

--- a/app/org/sagebionetworks/bridge/upload/UploadValidationTaskFactory.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadValidationTaskFactory.java
@@ -52,6 +52,7 @@ public class UploadValidationTaskFactory {
     public UploadValidationTask newTask(@Nonnull StudyIdentifier study, @Nonnull Upload upload) {
         // context
         UploadValidationContext context = new UploadValidationContext();
+        context.setHealthCode(upload.getHealthCode());
         context.setStudy(study);
         context.setUpload(upload);
 

--- a/app/org/sagebionetworks/bridge/validators/HealthDataSubmissionValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/HealthDataSubmissionValidator.java
@@ -1,0 +1,65 @@
+package org.sagebionetworks.bridge.validators;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+
+import org.sagebionetworks.bridge.models.healthdata.HealthDataSubmission;
+
+/** Validator for HealthDataSubmission. */
+public class HealthDataSubmissionValidator implements Validator {
+    /** Singleton instance of this validator. */
+    public static final HealthDataSubmissionValidator INSTANCE = new HealthDataSubmissionValidator();
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean supports(Class<?> clazz) {
+        return HealthDataSubmission.class.isAssignableFrom(clazz);
+    }
+
+    /** Validates a health data submission. All fields except metadata are required. */
+    @Override
+    public void validate(Object target, Errors errors) {
+        if (target == null) {
+            errors.rejectValue("healthDataSubmission", "cannot be null");
+        } else if (!(target instanceof HealthDataSubmission)) {
+            errors.rejectValue("healthDataSubmission", "is the wrong type");
+        } else {
+            HealthDataSubmission healthDataSubmission = (HealthDataSubmission) target;
+
+            // appVersion
+            if (StringUtils.isBlank(healthDataSubmission.getAppVersion())) {
+                errors.rejectValue("appVersion", "is required");
+            }
+
+            // createdOn
+            if (healthDataSubmission.getCreatedOn() == null) {
+                errors.rejectValue("createdOn", "is required");
+            }
+
+            // data - Must be non-null and an ObjectNode.
+            JsonNode data = healthDataSubmission.getData();
+            if (data == null || data.isNull()) {
+                errors.rejectValue("data", "is required");
+            } else if (!data.isObject()) {
+                errors.rejectValue("data", "must be an object node");
+            }
+
+            // phoneInfo
+            if (StringUtils.isBlank(healthDataSubmission.getPhoneInfo())) {
+                errors.rejectValue("phoneInfo", "is required");
+            }
+
+            // schemaId
+            if (StringUtils.isBlank(healthDataSubmission.getSchemaId())) {
+                errors.rejectValue("schemaId", "is required");
+            }
+
+            // schemaRevision - must be positive
+            if (healthDataSubmission.getSchemaRevision() <= 0) {
+                errors.rejectValue("schemaRevision", "must be positive");
+            }
+        }
+    }
+}

--- a/conf/routes
+++ b/conf/routes
@@ -26,6 +26,9 @@ POST   /v3/compoundactivitydefinitions/:taskId @org.sagebionetworks.bridge.play.
 # Export
 POST /v3/export/start @org.sagebionetworks.bridge.play.controllers.ExportController.startOnDemandExport
 
+# Health Data
+POST /v3/healthdata @org.sagebionetworks.bridge.play.controllers.HealthDataController.submitHealthData
+
 # Participants Researcher APIs
 GET    /v3/participants                                      @org.sagebionetworks.bridge.play.controllers.ParticipantController.getParticipants(offsetBy: String ?= null, pageSize: String ?= null, emailFilter: String ?= null, startDate: String ?= null, endDate: String ?= null, startTime: String ?= null, endTime: String ?= null)
 POST   /v3/participants                                      @org.sagebionetworks.bridge.play.controllers.ParticipantController.createParticipant

--- a/test/org/sagebionetworks/bridge/models/MetricsTest.java
+++ b/test/org/sagebionetworks/bridge/models/MetricsTest.java
@@ -5,23 +5,35 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.Test;
-import org.sagebionetworks.bridge.models.Metrics;
+
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 
 public class MetricsTest {
 
     @Test
-    public void test() {
+    public void test() throws Exception {
+        // Create Metrics.
         String requestId = "12345";
         Metrics metrics = new Metrics(requestId);
         assertNotNull(metrics);
+
+        // Validate cache key.
         assertEquals("12345:Metrics", metrics.getCacheKey());
         assertEquals("12345:Metrics", Metrics.getCacheKey(requestId));
+
+        // Apply setters.
+        metrics.setRecordId("test-record");
+
+        // Validate JSON.
         final String json = metrics.toJsonString();
         assertNotNull(json);
-        assertTrue(json.contains("\"version\":1"));
-        assertTrue(json.contains("\"start\":"));
-        assertTrue(json.contains("\"request_id\":\"12345\""));
+        JsonNode metricsNode = BridgeObjectMapper.get().readTree(json);
+        assertEquals("test-record", metricsNode.get("record_id").textValue());
+        assertEquals(requestId, metricsNode.get("request_id").textValue());
+        assertTrue(metricsNode.hasNonNull("start"));
+        assertEquals(1, metricsNode.get("version").intValue());
     }
 
     @Test

--- a/test/org/sagebionetworks/bridge/models/healthdata/HealthDataRecordTest.java
+++ b/test/org/sagebionetworks/bridge/models/healthdata/HealthDataRecordTest.java
@@ -31,9 +31,11 @@ import org.sagebionetworks.bridge.validators.Validate;
 
 @SuppressWarnings("unchecked")
 public class HealthDataRecordTest {
+    private static final String APP_VERSION = "version 1.0.0, build 2";
     private static final long CREATED_ON_MILLIS = 1502498010000L;
     private static final JsonNode DUMMY_DATA = BridgeObjectMapper.get().createObjectNode();
     private static final JsonNode DUMMY_METADATA = BridgeObjectMapper.get().createObjectNode();
+    private static final String PHONE_INFO = "Unit Tests";
     private static final LocalDate UPLOAD_DATE = LocalDate.parse("2017-08-11");
 
     @Test
@@ -65,7 +67,9 @@ public class HealthDataRecordTest {
         // build
         HealthDataRecord record = makeValidRecord();
         record.setId("optional record ID");
+        record.setAppVersion(APP_VERSION);
         record.setCreatedOnTimeZone("+0900");
+        record.setPhoneInfo(PHONE_INFO);
         record.setSynapseExporterStatus(HealthDataRecord.ExporterStatus.NOT_EXPORTED);
         record.setUploadId("optional upload ID");
         record.setUploadedOn(uploadedOn);
@@ -76,7 +80,9 @@ public class HealthDataRecordTest {
         Validate.entityThrowingException(HealthDataRecordValidator.INSTANCE, record);
 
         assertEquals("optional record ID", record.getId());
+        assertEquals(APP_VERSION, record.getAppVersion());
         assertEquals("+0900", record.getCreatedOnTimeZone());
+        assertEquals(PHONE_INFO, record.getPhoneInfo());
         assertEquals(HealthDataRecord.ExporterStatus.NOT_EXPORTED, record.getSynapseExporterStatus());
         assertEquals("optional upload ID", record.getUploadId());
         assertEquals(uploadedOn, record.getUploadedOn().longValue());
@@ -244,12 +250,14 @@ public class HealthDataRecordTest {
 
         // start with JSON
         String jsonText = "{\n" +
+                "   \"appVersion\":\"" + APP_VERSION + "\",\n" +
                 "   \"createdOn\":\"2014-02-12T13:45-0800\",\n" +
                 "   \"createdOnTimeZone\":\"-0800\",\n" +
                 "   \"data\":{\"myData\":\"myDataValue\"},\n" +
                 "   \"healthCode\":\"json healthcode\",\n" +
                 "   \"id\":\"json record ID\",\n" +
                 "   \"metadata\":{\"myMetadata\":\"myMetaValue\"},\n" +
+                "   \"phoneInfo\":\"" + PHONE_INFO + "\",\n" +
                 "   \"schemaId\":\"json schema\",\n" +
                 "   \"schemaRevision\":3,\n" +
                 "   \"studyId\":\"json study\",\n" +
@@ -265,10 +273,12 @@ public class HealthDataRecordTest {
 
         // convert to POJO
         HealthDataRecord record = BridgeObjectMapper.get().readValue(jsonText, HealthDataRecord.class);
+        assertEquals(APP_VERSION, record.getAppVersion());
         assertEquals(measuredTimeMillis, record.getCreatedOn().longValue());
         assertEquals("-0800", record.getCreatedOnTimeZone());
         assertEquals("json healthcode", record.getHealthCode());
         assertEquals("json record ID", record.getId());
+        assertEquals(PHONE_INFO, record.getPhoneInfo());
         assertEquals("json schema", record.getSchemaId());
         assertEquals(3, record.getSchemaRevision());
         assertEquals("json study", record.getStudyId());
@@ -291,10 +301,12 @@ public class HealthDataRecordTest {
 
         // then convert to a map so we can validate the raw JSON
         Map<String, Object> jsonMap = BridgeObjectMapper.get().readValue(convertedJson, JsonUtils.TYPE_REF_RAW_MAP);
-        assertEquals(17, jsonMap.size());
+        assertEquals(19, jsonMap.size());
+        assertEquals(APP_VERSION, jsonMap.get("appVersion"));
         assertEquals("-0800", jsonMap.get("createdOnTimeZone"));
         assertEquals("json healthcode", jsonMap.get("healthCode"));
         assertEquals("json record ID", jsonMap.get("id"));
+        assertEquals(PHONE_INFO, jsonMap.get("phoneInfo"));
         assertEquals("json schema", jsonMap.get("schemaId"));
         assertEquals(3, jsonMap.get("schemaRevision"));
         assertEquals("json study", jsonMap.get("studyId"));
@@ -323,7 +335,7 @@ public class HealthDataRecordTest {
 
         // Convert back to map again. Only validate a few key fields are present and the filtered fields are absent.
         Map<String, Object> publicJsonMap = BridgeObjectMapper.get().readValue(publicJson, JsonUtils.TYPE_REF_RAW_MAP);
-        assertEquals(16, publicJsonMap.size());
+        assertEquals(18, publicJsonMap.size());
         assertFalse(publicJsonMap.containsKey("healthCode"));
         assertEquals("json record ID", publicJsonMap.get("id"));
     }

--- a/test/org/sagebionetworks/bridge/models/healthdata/HealthDataSubmissionTest.java
+++ b/test/org/sagebionetworks/bridge/models/healthdata/HealthDataSubmissionTest.java
@@ -1,0 +1,60 @@
+package org.sagebionetworks.bridge.models.healthdata;
+
+import static org.junit.Assert.assertEquals;
+import static org.sagebionetworks.bridge.TestUtils.assertDatesWithTimeZoneEqual;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+public class HealthDataSubmissionTest {
+    private static final String APP_VERSION = "version 1.0.0, build 2";
+    private static final String CREATED_ON_STR = "2017-08-24T14:38:57.340+0900";
+    private static final DateTime CREATED_ON = DateTime.parse(CREATED_ON_STR);
+    private static final String PHONE_INFO = "Unit Tests";
+    private static final String SCHEMA_ID = "test-schema";
+    private static final int SCHEMA_REV = 3;
+
+    @Test
+    public void serialization() throws Exception {
+        // start with JSON
+        String jsonText = "{\n" +
+                "   \"appVersion\":\"" + APP_VERSION + "\",\n" +
+                "   \"createdOn\":\"" + CREATED_ON_STR + "\",\n" +
+                "   \"phoneInfo\":\"" + PHONE_INFO + "\",\n" +
+                "   \"schemaId\":\"" + SCHEMA_ID + "\",\n" +
+                "   \"schemaRevision\":" + SCHEMA_REV + ",\n" +
+                "   \"data\":{\n" +
+                "       \"foo\":\"foo-value\",\n" +
+                "       \"bar\":42\n" +
+                "   }\n" +
+                "}";
+
+        // convert to POJO
+        HealthDataSubmission healthDataSubmission = BridgeObjectMapper.get().readValue(jsonText,
+                HealthDataSubmission.class);
+        assertEquals(APP_VERSION, healthDataSubmission.getAppVersion());
+        assertDatesWithTimeZoneEqual(CREATED_ON, healthDataSubmission.getCreatedOn());
+        assertEquals(PHONE_INFO, healthDataSubmission.getPhoneInfo());
+        assertEquals(SCHEMA_ID, healthDataSubmission.getSchemaId());
+        assertEquals(SCHEMA_REV, healthDataSubmission.getSchemaRevision());
+
+        JsonNode pojoData = healthDataSubmission.getData();
+        assertEquals(2, pojoData.size());
+        assertEquals("foo-value", pojoData.get("foo").textValue());
+        assertEquals(42, pojoData.get("bar").intValue());
+
+        // convert back to JSON
+        JsonNode jsonNode = BridgeObjectMapper.get().convertValue(healthDataSubmission, JsonNode.class);
+        assertEquals(7, jsonNode.size());
+        assertEquals(APP_VERSION, jsonNode.get("appVersion").textValue());
+        assertDatesWithTimeZoneEqual(CREATED_ON, DateTime.parse(jsonNode.get("createdOn").textValue()));
+        assertEquals(pojoData, jsonNode.get("data"));
+        assertEquals(PHONE_INFO, jsonNode.get("phoneInfo").textValue());
+        assertEquals(SCHEMA_ID, jsonNode.get("schemaId").textValue());
+        assertEquals(SCHEMA_REV, jsonNode.get("schemaRevision").intValue());
+        assertEquals("HealthDataSubmission", jsonNode.get("type").textValue());
+    }
+}

--- a/test/org/sagebionetworks/bridge/play/controllers/HealthDataControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/HealthDataControllerTest.java
@@ -1,25 +1,49 @@
 package org.sagebionetworks.bridge.play.controllers;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableList;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
+import org.sagebionetworks.bridge.cache.CacheProvider;
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.Metrics;
+import org.sagebionetworks.bridge.models.RequestInfo;
+import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.healthdata.HealthDataRecord;
+import org.sagebionetworks.bridge.models.healthdata.HealthDataSubmission;
 import org.sagebionetworks.bridge.models.healthdata.RecordExportStatusRequest;
 import org.sagebionetworks.bridge.services.HealthDataService;
 import play.mvc.Result;
-
-import java.util.Arrays;
+import play.test.Helpers;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.anyVararg;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
+@SuppressWarnings("ConstantConditions")
 public class HealthDataControllerTest {
+    private static final String APP_VERSION = "version 1.0.0, build 2";
+    private static final String CREATED_ON_STR = "2017-08-24T14:38:57.340+0900";
+    private static final DateTime CREATED_ON = DateTime.parse(CREATED_ON_STR);
+    private static final String HEALTH_CODE = "health-code";
+    private static final long MOCK_NOW_MILLIS = DateTime.parse("2017-05-19T14:45:27.593-0700").getMillis();
+    private static final StudyParticipant PARTICIPANT = new StudyParticipant.Builder().build();
+    private static final String PHONE_INFO = "Unit Tests";
+    private static final String SCHEMA_ID = "test-schema";
+    private static final int SCHEMA_REV = 3;
     private static final String TEST_RECORD_ID = "record-to-update";
     private static final HealthDataRecord.ExporterStatus TEST_STATUS = HealthDataRecord.ExporterStatus.SUCCEEDED;
 
@@ -31,7 +55,13 @@ public class HealthDataControllerTest {
     ArgumentCaptor<RecordExportStatusRequest> requestArgumentCaptor = ArgumentCaptor.forClass(RecordExportStatusRequest.class);
 
     @Mock
+    private CacheProvider cacheProvider;
+
+    @Mock
     private HealthDataService healthDataService;
+
+    @Mock
+    private Metrics metrics;
 
     @Mock
     private UserSession workerSession;
@@ -45,6 +75,91 @@ public class HealthDataControllerTest {
     @Mock
     private UserSession researcherSession;
 
+    @BeforeClass
+    public static void mockNow() {
+        DateTimeUtils.setCurrentMillisFixed(MOCK_NOW_MILLIS);
+    }
+
+    @AfterClass
+    public static void unmockNow() {
+        DateTimeUtils.setCurrentMillisSystem();
+    }
+
+    @Test
+    public void submitHealthData() throws Exception {
+        // mock request JSON
+        String jsonText = "{\n" +
+                "   \"appVersion\":\"" + APP_VERSION + "\",\n" +
+                "   \"createdOn\":\"" + CREATED_ON_STR + "\",\n" +
+                "   \"phoneInfo\":\"" + PHONE_INFO + "\",\n" +
+                "   \"schemaId\":\"" + SCHEMA_ID + "\",\n" +
+                "   \"schemaRevision\":" + SCHEMA_REV + ",\n" +
+                "   \"data\":{\n" +
+                "       \"foo\":\"foo-value\",\n" +
+                "       \"bar\":42\n" +
+                "   }\n" +
+                "}";
+        TestUtils.mockPlayContextWithJson(jsonText);
+
+        // spy controller
+        HealthDataController controller = spy(new HealthDataController());
+        controller.setCacheProvider(cacheProvider);
+        controller.setHealthDataService(healthDataService);
+
+        // mock Metrics
+        doReturn(metrics).when(controller).getMetrics();
+
+        // mock session
+        UserSession mockSession = new UserSession();
+        mockSession.setStudyIdentifier(TestConstants.TEST_STUDY);
+        mockSession.setParticipant(PARTICIPANT);
+        doReturn(mockSession).when(controller).getAuthenticatedAndConsentedSession();
+
+        // mock RequestInfo
+        doReturn(new RequestInfo.Builder()).when(controller).getRequestInfoBuilder(mockSession);
+
+        // mock back-end call - We only care about record ID. Also add Health Code to make sure it's being filtered.
+        HealthDataRecord svcRecord = HealthDataRecord.create();
+        svcRecord.setId(TEST_RECORD_ID);
+        svcRecord.setHealthCode(HEALTH_CODE);
+        when(healthDataService.submitHealthData(any(), any(), any())).thenReturn(svcRecord);
+
+        // execute and validate - Just check record ID. Health Code is filtered out.
+        Result result = controller.submitHealthData();
+        assertEquals(201, result.status());
+        HealthDataRecord controllerRecord = BridgeObjectMapper.get().readValue(Helpers.contentAsString(result),
+                HealthDataRecord.class);
+        assertEquals(TEST_RECORD_ID, controllerRecord.getId());
+        assertNull(controllerRecord.getHealthCode());
+
+        // validate call to healthDataService
+        ArgumentCaptor<HealthDataSubmission> submissionCaptor = ArgumentCaptor.forClass(HealthDataSubmission.class);
+        verify(healthDataService).submitHealthData(eq(TestConstants.TEST_STUDY), same(PARTICIPANT),
+                submissionCaptor.capture());
+
+        HealthDataSubmission submission = submissionCaptor.getValue();
+        assertEquals(APP_VERSION, submission.getAppVersion());
+        assertEquals(CREATED_ON, submission.getCreatedOn());
+        assertEquals(PHONE_INFO, submission.getPhoneInfo());
+        assertEquals(SCHEMA_ID, submission.getSchemaId());
+        assertEquals(SCHEMA_REV, submission.getSchemaRevision());
+
+        JsonNode data = submission.getData();
+        assertEquals(2, data.size());
+        assertEquals("foo-value", data.get("foo").textValue());
+        assertEquals(42, data.get("bar").intValue());
+
+        // validate metrics
+        verify(metrics).setRecordId(TEST_RECORD_ID);
+
+        // validate request info uploadedOn - Time zone doesn't matter because we flatten everything to UTC anyway.
+        ArgumentCaptor<RequestInfo> requestInfoCaptor = ArgumentCaptor.forClass(RequestInfo.class);
+        verify(cacheProvider).updateRequestInfo(requestInfoCaptor.capture());
+
+        RequestInfo requestInfo = requestInfoCaptor.getValue();
+        assertEquals(MOCK_NOW_MILLIS, requestInfo.getUploadedOn().getMillis());
+    }
+
     @Test
     public void updateRecordsStatus() throws Exception {
         // mock session
@@ -53,7 +168,7 @@ public class HealthDataControllerTest {
         // mock request JSON
         TestUtils.mockPlayContextWithJson(TEST_STATUS_JSON);
 
-        when(healthDataService.updateRecordsWithExporterStatus(anyVararg())).thenReturn(Arrays.asList(TEST_RECORD_ID));
+        when(healthDataService.updateRecordsWithExporterStatus(anyVararg())).thenReturn(ImmutableList.of(TEST_RECORD_ID));
 
         // spy controller
         HealthDataController controller = spy(new HealthDataController());
@@ -62,7 +177,7 @@ public class HealthDataControllerTest {
 
         // create a mock request entity
         RecordExportStatusRequest mockRequest = new RecordExportStatusRequest();
-        mockRequest.setRecordIds(Arrays.asList(TEST_RECORD_ID));
+        mockRequest.setRecordIds(ImmutableList.of(TEST_RECORD_ID));
         mockRequest.setSynapseExporterStatus(TEST_STATUS);
 
         // execute and validate
@@ -77,6 +192,6 @@ public class HealthDataControllerTest {
         assertEquals(TEST_STATUS, capturedRequest.getSynapseExporterStatus());
 
         // finally, verify the return result
-        TestUtils.assertResult(result, 200, "Update exporter status to: " + Arrays.asList(TEST_RECORD_ID) + " complete.");
+        TestUtils.assertResult(result, 200, "Update exporter status to: " + ImmutableList.of(TEST_RECORD_ID) + " complete.");
     }
 }

--- a/test/org/sagebionetworks/bridge/services/HealthDataServiceSubmitHealthDataTest.java
+++ b/test/org/sagebionetworks/bridge/services/HealthDataServiceSubmitHealthDataTest.java
@@ -1,0 +1,233 @@
+package org.sagebionetworks.bridge.services;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableList;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeUtils;
+import org.joda.time.LocalDate;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.exceptions.BadRequestException;
+import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
+import org.sagebionetworks.bridge.models.healthdata.HealthDataRecord;
+import org.sagebionetworks.bridge.models.healthdata.HealthDataSubmission;
+import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
+import org.sagebionetworks.bridge.models.upload.UploadFieldType;
+import org.sagebionetworks.bridge.models.upload.UploadSchema;
+import org.sagebionetworks.bridge.upload.StrictValidationHandler;
+import org.sagebionetworks.bridge.upload.TranscribeConsentHandler;
+import org.sagebionetworks.bridge.upload.UploadArtifactsHandler;
+import org.sagebionetworks.bridge.upload.UploadUtil;
+import org.sagebionetworks.bridge.upload.UploadValidationContext;
+import org.sagebionetworks.bridge.upload.UploadValidationException;
+
+public class HealthDataServiceSubmitHealthDataTest {
+    private static final String APP_VERSION = "version 1.0.0, build 2";
+    private static final JsonNode DATA = BridgeObjectMapper.get().createObjectNode();
+    private static final String HEALTH_CODE = "test-health-code";
+    private static final String PHONE_INFO = "Unit Tests";
+    private static final String RECORD_ID = "test-record";
+    private static final String SCHEMA_ID = "test-schema";
+    private static final int SCHEMA_REV = 3;
+
+    private static final DateTime CREATED_ON = DateTime.parse("2017-08-24T14:38:57.340+0900");
+    private static final long CREATED_ON_MILLIS = CREATED_ON.getMillis();
+    private static final String CREATED_ON_TIMEZONE = "+0900";
+
+    private static final LocalDate MOCK_NOW_DATE = LocalDate.parse("2017-05-19");
+    private static final long MOCK_NOW_MILLIS = DateTime.parse("2017-05-19T14:45:27.593-0700").getMillis();
+
+    private static final StudyParticipant PARTICIPANT = new StudyParticipant.Builder().withHealthCode(HEALTH_CODE)
+            .build();
+
+    @BeforeClass
+    public static void mockNow() {
+        DateTimeUtils.setCurrentMillisFixed(MOCK_NOW_MILLIS);
+    }
+
+    @AfterClass
+    public static void unmockNow() {
+        DateTimeUtils.setCurrentMillisSystem();
+    }
+
+    @Test(expected = InvalidEntityException.class)
+    public void nullSubmission() throws Exception {
+        new HealthDataService().submitHealthData(TestConstants.TEST_STUDY, PARTICIPANT, null);
+    }
+
+    @Test(expected = InvalidEntityException.class)
+    public void invalidSubmission() throws Exception {
+        HealthDataSubmission submission = makeValidBuilder().withData(null).build();
+        new HealthDataService().submitHealthData(TestConstants.TEST_STUDY, PARTICIPANT, submission);
+    }
+
+    @Test
+    public void submitHealthData() throws Exception {
+        // mock schema service
+        List<UploadFieldDefinition> fieldDefList = ImmutableList.of(
+                new UploadFieldDefinition.Builder().withName("sanitize____this").withType(UploadFieldType.STRING)
+                        .build(),
+                new UploadFieldDefinition.Builder().withName("no-value-field").withType(UploadFieldType.STRING)
+                        .withRequired(false).build(),
+                new UploadFieldDefinition.Builder().withName("null-value-field").withType(UploadFieldType.STRING)
+                        .withRequired(false).build(),
+                new UploadFieldDefinition.Builder().withName("attachment-field")
+                        .withType(UploadFieldType.ATTACHMENT_V2).build(),
+                new UploadFieldDefinition.Builder().withName("normal-field").withType(UploadFieldType.STRING).build());
+
+        UploadSchema schema = UploadSchema.create();
+        schema.setStudyId(TestConstants.TEST_STUDY_IDENTIFIER);
+        schema.setSchemaId(SCHEMA_ID);
+        schema.setRevision(SCHEMA_REV);
+        schema.setFieldDefinitions(fieldDefList);
+
+        UploadSchemaService mockSchemaService = mock(UploadSchemaService.class);
+        when(mockSchemaService.getUploadSchemaByIdAndRev(TestConstants.TEST_STUDY, SCHEMA_ID, SCHEMA_REV)).thenReturn(
+                schema);
+
+        // mock handlers
+        StrictValidationHandler mockStrictValidationHandler = mock(StrictValidationHandler.class);
+        TranscribeConsentHandler mockTranscribeConsentHandler = mock(TranscribeConsentHandler.class);
+        UploadArtifactsHandler mockUploadArtifactsHandler = mock(UploadArtifactsHandler.class);
+
+        // UploadArtifactsHandler needs to write record ID back into the context.
+        doAnswer(invocation -> {
+            UploadValidationContext context = invocation.getArgumentAt(0, UploadValidationContext.class);
+            context.setRecordId(RECORD_ID);
+            return null;
+        }).when(mockUploadArtifactsHandler).handle(any());
+
+        // set up service
+        HealthDataService svc = spy(new HealthDataService());
+        svc.setSchemaService(mockSchemaService);
+        svc.setStrictValidationHandler(mockStrictValidationHandler);
+        svc.setTranscribeConsentHandler(mockTranscribeConsentHandler);
+        svc.setUploadArtifactsHandler(mockUploadArtifactsHandler);
+
+        // Spy getRecordById(). This decouples the submitHealthData implementation from the getRecord implementation.
+        // At this point, we only care about data flow. Don't worry about the actual content.
+        HealthDataRecord internalRecord = HealthDataRecord.create();
+        doReturn(internalRecord).when(svc).getRecordById(RECORD_ID);
+
+        // setup input
+        ObjectNode inputData = BridgeObjectMapper.get().createObjectNode();
+        inputData.put("sanitize!@#$this", "sanitize this value");
+        inputData.putNull("null-value-field");
+        inputData.put("attachment-field", "attachment field value");
+        inputData.put("normal-field", "normal field value");
+        inputData.put("non-schema-field", "this is not in the schema");
+
+        HealthDataSubmission submission = makeValidBuilder().withData(inputData).build();
+
+        // execute
+        HealthDataRecord svcOutputRecord = svc.submitHealthData(TestConstants.TEST_STUDY, PARTICIPANT, submission);
+
+        // verify that we return the record returned by the internal getRecordById() call.
+        assertSame(internalRecord, svcOutputRecord);
+
+        // Verify strict validation handler called. While we're at it, verify that we constructed the context and
+        // record correctly.
+        ArgumentCaptor<UploadValidationContext> contextCaptor = ArgumentCaptor.forClass(UploadValidationContext.class);
+        verify(mockStrictValidationHandler).handle(contextCaptor.capture());
+
+        UploadValidationContext context = contextCaptor.getValue();
+        assertEquals(HEALTH_CODE, context.getHealthCode());
+        assertEquals(TestConstants.TEST_STUDY, context.getStudy());
+
+        // We have one attachment. Note: This includes the quote marks, because we serialize the entire JSON field.
+        // (This will normally be arrays or objects.)
+        Map<String, byte[]> attachmentMap = context.getAttachmentsByFieldName();
+        assertEquals(1, attachmentMap.size());
+        assertEquals("\"attachment field value\"", new String(attachmentMap.get("attachment-field")));
+
+        // validate the created record
+        HealthDataRecord contextRecord = context.getHealthDataRecord();
+        assertEquals(APP_VERSION, contextRecord.getAppVersion());
+        assertEquals(PHONE_INFO, contextRecord.getPhoneInfo());
+        assertEquals(SCHEMA_ID, contextRecord.getSchemaId());
+        assertEquals(SCHEMA_REV, contextRecord.getSchemaRevision());
+        assertEquals(HEALTH_CODE, contextRecord.getHealthCode());
+        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, contextRecord.getStudyId());
+        assertEquals(MOCK_NOW_DATE, contextRecord.getUploadDate());
+        assertEquals(MOCK_NOW_MILLIS, contextRecord.getUploadedOn().longValue());
+        assertEquals(CREATED_ON_MILLIS, contextRecord.getCreatedOn().longValue());
+        assertEquals(CREATED_ON_TIMEZONE, contextRecord.getCreatedOnTimeZone());
+
+        // validate the sanitized, filtered data
+        JsonNode filteredData = contextRecord.getData();
+        assertEquals(2, filteredData.size());
+        assertEquals("sanitize this value", filteredData.get("sanitize____this").textValue());
+        assertEquals("normal field value", filteredData.get("normal-field").textValue());
+
+        // validate app version and phone info in metadata
+        JsonNode metadata = contextRecord.getMetadata();
+        assertEquals(2, metadata.size());
+        assertEquals(APP_VERSION, metadata.get(UploadUtil.FIELD_APP_VERSION).textValue());
+        assertEquals(PHONE_INFO, metadata.get(UploadUtil.FIELD_PHONE_INFO).textValue());
+
+        // validate the other handlers are called
+        verify(mockTranscribeConsentHandler).handle(context);
+        verify(mockUploadArtifactsHandler).handle(context);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void strictValidationThrows() throws Exception {
+        // mock schema service
+        List<UploadFieldDefinition> fieldDefList = ImmutableList.of(new UploadFieldDefinition.Builder()
+                .withName("simple-field").withType(UploadFieldType.INT).build());
+
+        UploadSchema schema = UploadSchema.create();
+        schema.setStudyId(TestConstants.TEST_STUDY_IDENTIFIER);
+        schema.setSchemaId(SCHEMA_ID);
+        schema.setRevision(SCHEMA_REV);
+        schema.setFieldDefinitions(fieldDefList);
+
+        UploadSchemaService mockSchemaService = mock(UploadSchemaService.class);
+        when(mockSchemaService.getUploadSchemaByIdAndRev(TestConstants.TEST_STUDY, SCHEMA_ID, SCHEMA_REV)).thenReturn(
+                schema);
+
+        // mock handlers - Only StrictValidationHandler will be called. Also, since we're not calling the actual
+        // StrictValidationHandler, we need to make it throw.
+        StrictValidationHandler mockStrictValidationHandler = mock(StrictValidationHandler.class);
+        doThrow(UploadValidationException.class).when(mockStrictValidationHandler).handle(any());
+
+        // set up service
+        HealthDataService svc = new HealthDataService();
+        svc.setSchemaService(mockSchemaService);
+        svc.setStrictValidationHandler(mockStrictValidationHandler);
+
+        // setup input
+        ObjectNode inputData = BridgeObjectMapper.get().createObjectNode();
+        inputData.put("simple-field", "not an int");
+        HealthDataSubmission submission = makeValidBuilder().withData(inputData).build();
+
+        // execute - This throws.
+        svc.submitHealthData(TestConstants.TEST_STUDY, PARTICIPANT, submission);
+    }
+
+    private static HealthDataSubmission.Builder makeValidBuilder() {
+        return new HealthDataSubmission.Builder().withAppVersion(APP_VERSION).withCreatedOn(CREATED_ON).withData(DATA)
+                .withPhoneInfo(PHONE_INFO).withSchemaId(SCHEMA_ID).withSchemaRevision(SCHEMA_REV);
+    }
+}

--- a/test/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2Test.java
+++ b/test/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2Test.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -36,6 +37,8 @@ import org.sagebionetworks.bridge.services.SurveyService;
 import org.sagebionetworks.bridge.services.UploadSchemaService;
 
 public class IosSchemaValidationHandler2Test {
+    private static final String APP_VERSION = "version 1.0.0, build 2";
+    private static final String PHONE_INFO = "Unit Tests";
     private static final String TEST_HEALTHCODE = "test-healthcode";
     private static final String TEST_STUDY_ID = "test-study";
     private static final String TEST_UPLOAD_DATE_STRING = "2015-04-13";
@@ -236,7 +239,7 @@ public class IosSchemaValidationHandler2Test {
                 "   }],\n" +
                 "   \"item\":\"test-survey\"\n" +
                 "}";
-        JsonNode infoJsonNode = BridgeObjectMapper.get().readTree(infoJsonText);
+        JsonNode infoJsonNode = addAppVersionPhoneInfoToInfoJson(infoJsonText);
 
         String fooAnswerJsonText = "{\n" +
                 "   \"questionType\":0,\n" +
@@ -384,7 +387,7 @@ public class IosSchemaValidationHandler2Test {
                 "   \"surveyGuid\":\"test-guid\",\n" +
                 "   \"surveyCreatedOn\":\"2015-08-27T13:38:55-07:00\"\n" +
                 "}";
-        JsonNode infoJsonNode = BridgeObjectMapper.get().readTree(infoJsonText);
+        JsonNode infoJsonNode = addAppVersionPhoneInfoToInfoJson(infoJsonText);
 
         String fooAnswerJsonText = "{\n" +
                 "   \"questionType\":0,\n" +
@@ -471,7 +474,7 @@ public class IosSchemaValidationHandler2Test {
                 "   }],\n" +
                 "   \"item\":\"json-data\"\n" +
                 "}";
-        JsonNode infoJsonNode = BridgeObjectMapper.get().readTree(infoJsonText);
+        JsonNode infoJsonNode = addAppVersionPhoneInfoToInfoJson(infoJsonText);
 
         String stringJsonText = "{\n" +
                 "   \"string\":\"This is a string\",\n" +
@@ -547,7 +550,7 @@ public class IosSchemaValidationHandler2Test {
                 "   }],\n" +
                 "   \"item\":\"non-json-data\"\n" +
                 "}";
-        JsonNode infoJsonNode = BridgeObjectMapper.get().readTree(infoJsonText);
+        JsonNode infoJsonNode = addAppVersionPhoneInfoToInfoJson(infoJsonText);
 
         String jsonJsonText = "{\n" +
                 "   \"field\":\"This is JSON data\"\n" +
@@ -610,7 +613,7 @@ public class IosSchemaValidationHandler2Test {
                 "   }],\n" +
                 "   \"item\":\"mixed-data\"\n" +
                 "}";
-        JsonNode infoJsonNode = BridgeObjectMapper.get().readTree(infoJsonText);
+        JsonNode infoJsonNode = addAppVersionPhoneInfoToInfoJson(infoJsonText);
 
         String attachmentJsonText = "{\n" +
                 "   \"attachment\":\"This is an attachment\"\n" +
@@ -686,7 +689,7 @@ public class IosSchemaValidationHandler2Test {
                 "   }],\n" +
                 "   \"item\":\"schema-rev-test\"\n" +
                 "}";
-        JsonNode infoJsonNode = BridgeObjectMapper.get().readTree(infoJsonText);
+        JsonNode infoJsonNode = addAppVersionPhoneInfoToInfoJson(infoJsonText);
 
         String dummyJsonText = "{\n" +
                 "   \"field\":\"dummy field value\"\n" +
@@ -733,7 +736,7 @@ public class IosSchemaValidationHandler2Test {
                 "   \"item\":\"schema-rev-test\",\n" +
                 "   \"schemaRevision\":3\n" +
                 "}";
-        JsonNode infoJsonNode = BridgeObjectMapper.get().readTree(infoJsonText);
+        JsonNode infoJsonNode = addAppVersionPhoneInfoToInfoJson(infoJsonText);
 
         String dummyJsonText = "{\n" +
                 "   \"field\":\"dummy field value\"\n" +
@@ -781,7 +784,7 @@ public class IosSchemaValidationHandler2Test {
                 "   \"item\":\"simple-attachment-schema\",\n" +
                 "   \"schemaRevision\":1\n" +
                 "}";
-        JsonNode infoJsonNode = BridgeObjectMapper.get().readTree(infoJsonText);
+        JsonNode infoJsonNode = addAppVersionPhoneInfoToInfoJson(infoJsonText);
 
         context.setJsonDataMap(ImmutableMap.of(
                 "info.json", infoJsonNode));
@@ -800,9 +803,18 @@ public class IosSchemaValidationHandler2Test {
         assertNull(record.getCreatedOnTimeZone());
     }
 
+    private static JsonNode addAppVersionPhoneInfoToInfoJson(String infoJsonText) throws Exception {
+        ObjectNode infoJsonNode = (ObjectNode) BridgeObjectMapper.get().readTree(infoJsonText);
+        infoJsonNode.put(UploadUtil.FIELD_APP_VERSION, APP_VERSION);
+        infoJsonNode.put(UploadUtil.FIELD_PHONE_INFO, PHONE_INFO);
+        return infoJsonNode;
+    }
+
     private static void validateCommonProps(UploadValidationContext ctx) {
         HealthDataRecord record = ctx.getHealthDataRecord();
+        assertEquals(APP_VERSION, record.getAppVersion());
         assertEquals(TEST_HEALTHCODE, record.getHealthCode());
+        assertEquals(PHONE_INFO, record.getPhoneInfo());
         assertEquals(TEST_STUDY_ID, record.getStudyId());
         assertEquals(MOCK_NOW.toLocalDate(), record.getUploadDate());
         assertEquals(TEST_UPLOAD_ID, record.getUploadId());

--- a/test/org/sagebionetworks/bridge/upload/TranscribeConsentHandlerTest.java
+++ b/test/org/sagebionetworks/bridge/upload/TranscribeConsentHandlerTest.java
@@ -13,7 +13,6 @@ import com.google.common.collect.Sets;
 import org.junit.Test;
 
 import org.sagebionetworks.bridge.dao.ParticipantOption;
-import org.sagebionetworks.bridge.dynamodb.DynamoUpload2;
 import org.sagebionetworks.bridge.models.accounts.ParticipantOptionsLookup;
 import org.sagebionetworks.bridge.models.healthdata.HealthDataRecord;
 import org.sagebionetworks.bridge.services.ParticipantOptionsService;
@@ -88,12 +87,9 @@ public class TranscribeConsentHandlerTest {
         TranscribeConsentHandler handler = new TranscribeConsentHandler();
         handler.setOptionsService(optsService);
 
-        // set up context - handler expects Upload and RecordBuilder
-        DynamoUpload2 upload = new DynamoUpload2();
-        upload.setHealthCode(TEST_HEALTHCODE);
-
+        // set up context - handler expects Health Code and RecordBuilder
         UploadValidationContext context = new UploadValidationContext();
-        context.setUpload(upload);
+        context.setHealthCode(TEST_HEALTHCODE);
         context.setHealthDataRecord(record);
 
         // execute

--- a/test/org/sagebionetworks/bridge/upload/UploadValidationContextTest.java
+++ b/test/org/sagebionetworks/bridge/upload/UploadValidationContextTest.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge.upload;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
 import java.util.Map;
@@ -19,6 +20,22 @@ import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.upload.Upload;
 
 public class UploadValidationContextTest {
+    private static final String HEALTH_CODE = "health-code";
+    private static final String UPLOAD_ID = "upload-id";
+
+    @Test
+    public void uploadId() {
+        // null upload returns null upload ID
+        UploadValidationContext context = new UploadValidationContext();
+        assertNull(context.getUploadId());
+
+        // non-null upload returns the ID of that upload
+        DynamoUpload2 upload = new DynamoUpload2();
+        upload.setUploadId(UPLOAD_ID);
+        context.setUpload(upload);
+        assertEquals(UPLOAD_ID, context.getUploadId());
+    }
+
     @Test
     public void shallowCopy() {
         // dummy objects to test against
@@ -34,6 +51,7 @@ public class UploadValidationContextTest {
 
         // create original
         UploadValidationContext original = new UploadValidationContext();
+        original.setHealthCode(HEALTH_CODE);
         original.setStudy(study);
         original.setUpload(upload);
         original.setSuccess(false);
@@ -48,6 +66,7 @@ public class UploadValidationContextTest {
 
         // copy and validate
         UploadValidationContext copy = original.shallowCopy();
+        assertEquals(HEALTH_CODE, copy.getHealthCode());
         assertSame(study, copy.getStudy());
         assertSame(upload, copy.getUpload());
         assertFalse(copy.getSuccess());

--- a/test/org/sagebionetworks/bridge/upload/UploadValidationTaskFactoryTest.java
+++ b/test/org/sagebionetworks/bridge/upload/UploadValidationTaskFactoryTest.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.upload;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
 import java.util.Collections;
@@ -13,6 +14,8 @@ import org.sagebionetworks.bridge.dynamodb.DynamoUploadDao;
 import org.sagebionetworks.bridge.services.HealthDataService;
 
 public class UploadValidationTaskFactoryTest {
+    private static final String HEALTH_CODE = "health-code";
+
     @Test
     public void test() {
         // test dao and handlers
@@ -29,9 +32,11 @@ public class UploadValidationTaskFactoryTest {
         // inputs
         DynamoStudy study = TestUtils.getValidStudy(UploadValidationTaskFactoryTest.class);
         DynamoUpload2 upload2 = new DynamoUpload2();
+        upload2.setHealthCode(HEALTH_CODE);
 
         // execute and validate
         UploadValidationTask task = taskFactory.newTask(study, upload2);
+        assertEquals(HEALTH_CODE, task.getContext().getHealthCode());
         assertSame(study, task.getContext().getStudy());
         assertSame(upload2, task.getContext().getUpload());
         assertSame(handlerList, task.getHandlerList());

--- a/test/org/sagebionetworks/bridge/validators/HealthDataSubmissionValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/HealthDataSubmissionValidatorTest.java
@@ -1,0 +1,179 @@
+package org.sagebionetworks.bridge.validators;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
+
+import java.util.HashMap;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+import org.joda.time.DateTime;
+import org.junit.Test;
+import org.springframework.validation.MapBindingResult;
+
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.healthdata.HealthDataSubmission;
+
+public class HealthDataSubmissionValidatorTest {
+    private static final String APP_VERSION = "version 1.0.0, build 2";
+    private static final DateTime CREATED_ON = DateTime.parse("2017-08-24T14:38:57.340+0900");
+    private static final JsonNode DATA = BridgeObjectMapper.get().createObjectNode();
+    private static final String PHONE_INFO = "Unit Tests";
+    private static final String SCHEMA_ID = "test-schema";
+    private static final int SCHEMA_REV = 3;
+
+    // branch coverage
+    @Test
+    public void validatorSupportsClass() {
+        assertTrue(HealthDataSubmissionValidator.INSTANCE.supports(HealthDataSubmission.class));
+    }
+
+    // branch coverage
+    @Test
+    public void validatorDoesntSupportClass() {
+        assertFalse(HealthDataSubmissionValidator.INSTANCE.supports(String.class));
+    }
+
+    // branch coverage
+    // we call the validator directly, since Validate.validateThrowingException filters out nulls and wrong types
+    @Test
+    public void validateNull() {
+        MapBindingResult errors = new MapBindingResult(new HashMap<>(), "HealthDataSubmission");
+        HealthDataSubmissionValidator.INSTANCE.validate(null, errors);
+        assertTrue(errors.hasErrors());
+    }
+
+    // branch coverage
+    // we call the validator directly, since Validate.validateThrowingException filters out nulls and wrong types
+    @Test
+    public void validateWrongClass() {
+        MapBindingResult errors = new MapBindingResult(new HashMap<>(), "HealthDataSubmission");
+        HealthDataSubmissionValidator.INSTANCE.validate("this is the wrong class", errors);
+        assertTrue(errors.hasErrors());
+    }
+
+    @Test
+    public void validateHappyCase() {
+        HealthDataSubmission healthDataSubmission = makeValidBuilder().build();
+        Validate.entityThrowingException(HealthDataSubmissionValidator.INSTANCE, healthDataSubmission);
+    }
+
+    @Test
+    public void nullAppVersion() {
+        HealthDataSubmission healthDataSubmission = makeValidBuilder().withAppVersion(null).build();
+        assertValidatorMessage(HealthDataSubmissionValidator.INSTANCE, healthDataSubmission, "appVersion",
+                "is required");
+    }
+
+    @Test
+    public void emptyAppVersion() {
+        HealthDataSubmission healthDataSubmission = makeValidBuilder().withAppVersion("").build();
+        assertValidatorMessage(HealthDataSubmissionValidator.INSTANCE, healthDataSubmission, "appVersion",
+                "is required");
+    }
+
+    @Test
+    public void blankAppVersion() {
+        HealthDataSubmission healthDataSubmission = makeValidBuilder().withAppVersion("   ").build();
+        assertValidatorMessage(HealthDataSubmissionValidator.INSTANCE, healthDataSubmission, "appVersion",
+                "is required");
+    }
+
+    @Test
+    public void nullCreatedOn() {
+        HealthDataSubmission healthDataSubmission = makeValidBuilder().withCreatedOn(null).build();
+        assertValidatorMessage(HealthDataSubmissionValidator.INSTANCE, healthDataSubmission, "createdOn",
+                "is required");
+    }
+
+    @Test
+    public void dataJavaNull() {
+        HealthDataSubmission healthDataSubmission = makeValidBuilder().withData(null).build();
+        assertValidatorMessage(HealthDataSubmissionValidator.INSTANCE, healthDataSubmission, "data", "is required");
+    }
+
+    @Test
+    public void dataJsonNull() {
+        HealthDataSubmission healthDataSubmission = makeValidBuilder().withData(NullNode.getInstance()).build();
+        assertValidatorMessage(HealthDataSubmissionValidator.INSTANCE, healthDataSubmission, "data", "is required");
+    }
+
+    @Test
+    public void dataArrayNode() {
+        HealthDataSubmission healthDataSubmission = makeValidBuilder()
+                .withData(BridgeObjectMapper.get().createArrayNode()).build();
+        assertValidatorMessage(HealthDataSubmissionValidator.INSTANCE, healthDataSubmission, "data",
+                "must be an object node");
+    }
+
+    @Test
+    public void nullPhoneInfo() {
+        HealthDataSubmission healthDataSubmission = makeValidBuilder().withPhoneInfo(null).build();
+        assertValidatorMessage(HealthDataSubmissionValidator.INSTANCE, healthDataSubmission, "phoneInfo",
+                "is required");
+    }
+
+    @Test
+    public void emptyPhoneInfo() {
+        HealthDataSubmission healthDataSubmission = makeValidBuilder().withPhoneInfo("").build();
+        assertValidatorMessage(HealthDataSubmissionValidator.INSTANCE, healthDataSubmission, "phoneInfo",
+                "is required");
+    }
+
+    @Test
+    public void blankPhoneInfo() {
+        HealthDataSubmission healthDataSubmission = makeValidBuilder().withPhoneInfo("   ").build();
+        assertValidatorMessage(HealthDataSubmissionValidator.INSTANCE, healthDataSubmission, "phoneInfo",
+                "is required");
+    }
+
+    @Test
+    public void nullSchemaId() {
+        HealthDataSubmission healthDataSubmission = makeValidBuilder().withSchemaId(null).build();
+        assertValidatorMessage(HealthDataSubmissionValidator.INSTANCE, healthDataSubmission, "schemaId",
+                "is required");
+    }
+
+    @Test
+    public void emptySchemaId() {
+        HealthDataSubmission healthDataSubmission = makeValidBuilder().withSchemaId("").build();
+        assertValidatorMessage(HealthDataSubmissionValidator.INSTANCE, healthDataSubmission, "schemaId",
+                "is required");
+    }
+
+    @Test
+    public void blankSchemaId() {
+        HealthDataSubmission healthDataSubmission = makeValidBuilder().withSchemaId("   ").build();
+        assertValidatorMessage(HealthDataSubmissionValidator.INSTANCE, healthDataSubmission, "schemaId",
+                "is required");
+    }
+
+    @Test
+    public void zeroSchemaRev() {
+        HealthDataSubmission healthDataSubmission = makeValidBuilder().withSchemaRevision(0).build();
+        assertValidatorMessage(HealthDataSubmissionValidator.INSTANCE, healthDataSubmission, "schemaRevision",
+                "must be positive");
+    }
+
+    @Test
+    public void negativeSchemaRev() {
+        HealthDataSubmission healthDataSubmission = makeValidBuilder().withSchemaRevision(-1).build();
+        assertValidatorMessage(HealthDataSubmissionValidator.INSTANCE, healthDataSubmission, "schemaRevision",
+                "must be positive");
+    }
+
+    // special case - unspecified schema rev will fail validation
+    @Test
+    public void unspecitiedSchemaRev() {
+        HealthDataSubmission healthDataSubmission = new HealthDataSubmission.Builder().withAppVersion(APP_VERSION)
+                .withCreatedOn(CREATED_ON).withData(DATA).withPhoneInfo(PHONE_INFO).withSchemaId(SCHEMA_ID).build();
+        assertValidatorMessage(HealthDataSubmissionValidator.INSTANCE, healthDataSubmission, "schemaRevision",
+                "must be positive");
+    }
+
+    private static HealthDataSubmission.Builder makeValidBuilder() {
+        return new HealthDataSubmission.Builder().withAppVersion(APP_VERSION).withCreatedOn(CREATED_ON).withData(DATA)
+                .withPhoneInfo(PHONE_INFO).withSchemaId(SCHEMA_ID).withSchemaRevision(SCHEMA_REV);
+    }
+}


### PR DESCRIPTION
Synchronous health data API. Used to submit small health data payloads (such as survey responses) without incurring the overhead of creating a bunch of small files to upload to S3.

See https://sagebionetworks.jira.com/wiki/spaces/BRIDGE/pages/97517599/Upload+Format+v2#UploadFormatv2-SynchronousHealthDataSubmission for more details. (Docs to be updated shortly to reflect implementation details.

Testing done: unit tests and integ tests