### PR TITLE
BRIDGE-1943: workaround to ignore 4xx status codes

### DIFF
--- a/dist/.ebextensions/ignore_4xx.config
+++ b/dist/.ebextensions/ignore_4xx.config
@@ -1,0 +1,6 @@
+container_commands:
+  01-patch-healthd:
+    command: "sudo /bin/sed -i 's/\\# normalize units to seconds with millisecond resolution/if status \\&\\& status.index(\"4\") == 0 then next end/g' /opt/elasticbeanstalk/lib/ruby/lib/ruby/gems/2.2.0/gems/healthd-appstat-1.0.1/lib/healthd-appstat/plugin.rb"
+  02-restart-healthd:
+    command: "sudo /usr/bin/kill $(/bin/ps aux | /bin/grep -e '/bin/bash -c healthd' | /usr/bin/awk '{ print $2 }')"
+    ignoreErrors: true


### PR DESCRIPTION
AWS currently does not provide a way to ignore 4xx errors from enhanced
health monitoring metrics[1].  This is a workaround from stackoverflow[2]
that will make AWS ignore all 4xx errors.

This means that EB will never degrade the environment health due to
4xx errors because it just won't know that they're occurring. This also
means that the "Health" page in the EB environment will always display
0 for the 4xx response code count.

[1] https://forums.aws.amazon.com/thread.jspa?messageID=716284
[2] https://stackoverflow.com/questions/36398456/elastic-beanstalk-disable-health-state-change-based-on-4xx-responses