### PR TITLE
BRIDGE-1946: set JVM hostname on new relic UI.

### DIFF
--- a/dist/.ebextensions/newrelic-server.config
+++ b/dist/.ebextensions/newrelic-server.config
@@ -8,5 +8,7 @@ container_commands:
     command: "nrsysmond-config --set license_key=$NEW_RELIC_LICENSE_KEY"
   "02SetInstanceId":
     command: "export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo hostname=$INSTANCE_ID && echo hostname=$INSTANCE_ID >> /etc/newrelic/nrsysmond.cfg"
-  "03StartMonitor":
+  "03SetNRJVMHostname":
+    command: "export NEW_RELIC_PROCESS_HOST_DISPLAY_NAME=$(curl http://instance-data/latest/meta-data/instance-id)"
+  "04StartMonitor":
     command: "/etc/init.d/newrelic-sysmond start"


### PR DESCRIPTION
The APM -> JVM dashboard lists aws EC2 machines by IP addresses[1].
Change it to list the machines with the EC2 instance IDs.

[1] https://imgur.com/a/POZWt