### PR TITLE
remove extraneous null checks, fix UploadUtilTest

### DIFF
--- a/app/org/sagebionetworks/bridge/upload/UploadUtil.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadUtil.java
@@ -356,22 +356,17 @@ public class UploadUtil {
             return false;
         }
 
+        // Note: multiChoiceAnswerList can never be null.
         List<String> oldMultiChoiceAnswerList = oldFieldDef.getMultiChoiceAnswerList();
         List<String> newMultiChoiceAnswerList = newFieldDef.getMultiChoiceAnswerList();
-        if (oldMultiChoiceAnswerList != null && newMultiChoiceAnswerList != null) {
-            // Choices might have been re-ordered, so convert to sets so we can determine the choices that have been
-            // added, deleted, or retained.
-            Set<String> oldMultiChoiceAnswerSet = new HashSet<>(oldMultiChoiceAnswerList);
-            Set<String> newMultiChoiceAnswerSet = new HashSet<>(newMultiChoiceAnswerList);
+        // Choices might have been re-ordered, so convert to sets so we can determine the choices that have been
+        // added, deleted, or retained.
+        Set<String> oldMultiChoiceAnswerSet = new HashSet<>(oldMultiChoiceAnswerList);
+        Set<String> newMultiChoiceAnswerSet = new HashSet<>(newMultiChoiceAnswerList);
 
-            // Adding choices is okay. Deleting choices is not. (Renaming is deleting one choice and adding another.)
-            Set<String> deletedChoiceSet = Sets.difference(oldMultiChoiceAnswerSet, newMultiChoiceAnswerSet);
-            if (!deletedChoiceSet.isEmpty()) {
-                return false;
-            }
-        } else if (oldMultiChoiceAnswerList != null || newMultiChoiceAnswerList != null) {
-            // This should never happen, but if we add or remove a multi-choice answer list, we should flag the field
-            // defs as incompatible.
+        // Adding choices is okay. Deleting choices is not. (Renaming is deleting one choice and adding another.)
+        Set<String> deletedChoiceSet = Sets.difference(oldMultiChoiceAnswerSet, newMultiChoiceAnswerSet);
+        if (!deletedChoiceSet.isEmpty()) {
             return false;
         }
 

--- a/test/org/sagebionetworks/bridge/upload/UploadUtilTest.java
+++ b/test/org/sagebionetworks/bridge/upload/UploadUtilTest.java
@@ -447,7 +447,7 @@ public class UploadUtilTest {
         // { oldList, newList, expected }
         Object[][] testCases = {
                 { null, null, true },
-                { null, ImmutableList.of("foo", "bar"), false },
+                { null, ImmutableList.of("foo", "bar"), true },
                 { ImmutableList.of("foo", "bar"), null, false },
                 { ImmutableList.of("foo", "bar"), ImmutableList.of("foo", "bar"), true },
                 { ImmutableList.of("foo", "bar"), ImmutableList.of("foo"), false },


### PR DESCRIPTION
We recently changed fieldDef.multiChoiceAnswerList to never be null, to be consistent with the JavaSDK.

This exposed a bug in UploadUtil, where a null multiChoiceAnswerList couldn't be replaced by a non-null one, but an empty one could be replaced by a non-empty one.

This removes the extraneous null check and changes the test to test for the correct behavior.