### PR TITLE
excludeStudyIdInExport flag

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
@@ -29,7 +29,7 @@ public final class DynamoStudy implements Study {
     private String name;
     private String sponsorName;
     private String identifier;
-    private boolean excludeStudyIdInExport;
+    private boolean studyIdExcludedInExport;
     private String supportEmail;
     private Long synapseDataAccessTeamId;
     private String synapseProjectId;
@@ -123,18 +123,6 @@ public final class DynamoStudy implements Study {
 
     /** {@inheritDoc} */
     @Override
-    public boolean getExcludeStudyIdInExport() {
-        return excludeStudyIdInExport;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void setExcludeStudyIdInExport(boolean excludeStudyIdInExport) {
-        this.excludeStudyIdInExport = excludeStudyIdInExport;
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public int getMinAgeOfConsent() {
         return minAgeOfConsent;
     }
@@ -142,6 +130,18 @@ public final class DynamoStudy implements Study {
     @Override
     public void setMinAgeOfConsent(int minAge) {
         this.minAgeOfConsent = minAge;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean isStudyIdExcludedInExport() {
+        return studyIdExcludedInExport;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setStudyIdExcludedInExport(boolean studyIdExcludedInExport) {
+        this.studyIdExcludedInExport = studyIdExcludedInExport;
     }
 
     /** {@inheritDoc} */
@@ -446,7 +446,7 @@ public final class DynamoStudy implements Study {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, sponsorName, identifier, excludeStudyIdInExport, supportEmail, synapseDataAccessTeamId,
+        return Objects.hash(name, sponsorName, identifier, studyIdExcludedInExport, supportEmail, synapseDataAccessTeamId,
                 synapseProjectId, technicalEmail, usesCustomExportSchedule, consentNotificationEmail, minAgeOfConsent,
                 accountLimit, version, active, profileAttributes, taskIdentifiers, activityEventKeys, dataGroups,
                 passwordPolicy, verifyEmailTemplate, resetPasswordTemplate, emailSignInTemplate, accountExistsTemplate,
@@ -463,8 +463,9 @@ public final class DynamoStudy implements Study {
             return false;
         DynamoStudy other = (DynamoStudy) obj;
 
-        return (Objects.equals(identifier, other.identifier) && Objects.equals(supportEmail, other.supportEmail)
-                && Objects.equals(excludeStudyIdInExport, other.excludeStudyIdInExport)
+        return (Objects.equals(identifier, other.identifier)
+                && Objects.equals(studyIdExcludedInExport, other.studyIdExcludedInExport)
+                && Objects.equals(supportEmail, other.supportEmail)
                 && Objects.equals(minAgeOfConsent, other.minAgeOfConsent) && Objects.equals(name, other.name)
                 && Objects.equals(passwordPolicy, other.passwordPolicy) && Objects.equals(active, other.active))
                 && Objects.equals(verifyEmailTemplate, other.verifyEmailTemplate)
@@ -497,7 +498,7 @@ public final class DynamoStudy implements Study {
     @Override
     public String toString() {
         return String.format(
-            "DynamoStudy [name=%s, active=%s, sponsorName=%s, identifier=%s, excludeStudyIdInExport=%b, minAgeOfConsent=%s, "
+            "DynamoStudy [name=%s, active=%s, sponsorName=%s, identifier=%s, minAgeOfConsent=%s, studyIdExcludedInExport=%b, "
                         + "supportEmail=%s, synapseDataAccessTeamId=%s, synapseProjectId=%s, technicalEmail=%s, "
                         + "consentNotificationEmail=%s, version=%s, userProfileAttributes=%s, taskIdentifiers=%s, "
                         + "activityEventKeys=%s, dataGroups=%s, passwordPolicy=%s, verifyEmailTemplate=%s, "
@@ -505,7 +506,7 @@ public final class DynamoStudy implements Study {
                         + "emailVerificationEnabled=%s, externalIdValidationEnabled=%s, externalIdRequiredOnSignup=%s, "
                         + "minSupportedAppVersions=%s, usesCustomExportSchedule=%s, pushNotificationARNs=%s, "
                         + "disableExport=%s, emailSignInTemplate=%s, emailSignInEnabled=%s, accountLimit=%s]",
-                name, active, sponsorName, identifier, excludeStudyIdInExport, minAgeOfConsent, supportEmail,
+                name, active, sponsorName, identifier, minAgeOfConsent, studyIdExcludedInExport, supportEmail,
                 synapseDataAccessTeamId, synapseProjectId, technicalEmail, consentNotificationEmail, version,
                 profileAttributes, taskIdentifiers, activityEventKeys, dataGroups, passwordPolicy, verifyEmailTemplate,
                 resetPasswordTemplate, strictUploadValidationEnabled, healthCodeExportEnabled, emailVerificationEnabled,

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
@@ -29,6 +29,7 @@ public final class DynamoStudy implements Study {
     private String name;
     private String sponsorName;
     private String identifier;
+    private boolean excludeStudyIdInExport;
     private String supportEmail;
     private Long synapseDataAccessTeamId;
     private String synapseProjectId;
@@ -118,6 +119,18 @@ public final class DynamoStudy implements Study {
 
     public void setVersion(Long version) {
         this.version = version;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean getExcludeStudyIdInExport() {
+        return excludeStudyIdInExport;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setExcludeStudyIdInExport(boolean excludeStudyIdInExport) {
+        this.excludeStudyIdInExport = excludeStudyIdInExport;
     }
 
     /** {@inheritDoc} */
@@ -433,7 +446,7 @@ public final class DynamoStudy implements Study {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, sponsorName, identifier, supportEmail, synapseDataAccessTeamId,
+        return Objects.hash(name, sponsorName, identifier, excludeStudyIdInExport, supportEmail, synapseDataAccessTeamId,
                 synapseProjectId, technicalEmail, usesCustomExportSchedule, consentNotificationEmail, minAgeOfConsent,
                 accountLimit, version, active, profileAttributes, taskIdentifiers, activityEventKeys, dataGroups,
                 passwordPolicy, verifyEmailTemplate, resetPasswordTemplate, emailSignInTemplate, accountExistsTemplate,
@@ -451,6 +464,7 @@ public final class DynamoStudy implements Study {
         DynamoStudy other = (DynamoStudy) obj;
 
         return (Objects.equals(identifier, other.identifier) && Objects.equals(supportEmail, other.supportEmail)
+                && Objects.equals(excludeStudyIdInExport, other.excludeStudyIdInExport)
                 && Objects.equals(minAgeOfConsent, other.minAgeOfConsent) && Objects.equals(name, other.name)
                 && Objects.equals(passwordPolicy, other.passwordPolicy) && Objects.equals(active, other.active))
                 && Objects.equals(verifyEmailTemplate, other.verifyEmailTemplate)
@@ -483,7 +497,7 @@ public final class DynamoStudy implements Study {
     @Override
     public String toString() {
         return String.format(
-            "DynamoStudy [name=%s, active=%s, sponsorName=%s, identifier=%s, minAgeOfConsent=%s, "
+            "DynamoStudy [name=%s, active=%s, sponsorName=%s, identifier=%s, excludeStudyIdInExport=%b, minAgeOfConsent=%s, "
                         + "supportEmail=%s, synapseDataAccessTeamId=%s, synapseProjectId=%s, technicalEmail=%s, "
                         + "consentNotificationEmail=%s, version=%s, userProfileAttributes=%s, taskIdentifiers=%s, "
                         + "activityEventKeys=%s, dataGroups=%s, passwordPolicy=%s, verifyEmailTemplate=%s, "
@@ -491,12 +505,12 @@ public final class DynamoStudy implements Study {
                         + "emailVerificationEnabled=%s, externalIdValidationEnabled=%s, externalIdRequiredOnSignup=%s, "
                         + "minSupportedAppVersions=%s, usesCustomExportSchedule=%s, pushNotificationARNs=%s, "
                         + "disableExport=%s, emailSignInTemplate=%s, emailSignInEnabled=%s, accountLimit=%s]",
-                name, active, sponsorName, identifier, minAgeOfConsent, supportEmail,
+                name, active, sponsorName, identifier, excludeStudyIdInExport, minAgeOfConsent, supportEmail,
                 synapseDataAccessTeamId, synapseProjectId, technicalEmail, consentNotificationEmail, version,
                 profileAttributes, taskIdentifiers, activityEventKeys, dataGroups, passwordPolicy, verifyEmailTemplate,
                 resetPasswordTemplate, strictUploadValidationEnabled, healthCodeExportEnabled, emailVerificationEnabled,
                 externalIdValidationEnabled, externalIdRequiredOnSignup, minSupportedAppVersions,
                 usesCustomExportSchedule, pushNotificationARNs, disableExport, emailSignInTemplate,
-                emailSignInEnabled, accountLimit, accountExistsTemplate);
+                emailSignInEnabled, accountLimit);
     }
 }

--- a/app/org/sagebionetworks/bridge/models/studies/Study.java
+++ b/app/org/sagebionetworks/bridge/models/studies/Study.java
@@ -63,6 +63,13 @@ public interface Study extends BridgeEntity, StudyIdentifier {
     void setVersion(Long version);
 
     /**
+     * User must confirm that they are at least this many years old in order to
+     * participate in the study. 
+     */
+    int getMinAgeOfConsent();
+    void setMinAgeOfConsent(int minAge);
+
+    /**
      * <p>
      * True if the Bridge Exporter should include the studyId prefix in the "originalTable" field in the appVersion
      * (now "Health Data Summary") table in Synapse. This exists primarily because we want to remove redundant prefixes
@@ -77,18 +84,11 @@ public interface Study extends BridgeEntity, StudyIdentifier {
      * this flag set to true, and only admins can change the flag.
      * </p>
      */
-    boolean getExcludeStudyIdInExport();
+    boolean isStudyIdExcludedInExport();
 
-    /** @see #getExcludeStudyIdInExport */
-    void setExcludeStudyIdInExport(boolean excludeStudyIdInExport);
+    /** @see #isStudyIdExcludedInExport */
+    void setStudyIdExcludedInExport(boolean studyIdExcludedInExport);
 
-    /**
-     * User must confirm that they are at least this many years old in order to
-     * participate in the study. 
-     */
-    int getMinAgeOfConsent();
-    void setMinAgeOfConsent(int minAge);
-    
     /**
      * The email address that will be given to study participants and other end user for all support 
      * requests and queries (technical, study-related, etc.). This can be a comma-separated list of 

--- a/app/org/sagebionetworks/bridge/models/studies/Study.java
+++ b/app/org/sagebionetworks/bridge/models/studies/Study.java
@@ -61,7 +61,27 @@ public interface Study extends BridgeEntity, StudyIdentifier {
      */
     Long getVersion();
     void setVersion(Long version);
-    
+
+    /**
+     * <p>
+     * True if the Bridge Exporter should include the studyId prefix in the "originalTable" field in the appVersion
+     * (now "Health Data Summary") table in Synapse. This exists primarily because we want to remove redundant prefixes
+     * from the Synapse tables (to improve reporting), but we don't want to break existing studies or partition
+     * existing data.
+     * </p>
+     * <p>
+     * The setting is "reversed" so we don't have to backfill a bunch of old studies.
+     * </p>
+     * <p>
+     * This is a "hidden" setting, primarily to support back-compat for old studies. New studies should be created with
+     * this flag set to true, and only admins can change the flag.
+     * </p>
+     */
+    boolean getExcludeStudyIdInExport();
+
+    /** @see #getExcludeStudyIdInExport */
+    void setExcludeStudyIdInExport(boolean excludeStudyIdInExport);
+
     /**
      * User must confirm that they are at least this many years old in order to
      * participate in the study. 

--- a/app/org/sagebionetworks/bridge/services/StudyService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyService.java
@@ -317,8 +317,8 @@ public class StudyService {
         }
 
         study.setActive(true);
-        study.setExcludeStudyIdInExport(true);
         study.setStrictUploadValidationEnabled(true);
+        study.setStudyIdExcludedInExport(true);
         study.getDataGroups().add(BridgeConstants.TEST_USER_GROUP);
         setDefaultsIfAbsent(study);
         sanitizeHTML(study);
@@ -436,7 +436,6 @@ public class StudyService {
             if (!originalStudy.isActive()) {
                 throw new EntityNotFoundException(Study.class, "Study '"+ study.getIdentifier() +"' not found.");
             }
-            study.setExcludeStudyIdInExport(originalStudy.getExcludeStudyIdInExport());
             study.setHealthCodeExportEnabled(originalStudy.isHealthCodeExportEnabled());
             study.setEmailVerificationEnabled(originalStudy.isEmailVerificationEnabled());
             study.setExternalIdValidationEnabled(originalStudy.isExternalIdValidationEnabled());
@@ -444,6 +443,7 @@ public class StudyService {
             study.setEmailSignInEnabled(originalStudy.isEmailSignInEnabled());
             study.setAccountLimit(originalStudy.getAccountLimit());
             study.setStrictUploadValidationEnabled(originalStudy.isStrictUploadValidationEnabled());
+            study.setStudyIdExcludedInExport(originalStudy.isStudyIdExcludedInExport());
         }
 
         // prevent anyone changing active to false -- it should be done by deactivateStudy() method

--- a/app/org/sagebionetworks/bridge/services/StudyService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyService.java
@@ -317,6 +317,7 @@ public class StudyService {
         }
 
         study.setActive(true);
+        study.setExcludeStudyIdInExport(true);
         study.setStrictUploadValidationEnabled(true);
         study.getDataGroups().add(BridgeConstants.TEST_USER_GROUP);
         setDefaultsIfAbsent(study);
@@ -435,6 +436,7 @@ public class StudyService {
             if (!originalStudy.isActive()) {
                 throw new EntityNotFoundException(Study.class, "Study '"+ study.getIdentifier() +"' not found.");
             }
+            study.setExcludeStudyIdInExport(originalStudy.getExcludeStudyIdInExport());
             study.setHealthCodeExportEnabled(originalStudy.isHealthCodeExportEnabled());
             study.setEmailVerificationEnabled(originalStudy.isEmailVerificationEnabled());
             study.setExternalIdValidationEnabled(originalStudy.isExternalIdValidationEnabled());

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -373,6 +373,7 @@ public class TestUtils {
         // This study will save without further modification.
         DynamoStudy study = new DynamoStudy();
         study.setName("Test Study ["+clazz.getSimpleName()+"]");
+        study.setExcludeStudyIdInExport(true);
         study.setPasswordPolicy(PasswordPolicy.DEFAULT_PASSWORD_POLICY);
         study.setVerifyEmailTemplate(new EmailTemplate("verifyEmail subject", "body with ${url}", MimeType.TEXT));
         study.setResetPasswordTemplate(new EmailTemplate("resetPassword subject", "body with ${url}", MimeType.TEXT));

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -373,8 +373,8 @@ public class TestUtils {
         // This study will save without further modification.
         DynamoStudy study = new DynamoStudy();
         study.setName("Test Study ["+clazz.getSimpleName()+"]");
-        study.setExcludeStudyIdInExport(true);
         study.setPasswordPolicy(PasswordPolicy.DEFAULT_PASSWORD_POLICY);
+        study.setStudyIdExcludedInExport(true);
         study.setVerifyEmailTemplate(new EmailTemplate("verifyEmail subject", "body with ${url}", MimeType.TEXT));
         study.setResetPasswordTemplate(new EmailTemplate("resetPassword subject", "body with ${url}", MimeType.TEXT));
         study.setEmailSignInTemplate(new EmailTemplate("${studyName} link", "Follow link ${token}", MimeType.TEXT));

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
@@ -47,7 +47,7 @@ public class DynamoStudyTest {
         final JsonNode node = BridgeObjectMapper.get().readTree(json);
         
         assertEqualsAndNotNull(study.getConsentNotificationEmail(), node.get("consentNotificationEmail").asText());
-        assertTrue(node.get("excludeStudyIdInExport").booleanValue());
+        assertTrue(node.get("studyIdExcludedInExport").booleanValue());
         assertEqualsAndNotNull(study.getSupportEmail(), node.get("supportEmail").asText());
         assertEqualsAndNotNull(study.getSynapseDataAccessTeamId(), node.get("synapseDataAccessTeamId").longValue());
         assertEqualsAndNotNull(study.getSynapseProjectId(), node.get("synapseProjectId").textValue());

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
@@ -47,6 +47,7 @@ public class DynamoStudyTest {
         final JsonNode node = BridgeObjectMapper.get().readTree(json);
         
         assertEqualsAndNotNull(study.getConsentNotificationEmail(), node.get("consentNotificationEmail").asText());
+        assertTrue(node.get("excludeStudyIdInExport").booleanValue());
         assertEqualsAndNotNull(study.getSupportEmail(), node.get("supportEmail").asText());
         assertEqualsAndNotNull(study.getSynapseDataAccessTeamId(), node.get("synapseDataAccessTeamId").longValue());
         assertEqualsAndNotNull(study.getSynapseProjectId(), node.get("synapseProjectId").textValue());

--- a/test/org/sagebionetworks/bridge/services/StudyServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceTest.java
@@ -110,6 +110,7 @@ public class StudyServiceTest {
     public void crudStudy() {
         study = TestUtils.getValidStudy(StudyServiceTest.class);
         // verify this can be null, that's okay, and the flags are reset correctly on create
+        study.setExcludeStudyIdInExport(false);
         study.setTaskIdentifiers(null);
         study.setActivityEventKeys(null);
         study.setHealthCodeExportEnabled(true);
@@ -118,9 +119,12 @@ public class StudyServiceTest {
         study.setEmailVerificationEnabled(false);
         study.setEmailSignInEnabled(true);
         study = studyService.createStudy(study);
-        
+
+        // Verify that the flags are set correctly on create.
         assertNotNull("Version has been set", study.getVersion());
         assertTrue(study.isActive());
+        assertTrue(study.getExcludeStudyIdInExport());
+        assertTrue(study.isStrictUploadValidationEnabled());
 
         verify(mockCache).setStudy(study);
         verifyNoMoreInteractions(mockCache);
@@ -134,7 +138,9 @@ public class StudyServiceTest {
 
         Study newStudy = studyService.getStudy(study.getIdentifier());
         assertTrue(newStudy.isActive());
-        
+        assertTrue(newStudy.getExcludeStudyIdInExport());
+        assertTrue(newStudy.isStrictUploadValidationEnabled());
+
         assertEquals(study.getIdentifier(), newStudy.getIdentifier());
         assertEquals("Test Study [StudyServiceTest]", newStudy.getName());
         assertEquals(18, newStudy.getMinAgeOfConsent());
@@ -291,6 +297,7 @@ public class StudyServiceTest {
     }
 
     private void assertStudyDefaults(Study study) {
+        assertTrue(study.getExcludeStudyIdInExport());
         assertTrue(study.isStrictUploadValidationEnabled());
         assertTrue(study.isEmailVerificationEnabled());
         assertFalse(study.isExternalIdValidationEnabled());
@@ -300,6 +307,7 @@ public class StudyServiceTest {
     }
     
     private void assertStudyChanged(Study study) {
+        assertFalse(study.getExcludeStudyIdInExport());
         assertFalse(study.isStrictUploadValidationEnabled());
         assertFalse(study.isEmailVerificationEnabled());
         assertTrue(study.isExternalIdValidationEnabled());
@@ -309,6 +317,7 @@ public class StudyServiceTest {
     }
     
     private void setStudyDefaults(Study study) {
+        study.setExcludeStudyIdInExport(true);
         study.setStrictUploadValidationEnabled(true);
         study.setEmailVerificationEnabled(true);
         study.setExternalIdValidationEnabled(false);
@@ -318,6 +327,7 @@ public class StudyServiceTest {
     }
     
     private void changeStudyDefaults(Study study) {
+        study.setExcludeStudyIdInExport(false);
         study.setStrictUploadValidationEnabled(false);
         study.setEmailVerificationEnabled(false);
         study.setExternalIdValidationEnabled(true);

--- a/test/org/sagebionetworks/bridge/services/StudyServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceTest.java
@@ -110,7 +110,7 @@ public class StudyServiceTest {
     public void crudStudy() {
         study = TestUtils.getValidStudy(StudyServiceTest.class);
         // verify this can be null, that's okay, and the flags are reset correctly on create
-        study.setExcludeStudyIdInExport(false);
+        study.setStudyIdExcludedInExport(false);
         study.setTaskIdentifiers(null);
         study.setActivityEventKeys(null);
         study.setHealthCodeExportEnabled(true);
@@ -123,8 +123,8 @@ public class StudyServiceTest {
         // Verify that the flags are set correctly on create.
         assertNotNull("Version has been set", study.getVersion());
         assertTrue(study.isActive());
-        assertTrue(study.getExcludeStudyIdInExport());
         assertTrue(study.isStrictUploadValidationEnabled());
+        assertTrue(study.isStudyIdExcludedInExport());
 
         verify(mockCache).setStudy(study);
         verifyNoMoreInteractions(mockCache);
@@ -138,8 +138,8 @@ public class StudyServiceTest {
 
         Study newStudy = studyService.getStudy(study.getIdentifier());
         assertTrue(newStudy.isActive());
-        assertTrue(newStudy.getExcludeStudyIdInExport());
         assertTrue(newStudy.isStrictUploadValidationEnabled());
+        assertTrue(newStudy.isStudyIdExcludedInExport());
 
         assertEquals(study.getIdentifier(), newStudy.getIdentifier());
         assertEquals("Test Study [StudyServiceTest]", newStudy.getName());
@@ -297,8 +297,8 @@ public class StudyServiceTest {
     }
 
     private void assertStudyDefaults(Study study) {
-        assertTrue(study.getExcludeStudyIdInExport());
         assertTrue(study.isStrictUploadValidationEnabled());
+        assertTrue(study.isStudyIdExcludedInExport());
         assertTrue(study.isEmailVerificationEnabled());
         assertFalse(study.isExternalIdValidationEnabled());
         assertFalse(study.isExternalIdRequiredOnSignup());
@@ -307,8 +307,8 @@ public class StudyServiceTest {
     }
     
     private void assertStudyChanged(Study study) {
-        assertFalse(study.getExcludeStudyIdInExport());
         assertFalse(study.isStrictUploadValidationEnabled());
+        assertFalse(study.isStudyIdExcludedInExport());
         assertFalse(study.isEmailVerificationEnabled());
         assertTrue(study.isExternalIdValidationEnabled());
         assertTrue(study.isExternalIdRequiredOnSignup());
@@ -317,8 +317,8 @@ public class StudyServiceTest {
     }
     
     private void setStudyDefaults(Study study) {
-        study.setExcludeStudyIdInExport(true);
         study.setStrictUploadValidationEnabled(true);
+        study.setStudyIdExcludedInExport(true);
         study.setEmailVerificationEnabled(true);
         study.setExternalIdValidationEnabled(false);
         study.setExternalIdRequiredOnSignup(false);
@@ -327,8 +327,8 @@ public class StudyServiceTest {
     }
     
     private void changeStudyDefaults(Study study) {
-        study.setExcludeStudyIdInExport(false);
         study.setStrictUploadValidationEnabled(false);
+        study.setStudyIdExcludedInExport(false);
         study.setEmailVerificationEnabled(false);
         study.setExternalIdValidationEnabled(true);
         study.setExternalIdRequiredOnSignup(true);


### PR DESCRIPTION
See https://sagebionetworks.jira.com/browse/BRIDGE-1942

This is needed because we want new studies to not include studyId in the exported data, but we don't want to break old studies. This flag is only changeable by admins. It defaults to false, and new studies are created with this flag set to true.