### PR TITLE
Using appConfigService to resolve scheduled activities.

### DIFF
--- a/app/org/sagebionetworks/bridge/services/AppConfigService.java
+++ b/app/org/sagebionetworks/bridge/services/AppConfigService.java
@@ -3,21 +3,24 @@ package org.sagebionetworks.bridge.services;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.sagebionetworks.bridge.util.BridgeCollectors.toImmutableList;
 
 import java.util.Comparator;
 import java.util.List;
 
+import org.joda.time.DateTime;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.dao.AppConfigDao;
 import org.sagebionetworks.bridge.dynamodb.DynamoAppConfig;
-import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.json.DateUtils;
+import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.CriteriaUtils;
 import org.sagebionetworks.bridge.models.appconfig.AppConfig;
+import org.sagebionetworks.bridge.models.schedules.SchemaReference;
+import org.sagebionetworks.bridge.models.schedules.SurveyReference;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
-import org.sagebionetworks.bridge.util.BridgeCollectors;
 import org.sagebionetworks.bridge.validators.AppConfigValidator;
 import org.sagebionetworks.bridge.validators.Validate;
 import org.slf4j.Logger;
@@ -34,6 +37,10 @@ public class AppConfigService {
     
     private StudyService studyService;
     
+    private UploadSchemaService schemaService;
+
+    private SurveyService surveyService;
+    
     @Autowired
     final void setAppConfigDao(AppConfigDao appConfigDao) {
         this.appConfigDao = appConfigDao;
@@ -43,6 +50,16 @@ public class AppConfigService {
     final void setStudyService(StudyService studyService) {
         this.studyService = studyService;
     }
+    
+    @Autowired
+    final void setSchemaService(UploadSchemaService schemaService) {
+        this.schemaService = schemaService;
+    }
+
+    @Autowired
+    final void setSurveyService(SurveyService surveyService) {
+        this.surveyService = surveyService;
+    }    
     
     // In order to mock this value;
     protected long getCurrentTimestamp() {
@@ -75,13 +92,13 @@ public class AppConfigService {
         List<AppConfig> matches = appConfigs.stream().filter(oneAppConfig -> {
             return CriteriaUtils.matchCriteria(context, oneAppConfig.getCriteria());
         }).sorted(Comparator.comparingLong(AppConfig::getCreatedOn))
-          .collect(BridgeCollectors.toImmutableList());
+          .collect(toImmutableList());
 
         // Should have matched one and only one app config.
         // The goal of the following code is not to introduce production exceptions when changing app configs.
         if (matches.isEmpty()) {
-            // If there are no matches, return the "default" app config (TBD: for now, throw exception)
-            throw new EntityNotFoundException(AppConfig.class);
+            // If there are no matches, return the "default" app config
+            return getDefaultAppConfig(context.getStudyIdentifier(), context.getClientInfo());
         } else if (matches.size() != 1) {
             // If there is more than one match, return the one created first, but log an error
             LOG.error("CriteriaContext matches more than one app config: criteriaContext=" + context + ", appConfigs="+matches);
@@ -147,6 +164,38 @@ public class AppConfigService {
         checkNotNull(studyId);
         
         appConfigDao.deleteAllAppConfigs(studyId);
+    }
+    
+    /**
+     * If no app config has been defined by the study designer, return an app config
+     * that selects the most recently published versions of all schemas and surveys
+     * in the study.
+     */
+    public AppConfig getDefaultAppConfig(final StudyIdentifier studyId, final ClientInfo clientInfo) {
+        long timestamp = getCurrentTimestamp();
+        AppConfig appConfig = AppConfig.create();
+        appConfig.setLabel(studyId.getIdentifier() + " default app config");
+        appConfig.setGuid(studyId.getIdentifier());
+        appConfig.setStudyId(studyId.getIdentifier());
+        appConfig.setCreatedOn(timestamp);
+        appConfig.setModifiedOn(timestamp);
+        
+        List<SurveyReference> publishedSurveyReferences = surveyService.getAllSurveysMostRecentlyPublishedVersion(studyId)
+                .stream().map((survey) -> {
+                    return new SurveyReference(survey.getIdentifier(), survey.getGuid(), new DateTime(survey.getCreatedOn()));
+        }).collect(toImmutableList());
+
+        appConfig.setSurveyReferences(publishedSurveyReferences);
+        
+        List<SchemaReference> schemaReferences = schemaService.getUploadSchemasForStudy(studyId).stream().map((schema) -> {
+                    return schemaService.getLatestUploadSchemaRevisionForAppVersion(studyId, schema.getSchemaId(), clientInfo);
+        }).map((schema) -> {
+            return new SchemaReference(schema.getSchemaId(), schema.getRevision());
+        }).collect(toImmutableList());
+        
+        appConfig.setSchemaReferences(schemaReferences);
+        
+        return appConfig;
     }
     
 }

--- a/app/org/sagebionetworks/bridge/services/ModelReferenceResolver.java
+++ b/app/org/sagebionetworks/bridge/services/ModelReferenceResolver.java
@@ -16,8 +16,12 @@ import org.sagebionetworks.bridge.models.schedules.TaskReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 
+/**
+ * Helper class that converts scheduled activities so that all surveys, schemas, and compound activities 
+ * reference a recent and published version that the client should be using. 
+ */
 class ModelReferenceResolver {
     private static final Logger LOG = LoggerFactory.getLogger(ModelReferenceResolver.class);
     
@@ -31,20 +35,8 @@ class ModelReferenceResolver {
         this.compoundActivityCache = new HashMap<>();
         this.schemaCache = new HashMap<>();
         this.surveyCache = new HashMap<>();
-        {
-            ImmutableMap.Builder<String,SurveyReference> builder = new ImmutableMap.Builder<>();
-            for (SurveyReference ref : appConfig.getSurveyReferences()) {
-                builder.put(ref.getGuid(), ref);
-            }
-            this.surveyReferences = builder.build();
-        }
-        {
-            ImmutableMap.Builder<String,SchemaReference> builder = new ImmutableMap.Builder<>();
-            for (SchemaReference ref : appConfig.getSchemaReferences()) {
-                builder.put(ref.getId(), ref);
-            }
-            this.schemaReferences = builder.build();
-        }
+        this.surveyReferences = Maps.uniqueIndex(appConfig.getSurveyReferences(), SurveyReference::getGuid);
+        this.schemaReferences = Maps.uniqueIndex(appConfig.getSchemaReferences(), SchemaReference::getId);
     }
     
     // Allows for verification via a spy

--- a/app/org/sagebionetworks/bridge/services/ModelReferenceResolver.java
+++ b/app/org/sagebionetworks/bridge/services/ModelReferenceResolver.java
@@ -1,0 +1,187 @@
+package org.sagebionetworks.bridge.services;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.sagebionetworks.bridge.models.appconfig.AppConfig;
+import org.sagebionetworks.bridge.models.schedules.Activity;
+import org.sagebionetworks.bridge.models.schedules.ActivityType;
+import org.sagebionetworks.bridge.models.schedules.CompoundActivity;
+import org.sagebionetworks.bridge.models.schedules.ScheduledActivity;
+import org.sagebionetworks.bridge.models.schedules.SchemaReference;
+import org.sagebionetworks.bridge.models.schedules.SurveyReference;
+import org.sagebionetworks.bridge.models.schedules.TaskReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableMap;
+
+class ModelReferenceResolver {
+    private static final Logger LOG = LoggerFactory.getLogger(ModelReferenceResolver.class);
+    
+    private final Map<String, CompoundActivity> compoundActivityCache;
+    private final Map<String, SchemaReference> schemaCache;
+    private final Map<String, SurveyReference> surveyCache;
+    private Map<String, SchemaReference> schemaReferences;
+    private Map<String, SurveyReference> surveyReferences;
+
+    ModelReferenceResolver(AppConfig appConfig) {
+        this.compoundActivityCache = new HashMap<>();
+        this.schemaCache = new HashMap<>();
+        this.surveyCache = new HashMap<>();
+        {
+            ImmutableMap.Builder<String,SurveyReference> builder = new ImmutableMap.Builder<>();
+            for (SurveyReference ref : appConfig.getSurveyReferences()) {
+                builder.put(ref.getGuid(), ref);
+            }
+            this.surveyReferences = builder.build();
+        }
+        {
+            ImmutableMap.Builder<String,SchemaReference> builder = new ImmutableMap.Builder<>();
+            for (SchemaReference ref : appConfig.getSchemaReferences()) {
+                builder.put(ref.getId(), ref);
+            }
+            this.schemaReferences = builder.build();
+        }
+    }
+    
+    // Allows for verification via a spy
+    SurveyReference getSurveyReference(String guid) {
+        return surveyReferences.get(guid);
+    }
+    
+    // Allows for verification via a spy
+    SchemaReference getSchemaReference(String schemaId) {
+        return schemaReferences.get(schemaId);
+    }
+    
+    void resolve(ScheduledActivity schActivity) {
+        Activity activity = schActivity.getActivity();
+        ActivityType activityType = activity.getActivityType();
+        
+        // Multiplex on activity type and resolve the activity, as needed.
+        Activity resolvedActivity = null;
+        if (activityType == ActivityType.COMPOUND) {
+            // Resolve compound activity.
+            CompoundActivity compoundActivity = activity.getCompoundActivity();
+            CompoundActivity resolvedCompoundActivity = resolveCompoundActivity(compoundActivity);
+
+            // If resolution changed the compound activity, generate a new activity instance that contains it.
+            if (resolvedCompoundActivity != null && !resolvedCompoundActivity.equals(compoundActivity)) {
+                resolvedActivity = new Activity.Builder().withActivity(activity)
+                        .withCompoundActivity(resolvedCompoundActivity).build();
+            }
+        } else if (activityType == ActivityType.SURVEY) {
+            SurveyReference surveyRef = activity.getSurvey();
+            SurveyReference resolvedSurveyRef = resolveSurvey(surveyRef);
+
+            if (resolvedSurveyRef != null && !resolvedSurveyRef.equals(surveyRef)) {
+                resolvedActivity = new Activity.Builder().withActivity(activity).withSurvey(resolvedSurveyRef)
+                        .build();
+            }
+        } else if (activityType == ActivityType.TASK) {
+            TaskReference taskRef = activity.getTask();
+            SchemaReference schemaRef = taskRef.getSchema();
+            // note: the editor doesn't allow you to set this right now.
+            if (schemaRef != null) {
+                SchemaReference resolvedSchemaRef = resolveSchema(schemaRef);
+
+                if (resolvedSchemaRef != null && !resolvedSchemaRef.equals(schemaRef)) {
+                    TaskReference resolvedTaskRef = new TaskReference(taskRef.getIdentifier(), resolvedSchemaRef);
+                    resolvedActivity = new Activity.Builder().withActivity(activity).withTask(resolvedTaskRef)
+                            .build();
+                }
+            }
+        }
+
+        // Set the activity back into the ScheduledActivity, if needed.
+        if (resolvedActivity != null) {
+            schActivity.setActivity(resolvedActivity);
+        }
+    }
+    
+    // Helper method to resolve a compound activity reference from its definition.
+    private CompoundActivity resolveCompoundActivity(CompoundActivity compoundActivity) {
+        String taskId = compoundActivity.getTaskIdentifier();
+        CompoundActivity resolvedCompoundActivity = compoundActivityCache.get(taskId);
+        if (resolvedCompoundActivity == null) {
+            // Pure "reference" compound activities are fully loaded before the references are resolved by the 
+            // model reference resolver. Before we cache it, resolve the surveys and schemas in the list.
+            resolvedCompoundActivity = resolveListsInCompoundActivity(compoundActivity);
+            compoundActivityCache.put(taskId, resolvedCompoundActivity);
+        }
+        return resolvedCompoundActivity;
+    }
+    
+    // Helper method to resolve schema refs and survey refs inside of a compound activity.
+    private CompoundActivity resolveListsInCompoundActivity(CompoundActivity compoundActivity) {
+        // Resolve schemas.
+        // Lists in CompoundActivity are always non-null, so we don't need to null-check.
+        List<SchemaReference> schemaList = new ArrayList<>();
+        for (SchemaReference oneSchemaRef : compoundActivity.getSchemaList()) {
+            SchemaReference resolvedSchemaRef = resolveSchema(oneSchemaRef);
+
+            if (resolvedSchemaRef != null) {
+                schemaList.add(resolvedSchemaRef);
+            }
+        }
+
+        // Similarly, resolve surveys.
+        List<SurveyReference> surveyList = new ArrayList<>();
+        for (SurveyReference oneSurveyRef : compoundActivity.getSurveyList()) {
+            SurveyReference resolvedSurveyRef = resolveSurvey(oneSurveyRef);
+
+            if (resolvedSurveyRef != null) {
+                surveyList.add(resolvedSurveyRef);
+            }
+        }
+
+        // Make a new compound activity with the resolved schemas and surveys. This is cached in
+        // resolveCompoundActivities(), so this is okay.
+        return new CompoundActivity.Builder().copyOf(compoundActivity).withSchemaList(schemaList)
+                .withSurveyList(surveyList).build();
+    }
+
+    // Helper method to resolve a published survey to a specific survey version.
+    private SurveyReference resolveSurvey(SurveyReference surveyRef) {
+        if (surveyRef.getCreatedOn() != null) {
+            // Already has a createdOn timestamp. No need to resolve. Return as is.
+            return surveyRef;
+        }
+
+        String surveyGuid = surveyRef.getGuid();
+        SurveyReference resolvedSurveyRef = surveyCache.get(surveyGuid);
+        if (resolvedSurveyRef == null) {
+            resolvedSurveyRef = getSurveyReference(surveyGuid);
+            if (resolvedSurveyRef == null) {
+                LOG.error("Schedule references non-existent survey " + surveyGuid);
+                return null;
+            }
+            surveyCache.put(surveyGuid, resolvedSurveyRef);
+        }
+        return resolvedSurveyRef;
+    }
+    
+    // Helper method to resolve a schema ref to the latest revision for the client.
+    private SchemaReference resolveSchema(SchemaReference schemaRef) {
+        if (schemaRef.getRevision() != null) {
+            // Already has a revision. No need to resolve. Return as is.
+            return schemaRef;
+        }
+
+        String schemaId = schemaRef.getId();
+        SchemaReference resolvedSchemaRef = schemaCache.get(schemaId);
+        if (resolvedSchemaRef == null) {
+            resolvedSchemaRef = getSchemaReference(schemaId);
+            if (resolvedSchemaRef == null) {
+                LOG.error("Schedule references non-existent schema " + schemaId);
+                return null;
+            }
+            schemaCache.put(schemaId, resolvedSchemaRef);
+        }
+        return resolvedSchemaRef;
+    }
+    
+}

--- a/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceDuplicateTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceDuplicateTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Map;
@@ -28,6 +29,7 @@ import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
 import org.sagebionetworks.bridge.dynamodb.DynamoScheduledActivity;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.ClientInfo;
+import org.sagebionetworks.bridge.models.appconfig.AppConfig;
 import org.sagebionetworks.bridge.models.schedules.Schedule;
 import org.sagebionetworks.bridge.models.schedules.ScheduleContext;
 import org.sagebionetworks.bridge.models.schedules.SchedulePlan;
@@ -148,6 +150,9 @@ public class ScheduledActivityServiceDuplicateTest {
     @Mock
     SchedulePlanService schedulePlanService;
     
+    @Mock
+    AppConfigService appConfigService;
+    
     ScheduledActivityService service;
     
     ScheduleContext.Builder contextBuilder;
@@ -161,6 +166,10 @@ public class ScheduledActivityServiceDuplicateTest {
         service.setScheduledActivityDao(activityDao);
         service.setActivityEventService(activityEventService);
         service.setSchedulePlanService(schedulePlanService);
+        service.setAppConfigService(appConfigService);
+        
+        AppConfig appConfig = AppConfig.create();
+        when(appConfigService.getAppConfigForUser(any())).thenReturn(appConfig);
         
         contextBuilder = new ScheduleContext.Builder()
                 .withClientInfo(ClientInfo.fromUserAgentCache("Lilly/25 (iPhone Simulator; iPhone OS/9.3) BridgeSDK/12"))


### PR DESCRIPTION
The app config service requests all the information from the appConfigService, and then uses that to resolve any activities that are not linking to concrete versions.

If no app configs have been added to the system, we create a "default" app config that includes all the surveys and schemas at their most recently published versions. 

We are not caching the default app config, we could. However, it's specific to a user's ClientInfo object, so it's a little more complicated to cache. Also it potentially includes all surveys and schemas so any add/edit/delete of surveys, schemas, or compound activities would need to clear the cache for a study.