### PR TITLE
BRIDGE-1937: Configure new relic application settings

### DIFF
--- a/dist/newrelic/newrelic.yml
+++ b/dist/newrelic/newrelic.yml
@@ -93,7 +93,7 @@ common: &default_settings
     # by providing a comma separated list of status codes.
     # The default is to exclude 404s. If you want to override
     # this, you must provide any new value as an empty list is ignored.
-    ignore_status_codes: 400,401,403,404,409,410,412
+    ignore_status_codes: 400,401,403,404,409,410,412,423,429
 
   # Cross Application Tracing adds request and response headers to
   # external calls using supported HTTP libraries to provide better

--- a/dist/newrelic/newrelic.yml
+++ b/dist/newrelic/newrelic.yml
@@ -45,3 +45,61 @@ common: &default_settings
   # Default is info.
   log_level: info
 
+  # New Relic Real User Monitoring gives you insight into the performance real users are
+  # experiencing with your website. This is accomplished by measuring the time it takes for
+  # your users' browsers to download and render your web pages by injecting a small amount
+  # of JavaScript code into the header and footer of each page. 
+  browser_monitoring:
+
+    # By default the agent automatically inserts API calls in compiled JSPs to
+    # inject the monitoring JavaScript into web pages. Not all rendering engines are supported.
+    # See https://docs.newrelic.com/docs/java/real-user-monitoring-in-java#manual_instrumentation
+    # for instructions to add these manually to your pages.
+    # Set this attribute to false to turn off this behavior.
+    auto_instrument: false
+
+  # Transaction tracer captures deep information about slow
+  # transactions and sends this to the New Relic service once a
+  # minute. Included in the transaction is the exact call sequence of
+  # the transactions including any SQL statements issued.
+  transaction_tracer:
+
+    # Threshold in seconds for when to collect a transaction
+    # trace. When the response time of a controller action exceeds
+    # this threshold, a transaction trace will be recorded and sent to
+    # New Relic. Valid values are any float value, or (default) "apdex_f",
+    # which will use the threshold for the "Frustrated" Apdex level
+    # (greater than four times the apdex_t value).
+    # Default is apdex_f.
+    transaction_threshold: 5.0
+
+    # When transaction tracer is on, SQL statements can optionally be
+    # recorded. The recorder has three modes, "off" which sends no
+    # SQL, "raw" which sends the SQL statement in its original form,
+    # and "obfuscated", which strips out numeric and string literals.
+    # Default is obfuscated.
+    record_sql: off
+
+    # Determines whether the agent will capture query plans for slow
+    # SQL queries. Only supported for MySQL and PostgreSQL.
+    # Default is true.
+    explain_enabled: false
+
+  # Error collector captures information about uncaught exceptions and
+  # sends them to New Relic for viewing.
+  error_collector:
+
+    # Use this property to exclude specific http status codes from being reported as errors
+    # by providing a comma separated list of status codes.
+    # The default is to exclude 404s. If you want to override
+    # this, you must provide any new value as an empty list is ignored.
+    ignore_status_codes: 400,401,403,404,409,410,412
+
+  # Cross Application Tracing adds request and response headers to
+  # external calls using supported HTTP libraries to provide better
+  # performance data when calling applications monitored by other New Relic Agents.
+  cross_application_tracer:
+
+    # Set to false to disable cross application tracing.
+    # Default is true.
+    enabled: false


### PR DESCRIPTION
Configure the AWS NR application settings to match settings
that are on the Heroku new relic BridgePF-prod account.
This includes the setting to ignore 4XX status codes.