### PR TITLE
fieldDef.multiChoiceAnswerList should never be null

### DIFF
--- a/app/org/sagebionetworks/bridge/models/upload/UploadFieldDefinition.java
+++ b/app/org/sagebionetworks/bridge/models/upload/UploadFieldDefinition.java
@@ -246,9 +246,11 @@ public final class UploadFieldDefinition {
             }
 
             // If the answer list was specified, make an immutable copy.
-            List<String> multiChoiceAnswerListCopy = null;
+            List<String> multiChoiceAnswerListCopy;
             if (multiChoiceAnswerList != null) {
                 multiChoiceAnswerListCopy = ImmutableList.copyOf(multiChoiceAnswerList);
+            } else {
+                multiChoiceAnswerListCopy = ImmutableList.of();
             }
 
             return new UploadFieldDefinition(allowOtherChoices, fileExtension, mimeType, maxLength,

--- a/test/org/sagebionetworks/bridge/models/upload/UploadFieldDefinitionTest.java
+++ b/test/org/sagebionetworks/bridge/models/upload/UploadFieldDefinitionTest.java
@@ -70,6 +70,20 @@ public class UploadFieldDefinitionTest {
     }
 
     @Test
+    public void testMultiChoiceAnswerListNull() {
+        // Fields that are not multi_choice usually won't specify this, but we expect it to be, by default, an empty
+        // list instead of a null list.
+        UploadFieldDefinition fieldDef1 = new UploadFieldDefinition.Builder().withName("test-field")
+                .withType(UploadFieldType.INT).build();
+        assertTrue(fieldDef1.getMultiChoiceAnswerList().isEmpty());
+
+        // Explicitly set it to null, and it still comes up as an empty list.
+        UploadFieldDefinition fieldDef2 = new UploadFieldDefinition.Builder().withName("test-field")
+                .withType(UploadFieldType.INT).withMultiChoiceAnswerList((List<String>) null).build();
+        assertTrue(fieldDef2.getMultiChoiceAnswerList().isEmpty());
+    }
+
+    @Test
     public void testOptionalFields() {
         List<String> multiChoiceAnswerList = ImmutableList.of("foo", "bar", "baz");
 


### PR DESCRIPTION
This fixes a rather obscure bug. Currently, if you don't specify a multiChoiceAnswerList, it gets parsed and saved as null. However, the JavaSDK always submits an empty list for this rather than null. This means that, if you create a field def directly through the HTTP interface, then try to append to the field def list using the JavaSDK, you'll get obscure error messages.

Fix is to make it so null lists are converted to empty lists. Side effect is that all field defs now have an extra parameter on them.

Testing done: unit tests, integ tests, manually tested this specific error case