### PR TITLE
BRIDGE-1947: Refactor for easier NR agent upgrades

### DIFF
--- a/dist/.ebextensions/newrelic-server.config
+++ b/dist/.ebextensions/newrelic-server.config
@@ -7,12 +7,10 @@ container_commands:
   "01SetLicenseKey":
     command: "nrsysmond-config --set license_key=$NEW_RELIC_LICENSE_KEY"
   "02SetNRServerInstanceId":
-    command: "export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo hostname=$INSTANCE_ID && echo hostname=$INSTANCE_ID >> $NEW_RELIC_SERVER_CONFIG"
+    command: "export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo hostname=$INSTANCE_ID && echo hostname=$INSTANCE_ID >> /etc/newrelic/nrsysmond.cfg"
   "03CopyNRApmAgent":
     command: "/bin/mkdir -p /usr/local/lib/newrelic && cp -rf /var/app/staging/lib/com.newrelic.agent.java.newrelic-agent-3.32.0.jar $NEW_RELIC_APM_AGENT"
-  "04CopyNRApmConfig":
-     command: "/bin/cp -rf /var/app/staging/newrelic/newrelic.yml $NEW_RELIC_APM_CONFIG"
-  "05SetNRJVMInstanceId":
-    command: "export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo -e \"\n  process_host:\n    display_name: $INSTANCE_ID\" >> $NEW_RELIC_APM_CONFIG"
+  "04SetNRJVMInstanceId":
+    command: 'export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo -e "\n  process_host:\n    display_name: $INSTANCE_ID" >> /var/app/staging/newrelic/newrelic.yml'
   "09StartMonitor":
     command: "/etc/init.d/newrelic-sysmond start"

--- a/dist/.ebextensions/newrelic-server.config
+++ b/dist/.ebextensions/newrelic-server.config
@@ -7,8 +7,12 @@ container_commands:
   "01SetLicenseKey":
     command: "nrsysmond-config --set license_key=$NEW_RELIC_LICENSE_KEY"
   "02SetNRServerInstanceId":
-    command: "export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo hostname=$INSTANCE_ID && echo hostname=$INSTANCE_ID >> /etc/newrelic/nrsysmond.cfg"
-  "04SetNRJVMInstanceId":
-    command: 'export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo -e "\n  process_host:\n    display_name: $INSTANCE_ID" >> /var/app/staging/newrelic/newrelic.yml'
+    command: "export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo hostname=$INSTANCE_ID && echo hostname=$INSTANCE_ID >> $NEW_RELIC_SERVER_CONFIG""
+  "03MoveNRApmAgent":
+    command: "/bin/mkdir -p /usr/local/lib/newrelic && cp -rf /var/app/staging/lib/com.newrelic.agent.java.newrelic-agent-3.32.0.jar $NEW_RELIC_APM_AGENT"
+  "04MoveNRConfig":
+     command: "/bin/cp -rf /var/app/staging/newrelic/newrelic.yml $NEW_RELIC_APM_CONFIG"
+  "05SetNRJVMInstanceId":
+    command: "export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo -e \"\n  process_host:\n    display_name: $INSTANCE_ID\" >> $NEW_RELIC_APM_CONFIG"
   "09StartMonitor":
     command: "/etc/init.d/newrelic-sysmond start"

--- a/dist/.ebextensions/newrelic-server.config
+++ b/dist/.ebextensions/newrelic-server.config
@@ -7,10 +7,10 @@ container_commands:
   "01SetLicenseKey":
     command: "nrsysmond-config --set license_key=$NEW_RELIC_LICENSE_KEY"
   "02SetNRServerInstanceId":
-    command: "export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo hostname=$INSTANCE_ID && echo hostname=$INSTANCE_ID >> $NEW_RELIC_SERVER_CONFIG""
-  "03MoveNRApmAgent":
+    command: "export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo hostname=$INSTANCE_ID && echo hostname=$INSTANCE_ID >> $NEW_RELIC_SERVER_CONFIG"
+  "03CopyNRApmAgent":
     command: "/bin/mkdir -p /usr/local/lib/newrelic && cp -rf /var/app/staging/lib/com.newrelic.agent.java.newrelic-agent-3.32.0.jar $NEW_RELIC_APM_AGENT"
-  "04MoveNRConfig":
+  "04CopyNRApmConfig":
      command: "/bin/cp -rf /var/app/staging/newrelic/newrelic.yml $NEW_RELIC_APM_CONFIG"
   "05SetNRJVMInstanceId":
     command: "export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo -e \"\n  process_host:\n    display_name: $INSTANCE_ID\" >> $NEW_RELIC_APM_CONFIG"

--- a/dist/.ebextensions/newrelic-server.config
+++ b/dist/.ebextensions/newrelic-server.config
@@ -9,7 +9,7 @@ container_commands:
   "02SetNRServerInstanceId":
     command: "export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo hostname=$INSTANCE_ID && echo hostname=$INSTANCE_ID >> /etc/newrelic/nrsysmond.cfg"
   "03CopyNRApmAgent":
-    command: "/bin/mkdir -p /usr/local/lib/newrelic && cp -rf /var/app/staging/lib/com.newrelic.agent.java.newrelic-agent-3.32.0.jar $NEW_RELIC_APM_AGENT"
+    command: "/bin/mkdir -p /usr/local/lib/newrelic && cp -rf /var/app/staging/lib/com.newrelic.agent.java.newrelic-agent-3.32.0.jar /usr/local/lib/newrelic/com.newrelic.agent.java.newrelic-agent.jar"
   "04SetNRJVMInstanceId":
     command: 'export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo -e "\n  process_host:\n    display_name: $INSTANCE_ID" >> /var/app/staging/newrelic/newrelic.yml'
   "09StartMonitor":


### PR DESCRIPTION
The current setup requires coordinated config changes to both BridgePF and
BridgePF-infra on a new relic agent upgrade. The purpose of this change is
to make it so that NR agent upgrades only require changes to BridgePF.

* This PR depends on https://github.com/Sage-Bionetworks/BridgePF-infra/pull/37
* Setup new relic agent without the version info.
* Reference new relic parameters from AWS env vars instead of duplicating
them in both repos.