### PR TITLE
BRIDGE-1947: Upgrade new relic java agent

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-ses" % "1.10.20",
   
   // New Relic
-  "com.newrelic.agent.java" % "newrelic-agent" % "3.32.0",
+  "com.newrelic.agent.java" % "newrelic-agent" % "3.42.0",
   // Dom4j, needed to resolve dependency conflicts for Hibernate
   "dom4j" % "dom4j" % "1.6.1",
   // MySQL JDBC connector

--- a/dist/.ebextensions/newrelic-server.config
+++ b/dist/.ebextensions/newrelic-server.config
@@ -9,7 +9,7 @@ container_commands:
   "02SetNRServerInstanceId":
     command: "export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo hostname=$INSTANCE_ID && echo hostname=$INSTANCE_ID >> /etc/newrelic/nrsysmond.cfg"
   "03CopyNRApmAgent":
-    command: "/bin/mkdir -p /usr/local/lib/newrelic && cp -rf /var/app/staging/lib/com.newrelic.agent.java.newrelic-agent-3.32.0.jar /usr/local/lib/newrelic/com.newrelic.agent.java.newrelic-agent.jar"
+    command: "/bin/mkdir -p /usr/local/lib/newrelic && cp -rf /var/app/staging/lib/com.newrelic.agent.java.newrelic-agent-3.42.0.jar /usr/local/lib/newrelic/com.newrelic.agent.java.newrelic-agent.jar"
   "04SetNRJVMInstanceId":
     command: 'export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo -e "\n  process_host:\n    display_name: $INSTANCE_ID" >> /var/app/staging/newrelic/newrelic.yml'
   "09StartMonitor":


### PR DESCRIPTION
Upgrade newrelic agent so we can take advantage of newer features and bug fixes[1].

Notable features:

v 3.38.0
This release provides you with several flexible error configuration options to control how your errors are reported(2). With this addition, you can now configure certain exceptions that you expect your application logic will throw. These “expected errors” will not be counted towards your application error rate and Apdex; you will only be alerted on errors that truly affect the health of your application.

ver 3.40.0
The Java agent now provides visibility into your applications’ usage of DynamoDB when using the client versions 1.11.106 and greater. You will see the calls in the application breakdown, in trace details, on the Databases page, in Transaction maps, and in Service maps.

[1] https://docs.newrelic.com/docs/release-notes/agent-release-notes/java-release-notes
[2] https://docs.newrelic.com/docs/agents/java-agent/configuration/java-agent-error-configuration