### PR TITLE
Cleanup of report APIs

### DIFF
--- a/app/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/app/org/sagebionetworks/bridge/BridgeUtils.java
@@ -22,11 +22,13 @@ import javax.annotation.Nonnull;
 
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
 import org.joda.time.LocalDateTime;
 
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.json.BridgeTypeName;
+import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.models.schedules.Activity;
 import org.sagebionetworks.bridge.models.schedules.ActivityType;
 import org.sagebionetworks.bridge.models.studies.PasswordPolicy;
@@ -284,6 +286,18 @@ public class BridgeUtils {
             return DateTime.parse(value);
         } catch(Exception e) {
             throw new BadRequestException(value + " is not a DateTime value");
+        }
+    }
+    
+    public static LocalDate getLocalDateOrDefault(String value, LocalDate defaultValue) {
+        if (isBlank(value)) {
+            return defaultValue;
+        } else {
+            try {
+                return DateUtils.parseCalendarDate(value);
+            } catch (RuntimeException ex) {
+                throw new BadRequestException(value + " is not a LocalDate value");
+            }
         }
     }
     

--- a/app/org/sagebionetworks/bridge/play/controllers/ParticipantReportController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ParticipantReportController.java
@@ -1,0 +1,186 @@
+package org.sagebionetworks.bridge.play.controllers;
+
+import static org.sagebionetworks.bridge.Roles.ADMIN;
+import static org.sagebionetworks.bridge.Roles.DEVELOPER;
+import static org.sagebionetworks.bridge.Roles.RESEARCHER;
+import static org.sagebionetworks.bridge.Roles.WORKER;
+import static org.sagebionetworks.bridge.BridgeUtils.getLocalDateOrDefault;
+
+import org.joda.time.LocalDate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+
+import org.sagebionetworks.bridge.dao.AccountDao;
+import org.sagebionetworks.bridge.exceptions.BadRequestException;
+import org.sagebionetworks.bridge.models.DateRangeResourceList;
+import org.sagebionetworks.bridge.models.ReportTypeResourceList;
+import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.UserSession;
+import org.sagebionetworks.bridge.models.reports.ReportData;
+import org.sagebionetworks.bridge.models.reports.ReportIndex;
+import org.sagebionetworks.bridge.models.reports.ReportType;
+import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.services.ReportService;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import play.mvc.Result;
+
+/**
+ * <p>Permissions for participant reports are more complicated than other controllers:</p>
+ * 
+ * <p><b>Participant Reports</b></p>
+ * <ul>
+ *   <li>any authenticated user can get the participant identifiers (indices)</li>
+ *   <li>user or researcher can see reports (for user, only self report)</li>
+ *   <li>developers/workers can add/delete</li>
+ * </ul>
+ */
+@Controller
+public class ParticipantReportController extends BaseController {
+    
+    @Autowired
+    ReportService reportService;
+    
+    @Autowired
+    AccountDao accountDao;
+    
+    final void setReportService(ReportService reportService) {
+        this.reportService = reportService;
+    }
+    
+    final void setAccountDao(AccountDao accountDao) {
+        this.accountDao = accountDao;
+    }
+    
+    public Result getParticipantReportForSelf(String identifier, String startDateString, String endDateString) {
+        UserSession session = getAuthenticatedSession();
+
+        LocalDate startDate = getLocalDateOrDefault(startDateString, null);
+        LocalDate endDate = getLocalDateOrDefault(endDateString, null);
+        
+        DateRangeResourceList<? extends ReportData> results = reportService.getParticipantReport(
+                session.getStudyIdentifier(), identifier, session.getHealthCode(), startDate, endDate);
+        
+        return okResult(results);
+    }
+    
+    public Result saveParticipantReportForSelf(String identifier) {
+        UserSession session = getAuthenticatedSession();
+        
+        ReportData reportData = parseJson(request(), ReportData.class);
+        reportData.setKey(null); // set in service, but just so no future use depends on it
+        
+        reportService.saveParticipantReport(session.getStudyIdentifier(), identifier, 
+                session.getHealthCode(), reportData);
+        
+        return createdResult("Report data saved.");
+    }
+    
+    /**
+     * Get a list of the identifiers used for participant reports in this study.
+     */
+    public Result listParticipantReportIndices() throws Exception {
+        UserSession session = getAuthenticatedSession();
+        
+        ReportTypeResourceList<? extends ReportIndex> indices = reportService
+                .getReportIndices(session.getStudyIdentifier(), ReportType.PARTICIPANT);
+        return okResult(indices);
+    }
+    
+    public Result getParticipantReport(String userId, String identifier, String startDateString, String endDateString) {
+        UserSession session = getAuthenticatedSession(RESEARCHER);
+        Study study = studyService.getStudy(session.getStudyIdentifier());
+        
+        LocalDate startDate = getLocalDateOrDefault(startDateString, null);
+        LocalDate endDate = getLocalDateOrDefault(endDateString, null);
+        
+        Account account = accountDao.getAccount(study, userId);
+        
+        DateRangeResourceList<? extends ReportData> results = reportService.getParticipantReport(
+                session.getStudyIdentifier(), identifier, account.getHealthCode(), startDate, endDate);
+        
+        return okResult(results);
+    }
+    
+    /**
+     * Report participant data can be saved by developers or by worker processes. The JSON for these must 
+     * include a healthCode field. This is validated when constructing the DataReportKey.
+     */
+    public Result saveParticipantReport(String userId, String identifier) throws Exception {
+        UserSession session = getAuthenticatedSession(DEVELOPER);
+        Study study = studyService.getStudy(session.getStudyIdentifier());
+        
+        Account account = accountDao.getAccount(study, userId);
+        
+        ReportData reportData = parseJson(request(), ReportData.class);
+        reportData.setKey(null); // set in service, but just so no future use depends on it
+        
+        reportService.saveParticipantReport(session.getStudyIdentifier(), identifier, 
+                account.getHealthCode(), reportData);
+        
+        return createdResult("Report data saved.");
+    }
+    
+    /**
+     * When saving, worker accounts do not know the userId of the account, only the healthCode, so a 
+     * special method is needed.
+     */
+    public Result saveParticipantReportForWorker(String identifier) throws Exception {
+        UserSession session = getAuthenticatedSession(WORKER);
+        
+        JsonNode node = requestToJSON(request());
+        if (!node.has("healthCode")) {
+            throw new BadRequestException("A health code is required to save report data.");
+        }
+        String healthCode = node.get("healthCode").asText();
+        
+        ReportData reportData = MAPPER.treeToValue(node, ReportData.class);
+        reportData.setKey(null); // set in service, but just so no future use depends on it
+        
+        reportService.saveParticipantReport(session.getStudyIdentifier(), identifier, 
+                healthCode, reportData);
+        
+        return createdResult("Report data saved.");
+    }
+    
+    /**
+     * Developers and workers can delete participant report data (though worker accounts are unlikely 
+     * to know the user ID for records). This deletes all reports for all users. This is not 
+     * performant for large data sets and should only be done during testing. 
+     */
+    public Result deleteParticipantReport(String userId, String identifier) {
+        UserSession session = getAuthenticatedSession(DEVELOPER, WORKER);
+        Study study = studyService.getStudy(session.getStudyIdentifier());
+        
+        Account account = accountDao.getAccount(study, userId);
+        
+        reportService.deleteParticipantReport(session.getStudyIdentifier(), identifier, account.getHealthCode());
+        
+        return okResult("Report deleted.");
+    }
+    
+    /**
+     * Delete an individual participant report record
+     */
+    public Result deleteParticipantReportRecord(String userId, String identifier, String dateString) {
+        UserSession session = getAuthenticatedSession(DEVELOPER, WORKER);
+        Study study = studyService.getStudy(session.getStudyIdentifier());
+        LocalDate date = getLocalDateOrDefault(dateString, null);
+        
+        Account account = accountDao.getAccount(study, userId);
+        
+        reportService.deleteParticipantReportRecord(session.getStudyIdentifier(), identifier, date, account.getHealthCode());
+        
+        return okResult("Report record deleted.");
+    }
+    
+    public Result deleteParticipantReportIndex(String identifier) {
+        UserSession session = getAuthenticatedSession(ADMIN);
+        
+        reportService.deleteParticipantReportIndex(session.getStudyIdentifier(), identifier);
+        
+        return okResult("Report index deleted.");
+    }
+    
+}

