### PR TITLE
Reference new relic env vars in EB

### DIFF
--- a/dist/.ebextensions/newrelic-server.config
+++ b/dist/.ebextensions/newrelic-server.config
@@ -7,8 +7,10 @@ container_commands:
   "01SetLicenseKey":
     command: "nrsysmond-config --set license_key=$NEW_RELIC_LICENSE_KEY"
   "02SetNRServerInstanceId":
-    command: "export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo hostname=$INSTANCE_ID && echo hostname=$INSTANCE_ID >> /etc/newrelic/nrsysmond.cfg"
+    command: "export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo hostname=$INSTANCE_ID && echo hostname=$INSTANCE_ID >> $NEW_RELIC_SERVER_CONFIG"
+  "03MoveNRConfig":
+    command: "mv -f /var/app/staging/newrelic/newrelic.yml $NEW_RELIC_APM_CONFIG"
   "04SetNRJVMInstanceId":
-    command: 'export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo -e "\n  process_host:\n    display_name: $INSTANCE_ID" >> /var/app/staging/newrelic/newrelic.yml'
+    command: "export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo -e \"\n  process_host:\n    display_name: $INSTANCE_ID\" >> $NEW_RELIC_APM_CONFIG"
   "09StartMonitor":
     command: "/etc/init.d/newrelic-sysmond start"


### PR DESCRIPTION
This PR depends on https://github.com/Sage-Bionetworks/BridgePF-infra/pull/35

Reference new relic parameters from AWS elastic beanstalk instead of defining
them in this repo.