### PR TITLE
Sequence period in recurring schedules

### DIFF
--- a/app/org/sagebionetworks/bridge/models/schedules/ActivityScheduler.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/ActivityScheduler.java
@@ -164,9 +164,11 @@ public abstract class ActivityScheduler {
     private boolean scheduledOnAfterSequencePeriod(ScheduleContext context, DateTime scheduledTime, int currentCount) {
         // Don't know why you'd specify a sequence, then force N number of activities to be returned, but the 
         // minimum activities setting is part of the public API and it would be unexpected if it didn't work.
-        
+        /*
         boolean minMet = context.getMinimumPerSchedule() == 0 || currentCount >= context.getMinimumPerSchedule();
         return sequenceEndsOn != null && !scheduledTime.isBefore(sequenceEndsOn) && minMet;
+        */
+        return sequenceEndsOn != null && !scheduledTime.isBefore(sequenceEndsOn);
     }
     
     private boolean scheduledOnAfterEndsOnNoMinimumCount(ScheduleContext context, DateTime scheduledTime) {

--- a/app/org/sagebionetworks/bridge/models/schedules/ActivityScheduler.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/ActivityScheduler.java
@@ -14,6 +14,7 @@ import org.sagebionetworks.bridge.BridgeUtils;
 public abstract class ActivityScheduler {
     
     protected final Schedule schedule;
+    protected DateTime sequenceEndsOn;
     
     ActivityScheduler(Schedule schedule) {
         this.schedule = schedule;
@@ -39,6 +40,11 @@ public abstract class ActivityScheduler {
         if (schedule.getDelay() != null) {
             eventTime = eventTime.plus(schedule.getDelay());
         }
+        // Sequence period is measured from the first timestamp plus the delay, to the end of the period.
+        if (schedule.getSequencePeriod() != null) {
+            sequenceEndsOn = eventTime.plus(schedule.getSequencePeriod());
+        }
+        
         return eventTime;
     }
     
@@ -140,6 +146,9 @@ public abstract class ActivityScheduler {
     protected boolean shouldContinueScheduling(ScheduleContext context, DateTime scheduledTime,
             List<ScheduledActivity> scheduledActivities) {
 
+        if (scheduledOnAfterSequencePeriod(context, scheduledTime, scheduledActivities.size())) {
+            return false;
+        }
         if (scheduledOnAfterEndsOnNoMinimumCount(context, scheduledTime)) {
             return false;
         }
@@ -150,6 +159,14 @@ public abstract class ActivityScheduler {
                 hasNotMetMinimumCount(context, scheduledActivities.size());
         
         return boundaryNotMet;
+    }
+    
+    private boolean scheduledOnAfterSequencePeriod(ScheduleContext context, DateTime scheduledTime, int currentCount) {
+        // Don't know why you'd specify a sequence, then force N number of activities to be returned, but the 
+        // minimum activities setting is part of the public API and it would be unexpected if it didn't work.
+        
+        boolean minMet = context.getMinimumPerSchedule() == 0 || currentCount >= context.getMinimumPerSchedule();
+        return sequenceEndsOn != null && !scheduledTime.isBefore(sequenceEndsOn) && minMet;
     }
     
     private boolean scheduledOnAfterEndsOnNoMinimumCount(ScheduleContext context, DateTime scheduledTime) {

--- a/app/org/sagebionetworks/bridge/models/schedules/ActivityScheduler.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/ActivityScheduler.java
@@ -162,12 +162,6 @@ public abstract class ActivityScheduler {
     }
     
     private boolean scheduledOnAfterSequencePeriod(ScheduleContext context, DateTime scheduledTime, int currentCount) {
-        // Don't know why you'd specify a sequence, then force N number of activities to be returned, but the 
-        // minimum activities setting is part of the public API and it would be unexpected if it didn't work.
-        /*
-        boolean minMet = context.getMinimumPerSchedule() == 0 || currentCount >= context.getMinimumPerSchedule();
-        return sequenceEndsOn != null && !scheduledTime.isBefore(sequenceEndsOn) && minMet;
-        */
         return sequenceEndsOn != null && !scheduledTime.isBefore(sequenceEndsOn);
     }
     

--- a/app/org/sagebionetworks/bridge/models/schedules/Schedule.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/Schedule.java
@@ -232,11 +232,10 @@ public class Schedule implements BridgeEntity {
         Schedule other = (Schedule) obj;
         return (Objects.equals(activities, other.activities) && Objects.equals(cronTrigger, other.cronTrigger)
                 && Objects.equals(endsOn, other.endsOn) && Objects.equals(expires, other.expires)
-                && Objects.equals(sequencePeriod, other.sequencePeriod)
-                && Objects.equals(label, other.label) && Objects.equals(scheduleType, other.scheduleType) 
-                && Objects.equals(startsOn, other.startsOn) && Objects.equals(eventId, other.eventId) 
-                && Objects.equals(interval, other.interval) && Objects.equals(times, other.times)
-                && Objects.equals(delay, other.delay));
+                && Objects.equals(sequencePeriod, other.sequencePeriod) && Objects.equals(label, other.label)
+                && Objects.equals(scheduleType, other.scheduleType) && Objects.equals(startsOn, other.startsOn)
+                && Objects.equals(eventId, other.eventId) && Objects.equals(interval, other.interval)
+                && Objects.equals(times, other.times) && Objects.equals(delay, other.delay));
     }
     @Override
     public String toString() {

--- a/app/org/sagebionetworks/bridge/models/schedules/Schedule.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/Schedule.java
@@ -40,6 +40,8 @@ public class Schedule implements BridgeEntity {
     public static final String TYPE_PROPERTY_NAME = "type";
     public static final String ACTIVITIES_PROPERTY = "activities";
     public static final String TIMES_PROPERTY = "times";
+    public static final String SEQUENCE_PERIOD_PROPERTY = "sequencePeriod";
+    public static final String PERSISTENT_PROPERTY = "persistent";
 
     public static final Splitter EVENT_ID_SPLITTER = Splitter.on(Pattern.compile("\\s*,\\s*"));
    
@@ -49,6 +51,7 @@ public class Schedule implements BridgeEntity {
     private Period delay;
     private Period interval;
     private Period expires;
+    private Period sequencePeriod;
     private String cronTrigger;
     private DateTime startsOn;
     private DateTime endsOn;
@@ -129,6 +132,15 @@ public class Schedule implements BridgeEntity {
     public void setExpires(Period expires) {
         this.expires = expires;
     }
+    public Period getSequencePeriod() {
+        return sequencePeriod;
+    }
+    public void setSequencePeriod(Period sequencePeriod) {
+        this.sequencePeriod = sequencePeriod;
+    }
+    public void setSequencePeriod(String sequencePeriod) {
+        setSequencePeriod(Period.parse(sequencePeriod));
+    }
     public void setExpires(String expires) {
         setExpires(Period.parse(expires));
     }
@@ -206,7 +218,7 @@ public class Schedule implements BridgeEntity {
     }
     @Override
     public final int hashCode() {
-        return Objects.hash(activities, cronTrigger, endsOn, expires, delay, interval, label, 
+        return Objects.hash(activities, cronTrigger, endsOn, expires, sequencePeriod, delay, interval, label,
                 scheduleType, startsOn, eventId, times);
     }
     @Override
@@ -220,6 +232,7 @@ public class Schedule implements BridgeEntity {
         Schedule other = (Schedule) obj;
         return (Objects.equals(activities, other.activities) && Objects.equals(cronTrigger, other.cronTrigger)
                 && Objects.equals(endsOn, other.endsOn) && Objects.equals(expires, other.expires)
+                && Objects.equals(sequencePeriod, other.sequencePeriod)
                 && Objects.equals(label, other.label) && Objects.equals(scheduleType, other.scheduleType) 
                 && Objects.equals(startsOn, other.startsOn) && Objects.equals(eventId, other.eventId) 
                 && Objects.equals(interval, other.interval) && Objects.equals(times, other.times)
@@ -227,7 +240,7 @@ public class Schedule implements BridgeEntity {
     }
     @Override
     public String toString() {
-        return String.format("Schedule [label=%s, scheduleType=%s, cronTrigger=%s, startsOn=%s, endsOn=%s, delay=%s, expires=%s, interval=%s, times=%s, eventId=%s, activities=%s]", 
-            label, scheduleType, cronTrigger, startsOn, endsOn, delay, expires, interval, times, eventId, activities);
+        return String.format("Schedule [label=%s, scheduleType=%s, cronTrigger=%s, startsOn=%s, endsOn=%s, delay=%s, expires=%s, sequencePeriod=%s, interval=%s, times=%s, eventId=%s, activities=%s]", 
+            label, scheduleType, cronTrigger, startsOn, endsOn, delay, expires, sequencePeriod, interval, times, eventId, activities);
     }
 }    

--- a/app/org/sagebionetworks/bridge/validators/ScheduleValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/ScheduleValidator.java
@@ -83,7 +83,18 @@ public class ScheduleValidator implements Validator {
         if (timesNotOrderedChronologically(schedule)) {
             errors.rejectValue(Schedule.ENDS_ON_PROPERTY, "should be at least an hour after the startsOn time");
         }
+        if (iterationPeriodForNonRecurringSchedule(schedule)) {
+            errors.rejectValue(Schedule.SEQUENCE_PERIOD_PROPERTY, "cannot be set unless schedule is recurring");
+        }
         validateActivities(schedule, errors);
+    }
+    
+    /**
+     * Iteration period is specifically intended to limit the production of activities from recurring schedules 
+     * (whether interval based or cron based). It is an error to include it in other schedule types.
+     */
+    private boolean iterationPeriodForNonRecurringSchedule(Schedule schedule) {
+        return (schedule.getSequencePeriod() != null && schedule.getScheduleType() != ScheduleType.RECURRING);
     }
     
     /**

--- a/test/org/sagebionetworks/bridge/SchedulingTestSuite.java
+++ b/test/org/sagebionetworks/bridge/SchedulingTestSuite.java
@@ -17,8 +17,8 @@ import org.sagebionetworks.bridge.services.ScheduledActivityServiceRecurringTest
  * These are run as part of the entire test suite, but when working on the scheduling, it is useful
  * to be able to run these tests separately. 
  */
-@RunWith(Suite.class)
 @Ignore
+@RunWith(Suite.class)
 @Suite.SuiteClasses({
     ScheduledActivityServiceDuplicateTest.class,
     ScheduledActivityServiceMockTest.class,

--- a/test/org/sagebionetworks/bridge/SchedulingTestSuite.java
+++ b/test/org/sagebionetworks/bridge/SchedulingTestSuite.java
@@ -17,8 +17,8 @@ import org.sagebionetworks.bridge.services.ScheduledActivityServiceRecurringTest
  * These are run as part of the entire test suite, but when working on the scheduling, it is useful
  * to be able to run these tests separately. 
  */
-@Ignore
 @RunWith(Suite.class)
+@Ignore
 @Suite.SuiteClasses({
     ScheduledActivityServiceDuplicateTest.class,
     ScheduledActivityServiceMockTest.class,

--- a/test/org/sagebionetworks/bridge/models/schedules/ActivitySchedulerTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/ActivitySchedulerTest.java
@@ -9,6 +9,7 @@ import static org.sagebionetworks.bridge.models.schedules.ScheduleTestUtils.asDT
 import static org.sagebionetworks.bridge.models.schedules.ScheduleTestUtils.asLong;
 import static org.sagebionetworks.bridge.models.schedules.ScheduleTestUtils.assertDates;
 import static org.sagebionetworks.bridge.models.schedules.ScheduleType.ONCE;
+import static org.sagebionetworks.bridge.models.schedules.ScheduleType.RECURRING;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 
 import java.util.List;

--- a/test/org/sagebionetworks/bridge/models/schedules/CronActivitySchedulerTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/CronActivitySchedulerTest.java
@@ -30,11 +30,13 @@ import com.google.common.collect.Maps;
  */
 public class CronActivitySchedulerTest {
     
+    private static final DateTime NOW = DateTime.parse("2015-03-26T14:40:00-07:00");
+    private static final DateTimeZone PST = DateTimeZone.forOffsetHours(-7);
+    private static DateTime ENROLLMENT = DateTime.parse("2015-03-23T10:00:00Z");
+    
     private Map<String, DateTime> events;
     private List<ScheduledActivity> scheduledActivities;
     private SchedulePlan plan = new DynamoSchedulePlan();
-    
-    private DateTime ENROLLMENT = DateTime.parse("2015-03-23T10:00:00Z");
     
     @Before
     public void before() {
@@ -47,6 +49,54 @@ public class CronActivitySchedulerTest {
         events.put("two_months_before_enrollment", ENROLLMENT.minusMonths(2));
     }
     
+    @Test
+    public void canSpecifyASequence() {
+        Schedule schedule = new Schedule();
+        schedule.setScheduleType(RECURRING);
+        schedule.setCronTrigger("0 0 14 1/1 * ? *");
+        schedule.addTimes("14:00");
+        schedule.setSequencePeriod("P3D");
+        schedule.addActivity(TestUtils.getActivity3());
+        
+        ScheduleContext context = new ScheduleContext.Builder()
+            .withStudyIdentifier(TEST_STUDY)
+            .withInitialTimeZone(PST)
+            .withEndsOn(NOW.plusWeeks(2))
+            .withEvents(events).build();
+        scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, context);
+        
+        // three days of activities from enrollment
+        assertDates(scheduledActivities, PST, "2015-03-23 14:00", "2015-03-24 14:00", "2015-03-25 14:00");
+        
+        // delay one day, then one day period, you get two (the first and the second which is in the day
+        schedule.setSequencePeriod("P1D");
+        schedule.setInterval("P1D");
+        schedule.setDelay("P1D");
+        scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, context);
+        assertDates(scheduledActivities, PST, "2015-03-24 14:00");
+    }
+    
+    @Test
+    public void sequenceCanBeOverriddenByMinCount() {
+        Schedule schedule = new Schedule();
+        schedule.setScheduleType(RECURRING);
+        schedule.addTimes("14:00");
+        schedule.setSequencePeriod("P1D");
+        schedule.setCronTrigger("0 0 14 1/1 * ? *");
+        schedule.addActivity(TestUtils.getActivity3());
+        
+        ScheduleContext context = new ScheduleContext.Builder()
+            .withStudyIdentifier(TEST_STUDY)
+            .withInitialTimeZone(PST)
+            .withEndsOn(NOW.plusWeeks(2))
+            .withMinimumPerSchedule(3)
+            .withEvents(events).build();
+        scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, context);
+        
+        // Should be one given sequencePeriod = P1D, but we've asked for 3
+        assertDates(scheduledActivities, PST, "2015-03-23 14:00", "2015-03-24 14:00", "2015-03-25 14:00");
+    }
+     
     @Test
     public void onceCronScheduleWorks() {
         Schedule schedule = createScheduleWith(ONCE);

--- a/test/org/sagebionetworks/bridge/models/schedules/CronActivitySchedulerTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/CronActivitySchedulerTest.java
@@ -81,22 +81,44 @@ public class CronActivitySchedulerTest {
         Schedule schedule = new Schedule();
         schedule.setScheduleType(RECURRING);
         schedule.addTimes("14:00");
-        schedule.setSequencePeriod("P1D");
+        schedule.setSequencePeriod("P6D");
         schedule.setCronTrigger("0 0 14 1/1 * ? *");
         schedule.addActivity(TestUtils.getActivity3());
         
         ScheduleContext context = new ScheduleContext.Builder()
             .withStudyIdentifier(TEST_STUDY)
             .withInitialTimeZone(PST)
-            .withEndsOn(NOW.plusWeeks(2))
-            .withMinimumPerSchedule(3)
+            .withEndsOn(NOW.plusDays(4))
+            .withMinimumPerSchedule(8)
             .withEvents(events).build();
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, context);
         
-        // Should be one given sequencePeriod = P1D, but we've asked for 3
-        assertDates(scheduledActivities, PST, "2015-03-23 14:00", "2015-03-24 14:00", "2015-03-25 14:00");
+        // Period is 6 days, you ask for 4 days ahead, but insist on 8 tasks. You should get back
+        // 6 tasks... all the tasks in the period. But not 8 activities.
+        assertDates(scheduledActivities, PST, "2015-03-23 14:00", "2015-03-24 14:00", "2015-03-25 14:00",
+                "2015-03-26 14:00", "2015-03-27 14:00", "2015-03-28 14:00");
     }
      
+    @Test
+    public void sequenceShorterThanDaysAhead() {
+        Schedule schedule = new Schedule();
+        schedule.setScheduleType(RECURRING);
+        schedule.addTimes("14:00");
+        schedule.setSequencePeriod("P2D");
+        schedule.setCronTrigger("0 0 14 1/1 * ? *");
+        schedule.addActivity(TestUtils.getActivity3());
+        
+        ScheduleContext context = new ScheduleContext.Builder()
+            .withStudyIdentifier(TEST_STUDY)
+            .withInitialTimeZone(PST)
+            .withEndsOn(NOW.plusDays(4))
+            .withEvents(events).build();
+        scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, context);
+        
+        // 2 activities
+        assertDates(scheduledActivities, PST, "2015-03-23 14:00", "2015-03-24 14:00");
+    }
+    
     @Test
     public void onceCronScheduleWorks() {
         Schedule schedule = createScheduleWith(ONCE);

--- a/test/org/sagebionetworks/bridge/models/schedules/IntervalActivitySchedulerTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/IntervalActivitySchedulerTest.java
@@ -78,23 +78,47 @@ public class IntervalActivitySchedulerTest {
     
     @Test
     public void sequenceCanBeOverriddenByMinCount() {
+        // The min count should retrieve more than N days of scheduled activities, but not more
+        // that would be specified in the sequence period.
         Schedule schedule = new Schedule();
         schedule.setScheduleType(RECURRING);
         schedule.addTimes("14:00");
-        schedule.setSequencePeriod("P1D");
+        schedule.setSequencePeriod("P6D");
         schedule.setInterval("P1D");
         schedule.addActivity(TestUtils.getActivity3());
         
         ScheduleContext context = new ScheduleContext.Builder()
             .withStudyIdentifier(TEST_STUDY)
             .withInitialTimeZone(PST)
-            .withEndsOn(NOW.plusWeeks(2))
-            .withMinimumPerSchedule(3)
+            .withEndsOn(NOW.plusDays(4))
+            .withMinimumPerSchedule(8)
             .withEvents(events).build();
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, context);
         
-        // Should be one given sequencePeriod = P1D, but we've asked for 3
-        assertDates(scheduledActivities, PST, "2015-03-23 14:00", "2015-03-24 14:00", "2015-03-25 14:00");
+        // Period is 6 days, you ask for 4 days ahead, but insist on 8 tasks. You should get back
+        // 6 tasks... all the tasks in the period. But not 8 activities.
+        assertDates(scheduledActivities, PST, "2015-03-23 14:00", "2015-03-24 14:00", "2015-03-25 14:00",
+                "2015-03-26 14:00", "2015-03-27 14:00", "2015-03-28 14:00");
+    }
+    
+    @Test
+    public void sequenceShorterThanDaysAhead() {
+        Schedule schedule = new Schedule();
+        schedule.setScheduleType(RECURRING);
+        schedule.addTimes("14:00");
+        schedule.setSequencePeriod("P2D");
+        schedule.setInterval("P1D");
+        schedule.addActivity(TestUtils.getActivity3());
+        
+        ScheduleContext context = new ScheduleContext.Builder()
+            .withStudyIdentifier(TEST_STUDY)
+            .withInitialTimeZone(PST)
+            .withEndsOn(NOW.plusDays(4))
+            .withEvents(events).build();
+        scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, context);
+        
+        // 2 activities
+        assertDates(scheduledActivities, PST, "2015-03-23 14:00", "2015-03-24 14:00");
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/models/schedules/ScheduleTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/ScheduleTest.java
@@ -47,31 +47,31 @@ public class ScheduleTest {
         String string = mapper.writeValueAsString(schedule);
 
         JsonNode node = mapper.readTree(string);
-        assertEquals("label", node.get(Schedule.LABEL_PROPERTY).asText());
-        assertEquals("recurring", node.get(Schedule.SCHEDULE_TYPE_PROPERTY).asText());
-        assertEquals("eventId", node.get(Schedule.EVENT_ID_PROPERTY).asText());
-        assertEquals("0 0 8 ? * TUE *", node.get(Schedule.CRON_TRIGGER_PROPERTY).asText());
-        assertEquals("P1D", node.get(Schedule.DELAY_PROPERTY).asText());
-        assertEquals("P3D", node.get(Schedule.INTERVAL_PROPERTY).asText());
-        assertEquals("P2D", node.get(Schedule.EXPIRES_PROPERTY).asText());
-        assertEquals("P3W", node.get(Schedule.SEQUENCE_PERIOD_PROPERTY).asText());
-        assertEquals("2015-02-02T10:10:10.000Z", node.get(Schedule.STARTS_ON_PROPERTY).asText());
-        assertEquals("2015-01-01T10:10:10.000Z", node.get(Schedule.ENDS_ON_PROPERTY).asText());
-        assertFalse(node.get(Schedule.PERSISTENT_PROPERTY).asBoolean());
-        assertEquals("Schedule", node.get("type").asText());
+        assertEquals("label", node.get(Schedule.LABEL_PROPERTY).textValue());
+        assertEquals("recurring", node.get(Schedule.SCHEDULE_TYPE_PROPERTY).textValue());
+        assertEquals("eventId", node.get(Schedule.EVENT_ID_PROPERTY).textValue());
+        assertEquals("0 0 8 ? * TUE *", node.get(Schedule.CRON_TRIGGER_PROPERTY).textValue());
+        assertEquals("P1D", node.get(Schedule.DELAY_PROPERTY).textValue());
+        assertEquals("P3D", node.get(Schedule.INTERVAL_PROPERTY).textValue());
+        assertEquals("P2D", node.get(Schedule.EXPIRES_PROPERTY).textValue());
+        assertEquals("P3W", node.get(Schedule.SEQUENCE_PERIOD_PROPERTY).textValue());
+        assertEquals("2015-02-02T10:10:10.000Z", node.get(Schedule.STARTS_ON_PROPERTY).textValue());
+        assertEquals("2015-01-01T10:10:10.000Z", node.get(Schedule.ENDS_ON_PROPERTY).textValue());
+        assertFalse(node.get(Schedule.PERSISTENT_PROPERTY).booleanValue());
+        assertEquals("Schedule", node.get("type").textValue());
 
         ArrayNode times = (ArrayNode)node.get("times");
-        assertEquals("10:10:00.000", times.get(0).asText());
-        assertEquals("14:00:00.000", times.get(1).asText());
+        assertEquals("10:10:00.000", times.get(0).textValue());
+        assertEquals("14:00:00.000", times.get(1).textValue());
         
         JsonNode actNode = node.get("activities").get(0);
-        assertEquals("label", actNode.get("label").asText());
-        assertEquals("task", actNode.get("activityType").asText());
-        assertEquals("Activity", actNode.get("type").asText());
+        assertEquals("label", actNode.get("label").textValue());
+        assertEquals("task", actNode.get("activityType").textValue());
+        assertEquals("Activity", actNode.get("type").textValue());
 
         JsonNode taskNode = actNode.get("task");
-        assertEquals("ref", taskNode.get("identifier").asText());
-        assertEquals("TaskReference", taskNode.get("type").asText());
+        assertEquals("ref", taskNode.get("identifier").textValue());
+        assertEquals("TaskReference", taskNode.get("type").textValue());
         
         schedule = mapper.readValue(string, Schedule.class);
         assertEquals("0 0 8 ? * TUE *", schedule.getCronTrigger());
@@ -85,6 +85,7 @@ public class ScheduleTest {
         assertEquals("2015-01-01T10:10:10.000Z", schedule.getEndsOn().toString());
         assertEquals("10:10:00.000", schedule.getTimes().get(0).toString());
         assertEquals("14:00:00.000", schedule.getTimes().get(1).toString());
+        assertEquals("P3W", schedule.getSequencePeriod().toString());
         activity = schedule.getActivities().get(0);
         assertEquals("label", activity.getLabel());
         assertEquals("ref", activity.getTask().getIdentifier());

--- a/test/org/sagebionetworks/bridge/models/schedules/ScheduleTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/ScheduleTest.java
@@ -36,9 +36,10 @@ public class ScheduleTest {
         schedule.setExpires(Period.parse("P2D"));
         schedule.setStartsOn(DateTime.parse("2015-02-02T10:10:10.000Z"));
         schedule.setEndsOn(DateTime.parse("2015-01-01T10:10:10.000Z"));
-        schedule.setEventId("eventId");
+        schedule.setEventId(Schedule.EVENT_ID_PROPERTY);
         schedule.setInterval(Period.parse("P3D"));
-        schedule.setLabel("label");
+        schedule.setSequencePeriod(Period.parse("P3W"));
+        schedule.setLabel(Schedule.LABEL_PROPERTY);
         schedule.setScheduleType(ScheduleType.RECURRING);
         schedule.setTimes(Lists.newArrayList(LocalTime.parse("10:10"), LocalTime.parse("14:00")));
         
@@ -46,16 +47,17 @@ public class ScheduleTest {
         String string = mapper.writeValueAsString(schedule);
 
         JsonNode node = mapper.readTree(string);
-        assertEquals("label", node.get("label").asText());
-        assertEquals("recurring", node.get("scheduleType").asText());
-        assertEquals("eventId", node.get("eventId").asText());
-        assertEquals("0 0 8 ? * TUE *", node.get("cronTrigger").asText());
-        assertEquals("P1D", node.get("delay").asText());
-        assertEquals("P3D", node.get("interval").asText());
-        assertEquals("P2D", node.get("expires").asText());
-        assertEquals("2015-02-02T10:10:10.000Z", node.get("startsOn").asText());
-        assertEquals("2015-01-01T10:10:10.000Z", node.get("endsOn").asText());
-        assertFalse(node.get("persistent").asBoolean());
+        assertEquals("label", node.get(Schedule.LABEL_PROPERTY).asText());
+        assertEquals("recurring", node.get(Schedule.SCHEDULE_TYPE_PROPERTY).asText());
+        assertEquals("eventId", node.get(Schedule.EVENT_ID_PROPERTY).asText());
+        assertEquals("0 0 8 ? * TUE *", node.get(Schedule.CRON_TRIGGER_PROPERTY).asText());
+        assertEquals("P1D", node.get(Schedule.DELAY_PROPERTY).asText());
+        assertEquals("P3D", node.get(Schedule.INTERVAL_PROPERTY).asText());
+        assertEquals("P2D", node.get(Schedule.EXPIRES_PROPERTY).asText());
+        assertEquals("P3W", node.get(Schedule.SEQUENCE_PERIOD_PROPERTY).asText());
+        assertEquals("2015-02-02T10:10:10.000Z", node.get(Schedule.STARTS_ON_PROPERTY).asText());
+        assertEquals("2015-01-01T10:10:10.000Z", node.get(Schedule.ENDS_ON_PROPERTY).asText());
+        assertFalse(node.get(Schedule.PERSISTENT_PROPERTY).asBoolean());
         assertEquals("Schedule", node.get("type").asText());
 
         ArrayNode times = (ArrayNode)node.get("times");
@@ -98,6 +100,7 @@ public class ScheduleTest {
         schedule.setStartsOn("2015-02-02T10:10:10.000Z");
         schedule.setExpires("P1D");
         schedule.setInterval("P1D");
+        schedule.setSequencePeriod("P1D");
         schedule.addTimes("10:10");
         schedule.addTimes("12:10");
         
@@ -106,6 +109,7 @@ public class ScheduleTest {
         assertEquals(date, schedule.getStartsOn());
         assertEquals(period, schedule.getExpires());
         assertEquals(period, schedule.getInterval());
+        assertEquals(period, schedule.getSequencePeriod());
         assertEquals(Lists.newArrayList(LocalTime.parse("10:10"), LocalTime.parse("12:10")), schedule.getTimes());
     }
     

--- a/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceMockTest.java
@@ -30,6 +30,7 @@ import org.joda.time.DateTimeZone;
 import org.junit.After;
 import org.joda.time.Period;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -598,7 +599,7 @@ public class ScheduledActivityServiceMockTest {
     }
     
     @Test
-    public void orderActivitieFiltersAndSorts() {
+    public void orderActivitiesFiltersAndSorts() {
         DateTime time1 = DateTime.parse("2014-10-01T00:00:00.000Z");
         DateTime time2 = DateTime.parse("2014-10-02T00:00:00.000Z");
         DateTime time3 = DateTime.parse("2014-10-03T00:00:00.000Z");

--- a/test/org/sagebionetworks/bridge/validators/ScheduleValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/ScheduleValidatorTest.java
@@ -41,7 +41,7 @@ public class ScheduleValidatorTest {
     }
     
     @Test
-    public void dPeriodSameAsIntervalOK() {
+    public void sequencePeriodSameAsIntervalOK() {
         Schedule schedule = new Schedule();
         schedule.setScheduleType(ScheduleType.RECURRING);
         schedule.addActivity(TestUtils.getActivity3());

--- a/test/org/sagebionetworks/bridge/validators/ScheduleValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/ScheduleValidatorTest.java
@@ -32,6 +32,41 @@ public class ScheduleValidatorTest {
     }
     
     @Test
+    public void sequencePeriodForOnetimeSchedule() {
+        Schedule schedule = new Schedule();
+        schedule.setSequencePeriod("P3D");
+        schedule.setScheduleType(ScheduleType.ONCE);
+        
+        assertValidatorMessage(validator, schedule, Schedule.SEQUENCE_PERIOD_PROPERTY, "cannot be set unless schedule is recurring");
+    }
+    
+    @Test
+    public void dPeriodSameAsIntervalOK() {
+        Schedule schedule = new Schedule();
+        schedule.setScheduleType(ScheduleType.RECURRING);
+        schedule.addActivity(TestUtils.getActivity3());
+        schedule.setSequencePeriod("P3D");
+        schedule.addTimes("10:00");
+        schedule.setExpires("P3D");
+        schedule.setInterval("P3D");
+        
+        Validate.entityThrowingException(validator, schedule);
+    }
+    
+    @Test
+    public void iterationPeriodLongerThanIntervalOK() {
+        Schedule schedule = new Schedule();
+        schedule.setScheduleType(ScheduleType.RECURRING);
+        schedule.addActivity(TestUtils.getActivity3());
+        schedule.setSequencePeriod("P3W");
+        schedule.addTimes("10:00");
+        schedule.setExpires("P3D");
+        schedule.setInterval("P3D");
+        
+        Validate.entityThrowingException(validator, schedule);
+    }
+    
+    @Test
     public void cannotAddDuplicateTimesToSchedule() {
         Schedule schedule = new Schedule();
         schedule.addTimes(LocalTime.parse("10:00:00.000"), LocalTime.parse("10:00:00.000"));


### PR DESCRIPTION
JIRA: https://sagebionetworks.jira.com/browse/BRIDGE-1953

Sets a limit (relative to the start of a scheduling series) to the number of tasks that are issued to a user. Limit is declared using a period. This is similar to the time window, but that is in absolute, UTC time, whereas this can be used to create a sequence in a crossover study, where the user is moved through different protocols over the course of the study.