--- a/app/org/sagebionetworks/bridge/play/controllers/StudyReportController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/StudyReportController.java
@@ -1,54 +1,40 @@
 package org.sagebionetworks.bridge.play.controllers;
 
-import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.Roles.WORKER;
-import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.sagebionetworks.bridge.BridgeUtils.getLocalDateOrDefault;
 
 import org.joda.time.LocalDate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 
 import org.sagebionetworks.bridge.dao.AccountDao;
-import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
-import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.models.DateRangeResourceList;
 import org.sagebionetworks.bridge.models.ReportTypeResourceList;
-import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.reports.ReportData;
 import org.sagebionetworks.bridge.models.reports.ReportDataKey;
 import org.sagebionetworks.bridge.models.reports.ReportIndex;
 import org.sagebionetworks.bridge.models.reports.ReportType;
-import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.services.ReportService;
 
-import com.fasterxml.jackson.databind.JsonNode;
-
 import play.mvc.Result;
 
 /**
- * <p>Permissions for reports are more complicated than other controllers:</p>
+ * <p>Permissions for study reports are more complicated than other controllers:</p>
  * <p><b>Study Reports</b></p>
  * <ul>
  *   <li>any authenticated user can get the study identifiers (indices)</li>
  *   <li>any authenticated user can see a study report</li>  
  *   <li>developers/workers can add/delete</li>
  * </ul>
- * 
- * <p><b>Participant Reports</b></p>
- * <ul>
- *   <li>any authenticated user can get the participant identifiers (indices)</li>
- *   <li>user or researcher can see reports (for user, only self report)</li>
- *   <li>developers/workers can add/delete</li>
- * </ul>
  */
 @Controller
