### PR TITLE
Fix setting newrelic.yml on EC2 instance

### DIFF
--- a/dist/.ebextensions/newrelic-server.config
+++ b/dist/.ebextensions/newrelic-server.config
@@ -7,7 +7,7 @@ container_commands:
   "01SetLicenseKey":
     command: "nrsysmond-config --set license_key=$NEW_RELIC_LICENSE_KEY"
   "02SetInstanceId":
-    command: "export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo -e \"\nprocess_host:\n  display_name:$INSTANCE_ID\" >> /var/app/current/newrelic/newrelic.yml"
+    command: "export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo -e \"\nprocess_host:\n  display_name:$INSTANCE_ID\" >> /var/app/staging/bridgepf-0.1-SNAPSHOT/newrelic/newrelic.yml"
   "03SetInstanceId":
     command: "export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo -e \"\nhostname=$INSTANCE_ID\" >> /etc/newrelic/nrsysmond.cfg"
   "04StartMonitor":


### PR DESCRIPTION
Fix bug introduced by change  https://github.com/Sage-Bionetworks/BridgePF/pull/1546

The bug caused this error..
  /bin/sh: /var/app/current/newrelic/newrelic.yml: No such file or directory
  (ElasticBeanstalk::ExternalInvocationError)

The file referenced isn't available yet, change to reference the file
that is extracted during deployment...

 [2017-09-07T22:59:45.963Z] INFO [2980] - [Application deployment
 travis-abeee1b4948039a7f0e8cbfbc37956787e74c2dc-1504823806@71/StartupStage0/AppDeployPreHook/01_configure_application.sh] :
 Completed activity. Result:
 Executing: /usr/bin/unzip -o -d /var/app/staging /opt/elasticbeanstalk/deploy/appsource/source_bundle
 Archive: /opt/elasticbeanstalk/deploy/appsource/source_bundle
 inflating: /var/app/staging/bridgepf-0.1-SNAPSHOT/Procfile
 inflating: /var/app/staging/bridgepf-0.1-SNAPSHOT/newrelic/newrelic.yml
 inflating: /var/app/staging/bridgepf-0.1-SNAPSHOT/.ebextensions/00_awslogs.config