### PR TITLE
Fix shared study creation

### DIFF
--- a/app/org/sagebionetworks/bridge/DefaultStudyBootstrapper.java
+++ b/app/org/sagebionetworks/bridge/DefaultStudyBootstrapper.java
@@ -80,6 +80,7 @@ public class DefaultStudyBootstrapper {
             study.setTechnicalEmail("bridgeit@sagebridge.org");
             study.setConsentNotificationEmail("bridgeit@sagebridge.org");
             study.setPasswordPolicy(new PasswordPolicy(2, false, false, false, false));
+            study.setEmailVerificationEnabled(true);
             studyService.createStudy(study);
         }
     }


### PR DESCRIPTION
Need to enable email verification for shared study otherwise study
does not get created correctly and below error occurs on unit
test run.

2017-09-19 14:56:38,218 WARN  [pool-1-thread-1]
org.springframework.context.support.GenericApplicationContext - Exception
encountered during context initialization - cancelling refresh attempt:
org.springframework.beans.factory.BeanCreationException: Error creating bean
with name 'defaultStudyBootstrapper': Invocation of init method failed;
nested exception is InvalidEntityException [message=Study is invalid:
externalIdRequiredOnSignup cannot be disabled if email verification has been
disabled; externalIdValidationEnabled cannot be disabled if email verification
has been disabled, entity=DynamoStudy [name=Shared Module Library, active=true,
sponsorName=Sage Bionetworks, identifier=shared, minAgeOfConsent=0,
studyIdExcludedInExport=true, supportEmail=bridgeit@sagebridge.org,
synapseDataAccessTeamId=null, synapseProjectId=null,
technicalEmail=bridgeit@sagebridge.org, consentNotificationEmail=bridgeit@sagebridge.org,
version=null, userProfileAttributes=[], taskIdentifiers=[], activityEventKeys=[],
dataGroups=[test_user], passwordPolicy=PasswordPolicy [minLength=2, numericRequired=false,
symbolRequired=false, lowerCaseRequired=false, upperCaseRequired=false],
verifyEmailTemplate=EmailTemplate [subject=Verify your account, body=<p>Hi,</p>
<p>Thank you for registering for ${studyName}.</p>