### PR TITLE
getActivities to not throw when a reference is broken

### DIFF
--- a/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
+++ b/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
@@ -478,15 +478,12 @@ public class ScheduledActivityService {
             CompoundActivity compoundActivity) {
         // Resolve schemas.
         // Lists in CompoundActivity are always non-null, so we don't need to null-check.
-        boolean isModified = false;
         List<SchemaReference> schemaList = new ArrayList<>();
         for (SchemaReference oneSchemaRef : compoundActivity.getSchemaList()) {
             SchemaReference resolvedSchemaRef = resolveSchema(context, schemaCache, oneSchemaRef);
-            schemaList.add(resolvedSchemaRef);
 
-            if (!resolvedSchemaRef.equals(oneSchemaRef)) {
-                // Only mark the compound activity as dirty if resolution actually changed the schema.
-                isModified = true;
+            if (resolvedSchemaRef != null) {
+                schemaList.add(resolvedSchemaRef);
             }
         }
 
@@ -494,21 +491,16 @@ public class ScheduledActivityService {
         List<SurveyReference> surveyList = new ArrayList<>();
         for (SurveyReference oneSurveyRef : compoundActivity.getSurveyList()) {
             SurveyReference resolvedSurveyRef = resolveSurvey(context, surveyCache, oneSurveyRef);
-            surveyList.add(resolvedSurveyRef);
 
-            if (!resolvedSurveyRef.equals(oneSurveyRef)) {
-                isModified = true;
+            if (resolvedSurveyRef != null) {
+                surveyList.add(resolvedSurveyRef);
             }
         }
 
-        if (!isModified) {
-            // Resolution didn't change any of our schema and survey refs. Just return the compound activity as is.
-            return compoundActivity;
-        } else {
-            // We need to make a new compound activity with the resolved schemas and surveys.
-            return new CompoundActivity.Builder().copyOf(compoundActivity).withSchemaList(schemaList)
-                    .withSurveyList(surveyList).build();
-        }
+        // Make a new compound activity with the resolved schemas and surveys. This is cached in
+        // resolveCompoundActivities(), so this is okay.
+        return new CompoundActivity.Builder().copyOf(compoundActivity).withSchemaList(schemaList)
+                .withSurveyList(surveyList).build();
     }
 
     // Helper method to resolve a schema ref to the latest revision for the client.


### PR DESCRIPTION
See https://sagebionetworks.jira.com/browse/BRIDGE-1939

For a variety of reasons, we can't defend against broken references in schedule plans. The best we can do is ensure that broken references don't cause all getActivities calls to fail with a 404. Rather, this converts the 404 into a log error, so we can detect it, and the tasks are still vended to the user.

This might result in a 404 Survey Not Found later down the line, but it will be isolated to the offending survey rather than all activities.

Testing done:
* unit tests
* integ tests
* manually tested by creating a schedule with (a) broken schema ref (b) broken survey ref (c) broken compound activity ref (d) valid compound activity with a broken schema ref and broken survey ref. (Broken survey refs were created by creating a valid survey ref, then deleting the survey from DDB directly.) Called getActivities and verified the call succeeded. Verified the expected log errors in the logs.