-public class ReportController extends BaseController {
+public class StudyReportController extends BaseController {
     
     @Autowired
     ReportService reportService;
@@ -65,128 +51,15 @@ public class ReportController extends BaseController {
     }
     
     /**
-     * Get a list of the identifiers used for reports in this study. If the value is missing or invalid, 
-     * defaults to list of study identifiers.
+     * Get a list of the identifiers used for reports in this study. For backwards compatibility this method 
+     * takes an argument and can return participants, but there is now a separate endpoint for that.
      */
-    public Result getReportIndices(String type) throws Exception {
+    public Result listStudyReportIndices(String type) throws Exception {
         UserSession session = getAuthenticatedSession();
         ReportType reportType = ("participant".equals(type)) ? ReportType.PARTICIPANT : ReportType.STUDY;
         
         ReportTypeResourceList<? extends ReportIndex> indices = reportService.getReportIndices(session.getStudyIdentifier(), reportType);
         return okResult(indices);
-    }
-    
-    /**
-     * Individuals can get their own participant reports. For this request, because we are checking consent, 
-     * we also verify the consent-related headers are being sent (this report has been retrieved by embedded web 
-     * components that haven't sent the correct headers in the past).
-     */
-    public Result getParticipantReport(String identifier, String startDateString, String endDateString) {
-        UserSession session = getAuthenticatedSession();
-
-        LocalDate startDate = parseDateHelper(startDateString);
-        LocalDate endDate = parseDateHelper(endDateString);
-        
-        DateRangeResourceList<? extends ReportData> results = reportService.getParticipantReport(
-                session.getStudyIdentifier(), identifier, session.getHealthCode(), startDate, endDate);
-        
-        return okResult(results);
-    }
-    
-    public Result getParticipantReportForResearcher(String userId, String identifier, String startDateString,
-            String endDateString) {
-        UserSession session = getAuthenticatedSession(RESEARCHER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
-        
-        LocalDate startDate = parseDateHelper(startDateString);
-        LocalDate endDate = parseDateHelper(endDateString);
-        
-        Account account = accountDao.getAccount(study, userId);
-        
-        DateRangeResourceList<? extends ReportData> results = reportService.getParticipantReport(
-                session.getStudyIdentifier(), identifier, account.getHealthCode(), startDate, endDate);
-        
-        return okResult(results);
-    }
-    
-    /**
-     * Report participant data can be saved by developers or by worker processes. The JSON for these must 
-     * include a healthCode field. This is validated when constructing the DataReportKey.
-     */
-    public Result saveParticipantReport(String userId, String identifier) throws Exception {
-        UserSession session = getAuthenticatedSession(DEVELOPER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
-        
-        Account account = accountDao.getAccount(study, userId);
-        
-        ReportData reportData = parseJson(request(), ReportData.class);
-        reportData.setKey(null); // set in service, but just so no future use depends on it
-        
-        reportService.saveParticipantReport(session.getStudyIdentifier(), identifier, 
-                account.getHealthCode(), reportData);
-        
-        return createdResult("Report data saved.");
-    }
-    
-    /**
-     * When saving, worker accounts do not know the userId of the account, only the healthCode, so a 
-     * special method is needed.
-     */
-    public Result saveParticipantReportForWorker(String identifier) throws Exception {
-        UserSession session = getAuthenticatedSession(WORKER);
-        
-        JsonNode node = requestToJSON(request());
-        if (!node.has("healthCode")) {
-            throw new BadRequestException("A health code is required to save report data.");
-        }
-        String healthCode = node.get("healthCode").asText();
-        
-        ReportData reportData = MAPPER.treeToValue(node, ReportData.class);
-        reportData.setKey(null); // set in service, but just so no future use depends on it
-        
-        reportService.saveParticipantReport(session.getStudyIdentifier(), identifier, 
-                healthCode, reportData);
-        
-        return createdResult("Report data saved.");
-    }
-    
-    /**
-     * Developers and workers can delete participant report data (though worker accounts are unlikely 
-     * to know the user ID for records). This deletes all reports for all users. This is not 
-     * performant for large data sets and should only be done during testing. 
-     */
-    public Result deleteParticipantReport(String userId, String identifier) {
-        UserSession session = getAuthenticatedSession(DEVELOPER, WORKER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
-        
-        Account account = accountDao.getAccount(study, userId);
-        
-        reportService.deleteParticipantReport(session.getStudyIdentifier(), identifier, account.getHealthCode());
-        
-        return okResult("Report deleted.");
-    }
-    
-    /**
-     * Delete an individual participant report record
-     */
-    public Result deleteParticipantReportRecord(String userId, String identifier, String dateString) {
-        UserSession session = getAuthenticatedSession(DEVELOPER, WORKER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
-        LocalDate date = parseDateHelper(dateString);
-        
-        Account account = accountDao.getAccount(study, userId);
-        
-        reportService.deleteParticipantReportRecord(session.getStudyIdentifier(), identifier, date, account.getHealthCode());
-        
-        return okResult("Report record deleted.");
-    }
-    
-    public Result deleteParticipantReportIndex(String identifier) {
-        UserSession session = getAuthenticatedSession(ADMIN);
-        
-        reportService.deleteParticipantReportIndex(session.getStudyIdentifier(), identifier);
-        
-        return okResult("Report index deleted.");
     }
     
     /**
@@ -196,8 +69,8 @@ public class ReportController extends BaseController {
     public Result getStudyReport(String identifier, String startDateString, String endDateString) {
         UserSession session = getAuthenticatedSession();
         
-        LocalDate startDate = parseDateHelper(startDateString);
-        LocalDate endDate = parseDateHelper(endDateString);
+        LocalDate startDate = getLocalDateOrDefault(startDateString, null);
+        LocalDate endDate = getLocalDateOrDefault(endDateString, null);
         
         DateRangeResourceList<? extends ReportData> results = reportService
                 .getStudyReport(session.getStudyIdentifier(), identifier, startDate, endDate);
@@ -214,8 +87,8 @@ public class ReportController extends BaseController {
 
         verifyIndex(studyId, identifier);
 
-        LocalDate startDate = parseDateHelper(startDateString);
-        LocalDate endDate = parseDateHelper(endDateString);
+        LocalDate startDate = getLocalDateOrDefault(startDateString, null);
+        LocalDate endDate = getLocalDateOrDefault(endDateString, null);
         
         DateRangeResourceList<? extends ReportData> results = reportService.getStudyReport(
                 studyId, identifier, startDate, endDate);
@@ -240,7 +113,7 @@ public class ReportController extends BaseController {
     /**
      * A similar method as above but specifying study id only for WORKER
      */
-    public Result saveStudyReportForSpecifiedStudy(String studyIdString, String identifier) throws Exception {
+    public Result saveStudyReportForWorker(String studyIdString, String identifier) throws Exception {
         getAuthenticatedSession(WORKER);
 
         ReportData reportData = parseJson(request(), ReportData.class);
@@ -269,7 +142,7 @@ public class ReportController extends BaseController {
      */
     public Result deleteStudyReportRecord(String identifier, String dateString) {
         UserSession session = getAuthenticatedSession(DEVELOPER, WORKER);
-        LocalDate date = parseDateHelper(dateString);
+        LocalDate date = getLocalDateOrDefault(dateString, null);
         
         reportService.deleteStudyReportRecord(session.getStudyIdentifier(), identifier, date);
         
@@ -322,15 +195,4 @@ public class ReportController extends BaseController {
         }
     }
     
-    private static LocalDate parseDateHelper(String dateStr) {
-        if (isBlank(dateStr)) {
-            return null;
-        } else {
-            try {
-                return DateUtils.parseCalendarDate(dateStr);
-            } catch (RuntimeException ex) {
-                throw new BadRequestException("invalid date " + dateStr);
-            }
-        }
-    }    
 }

--- a/conf/routes
+++ b/conf/routes
@@ -106,22 +106,26 @@ POST   /v3/users/self/unsubscribeEmail    @org.sagebionetworks.bridge.play.contr
 POST   /v3/users/self/dataSharing         @org.sagebionetworks.bridge.play.controllers.ConsentController.changeSharingScope
 GET    /v3/users/self/dataGroups          @org.sagebionetworks.bridge.play.controllers.UserProfileController.getDataGroups
 POST   /v3/users/self/dataGroups          @org.sagebionetworks.bridge.play.controllers.UserProfileController.updateDataGroups
-GET    /v3/users/self/reports/:identifier @org.sagebionetworks.bridge.play.controllers.ReportController.getParticipantReport(identifier: String, startDate: String ?= null, endDate: String ?= null)
+GET    /v3/users/self/reports/:identifier @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.getParticipantReportForSelf(identifier: String, startDate: String ?= null, endDate: String ?= null)
+POST   /v3/users/self/reports/:identifier @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.saveParticipantReportForSelf(identifier: String)
 
-# Reports
-GET    /v3/reports                                        @org.sagebionetworks.bridge.play.controllers.ReportController.getReportIndices(type: String)
-GET    /v3/reports/:identifier                            @org.sagebionetworks.bridge.play.controllers.ReportController.getStudyReport(identifier: String, startDate: String ?= null, endDate: String ?= null)
-POST   /v3/reports/:identifier                            @org.sagebionetworks.bridge.play.controllers.ReportController.saveStudyReport(identifier: String)
-GET    /v3/reports/:identifier/index                      @org.sagebionetworks.bridge.play.controllers.ReportController.getStudyReportIndex(identifier: String)
-POST   /v3/reports/:identifier/index                      @org.sagebionetworks.bridge.play.controllers.ReportController.updateStudyReportIndex(identifier: String)
-DELETE /v3/reports/:identifier                            @org.sagebionetworks.bridge.play.controllers.ReportController.deleteStudyReport(identifier: String)
-DELETE /v3/reports/:identifier/:date                      @org.sagebionetworks.bridge.play.controllers.ReportController.deleteStudyReportRecord(identifier: String, date: String)
-POST   /v3/participants/reports/:identifier               @org.sagebionetworks.bridge.play.controllers.ReportController.saveParticipantReportForWorker(identifier: String)
-DELETE /v3/participants/reports/:identifier               @org.sagebionetworks.bridge.play.controllers.ReportController.deleteParticipantReportIndex(identifier: String)
-GET    /v3/participants/:userId/reports/:identifier       @org.sagebionetworks.bridge.play.controllers.ReportController.getParticipantReportForResearcher(userId: String, identifier: String, startDate: String ?= null, endDate: String ?= null)
-POST   /v3/participants/:userId/reports/:identifier       @org.sagebionetworks.bridge.play.controllers.ReportController.saveParticipantReport(userId: String, identifier: String)
-DELETE /v3/participants/:userId/reports/:identifier       @org.sagebionetworks.bridge.play.controllers.ReportController.deleteParticipantReport(userId: String, identifier: String)
-DELETE /v3/participants/:userId/reports/:identifier/:date @org.sagebionetworks.bridge.play.controllers.ReportController.deleteParticipantReportRecord(userId: String, identifier: String, date: String)
+# Participant reports (and see above for self endpoints)
+GET    /v3/participants/reports                           @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.listParticipantReportIndices()
+POST   /v3/participants/reports/:identifier               @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.saveParticipantReportForWorker(identifier: String)
+DELETE /v3/participants/reports/:identifier               @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.deleteParticipantReportIndex(identifier: String)
+GET    /v3/participants/:userId/reports/:identifier       @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.getParticipantReport(userId: String, identifier: String, startDate: String ?= null, endDate: String ?= null)
+POST   /v3/participants/:userId/reports/:identifier       @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.saveParticipantReport(userId: String, identifier: String)
+DELETE /v3/participants/:userId/reports/:identifier       @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.deleteParticipantReport(userId: String, identifier: String)
+DELETE /v3/participants/:userId/reports/:identifier/:date @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.deleteParticipantReportRecord(userId: String, identifier: String, date: String)
+
+# Study reports (and see below for worker endpoints)
+GET    /v3/reports                    @org.sagebionetworks.bridge.play.controllers.StudyReportController.listStudyReportIndices(type: String ?= null)
+GET    /v3/reports/:identifier        @org.sagebionetworks.bridge.play.controllers.StudyReportController.getStudyReport(identifier: String, startDate: String ?= null, endDate: String ?= null)
+POST   /v3/reports/:identifier        @org.sagebionetworks.bridge.play.controllers.StudyReportController.saveStudyReport(identifier: String)
+GET    /v3/reports/:identifier/index  @org.sagebionetworks.bridge.play.controllers.StudyReportController.getStudyReportIndex(identifier: String)
+POST   /v3/reports/:identifier/index  @org.sagebionetworks.bridge.play.controllers.StudyReportController.updateStudyReportIndex(identifier: String)
+DELETE /v3/reports/:identifier        @org.sagebionetworks.bridge.play.controllers.StudyReportController.deleteStudyReport(identifier: String)
+DELETE /v3/reports/:identifier/:date  @org.sagebionetworks.bridge.play.controllers.StudyReportController.deleteStudyReportRecord(identifier: String, date: String)
 
 # Surveys
 GET    /v3/surveys                                           @org.sagebionetworks.bridge.play.controllers.SurveyController.getAllSurveysMostRecentVersion
@@ -221,8 +225,8 @@ DELETE /v3/externalIds    @org.sagebionetworks.bridge.play.controllers.ExternalI
 # Worker APIs for getting entities across studies
 GET    /v3/studies/:studyId/surveys/published                           @org.sagebionetworks.bridge.play.controllers.SurveyController.getAllSurveysMostRecentlyPublishedVersionForStudy(studyId: String)
 GET    /v3/studies/:studyId/uploadschemas/:schemaId/revisions/:revision @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getUploadSchemaByStudyAndSchemaAndRev(studyId: String, schemaId: String, revision: Int)
-GET    /v3/studies/:studyId/reports/:identifier                         @org.sagebionetworks.bridge.play.controllers.ReportController.getPublicStudyReport(studyId: String, identifier: String, startDate: String ?= null, endDate: String ?= null)
-POST   /v3/studies/:studyId/reports/:identifier                         @org.sagebionetworks.bridge.play.controllers.ReportController.saveStudyReportForSpecifiedStudy(studyId: String, identifier: String)
+GET    /v3/studies/:studyId/reports/:identifier                         @org.sagebionetworks.bridge.play.controllers.StudyReportController.getPublicStudyReport(studyId: String, identifier: String, startDate: String ?= null, endDate: String ?= null)
+POST   /v3/studies/:studyId/reports/:identifier                         @org.sagebionetworks.bridge.play.controllers.StudyReportController.saveStudyReportForWorker(studyId: String, identifier: String)
 GET    /v3/studies/:studyId/uploads                                     @org.sagebionetworks.bridge.play.controllers.StudyController.getUploadsForStudy(studyId: String, startTime: String ?= null, endTime: String ?= null, pageSize: java.lang.Integer ?= null, offsetKey: String ?= null)
 GET    /v3/studies/:studyId/participants                                @org.sagebionetworks.bridge.play.controllers.ParticipantController.getParticipantsForWorker(studyId: String, offsetBy: String ?= null, pageSize: String ?= null, emailFilter: String ?= null, startDate: String ?= null, endDate: String ?= null, startTime: String ?= null, endTime: String ?= null)
 GET    /v3/studies/:studyId/participants/:userId                        @org.sagebionetworks.bridge.play.controllers.ParticipantController.getParticipantForWorker(studyId: String, userId: String)

--- a/conf/shared-config.xml
+++ b/conf/shared-config.xml
@@ -179,8 +179,12 @@
         <property name="targetName" value="externalIdController"/>
     </bean>
     
-    <bean id="ReportControllerProxied" parent="proxiedController">
-        <property name="targetName" value="reportController"/>
+    <bean id="StudyReportControllerProxied" parent="proxiedController">
+        <property name="targetName" value="studyReportController"/>
+    </bean>
+
+    <bean id="ParticipantReportControllerProxied" parent="proxiedController">
+        <property name="targetName" value="participantReportController"/>
     </bean>
 
     <bean id="HealthDataControllerProxied" parent="proxiedController">

--- a/test/org/sagebionetworks/bridge/play/controllers/ParticipantReportControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ParticipantReportControllerTest.java
@@ -38,6 +38,7 @@ import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.reports.ReportData;
+import org.sagebionetworks.bridge.models.reports.ReportDataKey;
 import org.sagebionetworks.bridge.models.reports.ReportIndex;
 import org.sagebionetworks.bridge.models.reports.ReportType;
 import org.sagebionetworks.bridge.models.studies.Study;
@@ -169,6 +170,26 @@ public class ParticipantReportControllerTest {
         Result result = controller.getParticipantReportForSelf(REPORT_ID, START_DATE.toString(), END_DATE.toString());
         assertEquals(200, result.status());
         assertResult(result);
+    }
+    
+    @Test
+    public void saveParticipantDataForSelf() throws Exception {
+        setupContext();
+        
+        String json = TestUtils.createJson("{'date':'2015-02-12','data':{'field1':'Last','field2':'Name'}}");
+        TestUtils.mockPlayContextWithJson(json);
+        
+        Result result = controller.saveParticipantReportForSelf(REPORT_ID);
+        assertEquals(201, result.status());
+        
+        verify(mockReportService).saveParticipantReport(eq(session.getStudyIdentifier()), eq(REPORT_ID),
+                eq(HEALTH_CODE), reportDataCaptor.capture());
+        
+        ReportData reportData = reportDataCaptor.getValue();
+        assertEquals(LocalDate.parse("2015-02-12"), reportData.getDate());
+        assertEquals("Last", reportData.getData().get("field1").asText());
+        assertEquals("Name", reportData.getData().get("field2").asText());
+        assertNull(reportData.getKey());
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/play/controllers/StudyReportControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/StudyReportControllerTest.java
@@ -1,0 +1,389 @@
+package org.sagebionetworks.bridge.play.controllers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
+
+import java.util.List;
+import java.util.Map;
+
+import org.joda.time.LocalDate;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import org.sagebionetworks.bridge.Roles;
+import org.sagebionetworks.bridge.TestUtils;
+import org.sagebionetworks.bridge.dao.AccountDao;
+import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
+import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
+import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.DateRangeResourceList;
+import org.sagebionetworks.bridge.models.ReportTypeResourceList;
+import org.sagebionetworks.bridge.models.ResourceList;
+import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
+import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
+import org.sagebionetworks.bridge.models.accounts.UserSession;
+import org.sagebionetworks.bridge.models.reports.ReportData;
+import org.sagebionetworks.bridge.models.reports.ReportDataKey;
+import org.sagebionetworks.bridge.models.reports.ReportIndex;
+import org.sagebionetworks.bridge.models.reports.ReportType;
+import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
+import org.sagebionetworks.bridge.services.ReportService;
+import org.sagebionetworks.bridge.services.StudyService;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+
+import play.mvc.Result;
+import play.test.Helpers;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StudyReportControllerTest {
+    
+    private static final TypeReference<DateRangeResourceList<? extends ReportData>> REPORT_REF = new TypeReference<DateRangeResourceList<? extends ReportData>>() {
+    };
+
+    private static final String REPORT_ID = "foo";
+
+    private static final String VALID_LANGUAGE_HEADER = "en-US";
+
+    private static final String VALID_USER_AGENT_HEADER = "Unknown Client/14 BridgeJavaSDK/10";
+
+    private static final String OTHER_PARTICIPANT_HEALTH_CODE = "ABC";
+
+    private static final String OTHER_PARTICIPANT_ID = "userId";
+
+    private static final String HEALTH_CODE = "healthCode";
+    
+    private static final LocalDate START_DATE = LocalDate.parse("2015-01-02");
+    
+    private static final LocalDate END_DATE = LocalDate.parse("2015-02-02");
+    
+    @Mock
+    ReportService mockReportService;
+    
+    @Mock
+    StudyService mockStudyService;
+    
+    @Mock
+    AccountDao mockAccountDao;
+    
+    @Mock
+    Account mockAccount;
+    
+    @Mock
+    Account mockOtherAccount;
+    
+    @Captor
+    ArgumentCaptor<ReportData> reportDataCaptor;
+    
+    @Captor
+    ArgumentCaptor<ReportIndex> reportDataIndex;
+    
+    StudyReportController controller;
+    
+    UserSession session;
+    
+    @Before
+    public void before() throws Exception {
+        DynamoStudy study = new DynamoStudy();
+        study.setIdentifier(TEST_STUDY_IDENTIFIER);
+        
+        controller = spy(new StudyReportController());
+        controller.setReportService(mockReportService);
+        controller.setStudyService(mockStudyService);
+        controller.setAccountDao(mockAccountDao);
+        
+        StudyParticipant participant = new StudyParticipant.Builder().withHealthCode(HEALTH_CODE)
+                .withRoles(Sets.newHashSet(Roles.DEVELOPER)).build();
+        
+        doReturn(mockOtherAccount).when(mockAccountDao).getAccount(study, OTHER_PARTICIPANT_ID);
+        
+        ConsentStatus status = new ConsentStatus.Builder().withName("Name").withGuid(SubpopulationGuid.create("GUID"))
+                .withConsented(true).withRequired(true).withSignedMostRecentConsent(true).build();
+        Map<SubpopulationGuid,ConsentStatus> statuses = Maps.newHashMap();
+        statuses.put(SubpopulationGuid.create(status.getSubpopulationGuid()), status);
+        
+        session = new UserSession(participant);
+        session.setStudyIdentifier(TEST_STUDY);
+        session.setAuthenticated(true);
+        session.setConsentStatuses(statuses);
+        
+        doReturn(study).when(mockStudyService).getStudy(TEST_STUDY);
+        doReturn(study).when(mockStudyService).getStudy(TEST_STUDY.getIdentifier());
+        doReturn(OTHER_PARTICIPANT_HEALTH_CODE).when(mockOtherAccount).getHealthCode();
+        doReturn(HEALTH_CODE).when(mockAccount).getHealthCode();
+        doReturn(session).when(controller).getSessionIfItExists();
+        doReturn(session).when(controller).getAuthenticatedAndConsentedSession();
+        doReturn(session).when(controller).getAuthenticatedSession();
+        doReturn(session).when(controller).getAuthenticatedSession(Roles.WORKER);
+        
+        ReportIndex index = ReportIndex.create();
+        index.setIdentifier("fofo");
+        ReportTypeResourceList<? extends ReportIndex> list = new ReportTypeResourceList<>(
+                Lists.newArrayList(index)).withRequestParam(ResourceList.REPORT_TYPE, ReportType.STUDY);
+        doReturn(list).when(mockReportService).getReportIndices(TEST_STUDY, ReportType.STUDY);
+        
+        index = ReportIndex.create();
+        index.setIdentifier("fofo");
+        list = new ReportTypeResourceList<>(Lists.newArrayList(index))
+                .withRequestParam(ResourceList.REPORT_TYPE, ReportType.PARTICIPANT);
+        doReturn(list).when(mockReportService).getReportIndices(TEST_STUDY, ReportType.PARTICIPANT);
+    }
+    
+    private void setupContext() throws Exception {
+        setupContext(VALID_USER_AGENT_HEADER, VALID_LANGUAGE_HEADER);
+    }
+    
+    private void setupContext(String userAgent, String languages) throws Exception {
+        Map<String,String[]> headers = Maps.newHashMap();
+        headers.put("User-Agent", new String[] {userAgent});
+        headers.put("Accept-Language", new String[] {languages});
+
+        TestUtils.mockPlayContextWithJson("{}", headers);
+    }
+    
+    @Test
+    public void getStudyReportIndexAsDeveloper() throws Exception {
+        // Developer is set up in the @Before method, no further changes necessary
+        getStudyReportIndex();
+    }
+    
+    @Test
+    public void getStudyReportIndexAsResearcher() throws Exception {
+        StudyParticipant participant = new StudyParticipant.Builder().withRoles(Sets.newHashSet(Roles.RESEARCHER))
+                .build();
+        session.setParticipant(participant);
+        
+        getStudyReportIndex();
+    }
+    
+    @Test(expected = UnauthorizedException.class) 
+    public void cannotAccessAsUser() throws Exception {
+        StudyParticipant participant = new StudyParticipant.Builder().withRoles(Sets.newHashSet()).build();
+        session.setParticipant(participant);
+        
+        getStudyReportIndex();
+    }
+
+    private void getStudyReportIndex() throws Exception {
+        ReportIndex index = ReportIndex.create();
+        index.setIdentifier(REPORT_ID);
+        index.setPublic(true);
+        index.setKey(REPORT_ID+":STUDY");
+        
+        ReportDataKey key = new ReportDataKey.Builder()
+                .withIdentifier(REPORT_ID)
+                .withReportType(ReportType.STUDY)
+                .withStudyIdentifier(TEST_STUDY).build();
+        
+        doReturn(index).when(mockReportService).getReportIndex(key);
+        
+        Result result = controller.getStudyReportIndex(REPORT_ID);
+        assertEquals(200, result.status());
+        ReportIndex deserIndex = BridgeObjectMapper.get().readValue(Helpers.contentAsString(result), ReportIndex.class);
+        assertEquals(REPORT_ID, deserIndex.getIdentifier());
+        assertTrue(deserIndex.isPublic());
+        assertNull(deserIndex.getKey()); // isn't returned in API
+    }
+
+    @Test
+    public void getStudyReportData() throws Exception {
+        setupContext();
+        doReturn(makeResults(START_DATE, END_DATE)).when(mockReportService).getStudyReport(session.getStudyIdentifier(),
+                REPORT_ID, START_DATE, END_DATE);
+        
+        Result result = controller.getStudyReport(REPORT_ID, START_DATE.toString(), END_DATE.toString());
+        assertEquals(200, result.status());
+        assertResult(result);
+    }
+    
+    @Test
+    public void getStudyReportDataWithNoDates() throws Exception {
+        setupContext();
+        doReturn(makeResults(START_DATE, END_DATE)).when(mockReportService).getStudyReport(session.getStudyIdentifier(),
+                REPORT_ID, null, null);
+        
+        Result result = controller.getStudyReport(REPORT_ID, null, null);
+        assertEquals(200, result.status());
+        assertResult(result);
+    }
+    
+    @Test
+    public void getStudyReportDataWithNoUserAgentAsResearcherOK() throws Exception {
+        setupContext("", VALID_LANGUAGE_HEADER);
+        doReturn(makeResults(START_DATE, END_DATE)).when(mockReportService).getStudyReport(session.getStudyIdentifier(),
+                REPORT_ID, START_DATE, END_DATE);
+        
+        controller.getStudyReport(REPORT_ID, START_DATE.toString(), END_DATE.toString());
+    }    
+    
+    @Test
+    public void saveStudyReportData() throws Exception {
+        String json = TestUtils.createJson("{'date':'2015-02-12','data':{'field1':'Last','field2':'Name'}}");
+        TestUtils.mockPlayContextWithJson(json);
+                
+        Result result = controller.saveStudyReport(REPORT_ID);
+        TestUtils.assertResult(result, 201, "Report data saved.");
+        
+        verify(mockReportService).saveStudyReport(eq(TEST_STUDY), eq(REPORT_ID), reportDataCaptor.capture());
+        ReportData reportData = reportDataCaptor.getValue();
+        assertEquals(LocalDate.parse("2015-02-12").toString(), reportData.getDate().toString());
+        assertNull(reportData.getKey());
+        assertEquals("Last", reportData.getData().get("field1").asText());
+        assertEquals("Name", reportData.getData().get("field2").asText());
+    }
+
+    @Test
+    public void deleteStudyReportData() throws Exception {
+        Result result = controller.deleteStudyReport(REPORT_ID);
+        TestUtils.assertResult(result, 200, "Report deleted.");
+        
+        verify(mockReportService).deleteStudyReport(session.getStudyIdentifier(), REPORT_ID);
+    }
+    
+    @Test
+    public void deleteStudyReportDataRecord() throws Exception {
+        Result result = controller.deleteStudyReportRecord(REPORT_ID, "2014-05-10");
+        TestUtils.assertResult(result, 200, "Report record deleted.");
+        
+        verify(mockReportService).deleteStudyReportRecord(session.getStudyIdentifier(), REPORT_ID,
+                LocalDate.parse("2014-05-10"));
+    }
+    
+    @Test(expected = UnauthorizedException.class)
+    public void deleteStudyRecordDataRecordDeveloper() {
+        StudyParticipant regularUser = new StudyParticipant.Builder().copyOf(session.getParticipant())
+            .withRoles(Sets.newHashSet()).build();
+        session.setParticipant(regularUser);
+        
+        controller.deleteStudyReportRecord(REPORT_ID, "2014-05-10");
+    }
+    
+    @Test
+    public void canUpdateStudyReportIndex() throws Exception {
+        TestUtils.mockPlayContextWithJson("{\"public\":true}");
+        
+        Result result = controller.updateStudyReportIndex(REPORT_ID);
+        
+        verify(mockReportService).updateReportIndex(eq(ReportType.STUDY), reportDataIndex.capture());
+        ReportIndex index = reportDataIndex.getValue();
+        assertTrue(index.isPublic());
+        assertEquals(REPORT_ID, index.getIdentifier());
+        assertEquals("api:STUDY", index.getKey());
+        
+        TestUtils.assertResult(result, 200, "Report index updated.");
+    }
+    
+    @Test
+    public void canGetPublicStudyReport() throws Exception {
+        ReportDataKey key = new ReportDataKey.Builder().withStudyIdentifier(TEST_STUDY).withIdentifier(REPORT_ID)
+                .withReportType(ReportType.STUDY).build();
+        
+        ReportIndex index = ReportIndex.create();
+        index.setPublic(true);
+        index.setIdentifier(REPORT_ID);
+        doReturn(index).when(mockReportService).getReportIndex(key);
+        
+        doReturn(makeResults(START_DATE, END_DATE)).when(mockReportService).getStudyReport(session.getStudyIdentifier(),
+                REPORT_ID, START_DATE, END_DATE);
+        
+        Result result = controller.getPublicStudyReport(
+                TEST_STUDY.getIdentifier(), REPORT_ID, START_DATE.toString(), END_DATE.toString());
+        
+        assertEquals(200, result.status());
+        DateRangeResourceList<? extends ReportData> reportData = BridgeObjectMapper.get()
+                .readValue(Helpers.contentAsString(result), REPORT_REF);
+        assertEquals(2, reportData.getItems().size());
+        
+        verify(mockReportService).getReportIndex(key);
+        verify(mockReportService).getStudyReport(TEST_STUDY, REPORT_ID, START_DATE, END_DATE);
+    }
+    
+    @Test(expected = EntityNotFoundException.class)
+    public void missingPublicStudyReturns404() throws Exception {
+        controller.getPublicStudyReport(TEST_STUDY.getIdentifier(), "does-not-exist", "2016-05-02", "2016-05-09");
+    }
+    
+    @Test(expected = EntityNotFoundException.class)
+    public void privatePublicStudyReturns404() throws Exception {
+        ReportDataKey key = new ReportDataKey.Builder()
+                .withIdentifier(REPORT_ID)
+                .withReportType(ReportType.STUDY)
+                .withStudyIdentifier(TEST_STUDY).build();
+        
+        ReportIndex index = ReportIndex.create();//reportService.getReportIndex(key);
+        index.setPublic(false);
+        index.setKey(key.getIndexKeyString());
+        index.setIdentifier(REPORT_ID);
+        
+        doReturn(index).when(mockReportService).getReportIndex(key);
+        
+        doReturn(makeResults(START_DATE, END_DATE)).when(mockReportService).getStudyReport(session.getStudyIdentifier(),
+                REPORT_ID, START_DATE, END_DATE);
+        
+        controller.getPublicStudyReport(TEST_STUDY.getIdentifier(), REPORT_ID, START_DATE.toString(), END_DATE.toString());
+    }
+    
+    private void assertResult(Result result) throws Exception {
+        JsonNode node = BridgeObjectMapper.get().readTree(Helpers.contentAsString(result));
+        assertEquals("2015-01-02", node.get("startDate").asText());
+        assertEquals("2015-02-02", node.get("endDate").asText());
+        assertEquals(2, node.get("items").size());
+        assertEquals("DateRangeResourceList", node.get("type").asText());
+        
+        JsonNode child1 = node.get("items").get(0);
+        assertEquals("2015-02-10", child1.get("date").asText());
+        assertEquals("ReportData", child1.get("type").asText());
+        JsonNode child1Data = child1.get("data");
+        assertEquals("First", child1Data.get("field1").asText());
+        assertEquals("Name", child1Data.get("field2").asText());
+        
+        JsonNode child2 = node.get("items").get(1);
+        assertEquals("2015-02-12", child2.get("date").asText());
+        assertEquals("ReportData", child2.get("type").asText());
+        JsonNode child2Data = child2.get("data");
+        assertEquals("Last", child2Data.get("field1").asText());
+        assertEquals("Name", child2Data.get("field2").asText());
+    }
+    
+    private DateRangeResourceList<ReportData> makeResults(LocalDate startDate, LocalDate endDate){
+        List<ReportData> list = Lists.newArrayList();
+        list.add(createReport(LocalDate.parse("2015-02-10"), "First", "Name"));
+        list.add(createReport(LocalDate.parse("2015-02-12"), "Last", "Name"));
+        
+        return new DateRangeResourceList<ReportData>(list)
+                .withRequestParam("startDate", startDate)
+                .withRequestParam("endDate", endDate);
+    }
+    
+    private ReportData createReport(LocalDate date, String fieldValue1, String fieldValue2) {
+        ObjectNode node = JsonNodeFactory.instance.objectNode();
+        node.put("field1", fieldValue1);
+        node.put("field2", fieldValue2);
+        ReportData report = ReportData.create();
+        report.setKey("foo:" + TEST_STUDY.getIdentifier());
+        report.setDate(date);
+        report.setData(node);
+        return report;
+    }
+    
+}


### PR DESCRIPTION
Added ability for authenticated users to save reports for their own account (they could already get reports for their own account);

Split the "get indices" call so it can be modeled better in the rest API (where right now you have to pass a string to get study or participant reports, which isn't type safe);

For my own sanity, split participant report and study report stuff into separate controllers.