### PR TITLE
Participant reports update

### DIFF
--- a/app/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/app/org/sagebionetworks/bridge/BridgeConstants.java
@@ -86,6 +86,8 @@ public class BridgeConstants {
     
     public static final int API_MAXIMUM_PAGE_SIZE = 100;
     
+    public static final String PAGE_SIZE_ERROR = "pageSize must be from "+API_MAXIMUM_PAGE_SIZE+"-"+API_MAXIMUM_PAGE_SIZE+" records";
+    
     public static final String TEST_USER_GROUP = "test_user";
     
     public static final Set<Roles> NO_CALLER_ROLES = ImmutableSet.of();

--- a/app/org/sagebionetworks/bridge/dao/ReportDataDao.java
+++ b/app/org/sagebionetworks/bridge/dao/ReportDataDao.java
@@ -51,7 +51,7 @@ public interface ReportDataDao {
      * @param key
      *         the key for this report
      * @param date
-     *         the date of the report
+     *         the date of the report (LocalDate or DateTime)
      */
-    void deleteReportDataRecord(ReportDataKey key, LocalDate date);
+    void deleteReportDataRecord(ReportDataKey key, String date);
 }

--- a/app/org/sagebionetworks/bridge/dao/ReportDataDao.java
+++ b/app/org/sagebionetworks/bridge/dao/ReportDataDao.java
@@ -1,8 +1,10 @@
 package org.sagebionetworks.bridge.dao;
 
+import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 
 import org.sagebionetworks.bridge.models.DateRangeResourceList;
+import org.sagebionetworks.bridge.models.ForwardCursorPagedResourceList;
 import org.sagebionetworks.bridge.models.reports.ReportData;
 import org.sagebionetworks.bridge.models.reports.ReportDataKey;
 
@@ -20,6 +22,12 @@ public interface ReportDataDao {
      */
     DateRangeResourceList<? extends ReportData> getReportData(ReportDataKey key, LocalDate startDate, LocalDate endDate);
 
+    /**
+     * Get report data in a given date range, with paging.
+     */
+    ForwardCursorPagedResourceList<ReportData> getReportDataV4(ReportDataKey key, DateTime startTime, DateTime endTime,
+            String offsetKey, int pageSize);
+    
     /**
      * Writes a report data record to the backing store. 
      *

--- a/app/org/sagebionetworks/bridge/dao/ReportDataDao.java
+++ b/app/org/sagebionetworks/bridge/dao/ReportDataDao.java
@@ -23,7 +23,9 @@ public interface ReportDataDao {
     DateRangeResourceList<? extends ReportData> getReportData(ReportDataKey key, LocalDate startDate, LocalDate endDate);
 
     /**
-     * Get report data in a given date range, with paging.
+     * Get report data in a given date range, with paging. Since individual records in this API can 
+     * be returned with DateTime range keys, paging must be introduced over earlier versions of this 
+     * API.
      */
     ForwardCursorPagedResourceList<ReportData> getReportDataV4(ReportDataKey key, DateTime startTime, DateTime endTime,
             String offsetKey, int pageSize);
@@ -46,12 +48,8 @@ public interface ReportDataDao {
     void deleteReportData(ReportDataKey key);
     
     /**
-     * Delete a single record in a report. 
-     * 
-     * @param key
-     *         the key for this report
-     * @param date
-     *         the date of the report (LocalDate or DateTime)
+     * Delete a single record in a report. The date string value may be a LocalDate or 
+     * DateTime value expressed as a string 
      */
-    void deleteReportDataRecord(ReportDataKey key, String date);
+    void deleteReportDataRecord(ReportDataKey key, String dateValue);
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoReportData.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoReportData.java
@@ -1,25 +1,24 @@
 package org.sagebionetworks.bridge.dynamodb;
 
+import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 
-import org.sagebionetworks.bridge.json.LocalDateToStringSerializer;
+import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.models.reports.ReportData;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIgnore;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTypeConverted;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.datatype.joda.deser.LocalDateDeserializer;
 
 @DynamoDBTable(tableName = "ReportData")
 public class DynamoReportData implements ReportData {
 
     private String key;
-    private LocalDate date;
+    private String date;
     private JsonNode data;
     
     @JsonIgnore
@@ -32,16 +31,13 @@ public class DynamoReportData implements ReportData {
     public void setKey(String key) {
         this.key = key;
     }
-    @DynamoDBTypeConverted(converter = LocalDateMarshaller.class)
     @DynamoDBRangeKey
-    @JsonSerialize(using = LocalDateToStringSerializer.class)
     @Override
-    public LocalDate getDate() {
+    public String getDate() {
         return date;
     }
-    @JsonDeserialize(using = LocalDateDeserializer.class)
     @Override
-    public void setDate(LocalDate date) {
+    public void setDate(String date) {
         this.date = date;
     }
     @DynamoDBTypeConverted(converter = JsonNodeMarshaller.class)
@@ -52,5 +48,24 @@ public class DynamoReportData implements ReportData {
     @Override
     public void setData(JsonNode data) {
         this.data = data;
+    }
+    
+    @DynamoDBIgnore
+    @Override
+    public LocalDate getLocalDate() {
+        return (date.contains("T")) ? null : DateUtils.parseCalendarDate(date);
+    }
+    @Override
+    public void setLocalDate(LocalDate localDate) {
+        this.date = localDate.toString();
+    }
+    @DynamoDBIgnore
+    @Override
+    public DateTime getDateTime() {
+        return (date.contains("T")) ? DateUtils.parseISODateTime(date) : null;
+    }
+    @Override
+    public void setDateTime(DateTime dateTime) {
+        this.date = dateTime.toString();
     }
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoReportData.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoReportData.java
@@ -3,8 +3,8 @@ package org.sagebionetworks.bridge.dynamodb;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 
-import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.models.reports.ReportData;
+import org.sagebionetworks.bridge.models.reports.ReportDataKey;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIgnore;
@@ -17,16 +17,28 @@ import com.fasterxml.jackson.databind.JsonNode;
 @DynamoDBTable(tableName = "ReportData")
 public class DynamoReportData implements ReportData {
 
+    private ReportDataKey reportDataKey;
     private String key;
-    //private String date;
     private LocalDate localDate;
     private DateTime dateTime;
     private JsonNode data;
     
     @JsonIgnore
+    @DynamoDBIgnore
+    public ReportDataKey getReportDataKey() {
+        return reportDataKey;
+    }
+    public void setReportDataKey(ReportDataKey reportDataKey) {
+        this.reportDataKey = reportDataKey;
+    }
+    @JsonIgnore
     @DynamoDBHashKey
     @Override
     public String getKey() {
+        // Transfer to the property that is persisted when it is requested.
+        if (reportDataKey != null) {
+            key = reportDataKey.getKeyString();
+        }
         return key;
     }
     @Override

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoReportData.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoReportData.java
@@ -18,7 +18,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 public class DynamoReportData implements ReportData {
 
     private String key;
-    private String date;
+    //private String date;
+    private LocalDate localDate;
+    private DateTime dateTime;
     private JsonNode data;
     
     @JsonIgnore
@@ -34,11 +36,22 @@ public class DynamoReportData implements ReportData {
     @DynamoDBRangeKey
     @Override
     public String getDate() {
-        return date;
+        if (localDate != null) {
+            return localDate.toString();
+        } else if (dateTime != null) {
+            return dateTime.toString();
+        }
+        return null;
     }
     @Override
     public void setDate(String date) {
-        this.date = date;
+        if (date != null) {
+            if (date.contains("T")) {
+                dateTime = DateTime.parse(date);
+            } else {
+                localDate = LocalDate.parse(date);
+            }
+        }
     }
     @DynamoDBTypeConverted(converter = JsonNodeMarshaller.class)
     @Override
@@ -53,19 +66,19 @@ public class DynamoReportData implements ReportData {
     @DynamoDBIgnore
     @Override
     public LocalDate getLocalDate() {
-        return (date.contains("T")) ? null : DateUtils.parseCalendarDate(date);
+        return localDate;
     }
     @Override
     public void setLocalDate(LocalDate localDate) {
-        this.date = localDate.toString();
+        this.localDate = localDate;
     }
     @DynamoDBIgnore
     @Override
     public DateTime getDateTime() {
-        return (date.contains("T")) ? DateUtils.parseISODateTime(date) : null;
+        return dateTime;
     }
     @Override
     public void setDateTime(DateTime dateTime) {
-        this.date = dateTime.toString();
+        this.dateTime = dateTime;
     }
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoReportData.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoReportData.java
@@ -17,9 +17,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 @DynamoDBTable(tableName = "ReportData")
 public class DynamoReportData implements ReportData {
 
-    private ReportDataKey reportDataKey;
     private String key;
     private LocalDate localDate;
+    // These values are held to make it easier to validate the report object
+    private ReportDataKey reportDataKey;
     private DateTime dateTime;
     private JsonNode data;
     
@@ -74,7 +75,6 @@ public class DynamoReportData implements ReportData {
     public void setData(JsonNode data) {
         this.data = data;
     }
-    
     @DynamoDBIgnore
     @Override
     public LocalDate getLocalDate() {

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoReportData.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoReportData.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge.dynamodb;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 
+import org.sagebionetworks.bridge.json.DateTimeSerializer;
 import org.sagebionetworks.bridge.models.reports.ReportData;
 import org.sagebionetworks.bridge.models.reports.ReportDataKey;
 
@@ -13,6 +14,7 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTypeConverted;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @DynamoDBTable(tableName = "ReportData")
 public class DynamoReportData implements ReportData {
@@ -85,6 +87,7 @@ public class DynamoReportData implements ReportData {
         this.localDate = localDate;
     }
     @DynamoDBIgnore
+    @JsonSerialize(using = DateTimeSerializer.class)
     @Override
     public DateTime getDateTime() {
         return dateTime;

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoReportDataDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoReportDataDao.java
@@ -153,13 +153,13 @@ public class DynamoReportDataDao implements ReportDataDao {
     }
     
     @Override
-    public void deleteReportDataRecord(ReportDataKey key, LocalDate date) {
+    public void deleteReportDataRecord(ReportDataKey key, String date) {
         checkNotNull(key);
         checkNotNull(date);
 
         DynamoReportData hashKey = new DynamoReportData();
         hashKey.setKey(key.getKeyString());
-        hashKey.setLocalDate(date);
+        hashKey.setDate(date);
         
         DynamoReportData reportDataRecord = mapper.load(hashKey);
         if (reportDataRecord != null) {

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoReportDataDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoReportDataDao.java
@@ -1,27 +1,38 @@
 package org.sagebionetworks.bridge.dynamodb;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.amazonaws.services.dynamodbv2.model.ComparisonOperator.BETWEEN;
+import static org.sagebionetworks.bridge.models.ResourceList.PAGE_SIZE;
+import static org.sagebionetworks.bridge.models.ResourceList.OFFSET_KEY;
+import static org.sagebionetworks.bridge.models.ResourceList.START_DATE;
+import static org.sagebionetworks.bridge.models.ResourceList.END_DATE;
+import static org.sagebionetworks.bridge.models.ResourceList.START_TIME;
+import static org.sagebionetworks.bridge.models.ResourceList.END_TIME;
 
 import java.util.List;
 
 import javax.annotation.Resource;
 
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
 import org.springframework.stereotype.Component;
 
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.dao.ReportDataDao;
 import org.sagebionetworks.bridge.models.DateRangeResourceList;
-import org.sagebionetworks.bridge.models.ResourceList;
+import org.sagebionetworks.bridge.models.ForwardCursorPagedResourceList;
 import org.sagebionetworks.bridge.models.reports.ReportData;
 import org.sagebionetworks.bridge.models.reports.ReportDataKey;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
+import com.amazonaws.services.dynamodbv2.datamodeling.QueryResultPage;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper.FailedBatch;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
 import com.amazonaws.services.dynamodbv2.model.Condition;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 
 @Component
 public class DynamoReportDataDao implements ReportDataDao {
@@ -43,7 +54,7 @@ public class DynamoReportDataDao implements ReportDataDao {
         hashKey.setKey(key.getKeyString());
         
         // range key is between start date and end date
-        Condition dateCondition = new Condition().withComparisonOperator(ComparisonOperator.BETWEEN)
+        Condition dateCondition = new Condition().withComparisonOperator(BETWEEN)
                 .withAttributeValueList(new AttributeValue().withS(startDate.toString()),
                         new AttributeValue().withS(endDate.toString()));
 
@@ -51,16 +62,76 @@ public class DynamoReportDataDao implements ReportDataDao {
                 new DynamoDBQueryExpression<DynamoReportData>().withHashKeyValues(hashKey)
                         .withRangeKeyCondition("date", dateCondition);
         List<DynamoReportData> results = mapper.query(DynamoReportData.class, query);
-
+        
         return new DateRangeResourceList<DynamoReportData>(results)
-                .withRequestParam(ResourceList.START_DATE, startDate)
-                .withRequestParam(ResourceList.END_DATE, endDate);
+                .withRequestParam(START_DATE, startDate)
+                .withRequestParam(END_DATE, endDate);
+    }
+    
+    /**
+     * Query for report records within a range of DateTime values, using the indicated page size and offset key. 
+     * The report's date field will be returned using the timezone provided in the startTime/endTime parameters, 
+     * but all searches are done against the values in UTC time so they remain accurate when a user switches 
+     * time zones.
+     */
+    @Override
+    public ForwardCursorPagedResourceList<ReportData> getReportDataV4(ReportDataKey key, final DateTime startTime,
+            final DateTime endTime, final String offsetKey, final int pageSize) {
+        checkNotNull(key);
+        checkNotNull(startTime);
+        checkNotNull(endTime);
+        
+        int pageSizeWithIndicatorRecord = pageSize+1;
+        DynamoReportData hashKey = new DynamoReportData();
+        hashKey.setKey(key.getKeyString());
+        
+        AttributeValue start = new AttributeValue().withS(startTime.withZone(DateTimeZone.UTC).toString());
+        AttributeValue end = new AttributeValue().withS(endTime.withZone(DateTimeZone.UTC).toString());
+        if (offsetKey != null) {
+            start = new AttributeValue().withS(offsetKey);
+        }
+        
+        Condition dateCondition = new Condition().withComparisonOperator(BETWEEN)
+                .withAttributeValueList(start, end);
+
+        DynamoDBQueryExpression<DynamoReportData> query = new DynamoDBQueryExpression<DynamoReportData>()
+                .withHashKeyValues(hashKey)
+                .withRangeKeyCondition("date", dateCondition)
+                .withLimit(pageSizeWithIndicatorRecord);
+        
+        QueryResultPage<DynamoReportData> page = mapper.queryPage(DynamoReportData.class, query);
+        
+        List<ReportData> list = Lists.newArrayListWithCapacity(pageSizeWithIndicatorRecord);
+        for (int i = 0, len = page.getResults().size(); i < len; i++) {
+            ReportData oneReport = page.getResults().get(i);
+            DateTime dateTime = oneReport.getDateTime();
+            if (dateTime != null) {
+                oneReport.setDateTime(dateTime.withZone(startTime.getZone()));
+            }
+            list.add(i, oneReport);
+        }
+        
+        String nextPageOffsetKey = null;
+        if (list.size() == pageSizeWithIndicatorRecord) {
+            nextPageOffsetKey = Iterables.getLast(list).getDate();
+        }
+
+        int limit = Math.min(list.size(), pageSize);
+        return new ForwardCursorPagedResourceList<ReportData>(list.subList(0, limit), nextPageOffsetKey)
+                .withRequestParam(PAGE_SIZE, pageSize)
+                .withRequestParam(OFFSET_KEY, offsetKey)
+                .withRequestParam(START_TIME, startTime)
+                .withRequestParam(END_TIME, endTime);
     }
 
     @Override
     public void saveReportData(ReportData reportData) {
         checkNotNull(reportData);
         
+        DateTime dateTime = reportData.getDateTime();
+        if (dateTime != null) {
+            reportData.setDateTime(dateTime.withZone(DateTimeZone.UTC));
+        }
         mapper.save(reportData);
     }
 
@@ -88,7 +159,7 @@ public class DynamoReportDataDao implements ReportDataDao {
 
         DynamoReportData hashKey = new DynamoReportData();
         hashKey.setKey(key.getKeyString());
-        hashKey.setDate(date);
+        hashKey.setLocalDate(date);
         
         DynamoReportData reportDataRecord = mapper.load(hashKey);
         if (reportDataRecord != null) {

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoReportDataDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoReportDataDao.java
@@ -62,7 +62,7 @@ public class DynamoReportDataDao implements ReportDataDao {
                 new DynamoDBQueryExpression<DynamoReportData>().withHashKeyValues(hashKey)
                         .withRangeKeyCondition("date", dateCondition);
         List<DynamoReportData> results = mapper.query(DynamoReportData.class, query);
-        
+
         return new DateRangeResourceList<DynamoReportData>(results)
                 .withRequestParam(START_DATE, startDate)
                 .withRequestParam(END_DATE, endDate);
@@ -75,7 +75,7 @@ public class DynamoReportDataDao implements ReportDataDao {
      * time zones.
      */
     @Override
-    public ForwardCursorPagedResourceList<ReportData> getReportDataV4(ReportDataKey key, final DateTime startTime,
+    public ForwardCursorPagedResourceList<ReportData> getReportDataV4(final ReportDataKey key, final DateTime startTime,
             final DateTime endTime, final String offsetKey, final int pageSize) {
         checkNotNull(key);
         checkNotNull(startTime);
@@ -87,6 +87,7 @@ public class DynamoReportDataDao implements ReportDataDao {
         
         AttributeValue start = new AttributeValue().withS(startTime.withZone(DateTimeZone.UTC).toString());
         AttributeValue end = new AttributeValue().withS(endTime.withZone(DateTimeZone.UTC).toString());
+        // The offsetKey should be in UTC
         if (offsetKey != null) {
             start = new AttributeValue().withS(offsetKey);
         }
@@ -154,9 +155,6 @@ public class DynamoReportDataDao implements ReportDataDao {
     
     @Override
     public void deleteReportDataRecord(ReportDataKey key, String date) {
-        checkNotNull(key);
-        checkNotNull(date);
-
         DynamoReportData hashKey = new DynamoReportData();
         hashKey.setKey(key.getKeyString());
         hashKey.setDate(date);

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDao.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 import javax.annotation.Resource;
 
+import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.dao.ScheduledActivityDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
@@ -52,8 +53,6 @@ public class DynamoScheduledActivityDao implements ScheduledActivityDao {
 
     private static final String INVALID_KEY_MSG = "Invalid offsetKey (may exceed maximum seek for value range): ";
     
-    static final String PAGE_SIZE_ERROR = "pageSize must be from 1-"+API_MAXIMUM_PAGE_SIZE+" records";
-    
     private DynamoDBMapper mapper;
     
     private DynamoIndexHelper referentIndex;
@@ -77,7 +76,7 @@ public class DynamoScheduledActivityDao implements ScheduledActivityDao {
         checkNotNull(activityGuid);
         
         if (pageSize < API_MINIMUM_PAGE_SIZE || pageSize > API_MAXIMUM_PAGE_SIZE) {
-            throw new BadRequestException(PAGE_SIZE_ERROR);
+            throw new BadRequestException(BridgeConstants.PAGE_SIZE_ERROR);
         }
         
         DynamoScheduledActivity hashKey = new DynamoScheduledActivity();

--- a/app/org/sagebionetworks/bridge/models/RangeTuple.java
+++ b/app/org/sagebionetworks/bridge/models/RangeTuple.java
@@ -1,0 +1,17 @@
+package org.sagebionetworks.bridge.models;
+
+public final class RangeTuple<S> {
+    private final S start;
+    private final S end;
+    
+    public RangeTuple(S start, S end) {
+        this.start = start;
+        this.end = end;
+    }
+    public final S getStart() {
+        return start;
+    }
+    public final S getEnd() {
+        return end;
+    }
+}

--- a/app/org/sagebionetworks/bridge/models/reports/ReportData.java
+++ b/app/org/sagebionetworks/bridge/models/reports/ReportData.java
@@ -6,13 +6,18 @@ import org.joda.time.LocalDate;
 import org.sagebionetworks.bridge.dynamodb.DynamoReportData;
 import org.sagebionetworks.bridge.json.BridgeTypeName;
 import org.sagebionetworks.bridge.models.BridgeEntity;
+import org.sagebionetworks.bridge.models.ForwardCursorPagedResourceList;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 @BridgeTypeName("ReportData")
 @JsonDeserialize(as=DynamoReportData.class)
 public interface ReportData extends BridgeEntity {
+
+    static TypeReference<ForwardCursorPagedResourceList<ReportData>> PAGED_REPORT_DATA = new TypeReference<ForwardCursorPagedResourceList<ReportData>>() {
+    };
 
     static ReportData create() {
         return new DynamoReportData();

--- a/app/org/sagebionetworks/bridge/models/reports/ReportData.java
+++ b/app/org/sagebionetworks/bridge/models/reports/ReportData.java
@@ -18,6 +18,9 @@ public interface ReportData extends BridgeEntity {
         return new DynamoReportData();
     }
     
+    ReportDataKey getReportDataKey();
+    void setReportDataKey(ReportDataKey key);
+    
     String getKey();
     void setKey(String key);
     

--- a/app/org/sagebionetworks/bridge/models/reports/ReportData.java
+++ b/app/org/sagebionetworks/bridge/models/reports/ReportData.java
@@ -5,13 +5,14 @@ import org.joda.time.LocalDate;
 
 import org.sagebionetworks.bridge.dynamodb.DynamoReportData;
 import org.sagebionetworks.bridge.json.BridgeTypeName;
+import org.sagebionetworks.bridge.models.BridgeEntity;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 @BridgeTypeName("ReportData")
 @JsonDeserialize(as=DynamoReportData.class)
-public interface ReportData {
+public interface ReportData extends BridgeEntity {
 
     static ReportData create() {
         return new DynamoReportData();
@@ -27,11 +28,13 @@ public interface ReportData {
     JsonNode getData();
     void setData(JsonNode data);
     
-    /** Local date for reports that use local dates as the range portion of their key. */ 
+    /** Local date for reports that use local dates as the range portion of their key. Either localDate 
+     * or dateTime must be provided, but never both. */ 
     LocalDate getLocalDate();
     void setLocalDate(LocalDate localDate);
     
-    /** DateTime for reports that use local dates as the range portion of their key. */ 
+    /** DateTime for reports that use specific dates and times as the range portion of their key. Either 
+     * localDate or dateTime must be provided, but never both. */ 
     DateTime getDateTime();
     void setDateTime(DateTime dateTime);
 }

--- a/app/org/sagebionetworks/bridge/models/reports/ReportData.java
+++ b/app/org/sagebionetworks/bridge/models/reports/ReportData.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.models.reports;
 
+import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 
 import org.sagebionetworks.bridge.dynamodb.DynamoReportData;
@@ -19,10 +20,18 @@ public interface ReportData {
     String getKey();
     void setKey(String key);
     
-    LocalDate getDate();
-    void setDate(LocalDate date);
+    /** Will be either a local date or date time string value. */
+    String getDate();
+    void setDate(String date);
     
     JsonNode getData();
     void setData(JsonNode data);
     
+    /** Local date for reports that use local dates as the range portion of their key. */ 
+    LocalDate getLocalDate();
+    void setLocalDate(LocalDate localDate);
+    
+    /** DateTime for reports that use local dates as the range portion of their key. */ 
+    DateTime getDateTime();
+    void setDateTime(DateTime dateTime);
 }

--- a/app/org/sagebionetworks/bridge/models/reports/ReportDataKey.java
+++ b/app/org/sagebionetworks/bridge/models/reports/ReportDataKey.java
@@ -2,13 +2,8 @@ package org.sagebionetworks.bridge.models.reports;
 
 import java.util.Objects;
 
-import org.joda.time.LocalDate;
-import org.springframework.validation.Errors;
-
 import org.sagebionetworks.bridge.models.BridgeEntity;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
-import org.sagebionetworks.bridge.validators.ReportDataKeyValidator;
-import org.sagebionetworks.bridge.validators.Validate;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
@@ -19,8 +14,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  * required except healthCode, which is only required if the report type is PARTICIPANT.
  */
 public final class ReportDataKey implements BridgeEntity {
-    
-    private static final ReportDataKeyValidator VALIDATOR = new ReportDataKeyValidator();
     
     private final StudyIdentifier studyId;
     private final String identifier;
@@ -91,8 +84,6 @@ public final class ReportDataKey implements BridgeEntity {
         private String identifier;
         private String healthCode;
         private ReportType reportType;
-        private boolean validateDate = false;
-        private LocalDate date;
         
         public Builder withStudyIdentifier(StudyIdentifier studyId) {
             this.studyId = studyId;
@@ -110,23 +101,8 @@ public final class ReportDataKey implements BridgeEntity {
             this.reportType = reportType;
             return this;
         }
-        public Builder validateWithDate(LocalDate date) {
-            this.date = date;
-            this.validateDate = true;
-            return this;
-        }
         public ReportDataKey build() {
-            ReportDataKey key = new ReportDataKey(healthCode, identifier, studyId, reportType);
-            
-            Errors errors = Validate.getErrorsFor(key);
-            Validate.entity(VALIDATOR, errors, key);
-            if (validateDate && date == null) {
-                errors.rejectValue("date", "is required");
-            }
-            if (errors.hasErrors()) {
-                Validate.throwException(errors, key);
-            }
-            return key;
+            return new ReportDataKey(healthCode, identifier, studyId, reportType);
         }
     }
     

--- a/app/org/sagebionetworks/bridge/play/controllers/ParticipantReportController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ParticipantReportController.java
@@ -204,11 +204,10 @@ public class ParticipantReportController extends BaseController {
     public Result deleteParticipantReportRecord(String userId, String identifier, String dateString) {
         UserSession session = getAuthenticatedSession(DEVELOPER, WORKER);
         Study study = studyService.getStudy(session.getStudyIdentifier());
-        LocalDate date = getLocalDateOrDefault(dateString, null);
         
         Account account = accountDao.getAccount(study, userId);
         
-        reportService.deleteParticipantReportRecord(session.getStudyIdentifier(), identifier, date, account.getHealthCode());
+        reportService.deleteParticipantReportRecord(session.getStudyIdentifier(), identifier, dateString, account.getHealthCode());
         
         return okResult("Report record deleted.");
     }

--- a/app/org/sagebionetworks/bridge/play/controllers/ParticipantReportController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ParticipantReportController.java
@@ -4,15 +4,20 @@ import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.Roles.WORKER;
+import static org.sagebionetworks.bridge.BridgeUtils.getDateTimeOrDefault;
+import static org.sagebionetworks.bridge.BridgeUtils.getIntOrDefault;
 import static org.sagebionetworks.bridge.BridgeUtils.getLocalDateOrDefault;
 
+import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 
+import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.models.DateRangeResourceList;
+import org.sagebionetworks.bridge.models.ForwardCursorPagedResourceList;
 import org.sagebionetworks.bridge.models.ReportTypeResourceList;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
@@ -65,6 +70,21 @@ public class ParticipantReportController extends BaseController {
         return okResult(results);
     }
     
+    public Result getParticipantReportForSelfV4(String identifier, String startTimeString, String endTimeString,
+            String offsetKey, String pageSizeString) {
+        UserSession session = getAuthenticatedSession();
+
+        DateTime startTime = getDateTimeOrDefault(startTimeString, null);
+        DateTime endTime = getDateTimeOrDefault(endTimeString, null);
+        int pageSize = getIntOrDefault(pageSizeString, BridgeConstants.API_DEFAULT_PAGE_SIZE);
+        
+        ForwardCursorPagedResourceList<ReportData> results = reportService.getParticipantReportV4(
+                session.getStudyIdentifier(), identifier, session.getHealthCode(), startTime, endTime, offsetKey,
+                pageSize);
+        
+        return okResult(results);
+    }
+    
     public Result saveParticipantReportForSelf(String identifier) {
         UserSession session = getAuthenticatedSession();
         
@@ -101,6 +121,24 @@ public class ParticipantReportController extends BaseController {
                 session.getStudyIdentifier(), identifier, account.getHealthCode(), startDate, endDate);
         
         return okResult(results);
+    }
+    
+    public Result getParticipantReportV4(String userId, String identifier, String startTimeString, String endTimeString,
+            String offsetKey, String pageSizeString) {
+        UserSession session = getAuthenticatedSession(RESEARCHER);
+        Study study = studyService.getStudy(session.getStudyIdentifier());
+        
+        DateTime startTime = getDateTimeOrDefault(startTimeString, null);
+        DateTime endTime = getDateTimeOrDefault(endTimeString, null);
+        int pageSize = getIntOrDefault(pageSizeString, BridgeConstants.API_DEFAULT_PAGE_SIZE);
+        
+        Account account = accountDao.getAccount(study, userId);
+        
+        ForwardCursorPagedResourceList<ReportData> page = reportService.getParticipantReportV4(
+                session.getStudyIdentifier(), identifier, account.getHealthCode(), startTime, endTime, offsetKey,
+                pageSize);
+        
+        return okResult(page);
     }
     
     /**

--- a/app/org/sagebionetworks/bridge/play/controllers/StudyReportController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/StudyReportController.java
@@ -184,9 +184,8 @@ public class StudyReportController extends BaseController {
      */
     public Result deleteStudyReportRecord(String identifier, String dateString) {
         UserSession session = getAuthenticatedSession(DEVELOPER, WORKER);
-        LocalDate date = getLocalDateOrDefault(dateString, null);
         
-        reportService.deleteStudyReportRecord(session.getStudyIdentifier(), identifier, date);
+        reportService.deleteStudyReportRecord(session.getStudyIdentifier(), identifier, dateString);
         
         return okResult("Report record deleted.");
     }

--- a/app/org/sagebionetworks/bridge/play/controllers/StudyReportController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/StudyReportController.java
@@ -4,14 +4,19 @@ import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.Roles.WORKER;
 import static org.sagebionetworks.bridge.BridgeUtils.getLocalDateOrDefault;
+import static org.sagebionetworks.bridge.BridgeUtils.getDateTimeOrDefault;
+import static org.sagebionetworks.bridge.BridgeUtils.getIntOrDefault;
 
+import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 
+import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.DateRangeResourceList;
+import org.sagebionetworks.bridge.models.ForwardCursorPagedResourceList;
 import org.sagebionetworks.bridge.models.ReportTypeResourceList;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.reports.ReportData;
@@ -95,6 +100,43 @@ public class StudyReportController extends BaseController {
         
         return okResult(results);
     }
+    
+    /**
+     * Any authenticated user can get study reports, as some might be internal/administrative and some might 
+     * be intended for end users, and these do not expose user-specific information.
+     */
+    public Result getStudyReportV4(String identifier, String startTimeString, String endTimeString, String offsetKey,
+            String pageSizeString) {
+        UserSession session = getAuthenticatedSession();
+        
+        DateTime startTime = getDateTimeOrDefault(startTimeString, null);
+        DateTime endTime = getDateTimeOrDefault(endTimeString, null);
+        int pageSize = getIntOrDefault(pageSizeString, BridgeConstants.API_DEFAULT_PAGE_SIZE);
+        
+        ForwardCursorPagedResourceList<ReportData> results = reportService
+                .getStudyReportV4(session.getStudyIdentifier(), identifier, startTime, endTime, offsetKey, pageSize);
+        
+        return okResult(results);
+    }
+    
+    /**
+     * Get a study report *if* it is marked public, as this call does not require the user to be authenticated.
+     */
+    public Result getPublicStudyReportV4(String studyIdString, String identifier, String startTimeString,
+            String endTimeString, String offsetKey, String pageSizeString) {
+        StudyIdentifier studyId = new StudyIdentifierImpl(studyIdString);
+
+        verifyIndex(studyId, identifier);
+
+        DateTime startTime = getDateTimeOrDefault(startTimeString, null);
+        DateTime endTime = getDateTimeOrDefault(endTimeString, null);
+        int pageSize = getIntOrDefault(pageSizeString, BridgeConstants.API_DEFAULT_PAGE_SIZE);
+        
+        ForwardCursorPagedResourceList<ReportData> results = reportService.getStudyReportV4(studyId, identifier,
+                startTime, endTime, offsetKey, pageSize);
+        
+        return okResult(results);
+    }    
     
     /**
      * Report study data can be saved by developers or by worker processes.

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -67,8 +67,6 @@ import org.sagebionetworks.bridge.validators.Validate;
 public class ParticipantService {
     private static Logger LOG = LoggerFactory.getLogger(ParticipantService.class);
 
-    private static final String PAGE_SIZE_ERROR = "pageSize must be from " + API_MINIMUM_PAGE_SIZE + "-"
-            + API_MAXIMUM_PAGE_SIZE + " records";
     private static final String DATE_RANGE_ERROR = "startDate should be before endDate";
 
     private AccountDao accountDao;
@@ -215,7 +213,7 @@ public class ParticipantService {
         }
         // Just set a sane upper limit on this.
         if (pageSize < API_MINIMUM_PAGE_SIZE || pageSize > API_MAXIMUM_PAGE_SIZE) {
-            throw new BadRequestException(PAGE_SIZE_ERROR);
+            throw new BadRequestException(BridgeConstants.PAGE_SIZE_ERROR);
         }
         if (startTime != null && endTime != null && startTime.getMillis() >= endTime.getMillis()) {
             throw new BadRequestException(DATE_RANGE_ERROR);

--- a/app/org/sagebionetworks/bridge/services/ReportService.java
+++ b/app/org/sagebionetworks/bridge/services/ReportService.java
@@ -25,6 +25,8 @@ import org.sagebionetworks.bridge.models.reports.ReportDataKey;
 import org.sagebionetworks.bridge.models.reports.ReportIndex;
 import org.sagebionetworks.bridge.models.reports.ReportType;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
+import org.sagebionetworks.bridge.validators.ReportDataValidator;
+import org.sagebionetworks.bridge.validators.Validate;
 
 @Component
 public class ReportService {
@@ -148,14 +150,15 @@ public class ReportService {
 
     public void saveStudyReport(StudyIdentifier studyId, String identifier, ReportData reportData) {
         checkNotNull(reportData);
-        // ReportDataKey validates all other parameters to this method
-
+        
         ReportDataKey key = new ReportDataKey.Builder()
                 .withReportType(ReportType.STUDY)
                 .withIdentifier(identifier)
                 .withStudyIdentifier(studyId)
                 .validateWithDate(reportData.getLocalDate()).build();
         reportData.setKey(key.getKeyString());
+        
+        Validate.entityThrowingException(ReportDataValidator.INSTANCE, reportData);
         
         reportDataDao.saveReportData(reportData);
         addToIndex(key);
@@ -164,7 +167,6 @@ public class ReportService {
     public void saveParticipantReport(StudyIdentifier studyId, String identifier, String healthCode,
             ReportData reportData) {
         checkNotNull(reportData);
-        // ReportDataKey validates all other parameters to this method
         
         ReportDataKey key = new ReportDataKey.Builder()
                 .withHealthCode(healthCode)
@@ -173,6 +175,8 @@ public class ReportService {
                 .withStudyIdentifier(studyId)
                 .validateWithDate(reportData.getLocalDate()).build();
         reportData.setKey(key.getKeyString());
+        
+        Validate.entityThrowingException(ReportDataValidator.INSTANCE, reportData);
         
         reportDataDao.saveReportData(reportData);
         addToIndex(key);        

--- a/app/org/sagebionetworks/bridge/services/ReportService.java
+++ b/app/org/sagebionetworks/bridge/services/ReportService.java
@@ -1,18 +1,24 @@
 package org.sagebionetworks.bridge.services;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
+import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
 
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
 import org.joda.time.Period;
 import org.joda.time.PeriodType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.dao.ReportDataDao;
 import org.sagebionetworks.bridge.dao.ReportIndexDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.models.DateRangeResourceList;
+import org.sagebionetworks.bridge.models.ForwardCursorPagedResourceList;
 import org.sagebionetworks.bridge.models.ReportTypeResourceList;
 import org.sagebionetworks.bridge.models.reports.ReportData;
 import org.sagebionetworks.bridge.models.reports.ReportDataKey;
@@ -23,6 +29,12 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 @Component
 public class ReportService {
     private static final int MAX_RANGE_DAYS = 45;
+    
+    private static final String EITHER_BOTH_DATES_OR_NEITHER = "Only one date of a date range provided (both startTime and endTime required)";
+
+    private static final String AMBIGUOUS_TIMEZONE_ERROR = "startTime and endTime must be in the same time zone";
+    
+    private static final String INVALID_TIME_RANGE = "startTime later in time than endTime";
     
     private ReportDataDao reportDataDao;
     private ReportIndexDao reportIndexDao;
@@ -59,7 +71,8 @@ public class ReportService {
         return reportDataDao.getReportData(key, startDate, endDate);
     }
     
-    public DateRangeResourceList<? extends ReportData> getParticipantReport(StudyIdentifier studyId, String identifier, String healthCode, LocalDate startDate, LocalDate endDate) {
+    public DateRangeResourceList<? extends ReportData> getParticipantReport(StudyIdentifier studyId, String identifier,
+            String healthCode, LocalDate startDate, LocalDate endDate) {
         // ReportDataKey validates all parameters to this method
         
         startDate = defaultValueToMinusDays(startDate, 1);
@@ -73,6 +86,65 @@ public class ReportService {
                 .withStudyIdentifier(studyId).build();
         return reportDataDao.getReportData(key, startDate, endDate);
     }
+    
+    public ForwardCursorPagedResourceList<ReportData> getParticipantReportV4(final StudyIdentifier studyId,
+            final String identifier, final String healthCode, final DateTime startTime, final DateTime endTime,
+            final String offsetKey, final int pageSize) {
+        
+        if (pageSize < API_MINIMUM_PAGE_SIZE || pageSize > API_MAXIMUM_PAGE_SIZE) {
+            throw new BadRequestException(BridgeConstants.PAGE_SIZE_ERROR);
+        }
+        DateTime[] finalTimes = validateDateRange(startTime, endTime);
+        
+        ReportDataKey key = new ReportDataKey.Builder()
+                .withHealthCode(healthCode)
+                .withReportType(ReportType.PARTICIPANT)
+                .withIdentifier(identifier)
+                .withStudyIdentifier(studyId).build();
+        return reportDataDao.getReportDataV4(key, finalTimes[0], finalTimes[1], offsetKey, pageSize);
+        
+    }
+    
+    public ForwardCursorPagedResourceList<ReportData> getStudyReportV4(final StudyIdentifier studyId,
+            final String identifier, final DateTime startTime, final DateTime endTime, final String offsetKey,
+            final int pageSize) {
+        
+        if (pageSize < API_MINIMUM_PAGE_SIZE || pageSize > API_MAXIMUM_PAGE_SIZE) {
+            throw new BadRequestException(BridgeConstants.PAGE_SIZE_ERROR);
+        }
+        DateTime[] finalTimes = validateDateRange(startTime, endTime);
+        
+        ReportDataKey key = new ReportDataKey.Builder()
+                .withReportType(ReportType.STUDY)
+                .withIdentifier(identifier)
+                .withStudyIdentifier(studyId).build();
+        return reportDataDao.getReportDataV4(key, finalTimes[0], finalTimes[1], offsetKey, pageSize);
+        
+    }
+    
+    private DateTime[] validateDateRange(DateTime startTime, DateTime endTime) {
+        // If nothing is provided, we will default to two weeks, going max days into future.
+        if (startTime == null && endTime == null) {
+            DateTime now = getDateTime();
+            startTime = now.minusDays(14);
+            endTime = now;
+        }
+        if (startTime == null || endTime == null) {
+            throw new BadRequestException(EITHER_BOTH_DATES_OR_NEITHER);
+        }
+        if (startTime.isAfter(endTime)) {
+            throw new BadRequestException(INVALID_TIME_RANGE);
+        }
+        DateTimeZone timezone = startTime.getZone();
+        if (!timezone.equals(endTime.getZone())) {
+            throw new BadRequestException(AMBIGUOUS_TIMEZONE_ERROR);
+        }
+        return new DateTime[] {startTime, endTime};
+    }
+    
+    protected DateTime getDateTime() {
+        return DateTime.now();
+    }
 
     public void saveStudyReport(StudyIdentifier studyId, String identifier, ReportData reportData) {
         checkNotNull(reportData);
@@ -82,7 +154,7 @@ public class ReportService {
                 .withReportType(ReportType.STUDY)
                 .withIdentifier(identifier)
                 .withStudyIdentifier(studyId)
-                .validateWithDate(reportData.getDate()).build();
+                .validateWithDate(reportData.getLocalDate()).build();
         reportData.setKey(key.getKeyString());
         
         reportDataDao.saveReportData(reportData);
@@ -99,7 +171,7 @@ public class ReportService {
                 .withReportType(ReportType.PARTICIPANT)
                 .withIdentifier(identifier)
                 .withStudyIdentifier(studyId)
-                .validateWithDate(reportData.getDate()).build();
+                .validateWithDate(reportData.getLocalDate()).build();
         reportData.setKey(key.getKeyString());
         
         reportDataDao.saveReportData(reportData);

--- a/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
+++ b/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
@@ -31,6 +31,7 @@ import org.joda.time.DateTimeZone;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.dao.ScheduledActivityDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.models.CriteriaContext;
@@ -63,9 +64,6 @@ public class ScheduledActivityService {
         return activity.getStatus() != ScheduledActivityStatus.DELETED;
     };
     
-    private static final String PAGE_SIZE_ERROR = "pageSize must be from " + API_MINIMUM_PAGE_SIZE + "-"
-            + API_MAXIMUM_PAGE_SIZE + " records";
-
     private static final String EITHER_BOTH_DATES_OR_NEITHER = "Only one date of a date range provided (both scheduledOnStart and scheduledOnEnd required)";
 
     private static final String AMBIGUOUS_TIMEZONE_ERROR = "scheduledOnStart and scheduledOnEnd must be in the same time zone";
@@ -156,7 +154,7 @@ public class ScheduledActivityService {
             throw new BadRequestException("Invalid activity type: " + activityType);
         }
         if (pageSize < API_MINIMUM_PAGE_SIZE || pageSize > API_MAXIMUM_PAGE_SIZE) {
-            throw new BadRequestException(PAGE_SIZE_ERROR);
+            throw new BadRequestException(BridgeConstants.PAGE_SIZE_ERROR);
         }
         // If nothing is provided, we will default to two weeks, going max days into future.
         if (scheduledOnStart == null && scheduledOnEnd == null) {

--- a/app/org/sagebionetworks/bridge/validators/ReportDataKeyValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/ReportDataKeyValidator.java
@@ -11,7 +11,8 @@ import org.sagebionetworks.bridge.models.reports.ReportType;
 
 public class ReportDataKeyValidator implements Validator {
 
-    public static final ReportDataKeyValidator INSTANCE = new ReportDataKeyValidator(); 
+    public static final ReportDataKeyValidator INSTANCE = new ReportDataKeyValidator();
+    private ReportDataKeyValidator() {}
     
     @Override
     public boolean supports(Class<?> clazz) {

--- a/app/org/sagebionetworks/bridge/validators/ReportDataKeyValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/ReportDataKeyValidator.java
@@ -11,6 +11,8 @@ import org.sagebionetworks.bridge.models.reports.ReportType;
 
 public class ReportDataKeyValidator implements Validator {
 
+    public static final ReportDataKeyValidator INSTANCE = new ReportDataKeyValidator(); 
+    
     @Override
     public boolean supports(Class<?> clazz) {
         return ReportDataKey.class.isAssignableFrom(clazz);

--- a/app/org/sagebionetworks/bridge/validators/ReportDataValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/ReportDataValidator.java
@@ -9,6 +9,7 @@ import org.sagebionetworks.bridge.models.reports.ReportDataKey;
 public class ReportDataValidator implements Validator {
 
     public static final ReportDataValidator INSTANCE = new ReportDataValidator();
+    private ReportDataValidator() {}
     
     @Override
     public boolean supports(Class<?> clazz) {

--- a/app/org/sagebionetworks/bridge/validators/ReportDataValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/ReportDataValidator.java
@@ -4,6 +4,7 @@ import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
 import org.sagebionetworks.bridge.models.reports.ReportData;
+import org.sagebionetworks.bridge.models.reports.ReportDataKey;
 
 public class ReportDataValidator implements Validator {
 
@@ -22,6 +23,15 @@ public class ReportDataValidator implements Validator {
             errors.reject("must include a localDate or dateTime, but not both");
         } else if (data.getLocalDate() == null && data.getDateTime() == null) {
             errors.reject("must include a localDate or dateTime");
+        }
+        if (data.getData() == null) {
+            errors.rejectValue("data", "is required");
+        }
+        ReportDataKey key = data.getReportDataKey();
+        if (key == null) {
+            errors.rejectValue("key", "is required");
+        } else {
+            ReportDataKeyValidator.INSTANCE.validate(key, errors);
         }
     }
 }

--- a/app/org/sagebionetworks/bridge/validators/ReportDataValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/ReportDataValidator.java
@@ -1,0 +1,27 @@
+package org.sagebionetworks.bridge.validators;
+
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+
+import org.sagebionetworks.bridge.models.reports.ReportData;
+
+public class ReportDataValidator implements Validator {
+
+    public static final ReportDataValidator INSTANCE = new ReportDataValidator();
+    
+    @Override
+    public boolean supports(Class<?> clazz) {
+        return ReportData.class.isAssignableFrom(clazz);
+    }
+
+    @Override
+    public void validate(Object object, Errors errors) {
+        ReportData data = (ReportData)object;
+        
+        if (data.getLocalDate() != null && data.getDateTime() != null) {
+            errors.reject("must include a localDate or dateTime, but not both");
+        } else if (data.getLocalDate() == null && data.getDateTime() == null) {
+            errors.reject("must include a localDate or dateTime");
+        }
+    }
+}

--- a/conf/routes
+++ b/conf/routes
@@ -108,6 +108,8 @@ GET    /v3/users/self/dataGroups          @org.sagebionetworks.bridge.play.contr
 POST   /v3/users/self/dataGroups          @org.sagebionetworks.bridge.play.controllers.UserProfileController.updateDataGroups
 GET    /v3/users/self/reports/:identifier @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.getParticipantReportForSelf(identifier: String, startDate: String ?= null, endDate: String ?= null)
 POST   /v3/users/self/reports/:identifier @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.saveParticipantReportForSelf(identifier: String)
+GET    /v4/users/self/reports/:identifier @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.getParticipantReportForSelfV4(identifier: String, startTime: String ?= null, endTime: String ?= null, offsetKey: String ?= null, pageSize: String ?= null)
+POST   /v4/users/self/reports/:identifier @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.saveParticipantReportForSelf(identifier: String)
 
 # Participant reports (and see above for self endpoints)
 GET    /v3/participants/reports                           @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.listParticipantReportIndices()
@@ -117,6 +119,10 @@ GET    /v3/participants/:userId/reports/:identifier       @org.sagebionetworks.b
 POST   /v3/participants/:userId/reports/:identifier       @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.saveParticipantReport(userId: String, identifier: String)
 DELETE /v3/participants/:userId/reports/:identifier       @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.deleteParticipantReport(userId: String, identifier: String)
 DELETE /v3/participants/:userId/reports/:identifier/:date @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.deleteParticipantReportRecord(userId: String, identifier: String, date: String)
+GET    /v4/participants/:userId/reports/:identifier       @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.getParticipantReportV4(userId: String, identifier: String, startTime: String ?= null, endTime: String ?= null, offsetKey: String ?= null, pageSize: String ?= null)
+POST   /v4/participants/:userId/reports/:identifier       @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.saveParticipantReport(userId: String, identifier: String)
+DELETE /v4/participants/:userId/reports/:identifier       @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.deleteParticipantReport(userId: String, identifier: String)
+
 
 # Study reports (and see below for worker endpoints)
 GET    /v3/reports                    @org.sagebionetworks.bridge.play.controllers.StudyReportController.listStudyReportIndices(type: String ?= null)
@@ -126,6 +132,9 @@ GET    /v3/reports/:identifier/index  @org.sagebionetworks.bridge.play.controlle
 POST   /v3/reports/:identifier/index  @org.sagebionetworks.bridge.play.controllers.StudyReportController.updateStudyReportIndex(identifier: String)
 DELETE /v3/reports/:identifier        @org.sagebionetworks.bridge.play.controllers.StudyReportController.deleteStudyReport(identifier: String)
 DELETE /v3/reports/:identifier/:date  @org.sagebionetworks.bridge.play.controllers.StudyReportController.deleteStudyReportRecord(identifier: String, date: String)
+GET    /v4/reports/:identifier        @org.sagebionetworks.bridge.play.controllers.StudyReportController.getStudyReportV4(identifier: String, startTime: String ?= null, endTime: String ?= null, offsetKey: String ?= null, pageSize: String ?= null)
+POST   /v4/reports/:identifier        @org.sagebionetworks.bridge.play.controllers.StudyReportController.saveStudyReport(identifier: String)
+DELETE /v4/reports/:identifier        @org.sagebionetworks.bridge.play.controllers.StudyReportController.deleteStudyReport(identifier: String)
 
 # Surveys
 GET    /v3/surveys                                           @org.sagebionetworks.bridge.play.controllers.SurveyController.getAllSurveysMostRecentVersion

--- a/conf/routes
+++ b/conf/routes
@@ -29,6 +29,35 @@ POST /v3/export/start @org.sagebionetworks.bridge.play.controllers.ExportControl
 # Health Data
 POST /v3/healthdata @org.sagebionetworks.bridge.play.controllers.HealthDataController.submitHealthData
 
+# Users
+POST   /v3/users                          @org.sagebionetworks.bridge.play.controllers.UserManagementController.createUser
+DELETE /v3/users/:userId                  @org.sagebionetworks.bridge.play.controllers.UserManagementController.deleteUser(userId: String)
+GET    /v3/users/self                     @org.sagebionetworks.bridge.play.controllers.UserProfileController.getUserProfile
+POST   /v3/users/self                     @org.sagebionetworks.bridge.play.controllers.UserProfileController.updateUserProfile
+POST   /v3/users/self/externalId          @org.sagebionetworks.bridge.play.controllers.UserProfileController.createExternalIdentifier
+POST   /v3/users/self/emailData           @org.sagebionetworks.bridge.play.controllers.UserDataDownloadController.requestUserData(startDate: String ?= null, endDate: String ?= null)
+GET    /v3/users/self/unsubscribeEmail    @org.sagebionetworks.bridge.play.controllers.EmailController.unsubscribeFromEmail
+POST   /v3/users/self/unsubscribeEmail    @org.sagebionetworks.bridge.play.controllers.EmailController.unsubscribeFromEmail
+POST   /v3/users/self/dataSharing         @org.sagebionetworks.bridge.play.controllers.ConsentController.changeSharingScope
+GET    /v3/users/self/dataGroups          @org.sagebionetworks.bridge.play.controllers.UserProfileController.getDataGroups
+POST   /v3/users/self/dataGroups          @org.sagebionetworks.bridge.play.controllers.UserProfileController.updateDataGroups
+GET    /v3/users/self/reports/:identifier @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.getParticipantReportForSelf(identifier: String, startDate: String ?= null, endDate: String ?= null)
+POST   /v3/users/self/reports/:identifier @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.saveParticipantReportForSelf(identifier: String)
+GET    /v4/users/self/reports/:identifier @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.getParticipantReportForSelfV4(identifier: String, startTime: String ?= null, endTime: String ?= null, offsetKey: String ?= null, pageSize: String ?= null)
+POST   /v4/users/self/reports/:identifier @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.saveParticipantReportForSelf(identifier: String)
+
+# Participant reports (and see above for self endpoints)
+GET    /v3/participants/reports                           @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.listParticipantReportIndices()
+POST   /v3/participants/reports/:identifier               @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.saveParticipantReportForWorker(identifier: String)
+DELETE /v3/participants/reports/:identifier               @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.deleteParticipantReportIndex(identifier: String)
+GET    /v3/participants/:userId/reports/:identifier       @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.getParticipantReport(userId: String, identifier: String, startDate: String ?= null, endDate: String ?= null)
+POST   /v3/participants/:userId/reports/:identifier       @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.saveParticipantReport(userId: String, identifier: String)
+DELETE /v3/participants/:userId/reports/:identifier       @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.deleteParticipantReport(userId: String, identifier: String)
+DELETE /v3/participants/:userId/reports/:identifier/:date @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.deleteParticipantReportRecord(userId: String, identifier: String, date: String)
+GET    /v4/participants/:userId/reports/:identifier       @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.getParticipantReportV4(userId: String, identifier: String, startTime: String ?= null, endTime: String ?= null, offsetKey: String ?= null, pageSize: String ?= null)
+POST   /v4/participants/:userId/reports/:identifier       @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.saveParticipantReport(userId: String, identifier: String)
+DELETE /v4/participants/:userId/reports/:identifier       @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.deleteParticipantReport(userId: String, identifier: String)
+
 # Participants Researcher APIs
 GET    /v3/participants                                                @org.sagebionetworks.bridge.play.controllers.ParticipantController.getParticipants(offsetBy: String ?= null, pageSize: String ?= null, emailFilter: String ?= null, startDate: String ?= null, endDate: String ?= null, startTime: String ?= null, endTime: String ?= null)
 POST   /v3/participants                                                @org.sagebionetworks.bridge.play.controllers.ParticipantController.createParticipant
@@ -96,36 +125,6 @@ GET    /v3/consents/recent               @org.sagebionetworks.bridge.play.contro
 GET    /v3/consents/published            @org.sagebionetworks.bridge.play.controllers.StudyConsentController.getActiveConsent
 GET    /v3/consents/:timestamp           @org.sagebionetworks.bridge.play.controllers.StudyConsentController.getConsent(timestamp: String)
 POST   /v3/consents/:timestamp/publish   @org.sagebionetworks.bridge.play.controllers.StudyConsentController.publishConsent(timestamp: String)
-
-# Users
-POST   /v3/users                          @org.sagebionetworks.bridge.play.controllers.UserManagementController.createUser
-DELETE /v3/users/:userId                  @org.sagebionetworks.bridge.play.controllers.UserManagementController.deleteUser(userId: String)
-GET    /v3/users/self                     @org.sagebionetworks.bridge.play.controllers.UserProfileController.getUserProfile
-POST   /v3/users/self                     @org.sagebionetworks.bridge.play.controllers.UserProfileController.updateUserProfile
-POST   /v3/users/self/externalId          @org.sagebionetworks.bridge.play.controllers.UserProfileController.createExternalIdentifier
-POST   /v3/users/self/emailData           @org.sagebionetworks.bridge.play.controllers.UserDataDownloadController.requestUserData(startDate: String ?= null, endDate: String ?= null)
-GET    /v3/users/self/unsubscribeEmail    @org.sagebionetworks.bridge.play.controllers.EmailController.unsubscribeFromEmail
-POST   /v3/users/self/unsubscribeEmail    @org.sagebionetworks.bridge.play.controllers.EmailController.unsubscribeFromEmail
-POST   /v3/users/self/dataSharing         @org.sagebionetworks.bridge.play.controllers.ConsentController.changeSharingScope
-GET    /v3/users/self/dataGroups          @org.sagebionetworks.bridge.play.controllers.UserProfileController.getDataGroups
-POST   /v3/users/self/dataGroups          @org.sagebionetworks.bridge.play.controllers.UserProfileController.updateDataGroups
-GET    /v3/users/self/reports/:identifier @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.getParticipantReportForSelf(identifier: String, startDate: String ?= null, endDate: String ?= null)
-POST   /v3/users/self/reports/:identifier @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.saveParticipantReportForSelf(identifier: String)
-GET    /v4/users/self/reports/:identifier @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.getParticipantReportForSelfV4(identifier: String, startTime: String ?= null, endTime: String ?= null, offsetKey: String ?= null, pageSize: String ?= null)
-POST   /v4/users/self/reports/:identifier @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.saveParticipantReportForSelf(identifier: String)
-
-# Participant reports (and see above for self endpoints)
-GET    /v3/participants/reports                           @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.listParticipantReportIndices()
-POST   /v3/participants/reports/:identifier               @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.saveParticipantReportForWorker(identifier: String)
-DELETE /v3/participants/reports/:identifier               @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.deleteParticipantReportIndex(identifier: String)
-GET    /v3/participants/:userId/reports/:identifier       @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.getParticipantReport(userId: String, identifier: String, startDate: String ?= null, endDate: String ?= null)
-POST   /v3/participants/:userId/reports/:identifier       @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.saveParticipantReport(userId: String, identifier: String)
-DELETE /v3/participants/:userId/reports/:identifier       @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.deleteParticipantReport(userId: String, identifier: String)
-DELETE /v3/participants/:userId/reports/:identifier/:date @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.deleteParticipantReportRecord(userId: String, identifier: String, date: String)
-GET    /v4/participants/:userId/reports/:identifier       @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.getParticipantReportV4(userId: String, identifier: String, startTime: String ?= null, endTime: String ?= null, offsetKey: String ?= null, pageSize: String ?= null)
-POST   /v4/participants/:userId/reports/:identifier       @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.saveParticipantReport(userId: String, identifier: String)
-DELETE /v4/participants/:userId/reports/:identifier       @org.sagebionetworks.bridge.play.controllers.ParticipantReportController.deleteParticipantReport(userId: String, identifier: String)
-
 
 # Study reports (and see below for worker endpoints)
 GET    /v3/reports                    @org.sagebionetworks.bridge.play.controllers.StudyReportController.listStudyReportIndices(type: String ?= null)

--- a/test/org/sagebionetworks/bridge/BridgeUtilsTest.java
+++ b/test/org/sagebionetworks/bridge/BridgeUtilsTest.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import com.google.common.collect.ImmutableMap;
 
 import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
 import org.joda.time.LocalDateTime;
 import org.junit.Test;
 
@@ -365,6 +366,26 @@ public class BridgeUtilsTest {
         assertEquals("foo:task:2010-10-10T10:10:10.111", referent);
     }
     
+    @Test
+    public void getLocalDateWithValue() throws Exception {
+        LocalDate localDate = LocalDate.parse("2017-05-10");
+        LocalDate parsed = BridgeUtils.getLocalDateOrDefault(localDate.toString(), null);
+        
+        assertEquals(localDate, parsed);
+    }
+    
+    @Test
+    public void getLocalDateWithDefault() {
+        LocalDate localDate = LocalDate.parse("2017-05-10");
+        LocalDate parsed = BridgeUtils.getLocalDateOrDefault(null, localDate);
+        
+        assertEquals(localDate, parsed);
+    }
+    
+    @Test(expected = BadRequestException.class)
+    public void getLocalDateWithError() {
+        BridgeUtils.getLocalDateOrDefault("2017-05-10T05:05:10.000Z", null);
+    }
     
     // assertEquals with two sets doesn't verify the order is the same... hence this test method.
     private <T> void orderedSetsEqual(Set<T> first, Set<T> second) {

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoReportDataDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoReportDataDaoTest.java
@@ -164,10 +164,10 @@ public class DynamoReportDataDaoTest {
         dao.saveReportData(report2);
         assertEquals(2, dao.getReportData(reportDataKey, START_DATE, END_DATE).getItems().size());
         
-        dao.deleteReportDataRecord(reportDataKey, LocalDate.parse("2016-03-30"));
+        dao.deleteReportDataRecord(reportDataKey, "2016-03-30");
         assertEquals(1, dao.getReportData(reportDataKey, START_DATE, END_DATE).getItems().size());
         
-        dao.deleteReportDataRecord(reportDataKey, LocalDate.parse("2016-03-31"));
+        dao.deleteReportDataRecord(reportDataKey, "2016-03-31");
         assertEquals(0, dao.getReportData(reportDataKey, START_DATE, END_DATE).getItems().size());
     }
     

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoReportDataDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoReportDataDaoTest.java
@@ -3,6 +3,9 @@ package org.sagebionetworks.bridge.dynamodb;
 import static org.junit.Assert.assertEquals;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 
+import java.util.Set;
+
+import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.junit.After;
 import org.junit.Before;
@@ -14,12 +17,14 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.models.DateRangeResourceList;
+import org.sagebionetworks.bridge.models.ForwardCursorPagedResourceList;
 import org.sagebionetworks.bridge.models.reports.ReportData;
 import org.sagebionetworks.bridge.models.reports.ReportDataKey;
 import org.sagebionetworks.bridge.models.reports.ReportType;
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.Sets;
 
 @ContextConfiguration("classpath:test-context.xml")
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -88,6 +93,67 @@ public class DynamoReportDataDaoTest {
         results = dao.getReportData(reportDataKey, START_DATE, END_DATE);
         assertResourceList(results, 0);
     }
+    
+    @Test
+    public void canRetrievePagedRecordsWithDateTime() throws Exception {
+        String dateString = "2017-02-%02dT04:00:00.000Z";
+        for (int i=2; i <= 19; i++) {
+            DateTime dateTime = DateTime.parse(String.format(dateString, i));
+            ReportData report = createReport(dateTime, "a", "b");
+            dao.saveReportData(report);
+        }
+        DateTime startTime = DateTime.parse("2017-02-02T04:00:00.000Z");
+        DateTime endTime = DateTime.parse("2017-02-19T04:00:00.000Z");
+        
+        Set<String> keys = Sets.newHashSet();
+        
+        ForwardCursorPagedResourceList<ReportData> paged = dao.getReportDataV4(reportDataKey, startTime, endTime, null, 5);
+        for (ReportData data : paged.getItems()) {
+            keys.add(data.getDate());
+        }
+        assertEquals(5, keys.size());
+        assertEquals("2017-02-02T04:00:00.000Z", paged.getItems().get(0).getDate());
+        
+        paged = dao.getReportDataV4(reportDataKey, startTime, endTime, paged.getNextPageOffsetKey(), 5);
+        for (ReportData data : paged.getItems()) {
+            keys.add(data.getDate());
+        }
+        assertEquals(10, keys.size());
+        
+        paged = dao.getReportDataV4(reportDataKey, startTime, endTime, paged.getNextPageOffsetKey(), 5);
+        for (ReportData data : paged.getItems()) {
+            keys.add(data.getDate());
+        }
+        assertEquals(15, keys.size());
+        
+        paged = dao.getReportDataV4(reportDataKey, startTime, endTime, paged.getNextPageOffsetKey(), 5);
+        for (ReportData data : paged.getItems()) {
+            keys.add(data.getDate());
+        }
+        assertEquals(18, keys.size());
+        keys.clear();
+        
+        // Now, while we have these records, let's change the timezone and verify that works.
+        startTime = DateTime.parse("2017-02-02T04:00:00.000-07:00");
+        endTime = DateTime.parse("2017-02-19T04:00:00.000-07:00");
+        
+        // Should be missing the last record
+        paged = dao.getReportDataV4(reportDataKey, startTime, endTime, null, 100);
+        for (ReportData data : paged.getItems()) {
+            keys.add(data.getDate());
+        }
+        
+        assertEquals(17, keys.size());
+        assertEquals("2017-02-02T21:00:00.000-07:00", paged.getItems().get(0).getDate());
+        
+        // We can use the other API to get these records, it's implicitly UTC because what else could it be
+        LocalDate startDate = LocalDate.parse("2017-02-02");
+        LocalDate endDate = LocalDate.parse("2017-02-19");
+        
+        DateRangeResourceList<? extends ReportData> anotherPage = dao.getReportData(reportDataKey, startDate, endDate);
+        // It's 17 because "2017-02-19" comes before "2017-02-19T04:00:00.000Z" alphabetically (moral: don't mix the two types)
+        assertEquals(17, anotherPage.getItems().size());
+    }
 
     @Test
     public void canDeleteSingleStudyRecords() {
@@ -112,7 +178,18 @@ public class DynamoReportDataDaoTest {
         ReportData report = ReportData.create();
         report.setKey(reportDataKey.getKeyString());
         report.setData(node);
-        report.setDate(date);
+        report.setLocalDate(date);
+        return report;
+    }
+    
+    private ReportData createReport(DateTime date, String fieldValue1, String fieldValue2) {
+        ObjectNode node = JsonNodeFactory.instance.objectNode();
+        node.put("field1", fieldValue1);
+        node.put("field2", fieldValue2);
+        ReportData report = ReportData.create();
+        report.setKey(reportDataKey.getKeyString());
+        report.setData(node);
+        report.setDateTime(date);
         return report;
     }
     

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoReportDataTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoReportDataTest.java
@@ -68,6 +68,7 @@ public class DynamoReportDataTest {
         assertEquals(localDate, report.getLocalDate());
         assertNull(report.getDateTime());
         
+        report = new DynamoReportData();
         report.setDateTime(dateTime);
         assertEquals(dateTime.toString(), report.getDate());
         assertEquals(dateTime, report.getDateTime());

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoReportDataTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoReportDataTest.java
@@ -48,6 +48,8 @@ public class DynamoReportDataTest {
         assertTrue(node.get("data").get("a").asBoolean());
         assertEquals("string", node.get("data").get("b").asText());
         assertEquals(10, node.get("data").get("c").asInt());
+        assertEquals("ReportData", node.get("type").asText());
+        assertEquals(4, node.size());
         
         ReportData deser = MAPPER.readValue(json, ReportData.class);
         assertNull(deser.getKey());

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoReportDataTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoReportDataTest.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 public class DynamoReportDataTest {
     
     private static final BridgeObjectMapper MAPPER = BridgeObjectMapper.get();
-    private static final LocalDate DATE = LocalDate.parse("2015-02-20");
+    private static final DateTime DATETIME = DateTime.parse("2015-02-20T16:32:12.123-05:00");
 
     @Test
     public void canSerialize() throws Exception {
@@ -37,14 +37,15 @@ public class DynamoReportDataTest {
         objNode.put("c", 10);
         
         reportData.setKey(key.getKeyString());
-        reportData.setLocalDate(DATE);
+        reportData.setDateTime(DATETIME);
         reportData.setData(objNode);
         
         String json = MAPPER.writeValueAsString(reportData);
         
         JsonNode node = MAPPER.readTree(json);
         assertNull(node.get("key"));
-        assertEquals(DATE.toString(), node.get("date").asText());
+        assertEquals(DATETIME.toString(), node.get("date").asText());
+        assertEquals(DATETIME.toString(), node.get("dateTime").asText());
         assertTrue(node.get("data").get("a").asBoolean());
         assertEquals("string", node.get("data").get("b").asText());
         assertEquals(10, node.get("data").get("c").asInt());
@@ -53,7 +54,8 @@ public class DynamoReportDataTest {
         
         ReportData deser = MAPPER.readValue(json, ReportData.class);
         assertNull(deser.getKey());
-        assertEquals(DATE, deser.getLocalDate());
+        assertEquals(DATETIME, deser.getDateTime());
+        assertEquals(DATETIME.toString(), deser.getDate());
         assertTrue(deser.getData().get("a").asBoolean());
         assertEquals("string", deser.getData().get("b").asText());
         assertEquals(10, deser.getData().get("c").asInt());

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoReportDataTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoReportDataTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.junit.Test;
 
@@ -36,7 +37,7 @@ public class DynamoReportDataTest {
         objNode.put("c", 10);
         
         reportData.setKey(key.getKeyString());
-        reportData.setDate(DATE);
+        reportData.setLocalDate(DATE);
         reportData.setData(objNode);
         
         String json = MAPPER.writeValueAsString(reportData);
@@ -50,9 +51,26 @@ public class DynamoReportDataTest {
         
         ReportData deser = MAPPER.readValue(json, ReportData.class);
         assertNull(deser.getKey());
-        assertEquals(DATE, deser.getDate());
+        assertEquals(DATE, deser.getLocalDate());
         assertTrue(deser.getData().get("a").asBoolean());
         assertEquals("string", deser.getData().get("b").asText());
         assertEquals(10, deser.getData().get("c").asInt());
+    }
+    
+    @Test
+    public void canSetEitherLocalDateOrDateTime() throws Exception {
+        DateTime dateTime = DateTime.parse("2016-10-10T10:42:42.123-07:00");
+        LocalDate localDate = LocalDate.parse("2016-10-10");
+        
+        DynamoReportData report = new DynamoReportData();
+        report.setLocalDate(localDate);
+        assertEquals(localDate.toString(), report.getDate());
+        assertEquals(localDate, report.getLocalDate());
+        assertNull(report.getDateTime());
+        
+        report.setDateTime(dateTime);
+        assertEquals(dateTime.toString(), report.getDate());
+        assertEquals(dateTime, report.getDateTime());
+        assertNull(report.getLocalDate());
     }
 }

--- a/test/org/sagebionetworks/bridge/models/RangeTupleTest.java
+++ b/test/org/sagebionetworks/bridge/models/RangeTupleTest.java
@@ -1,0 +1,25 @@
+package org.sagebionetworks.bridge.models;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class RangeTupleTest {
+
+    @Test
+    public void test() {
+        RangeTuple<String> tuple = new RangeTuple<>("startValue", "endValue");
+        
+        assertEquals("startValue", tuple.getStart());
+        assertEquals("endValue", tuple.getEnd());
+    }
+    
+    @Test
+    public void testNull() {
+        RangeTuple<String> tuple = new RangeTuple<>(null, null);
+        
+        assertNull(tuple.getStart());
+        assertNull(tuple.getEnd());
+    }
+}

--- a/test/org/sagebionetworks/bridge/models/reports/ReportDataKeyTest.java
+++ b/test/org/sagebionetworks/bridge/models/reports/ReportDataKeyTest.java
@@ -4,10 +4,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 
-import org.joda.time.LocalDate;
 import org.junit.Test;
 
-import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -34,23 +32,10 @@ public class ReportDataKeyTest {
     }
     
     @Test
-    public void canIncludeDateValidation() {
-        try {
-            // This is tested in tests for the validator, but date is actually validated in the 
-            // build method.
-            new ReportDataKey.Builder().validateWithDate(null).build();
-        } catch(InvalidEntityException e) {
-            assertEquals("date is required", e.getErrors().get("date").get(0));
-            // integrated alongside Validator errors
-            assertEquals("identifier cannot be missing or blank", e.getErrors().get("identifier").get(0));
-        }
-    }
-    
-    @Test
     public void constructStudyKey() {
         ReportDataKey key = new ReportDataKey.Builder()
                 .withReportType(ReportType.STUDY).withStudyIdentifier(TEST_STUDY)
-                .withIdentifier("report").validateWithDate(LocalDate.parse("2012-02-02")).build();
+                .withIdentifier("report").build();
         
         // This was constructed, the date is valid. It's not part of the key, it's validated in the builder
         // so validation errors are combined with key validation errors.
@@ -75,6 +60,8 @@ public class ReportDataKeyTest {
     
     @Test
     public void canSerialize() throws Exception {
+        // NOTE: Although we use @JsonIgnore annotations, we never serialize this value and return it via the API,
+        // so arguably none of this is necessary.
         ReportDataKey key = new ReportDataKey.Builder().withHealthCode("healthCode").withStudyIdentifier(TEST_STUDY)
                 .withReportType(ReportType.PARTICIPANT).withIdentifier("report").build();
         

--- a/test/org/sagebionetworks/bridge/play/controllers/ParticipantReportControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ParticipantReportControllerTest.java
@@ -61,9 +61,6 @@ import play.test.Helpers;
 @RunWith(MockitoJUnitRunner.class)
 public class ParticipantReportControllerTest {
     
-    private static final TypeReference<ForwardCursorPagedResourceList<ReportData>> PAGED_REPORT_REF = new TypeReference<ForwardCursorPagedResourceList<ReportData>>() {
-    };
-
     private static final String REPORT_ID = "foo";
 
     private static final String VALID_LANGUAGE_HEADER = "en-US";
@@ -196,7 +193,7 @@ public class ParticipantReportControllerTest {
         assertEquals(200, result.status());
         
         ForwardCursorPagedResourceList<ReportData> page = BridgeObjectMapper.get()
-                .readValue(Helpers.contentAsString(result), PAGED_REPORT_REF);
+                .readValue(Helpers.contentAsString(result), ReportData.PAGED_REPORT_DATA);
         
         assertEquals("nextPageOffsetKey", page.getNextPageOffsetKey());
         assertEquals(OFFSET_KEY, page.getRequestParams().get(ResourceList.OFFSET_KEY));
@@ -254,7 +251,7 @@ public class ParticipantReportControllerTest {
         assertEquals(200, result.status());
         
         ForwardCursorPagedResourceList<ReportData> page = BridgeObjectMapper.get()
-                .readValue(Helpers.contentAsString(result), PAGED_REPORT_REF);
+                .readValue(Helpers.contentAsString(result), ReportData.PAGED_REPORT_DATA);
         
         assertEquals("nextPageOffsetKey", page.getNextPageOffsetKey());
         assertEquals(OFFSET_KEY, page.getRequestParams().get(ResourceList.OFFSET_KEY));

--- a/test/org/sagebionetworks/bridge/play/controllers/ParticipantReportControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ParticipantReportControllerTest.java
@@ -14,6 +14,7 @@ import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 import java.util.List;
 import java.util.Map;
 
+import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,6 +32,7 @@ import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.DateRangeResourceList;
+import org.sagebionetworks.bridge.models.ForwardCursorPagedResourceList;
 import org.sagebionetworks.bridge.models.ReportTypeResourceList;
 import org.sagebionetworks.bridge.models.ResourceList;
 import org.sagebionetworks.bridge.models.accounts.Account;
@@ -38,7 +40,6 @@ import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.reports.ReportData;
-import org.sagebionetworks.bridge.models.reports.ReportDataKey;
 import org.sagebionetworks.bridge.models.reports.ReportIndex;
 import org.sagebionetworks.bridge.models.reports.ReportType;
 import org.sagebionetworks.bridge.models.studies.Study;
@@ -59,6 +60,9 @@ import play.test.Helpers;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ParticipantReportControllerTest {
+    
+    private static final TypeReference<ForwardCursorPagedResourceList<ReportData>> PAGED_REPORT_REF = new TypeReference<ForwardCursorPagedResourceList<ReportData>>() {
+    };
 
     private static final String REPORT_ID = "foo";
 
@@ -75,6 +79,14 @@ public class ParticipantReportControllerTest {
     private static final LocalDate START_DATE = LocalDate.parse("2015-01-02");
     
     private static final LocalDate END_DATE = LocalDate.parse("2015-02-02");
+
+    private static final DateTime START_TIME = DateTime.parse("2015-01-02T08:32:50.000-07:00");
+    
+    private static final DateTime END_TIME = DateTime.parse("2015-02-02T15:00:32.123-07:00");
+    
+    private static final String OFFSET_KEY = "offsetKey";
+    
+    private static final String PAGE_SIZE = "20";
     
     @Mock
     ReportService mockReportService;
@@ -173,6 +185,27 @@ public class ParticipantReportControllerTest {
     }
     
     @Test
+    public void getParticipantReportDataForSelfV4() throws Exception {
+        setupContext();
+        
+        doReturn(makePagedResults()).when(mockReportService).getParticipantReportV4(session.getStudyIdentifier(),
+                REPORT_ID, HEALTH_CODE, START_TIME, END_TIME, OFFSET_KEY, Integer.parseInt(PAGE_SIZE));
+        
+        Result result = controller.getParticipantReportForSelfV4(REPORT_ID, START_TIME.toString(), END_TIME.toString(),
+                OFFSET_KEY, PAGE_SIZE);
+        assertEquals(200, result.status());
+        
+        ForwardCursorPagedResourceList<ReportData> page = BridgeObjectMapper.get()
+                .readValue(Helpers.contentAsString(result), PAGED_REPORT_REF);
+        
+        assertEquals("nextPageOffsetKey", page.getNextPageOffsetKey());
+        assertEquals(OFFSET_KEY, page.getRequestParams().get(ResourceList.OFFSET_KEY));
+        assertEquals(Integer.parseInt(PAGE_SIZE), page.getRequestParams().get(ResourceList.PAGE_SIZE));
+        assertEquals(START_TIME.toString(), page.getRequestParams().get(ResourceList.START_TIME));
+        assertEquals(END_TIME.toString(), page.getRequestParams().get(ResourceList.END_TIME));
+    }
+    
+    @Test
     public void saveParticipantDataForSelf() throws Exception {
         setupContext();
         
@@ -186,7 +219,7 @@ public class ParticipantReportControllerTest {
                 eq(HEALTH_CODE), reportDataCaptor.capture());
         
         ReportData reportData = reportDataCaptor.getValue();
-        assertEquals(LocalDate.parse("2015-02-12"), reportData.getDate());
+        assertEquals("2015-02-12", reportData.getDate());
         assertEquals("Last", reportData.getData().get("field1").asText());
         assertEquals("Name", reportData.getData().get("field2").asText());
         assertNull(reportData.getKey());
@@ -204,6 +237,32 @@ public class ParticipantReportControllerTest {
         assertResult(result);
     }
 
+    @Test
+    public void getParticipantReportDataV4() throws Exception {
+        setupContext();
+        StudyParticipant participant = new StudyParticipant.Builder().withHealthCode(HEALTH_CODE)
+                .withRoles(Sets.newHashSet(Roles.RESEARCHER)).build();
+        session.setParticipant(participant);
+        
+        doReturn(mockAccount).when(mockAccountDao).getAccount(any(Study.class), eq(OTHER_PARTICIPANT_ID));
+        
+        doReturn(makePagedResults()).when(mockReportService).getParticipantReportV4(session.getStudyIdentifier(),
+                REPORT_ID, HEALTH_CODE, START_TIME, END_TIME, OFFSET_KEY, Integer.parseInt(PAGE_SIZE));
+        
+        Result result = controller.getParticipantReportV4(OTHER_PARTICIPANT_ID, REPORT_ID, START_TIME.toString(),
+                END_TIME.toString(), OFFSET_KEY, PAGE_SIZE);
+        assertEquals(200, result.status());
+        
+        ForwardCursorPagedResourceList<ReportData> page = BridgeObjectMapper.get()
+                .readValue(Helpers.contentAsString(result), PAGED_REPORT_REF);
+        
+        assertEquals("nextPageOffsetKey", page.getNextPageOffsetKey());
+        assertEquals(OFFSET_KEY, page.getRequestParams().get(ResourceList.OFFSET_KEY));
+        assertEquals(Integer.parseInt(PAGE_SIZE), page.getRequestParams().get(ResourceList.PAGE_SIZE));
+        assertEquals(START_TIME.toString(), page.getRequestParams().get(ResourceList.START_TIME));
+        assertEquals(END_TIME.toString(), page.getRequestParams().get(ResourceList.END_TIME));
+    }
+    
     @Test
     public void getParticipantReportDataAsResearcher() throws Exception {
         // No consents so user is not consented, but is a researcher and can also see these reports
@@ -360,6 +419,17 @@ public class ParticipantReportControllerTest {
         assertEquals("Name", child2Data.get("field2").asText());
     }
     
+    private ForwardCursorPagedResourceList<ReportData> makePagedResults() {
+        List<ReportData> list = Lists.newArrayList();
+        list.add(createReport(DateTime.parse("2015-02-10T00:00:00.000Z"), "First", "Name"));
+        list.add(createReport(DateTime.parse("2015-02-12T00:00:00.000Z"), "Last", "Name"));
+        return new ForwardCursorPagedResourceList<ReportData>(list, "nextPageOffsetKey")
+            .withRequestParam(ResourceList.OFFSET_KEY, OFFSET_KEY)
+            .withRequestParam(ResourceList.PAGE_SIZE, Integer.parseInt(PAGE_SIZE))
+            .withRequestParam(ResourceList.START_TIME, START_TIME)
+            .withRequestParam(ResourceList.END_TIME, END_TIME);
+    }
+    
     private DateRangeResourceList<ReportData> makeResults(LocalDate startDate, LocalDate endDate){
         List<ReportData> list = Lists.newArrayList();
         list.add(createReport(LocalDate.parse("2015-02-10"), "First", "Name"));
@@ -376,9 +446,19 @@ public class ParticipantReportControllerTest {
         node.put("field2", fieldValue2);
         ReportData report = ReportData.create();
         report.setKey("foo:" + TEST_STUDY.getIdentifier());
-        report.setDate(date);
+        report.setLocalDate(date);
         report.setData(node);
         return report;
     }
     
+    private ReportData createReport(DateTime date, String fieldValue1, String fieldValue2) {
+        ObjectNode node = JsonNodeFactory.instance.objectNode();
+        node.put("field1", fieldValue1);
+        node.put("field2", fieldValue2);
+        ReportData report = ReportData.create();
+        report.setKey("foo:" + TEST_STUDY.getIdentifier());
+        report.setDateTime(date);
+        report.setData(node);
+        return report;
+    }
 }

--- a/test/org/sagebionetworks/bridge/play/controllers/ParticipantReportControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ParticipantReportControllerTest.java
@@ -370,7 +370,7 @@ public class ParticipantReportControllerTest {
         TestUtils.assertResult(result, 200, "Report record deleted.");
         
         verify(mockReportService).deleteParticipantReportRecord(session.getStudyIdentifier(), REPORT_ID,
-                LocalDate.parse("2014-05-10"), OTHER_PARTICIPANT_HEALTH_CODE);
+                "2014-05-10", OTHER_PARTICIPANT_HEALTH_CODE);
     }
     
     @Test(expected = UnauthorizedException.class)

--- a/test/org/sagebionetworks/bridge/play/controllers/StudyReportControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/StudyReportControllerTest.java
@@ -62,9 +62,6 @@ public class StudyReportControllerTest {
     
     private static final TypeReference<DateRangeResourceList<? extends ReportData>> REPORT_REF = new TypeReference<DateRangeResourceList<? extends ReportData>>() {
     };
-
-    private static final TypeReference<ForwardCursorPagedResourceList<ReportData>> PAGED_REPORT_REF = new TypeReference<ForwardCursorPagedResourceList<ReportData>>() {
-    };
     
     private static final String REPORT_ID = "foo";
 
@@ -388,7 +385,7 @@ public class StudyReportControllerTest {
         assertEquals(200, result.status());
         
         ForwardCursorPagedResourceList<ReportData> page = BridgeObjectMapper.get()
-                .readValue(Helpers.contentAsString(result), PAGED_REPORT_REF);        
+                .readValue(Helpers.contentAsString(result), ReportData.PAGED_REPORT_DATA);        
         
         assertEquals("nextPageOffsetKey", page.getNextPageOffsetKey());
         assertEquals(OFFSET_KEY, page.getRequestParams().get(ResourceList.OFFSET_KEY));
@@ -421,7 +418,7 @@ public class StudyReportControllerTest {
         assertEquals(200, result.status());
         
         ForwardCursorPagedResourceList<ReportData> page = BridgeObjectMapper.get()
-                .readValue(Helpers.contentAsString(result), PAGED_REPORT_REF);        
+                .readValue(Helpers.contentAsString(result), ReportData.PAGED_REPORT_DATA);        
         
         assertEquals("nextPageOffsetKey", page.getNextPageOffsetKey());
         assertEquals(OFFSET_KEY, page.getRequestParams().get(ResourceList.OFFSET_KEY));

--- a/test/org/sagebionetworks/bridge/play/controllers/StudyReportControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/StudyReportControllerTest.java
@@ -288,8 +288,7 @@ public class StudyReportControllerTest {
         Result result = controller.deleteStudyReportRecord(REPORT_ID, "2014-05-10");
         TestUtils.assertResult(result, 200, "Report record deleted.");
         
-        verify(mockReportService).deleteStudyReportRecord(session.getStudyIdentifier(), REPORT_ID,
-                LocalDate.parse("2014-05-10"));
+        verify(mockReportService).deleteStudyReportRecord(session.getStudyIdentifier(), REPORT_ID, "2014-05-10");
     }
     
     @Test(expected = UnauthorizedException.class)

--- a/test/org/sagebionetworks/bridge/play/controllers/StudyReportControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/StudyReportControllerTest.java
@@ -13,6 +13,7 @@ import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 import java.util.List;
 import java.util.Map;
 
+import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,6 +31,7 @@ import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.DateRangeResourceList;
+import org.sagebionetworks.bridge.models.ForwardCursorPagedResourceList;
 import org.sagebionetworks.bridge.models.ReportTypeResourceList;
 import org.sagebionetworks.bridge.models.ResourceList;
 import org.sagebionetworks.bridge.models.accounts.Account;
@@ -61,6 +63,9 @@ public class StudyReportControllerTest {
     private static final TypeReference<DateRangeResourceList<? extends ReportData>> REPORT_REF = new TypeReference<DateRangeResourceList<? extends ReportData>>() {
     };
 
+    private static final TypeReference<ForwardCursorPagedResourceList<ReportData>> PAGED_REPORT_REF = new TypeReference<ForwardCursorPagedResourceList<ReportData>>() {
+    };
+    
     private static final String REPORT_ID = "foo";
 
     private static final String VALID_LANGUAGE_HEADER = "en-US";
@@ -76,6 +81,15 @@ public class StudyReportControllerTest {
     private static final LocalDate START_DATE = LocalDate.parse("2015-01-02");
     
     private static final LocalDate END_DATE = LocalDate.parse("2015-02-02");
+    
+    private static final DateTime START_TIME = DateTime.parse("2015-01-02T08:32:50.000-07:00");
+    
+    private static final DateTime END_TIME = DateTime.parse("2015-02-02T15:00:32.123-07:00");
+    
+    private static final String OFFSET_KEY = "offsetKey";
+    
+    private static final String PAGE_SIZE = "20";
+    
     
     @Mock
     ReportService mockReportService;
@@ -97,6 +111,8 @@ public class StudyReportControllerTest {
     
     @Captor
     ArgumentCaptor<ReportIndex> reportDataIndex;
+    
+    ForwardCursorPagedResourceList<ReportData> page;
     
     StudyReportController controller;
     
@@ -147,6 +163,13 @@ public class StudyReportControllerTest {
         list = new ReportTypeResourceList<>(Lists.newArrayList(index))
                 .withRequestParam(ResourceList.REPORT_TYPE, ReportType.PARTICIPANT);
         doReturn(list).when(mockReportService).getReportIndices(TEST_STUDY, ReportType.PARTICIPANT);
+        
+        List<ReportData> reportList = Lists.newArrayList();
+        page = new ForwardCursorPagedResourceList<ReportData>(reportList, "nextPageOffsetKey")
+                .withRequestParam(ResourceList.OFFSET_KEY, OFFSET_KEY)
+                .withRequestParam(ResourceList.PAGE_SIZE, Integer.parseInt(PAGE_SIZE))
+                .withRequestParam(ResourceList.START_TIME, START_TIME)
+                .withRequestParam(ResourceList.END_TIME, END_TIME);
     }
     
     private void setupContext() throws Exception {
@@ -330,7 +353,7 @@ public class StudyReportControllerTest {
                 .withReportType(ReportType.STUDY)
                 .withStudyIdentifier(TEST_STUDY).build();
         
-        ReportIndex index = ReportIndex.create();//reportService.getReportIndex(key);
+        ReportIndex index = ReportIndex.create();
         index.setPublic(false);
         index.setKey(key.getIndexKeyString());
         index.setIdentifier(REPORT_ID);
@@ -341,6 +364,71 @@ public class StudyReportControllerTest {
                 REPORT_ID, START_DATE, END_DATE);
         
         controller.getPublicStudyReport(TEST_STUDY.getIdentifier(), REPORT_ID, START_DATE.toString(), END_DATE.toString());
+    }
+    
+    @Test
+    public void getStudyReportV4() throws Exception {
+        ReportDataKey key = new ReportDataKey.Builder()
+                .withIdentifier(REPORT_ID)
+                .withReportType(ReportType.STUDY)
+                .withStudyIdentifier(TEST_STUDY).build();
+        
+        ReportIndex index = ReportIndex.create();
+        index.setPublic(false);
+        index.setKey(key.getIndexKeyString());
+        index.setIdentifier(REPORT_ID);
+        
+        doReturn(page).when(mockReportService).getStudyReportV4(session.getStudyIdentifier(), REPORT_ID, START_TIME,
+                END_TIME, OFFSET_KEY, Integer.parseInt(PAGE_SIZE));
+        doReturn(index).when(mockReportService).getReportIndex(key);
+        
+        Result result = controller.getStudyReportV4(REPORT_ID, START_TIME.toString(), END_TIME.toString(), OFFSET_KEY, PAGE_SIZE);
+        
+        verify(mockReportService).getStudyReportV4(TEST_STUDY, REPORT_ID, START_TIME, END_TIME,
+                OFFSET_KEY, Integer.parseInt(PAGE_SIZE));
+        assertEquals(200, result.status());
+        
+        ForwardCursorPagedResourceList<ReportData> page = BridgeObjectMapper.get()
+                .readValue(Helpers.contentAsString(result), PAGED_REPORT_REF);        
+        
+        assertEquals("nextPageOffsetKey", page.getNextPageOffsetKey());
+        assertEquals(OFFSET_KEY, page.getRequestParams().get(ResourceList.OFFSET_KEY));
+        assertEquals(Integer.parseInt(PAGE_SIZE), page.getRequestParams().get(ResourceList.PAGE_SIZE));
+        assertEquals(START_TIME.toString(), page.getRequestParams().get(ResourceList.START_TIME));
+        assertEquals(END_TIME.toString(), page.getRequestParams().get(ResourceList.END_TIME));
+    }
+    
+    @Test
+    public void getPublicStudyReportV4() throws Exception {
+        ReportDataKey key = new ReportDataKey.Builder()
+                .withIdentifier(REPORT_ID)
+                .withReportType(ReportType.STUDY)
+                .withStudyIdentifier(TEST_STUDY).build();
+        
+        ReportIndex index = ReportIndex.create();
+        index.setPublic(true);
+        index.setKey(key.getIndexKeyString());
+        index.setIdentifier(REPORT_ID);
+        
+        doReturn(page).when(mockReportService).getStudyReportV4(TEST_STUDY, REPORT_ID, START_TIME,
+                END_TIME, OFFSET_KEY, Integer.parseInt(PAGE_SIZE));
+        doReturn(index).when(mockReportService).getReportIndex(key);
+        
+        Result result = controller.getPublicStudyReportV4(TEST_STUDY.getIdentifier(), REPORT_ID, START_TIME.toString(),
+                END_TIME.toString(), OFFSET_KEY, PAGE_SIZE);
+        
+        verify(mockReportService).getStudyReportV4(TEST_STUDY, REPORT_ID, START_TIME, END_TIME,
+                OFFSET_KEY, Integer.parseInt(PAGE_SIZE));
+        assertEquals(200, result.status());
+        
+        ForwardCursorPagedResourceList<ReportData> page = BridgeObjectMapper.get()
+                .readValue(Helpers.contentAsString(result), PAGED_REPORT_REF);        
+        
+        assertEquals("nextPageOffsetKey", page.getNextPageOffsetKey());
+        assertEquals(OFFSET_KEY, page.getRequestParams().get(ResourceList.OFFSET_KEY));
+        assertEquals(Integer.parseInt(PAGE_SIZE), page.getRequestParams().get(ResourceList.PAGE_SIZE));
+        assertEquals(START_TIME.toString(), page.getRequestParams().get(ResourceList.START_TIME));
+        assertEquals(END_TIME.toString(), page.getRequestParams().get(ResourceList.END_TIME));
     }
     
     private void assertResult(Result result) throws Exception {
@@ -381,7 +469,7 @@ public class StudyReportControllerTest {
         node.put("field2", fieldValue2);
         ReportData report = ReportData.create();
         report.setKey("foo:" + TEST_STUDY.getIdentifier());
-        report.setDate(date);
+        report.setLocalDate(date);
         report.setData(node);
         return report;
     }

--- a/test/org/sagebionetworks/bridge/validators/ReportDataValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/ReportDataValidatorTest.java
@@ -10,6 +10,9 @@ import org.junit.Test;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.models.reports.ReportData;
+import org.sagebionetworks.bridge.models.reports.ReportDataKey;
+import org.sagebionetworks.bridge.models.reports.ReportType;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 
 public class ReportDataValidatorTest {
     
@@ -21,8 +24,28 @@ public class ReportDataValidatorTest {
     }
 
     @Test
-    public void cannotHaveTwoDates() {
+    public void validWorks() {
+        ReportDataKey key = new ReportDataKey.Builder()
+                .withReportType(ReportType.STUDY)
+                .withIdentifier("foo")
+                .withStudyIdentifier(new StudyIdentifierImpl("test-study")).build();
+        
         ReportData data = ReportData.create();
+        data.setReportDataKey(key);
+        data.setData(TestUtils.getClientData());
+        data.setDateTime(DateTime.parse("2017-09-06T10:10:10.000Z"));
+        Validate.entityThrowingException(validator, data);
+    }
+    
+    @Test
+    public void cannotHaveTwoDates() {
+        ReportDataKey key = new ReportDataKey.Builder()
+                .withReportType(ReportType.STUDY)
+                .withIdentifier("foo")
+                .withStudyIdentifier(new StudyIdentifierImpl("test-study")).build();
+        
+        ReportData data = ReportData.create();
+        data.setReportDataKey(key);
         data.setData(TestUtils.getClientData());
         data.setLocalDate(LocalDate.parse("2017-09-06"));
         data.setDateTime(DateTime.parse("2017-09-06T10:10:10.000Z"));
@@ -42,5 +65,41 @@ public class ReportDataValidatorTest {
         } catch(InvalidEntityException e) {
             assertTrue(e.getMessage().contains("ReportData must include a localDate or dateTime"));
         }
+    }
+    
+    @Test
+    public void keyIsRequired() {
+        ReportData data = ReportData.create();
+        data.setData(TestUtils.getClientData());
+        
+        TestUtils.assertValidatorMessage(validator, data, "key", "is required");
+    }
+    
+    @Test
+    public void dataIsRequired() {
+        ReportDataKey key = new ReportDataKey.Builder()
+                .withReportType(ReportType.STUDY)
+                .withIdentifier("foo")
+                .withStudyIdentifier(new StudyIdentifierImpl("test-study")).build();
+        
+        ReportData data = ReportData.create();
+        data.setReportDataKey(key);
+        data.setDateTime(DateTime.parse("2017-09-06T10:10:10.000Z"));
+        
+        TestUtils.assertValidatorMessage(validator, data, "data", "is required");
+    }
+    
+    @Test
+    public void keyIsValidated() {
+        ReportDataKey key = new ReportDataKey.Builder()
+                .withReportType(ReportType.STUDY)
+                .withStudyIdentifier(new StudyIdentifierImpl("test-study")).build();
+        
+        ReportData data = ReportData.create();
+        data.setReportDataKey(key);
+        data.setData(TestUtils.getClientData());
+        data.setLocalDate(LocalDate.parse("2017-09-06"));
+        
+        TestUtils.assertValidatorMessage(validator, data, "identifier", "cannot be missing or blank");
     }
 }

--- a/test/org/sagebionetworks/bridge/validators/ReportDataValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/ReportDataValidatorTest.java
@@ -1,0 +1,46 @@
+package org.sagebionetworks.bridge.validators;
+
+import static org.junit.Assert.assertTrue;
+
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.TestUtils;
+import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
+import org.sagebionetworks.bridge.models.reports.ReportData;
+
+public class ReportDataValidatorTest {
+    
+    private ReportDataValidator validator;
+
+    @Before
+    public void before() throws Exception {
+        validator = new ReportDataValidator();
+    }
+
+    @Test
+    public void cannotHaveTwoDates() {
+        ReportData data = ReportData.create();
+        data.setData(TestUtils.getClientData());
+        data.setLocalDate(LocalDate.parse("2017-09-06"));
+        data.setDateTime(DateTime.parse("2017-09-06T10:10:10.000Z"));
+        try {
+            Validate.entityThrowingException(validator, data);
+        } catch(InvalidEntityException e) {
+            assertTrue(e.getMessage().contains("ReportData must include a localDate or dateTime, but not both"));
+        }
+    }
+    
+    @Test
+    public void mustHaveOneDate() {
+        ReportData data = ReportData.create();
+        data.setData(TestUtils.getClientData());
+        try {
+            Validate.entityThrowingException(validator, data);
+        } catch(InvalidEntityException e) {
+            assertTrue(e.getMessage().contains("ReportData must include a localDate or dateTime"));
+        }
+    }
+}

--- a/test/org/sagebionetworks/bridge/validators/ReportDataValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/ReportDataValidatorTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertTrue;
 
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
-import org.junit.Before;
 import org.junit.Test;
 
 import org.sagebionetworks.bridge.TestUtils;
@@ -16,12 +15,7 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 
 public class ReportDataValidatorTest {
     
-    private ReportDataValidator validator;
-
-    @Before
-    public void before() throws Exception {
-        validator = new ReportDataValidator();
-    }
+    private ReportDataValidator validator = ReportDataValidator.INSTANCE;
 
     @Test
     public void validWorks() {


### PR DESCRIPTION
Adding new APIs:

1) clients can now save and retrieve participant reports, using DateTime instead of LocalDate values (so "2017-09-07T18:01:20.398Z" in addition to "2017-09-07"), retrieving the reports using a paginated API.

2) get participants now has a v4 version of the API that can accept either DateTime/LocalDate values, and is also paginated

3) The other verbs on these v4 endpoints are also versioned at v4, according to our guidelines for versioning URLs 