### PR TITLE
BRIDGE-1946: set JVM hostname on new relic UI

### DIFF
--- a/dist/.ebextensions/newrelic-server.config
+++ b/dist/.ebextensions/newrelic-server.config
@@ -6,9 +6,9 @@ packages:
 container_commands:
   "01SetLicenseKey":
     command: "nrsysmond-config --set license_key=$NEW_RELIC_LICENSE_KEY"
-  "02SetInstanceId":
+  "02SetNRServerInstanceId":
     command: "export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo hostname=$INSTANCE_ID && echo hostname=$INSTANCE_ID >> /etc/newrelic/nrsysmond.cfg"
-  "03SetNRJVMHostname":
-    command: "export NEW_RELIC_PROCESS_HOST_DISPLAY_NAME=$(curl http://instance-data/latest/meta-data/instance-id)"
-  "04StartMonitor":
+  "04SetNRJVMInstanceId":
+    command: 'export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo -e "\n  process_host:\n    display_name: $INSTANCE_ID" >> /var/app/staging/newrelic/newrelic.yml'
+  "09StartMonitor":
     command: "/etc/init.d/newrelic-sysmond start"


### PR DESCRIPTION
An attempt to set the JVM hostname to the instance ID was made in PR
https://github.com/Sage-Bionetworks/BridgePF/pull/1551 however it didn't
work.  We need to set it in newrelic.yml file for it to work.