### PR TITLE
Show the time zone of the signing date of the user.

### DIFF
--- a/app/org/sagebionetworks/bridge/services/ConsentService.java
+++ b/app/org/sagebionetworks/bridge/services/ConsentService.java
@@ -175,8 +175,9 @@ public class ConsentService {
         
         // Send email, if required.
         if (sendEmail) {
-            MimeTypeEmailProvider consentEmail = new ConsentEmailProvider(study, participant.getEmail(),
-                    withConsentCreatedOnSignature, sharingScope, studyConsent.getDocumentContent(), consentTemplate);
+            MimeTypeEmailProvider consentEmail = new ConsentEmailProvider(study, participant.getTimeZone(),
+                    participant.getEmail(), withConsentCreatedOnSignature, sharingScope,
+                    studyConsent.getDocumentContent(), consentTemplate);
 
             sendMailService.sendEmail(consentEmail);
         }
@@ -297,8 +298,8 @@ public class ConsentService {
         
         String htmlTemplate = studyConsentService.getActiveConsent(subpop).getDocumentContent();
         
-        MimeTypeEmailProvider consentEmail = new ConsentEmailProvider(study, participant.getEmail(), consentSignature,
-                sharingScope, htmlTemplate, consentTemplate);
+        MimeTypeEmailProvider consentEmail = new ConsentEmailProvider(study, participant.getTimeZone(),
+                participant.getEmail(), consentSignature, sharingScope, htmlTemplate, consentTemplate);
         sendMailService.sendEmail(consentEmail);
     }
 

--- a/test/org/sagebionetworks/bridge/models/schedules/ActivitySchedulerTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/ActivitySchedulerTest.java
@@ -9,7 +9,6 @@ import static org.sagebionetworks.bridge.models.schedules.ScheduleTestUtils.asDT
 import static org.sagebionetworks.bridge.models.schedules.ScheduleTestUtils.asLong;
 import static org.sagebionetworks.bridge.models.schedules.ScheduleTestUtils.assertDates;
 import static org.sagebionetworks.bridge.models.schedules.ScheduleType.ONCE;
-import static org.sagebionetworks.bridge.models.schedules.ScheduleType.RECURRING;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 
 import java.util.List;

--- a/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceMockTest.java
@@ -30,7 +30,6 @@ import org.joda.time.DateTimeZone;
 import org.junit.After;
 import org.joda.time.Period;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;

--- a/test/org/sagebionetworks/bridge/services/SendEmailIntegTest.java
+++ b/test/org/sagebionetworks/bridge/services/SendEmailIntegTest.java
@@ -9,6 +9,7 @@ import java.nio.charset.StandardCharsets;
 import javax.annotation.Resource;
 
 import org.apache.commons.io.IOUtils;
+import org.joda.time.DateTimeZone;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.sagebionetworks.bridge.dao.ParticipantOption.SharingScope;
@@ -65,7 +66,7 @@ public class SendEmailIntegTest {
         
         Subpopulation subpopulation = subpopService.getSubpopulation(TEST_STUDY, SUBPOP_GUID);
         String htmlTemplate = studyConsentService.getActiveConsent(subpopulation).getDocumentContent();
-        sendEmailService.sendEmail(new ConsentEmailProvider(study, "bridge-testing@sagebase.org",
+        sendEmailService.sendEmail(new ConsentEmailProvider(study, DateTimeZone.UTC, "bridge-testing@sagebase.org",
                 signature, SharingScope.SPONSORS_AND_PARTNERS, htmlTemplate, consentBodyTemplate));
     }
     

--- a/test/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceConsentTest.java
+++ b/test/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceConsentTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.simpleemail.model.MessageRejectedException;
 import org.apache.commons.io.IOUtils;
+import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -43,6 +44,7 @@ import com.google.common.base.Charsets;
 public class SendMailViaAmazonServiceConsentTest {
     private static final String SUPPORT_EMAIL = "study-support-email@study.com";
     private static final String FROM_STUDY_AS_FORMATTED = "\"Test Study (Sage)\" <"+SUPPORT_EMAIL+">";
+    private static final DateTimeZone MSK = DateTimeZone.forID("Europe/Moscow");
 
     private SendMailViaAmazonService service;
     private AmazonSimpleEmailServiceClient emailClient;
@@ -98,7 +100,7 @@ public class SendMailViaAmazonServiceConsentTest {
         
         String htmlTemplate = studyConsentService.getActiveConsent(subpopulation).getDocumentContent();
         
-        ConsentEmailProvider provider = new ConsentEmailProvider(study, "test-user@sagebase.org", consent,
+        ConsentEmailProvider provider = new ConsentEmailProvider(study, MSK, "test-user@sagebase.org", consent,
                 SharingScope.SPONSORS_AND_PARTNERS, htmlTemplate, consentBodyTemplate);
         service.sendEmail(provider);
 
@@ -116,6 +118,7 @@ public class SendMailViaAmazonServiceConsentTest {
 
         // Validate message content. MIME message must be ASCII
         String rawMessage = new String(req.getRawMessage().getData().array(), Charsets.US_ASCII);
+        System.out.println(rawMessage);
         assertTrue("Contains consent content", rawMessage.contains("Had this been a real study"));
         assertTrue("Name transposed to document", rawMessage.contains("Test 2"));
         assertTrue("Email transposed to document", rawMessage.contains("test-user@sagebase.org"));
@@ -137,7 +140,7 @@ public class SendMailViaAmazonServiceConsentTest {
         
         String htmlTemplate = studyConsentService.getActiveConsent(subpopulation).getDocumentContent();
         
-        ConsentEmailProvider provider = new ConsentEmailProvider(study, "test-user@sagebase.org", consent,
+        ConsentEmailProvider provider = new ConsentEmailProvider(study, MSK, "test-user@sagebase.org", consent,
                 SharingScope.SPONSORS_AND_PARTNERS, htmlTemplate, consentBodyTemplate);
         service.sendEmail(provider);
 
@@ -178,7 +181,7 @@ public class SendMailViaAmazonServiceConsentTest {
         
         String htmlTemplate = studyConsentService.getActiveConsent(subpopulation).getDocumentContent();
 
-        ConsentEmailProvider provider = new ConsentEmailProvider(study, "test-user@sagebase.org", consent,
+        ConsentEmailProvider provider = new ConsentEmailProvider(study, MSK, "test-user@sagebase.org", consent,
                 SharingScope.SPONSORS_AND_PARTNERS, htmlTemplate, consentBodyTemplate);
 
         // execute
@@ -200,7 +203,7 @@ public class SendMailViaAmazonServiceConsentTest {
         
         String htmlTemplate = studyConsentService.getActiveConsent(subpopulation).getDocumentContent();
 
-        ConsentEmailProvider provider = new ConsentEmailProvider(study, "test-user@sagebase.org", consent,
+        ConsentEmailProvider provider = new ConsentEmailProvider(study, MSK, "test-user@sagebase.org", consent,
                 SharingScope.SPONSORS_AND_PARTNERS, htmlTemplate, consentBodyTemplate);
 
         // execute


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-1853

Signature is now given in the user's timezone, so the day is much more likely to be correct (no error because it's in UTC and you're in PST, etc.). We now also show the time zone in the "signed on" value to be very clear about when it was signed.