### PR TITLE
BRIDGE-1946: set hostname on new relic to instance IDs

### DIFF
--- a/dist/.ebextensions/newrelic-server.config
+++ b/dist/.ebextensions/newrelic-server.config
@@ -7,6 +7,8 @@ container_commands:
   "01SetLicenseKey":
     command: "nrsysmond-config --set license_key=$NEW_RELIC_LICENSE_KEY"
   "02SetInstanceId":
-    command: "export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo hostname=$INSTANCE_ID && echo hostname=$INSTANCE_ID >> /etc/newrelic/nrsysmond.cfg"
-  "03StartMonitor":
+    command: "export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo "process_host:\n  display_name:$INSTANCE_ID" >> /var/app/current/newrelic/newrelic.yml"
+  "03SetInstanceId":
+    command: "export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo hostname=$INSTANCE_ID >> /etc/newrelic/nrsysmond.cfg"
+  "04StartMonitor":
     command: "/etc/init.d/newrelic-sysmond start"

--- a/dist/.ebextensions/newrelic-server.config
+++ b/dist/.ebextensions/newrelic-server.config
@@ -7,8 +7,8 @@ container_commands:
   "01SetLicenseKey":
     command: "nrsysmond-config --set license_key=$NEW_RELIC_LICENSE_KEY"
   "02SetInstanceId":
-    command: "export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo "process_host:\n  display_name:$INSTANCE_ID" >> /var/app/current/newrelic/newrelic.yml"
+    command: "export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo -e "\nprocess_host:\n  display_name:$INSTANCE_ID" >> /var/app/current/newrelic/newrelic.yml"
   "03SetInstanceId":
-    command: "export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo hostname=$INSTANCE_ID >> /etc/newrelic/nrsysmond.cfg"
+    command: "export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo -e "\nhostname=$INSTANCE_ID" >> /etc/newrelic/nrsysmond.cfg"
   "04StartMonitor":
     command: "/etc/init.d/newrelic-sysmond start"


### PR DESCRIPTION
Setting hostname to EC2 instance IDs is more meaningful than
the IP address. Setting hostname in nrsysmond.cfg should do the
trick but doesn't work so we implement the work around suggested
in new relic forum[1]

[1] https://discuss.newrelic.com/t/how-do-you-change-hostname-labels/51655