### PR TITLE
Using app config (if it exists) to resolve scheduled activities.

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/AppConfigController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/AppConfigController.java
@@ -30,7 +30,7 @@ public class AppConfigController extends BaseController {
         
         CriteriaContext context = getCriteriaContext(session);
         
-        AppConfig appConfig = appConfigService.getAppConfigForUser(context);
+        AppConfig appConfig = appConfigService.getAppConfigForUser(context, true);
         
         return okResult(appConfig);
     }

--- a/app/org/sagebionetworks/bridge/services/AppConfigService.java
+++ b/app/org/sagebionetworks/bridge/services/AppConfigService.java
@@ -67,7 +67,7 @@ public class AppConfigService {
         return appConfigDao.getAppConfig(studyId, guid);
     }
     
-    public AppConfig getAppConfigForUser(CriteriaContext context) {
+    public AppConfig getAppConfigForUser(CriteriaContext context, boolean throwException) {
         checkNotNull(context);
 
         List<AppConfig> appConfigs = getAppConfigs(context.getStudyIdentifier());
@@ -78,10 +78,12 @@ public class AppConfigService {
           .collect(BridgeCollectors.toImmutableList());
 
         // Should have matched one and only one app config.
-        // The goal of the following code is not to introduce production exceptions when changing app configs.
         if (matches.isEmpty()) {
-            // If there are no matches, return the "default" app config (TBD: for now, throw exception)
-            throw new EntityNotFoundException(AppConfig.class);
+            if (throwException) {
+                throw new EntityNotFoundException(AppConfig.class);    
+            } else {
+                return null;
+            }
         } else if (matches.size() != 1) {
             // If there is more than one match, return the one created first, but log an error
             LOG.error("CriteriaContext matches more than one app config: criteriaContext=" + context + ", appConfigs="+matches);

--- a/app/org/sagebionetworks/bridge/services/ReferenceResolver.java
+++ b/app/org/sagebionetworks/bridge/services/ReferenceResolver.java
@@ -1,0 +1,216 @@
+package org.sagebionetworks.bridge.services;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.joda.time.DateTime;
+import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
+import org.sagebionetworks.bridge.models.ClientInfo;
+import org.sagebionetworks.bridge.models.schedules.Activity;
+import org.sagebionetworks.bridge.models.schedules.ActivityType;
+import org.sagebionetworks.bridge.models.schedules.CompoundActivity;
+import org.sagebionetworks.bridge.models.schedules.CompoundActivityDefinition;
+import org.sagebionetworks.bridge.models.schedules.ScheduledActivity;
+import org.sagebionetworks.bridge.models.schedules.SchemaReference;
+import org.sagebionetworks.bridge.models.schedules.SurveyReference;
+import org.sagebionetworks.bridge.models.schedules.TaskReference;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
+import org.sagebionetworks.bridge.models.surveys.Survey;
+import org.sagebionetworks.bridge.models.upload.UploadSchema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Activity references can be "abstract" in the sense that they need not specify the version of a survey 
+ * or schema that the client should use. When scheduled activities are generated, we "resolve" these 
+ * references to the most recent schema (that matches the app version of the requestor), or the most 
+ * recently published survey. In compound activities we resolve all references in the schema and survey 
+ * lists. Finally, if a compound activity only contains a taskIdentifier, we load the full compound 
+ * activity, resolve it, and return that in the scheduled activity. 
+ */
+class ReferenceResolver {
+    private static final Logger LOG = LoggerFactory.getLogger(ReferenceResolver.class);
+    
+    private final CompoundActivityDefinitionService compoundActivityDefinitionService;
+    private final UploadSchemaService schemaService;
+    private final SurveyService surveyService;
+    private final ClientInfo clientInfo;
+    private final StudyIdentifier studyId;
+    
+    private final Map<String,SurveyReference> surveyReferences;
+    private final Map<String,SchemaReference> schemaReferences;
+    
+    private final Map<String, CompoundActivity> compoundActivityCache = new HashMap<>();
+    private final Map<String, SchemaReference> schemaCache = new HashMap<>();
+    private final Map<String, SurveyReference> surveyCache = new HashMap<>();
+    
+    ReferenceResolver(CompoundActivityDefinitionService compoundActivityDefinitionService,
+            UploadSchemaService schemaService, SurveyService surveyService,
+            Map<String, SurveyReference> surveyReferences, Map<String, SchemaReference> schemaReferences,
+            ClientInfo clientInfo, StudyIdentifier studyId) {
+        this.compoundActivityDefinitionService = compoundActivityDefinitionService;
+        this.schemaService = schemaService;
+        this.surveyService = surveyService;
+        this.surveyReferences = surveyReferences;
+        this.schemaReferences = schemaReferences;
+        this.clientInfo = clientInfo;
+        this.studyId = studyId;
+    }
+
+    void resolve(ScheduledActivity schActivity) {
+        Activity activity = schActivity.getActivity();
+        ActivityType activityType = activity.getActivityType();
+
+        // Multiplex on activity type and resolve the activity, as needed.
+        Activity resolvedActivity = null;
+        if (activityType == ActivityType.COMPOUND) {
+            // Resolve compound activity.
+            CompoundActivity compoundActivity = activity.getCompoundActivity();
+            CompoundActivity resolvedCompoundActivity = resolveCompoundActivity(compoundActivity);
+
+            // If resolution changed the compound activity, generate a new activity instance that contains it.
+            if (resolvedCompoundActivity != null && !resolvedCompoundActivity.equals(compoundActivity)) {
+                resolvedActivity = new Activity.Builder().withActivity(activity)
+                        .withCompoundActivity(resolvedCompoundActivity).build();
+            }
+        } else if (activityType == ActivityType.SURVEY) {
+            SurveyReference surveyRef = activity.getSurvey();
+            SurveyReference resolvedSurveyRef = resolveSurvey(surveyRef);
+
+            if (resolvedSurveyRef != null && !resolvedSurveyRef.equals(surveyRef)) {
+                resolvedActivity = new Activity.Builder().withActivity(activity).withSurvey(resolvedSurveyRef).build();
+            }
+        } else if (activityType == ActivityType.TASK) {
+            TaskReference taskRef = activity.getTask();
+            SchemaReference schemaRef = taskRef.getSchema();
+
+            if (schemaRef != null) {
+                SchemaReference resolvedSchemaRef = resolveSchema(schemaRef);
+
+                if (resolvedSchemaRef != null && !resolvedSchemaRef.equals(schemaRef)) {
+                    TaskReference resolvedTaskRef = new TaskReference(taskRef.getIdentifier(), resolvedSchemaRef);
+                    resolvedActivity = new Activity.Builder().withActivity(activity).withTask(resolvedTaskRef).build();
+                }
+            }
+        }
+
+        // Set the activity back into the ScheduledActivity, if needed.
+        if (resolvedActivity != null) {
+            schActivity.setActivity(resolvedActivity);
+        }
+    }
+    // Helper method to resolve a compound activity reference from its definition.
+    private CompoundActivity resolveCompoundActivity(CompoundActivity compoundActivity) {
+        String taskId = compoundActivity.getTaskIdentifier();
+        
+        CompoundActivity resolvedCompoundActivity = compoundActivityCache.get(taskId);
+        if (resolvedCompoundActivity == null) {
+            if (compoundActivity.isReference()) {
+                // Compound activity has no schemas or surveys defined. Resolve it with its definition.
+                CompoundActivityDefinition compoundActivityDef;
+                try {
+                    compoundActivityDef = compoundActivityDefinitionService.getCompoundActivityDefinition(studyId,
+                            taskId);
+                } catch (EntityNotFoundException ex) {
+                    LOG.error("Schedule references non-existent compound activity " + taskId);
+                    return null;
+                }
+                resolvedCompoundActivity = compoundActivityDef.getCompoundActivity();
+            } else {
+                // Compound activity has schemas and surveys defined. Use the schemas and surveys from the lists, but
+                // we may need to resolve individual schema and survey refs at a later step.
+                resolvedCompoundActivity = compoundActivity;
+            }
+
+            // Before we cache it, resolve the surveys and schemas in the list.
+            resolvedCompoundActivity = resolveListsInCompoundActivity(resolvedCompoundActivity);
+
+            compoundActivityCache.put(taskId, resolvedCompoundActivity);
+        }
+        return resolvedCompoundActivity;
+    }
+
+    // Helper method to resolve schema refs and survey refs inside of a compound activity.
+    private CompoundActivity resolveListsInCompoundActivity(CompoundActivity compoundActivity) {
+        // Resolve schemas.
+        // Lists in CompoundActivity are always non-null, so we don't need to null-check.
+        List<SchemaReference> schemaList = new ArrayList<>();
+        for (SchemaReference oneSchemaRef : compoundActivity.getSchemaList()) {
+            SchemaReference resolvedSchemaRef = resolveSchema(oneSchemaRef);
+
+            if (resolvedSchemaRef != null) {
+                schemaList.add(resolvedSchemaRef);
+            }
+        }
+
+        // Similarly, resolve surveys.
+        List<SurveyReference> surveyList = new ArrayList<>();
+        for (SurveyReference oneSurveyRef : compoundActivity.getSurveyList()) {
+            SurveyReference resolvedSurveyRef = resolveSurvey(oneSurveyRef);
+
+            if (resolvedSurveyRef != null) {
+                surveyList.add(resolvedSurveyRef);
+            }
+        }
+
+        // Make a new compound activity with the resolved schemas and surveys. This is cached in
+        // resolveCompoundActivities(), so this is okay.
+        return new CompoundActivity.Builder().copyOf(compoundActivity).withSchemaList(schemaList)
+                .withSurveyList(surveyList).build();
+    }
+
+    // Helper method to resolve a schema ref to the latest revision for the client.
+    private SchemaReference resolveSchema(SchemaReference schemaRef) {
+        if (schemaRef.getRevision() != null) {
+            // Already has a revision. No need to resolve. Return as is.
+            return schemaRef;
+        }
+
+        String schemaId = schemaRef.getId();
+        SchemaReference resolvedSchemaRef = schemaCache.get(schemaId);
+        if (resolvedSchemaRef == null) {
+            resolvedSchemaRef = schemaReferences.get(schemaId);
+        }
+        if (resolvedSchemaRef == null) {
+            UploadSchema schema;
+            try {
+                schema = schemaService.getLatestUploadSchemaRevisionForAppVersion(studyId, schemaId, clientInfo);
+            } catch (EntityNotFoundException ex) {
+                LOG.error("Schedule references non-existent schema " + schemaId);
+                return null;
+            }
+            resolvedSchemaRef = new SchemaReference(schemaId, schema.getRevision());
+            schemaCache.put(schemaId, resolvedSchemaRef);
+        }
+        return resolvedSchemaRef;
+    }
+
+    // Helper method to resolve a published survey to a specific survey version.
+    private SurveyReference resolveSurvey(SurveyReference surveyRef) {
+        if (surveyRef.getCreatedOn() != null) {
+            return surveyRef;
+        }
+
+        String surveyGuid = surveyRef.getGuid();
+        SurveyReference resolvedSurveyRef = surveyCache.get(surveyGuid);
+        if (resolvedSurveyRef == null) {
+            resolvedSurveyRef = surveyReferences.get(surveyGuid);
+        }
+        if (resolvedSurveyRef == null) {
+            Survey survey;
+            try {
+                survey = surveyService.getSurveyMostRecentlyPublishedVersion(studyId, surveyGuid);
+            } catch (EntityNotFoundException ex) {
+                LOG.error("Schedule references non-existent survey " + surveyGuid);
+                return null;
+            }
+            resolvedSurveyRef = new SurveyReference(survey.getIdentifier(), surveyGuid,
+                    new DateTime(survey.getCreatedOn()));
+            surveyCache.put(surveyGuid, resolvedSurveyRef);
+        }
+        return resolvedSurveyRef;
+    }
+    
+}

--- a/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
+++ b/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
@@ -3,7 +3,6 @@ package org.sagebionetworks.bridge.services;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Comparator.comparing;
-import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
@@ -14,7 +13,6 @@ import static org.sagebionetworks.bridge.validators.ScheduleContextValidator.MAX
 
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -28,21 +26,16 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.dao.ScheduledActivityDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
-import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
-import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.ForwardCursorPagedResourceList;
-import org.sagebionetworks.bridge.models.schedules.Activity;
+import org.sagebionetworks.bridge.models.RangeTuple;
+import org.sagebionetworks.bridge.models.appconfig.AppConfig;
 import org.sagebionetworks.bridge.models.schedules.ActivityType;
-import org.sagebionetworks.bridge.models.schedules.CompoundActivity;
-import org.sagebionetworks.bridge.models.schedules.CompoundActivityDefinition;
 import org.sagebionetworks.bridge.models.schedules.Schedule;
 import org.sagebionetworks.bridge.models.schedules.ScheduleContext;
 import org.sagebionetworks.bridge.models.schedules.SchedulePlan;
@@ -50,15 +43,11 @@ import org.sagebionetworks.bridge.models.schedules.ScheduledActivity;
 import org.sagebionetworks.bridge.models.schedules.ScheduledActivityStatus;
 import org.sagebionetworks.bridge.models.schedules.SchemaReference;
 import org.sagebionetworks.bridge.models.schedules.SurveyReference;
-import org.sagebionetworks.bridge.models.schedules.TaskReference;
-import org.sagebionetworks.bridge.models.surveys.Survey;
-import org.sagebionetworks.bridge.models.upload.UploadSchema;
 import org.sagebionetworks.bridge.validators.ScheduleContextValidator;
 import org.sagebionetworks.bridge.validators.Validate;
 
 @Component
 public class ScheduledActivityService {
-    private static final Logger LOG = LoggerFactory.getLogger(ScheduledActivityService.class);
 
     static final Predicate<ScheduledActivity> V3_FILTER = activity -> {
         return ScheduledActivityStatus.VISIBLE_STATUSES.contains(activity.getStatus());
@@ -89,6 +78,8 @@ public class ScheduledActivityService {
     private UploadSchemaService schemaService;
 
     private SurveyService surveyService;
+    
+    private AppConfigService appConfigService;
 
     @Autowired
     final void setScheduledActivityDao(ScheduledActivityDao activityDao) {
@@ -123,6 +114,11 @@ public class ScheduledActivityService {
     final void setSurveyService(SurveyService surveyService) {
         this.surveyService = surveyService;
     }
+    
+    @Autowired
+    final void setAppConfigService(AppConfigService appConfigService) {
+        this.appConfigService = appConfigService;
+    }
 
     public ForwardCursorPagedResourceList<ScheduledActivity> getActivityHistory(String healthCode,
             String activityGuid, DateTime scheduledOnStart, DateTime scheduledOnEnd, String offsetKey,
@@ -130,12 +126,10 @@ public class ScheduledActivityService {
         checkArgument(isNotBlank(healthCode));
 
         // ActivityType.SURVEY is a placeholder vald to pass validation, it's not used in this version of the API
-        DateTime[] dateRange = validateHistoryParameters(ActivityType.SURVEY, pageSize, scheduledOnStart, scheduledOnEnd);
-        scheduledOnStart = dateRange[0];
-        scheduledOnEnd = dateRange[1];
+        RangeTuple<DateTime> dateRange = validateHistoryParameters(ActivityType.SURVEY, pageSize, scheduledOnStart, scheduledOnEnd);
         
-        return activityDao.getActivityHistoryV2(healthCode, activityGuid, scheduledOnStart, scheduledOnEnd, offsetKey,
-                pageSize);
+        return activityDao.getActivityHistoryV2(healthCode, activityGuid, dateRange.getStart(), dateRange.getEnd(),
+                offsetKey, pageSize);
     }
     
     public ForwardCursorPagedResourceList<ScheduledActivity> getActivityHistory(String healthCode, ActivityType activityType,
@@ -143,15 +137,13 @@ public class ScheduledActivityService {
         checkArgument(isNotBlank(healthCode));
         checkArgument(isNotBlank(referentGuid));
         
-        DateTime[] dateRange = validateHistoryParameters(activityType, pageSize, scheduledOnStart, scheduledOnEnd);
-        scheduledOnStart = dateRange[0];
-        scheduledOnEnd = dateRange[1];
+        RangeTuple<DateTime> dateRange = validateHistoryParameters(activityType, pageSize, scheduledOnStart, scheduledOnEnd);
 
-        return activityDao.getActivityHistoryV3(healthCode, activityType, referentGuid, scheduledOnStart,
-                scheduledOnEnd, offsetKey, pageSize);
+        return activityDao.getActivityHistoryV3(healthCode, activityType, referentGuid, dateRange.getStart(),
+                dateRange.getEnd(), offsetKey, pageSize);
     }
     
-    protected DateTime[] validateHistoryParameters(ActivityType activityType, int pageSize, DateTime scheduledOnStart,
+    protected RangeTuple<DateTime> validateHistoryParameters(ActivityType activityType, int pageSize, DateTime scheduledOnStart,
             DateTime scheduledOnEnd) {
 
         if (activityType == null) {
@@ -178,7 +170,7 @@ public class ScheduledActivityService {
         if (!timezone.equals(scheduledOnEnd.getZone())) {
             throw new BadRequestException(AMBIGUOUS_TIMEZONE_ERROR);
         }
-        return new DateTime[] {scheduledOnStart, scheduledOnEnd};
+        return new RangeTuple<>(scheduledOnStart, scheduledOnEnd);
     }
     
     // This needs to be exposed for tests because although we can fix a point of time for tests, we cannot
@@ -366,189 +358,32 @@ public class ScheduledActivityService {
     }
 
     protected List<ScheduledActivity> scheduleActivitiesForPlans(ScheduleContext context) {
-        // Cache compound activity defs, schemas, and surveys to reduce calls from duplicate requests.
-        Map<String, CompoundActivity> compoundActivityCache = new HashMap<>();
-        Map<String, SchemaReference> schemaCache = new HashMap<>();
-        Map<String, SurveyReference> surveyCache = new HashMap<>();
         List<ScheduledActivity> scheduledActivities = new ArrayList<>();
 
         List<SchedulePlan> plans = schedulePlanService.getSchedulePlans(context.getCriteriaContext().getClientInfo(),
                 context.getCriteriaContext().getStudyIdentifier());
+        
+        AppConfig appConfig = appConfigService.getAppConfigForUser(context.getCriteriaContext(), false);
+        Map<String, SurveyReference> surveyReferences = (appConfig == null) ? ImmutableMap.of()
+                : Maps.uniqueIndex(appConfig.getSurveyReferences(), SurveyReference::getGuid);
+        Map<String, SchemaReference> schemaReferences = (appConfig == null) ? ImmutableMap.of()
+                : Maps.uniqueIndex(appConfig.getSchemaReferences(), SchemaReference::getId);
 
+        ReferenceResolver resolver = new ReferenceResolver(compoundActivityDefinitionService, schemaService,
+                surveyService, surveyReferences, schemaReferences, context.getCriteriaContext().getClientInfo(),
+                context.getCriteriaContext().getStudyIdentifier());
+        
         for (SchedulePlan plan : plans) {
             Schedule schedule = plan.getStrategy().getScheduleForUser(plan, context);
             if (schedule != null) {
                 List<ScheduledActivity> activities = schedule.getScheduler().getScheduledActivities(plan, context);
-                List<ScheduledActivity> resolvedActivities = resolveLinks(context.getCriteriaContext(),
-                        compoundActivityCache, schemaCache, surveyCache, activities);
-                scheduledActivities.addAll(resolvedActivities);
+                for (ScheduledActivity schActivity : activities) {
+                    resolver.resolve(schActivity);
+                }
+                scheduledActivities.addAll(activities);
             }
         }
         return scheduledActivities;
     }
 
-    private List<ScheduledActivity> resolveLinks(CriteriaContext context,
-            Map<String, CompoundActivity> compoundActivityCache, Map<String, SchemaReference> schemaCache,
-            Map<String, SurveyReference> surveyCache, List<ScheduledActivity> activities) {
-
-        return activities.stream().map(schActivity -> {
-            Activity activity = schActivity.getActivity();
-            ActivityType activityType = activity.getActivityType();
-
-            // Multiplex on activity type and resolve the activity, as needed.
-            Activity resolvedActivity = null;
-            if (activityType == ActivityType.COMPOUND) {
-                // Resolve compound activity.
-                CompoundActivity compoundActivity = activity.getCompoundActivity();
-                CompoundActivity resolvedCompoundActivity = resolveCompoundActivity(context, compoundActivityCache,
-                        schemaCache, surveyCache, compoundActivity);
-
-                // If resolution changed the compound activity, generate a new activity instance that contains it.
-                if (resolvedCompoundActivity != null && !resolvedCompoundActivity.equals(compoundActivity)) {
-                    resolvedActivity = new Activity.Builder().withActivity(activity)
-                            .withCompoundActivity(resolvedCompoundActivity).build();
-                }
-            } else if (activityType == ActivityType.SURVEY) {
-                SurveyReference surveyRef = activity.getSurvey();
-                SurveyReference resolvedSurveyRef = resolveSurvey(context, surveyCache, surveyRef);
-
-                if (resolvedSurveyRef != null && !resolvedSurveyRef.equals(surveyRef)) {
-                    resolvedActivity = new Activity.Builder().withActivity(activity).withSurvey(resolvedSurveyRef)
-                            .build();
-                }
-            } else if (activityType == ActivityType.TASK) {
-                TaskReference taskRef = activity.getTask();
-                SchemaReference schemaRef = taskRef.getSchema();
-
-                if (schemaRef != null) {
-                    SchemaReference resolvedSchemaRef = resolveSchema(context, schemaCache, schemaRef);
-
-                    if (resolvedSchemaRef != null && !resolvedSchemaRef.equals(schemaRef)) {
-                        TaskReference resolvedTaskRef = new TaskReference(taskRef.getIdentifier(), resolvedSchemaRef);
-                        resolvedActivity = new Activity.Builder().withActivity(activity).withTask(resolvedTaskRef)
-                                .build();
-                    }
-                }
-            }
-
-            // Set the activity back into the ScheduledActivity, if needed.
-            if (resolvedActivity != null) {
-                schActivity.setActivity(resolvedActivity);
-            }
-            return schActivity;
-        }).collect(toList());
-    }
-
-    // Helper method to resolve a compound activity reference from its definition.
-    private CompoundActivity resolveCompoundActivity(CriteriaContext context,
-            Map<String, CompoundActivity> compoundActivityCache, Map<String, SchemaReference> schemaCache,
-            Map<String, SurveyReference> surveyCache, CompoundActivity compoundActivity) {
-        String taskId = compoundActivity.getTaskIdentifier();
-        CompoundActivity resolvedCompoundActivity = compoundActivityCache.get(taskId);
-        if (resolvedCompoundActivity == null) {
-            if (compoundActivity.isReference()) {
-                // Compound activity has no schemas or surveys defined. Resolve it with its definition.
-                CompoundActivityDefinition compoundActivityDef;
-                try {
-                    compoundActivityDef = compoundActivityDefinitionService.getCompoundActivityDefinition(
-                            context.getStudyIdentifier(), taskId);
-                } catch (EntityNotFoundException ex) {
-                    LOG.error("Schedule references non-existent compound activity " + taskId);
-                    return null;
-                }
-                resolvedCompoundActivity = compoundActivityDef.getCompoundActivity();
-            } else {
-                // Compound activity has schemas and surveys defined. Use the schemas and surveys from the lists, but
-                // we may need to resolve individual schema and survey refs at a later step.
-                resolvedCompoundActivity = compoundActivity;
-            }
-
-            // Before we cache it, resolve the surveys and schemas in the list.
-            resolvedCompoundActivity = resolveListsInCompoundActivity(context, schemaCache, surveyCache,
-                    resolvedCompoundActivity);
-
-            compoundActivityCache.put(taskId, resolvedCompoundActivity);
-        }
-        return resolvedCompoundActivity;
-    }
-
-    // Helper method to resolve schema refs and survey refs inside of a compound activity.
-    private CompoundActivity resolveListsInCompoundActivity(CriteriaContext context,
-            Map<String, SchemaReference> schemaCache, Map<String, SurveyReference> surveyCache,
-            CompoundActivity compoundActivity) {
-        // Resolve schemas.
-        // Lists in CompoundActivity are always non-null, so we don't need to null-check.
-        List<SchemaReference> schemaList = new ArrayList<>();
-        for (SchemaReference oneSchemaRef : compoundActivity.getSchemaList()) {
-            SchemaReference resolvedSchemaRef = resolveSchema(context, schemaCache, oneSchemaRef);
-
-            if (resolvedSchemaRef != null) {
-                schemaList.add(resolvedSchemaRef);
-            }
-        }
-
-        // Similarly, resolve surveys.
-        List<SurveyReference> surveyList = new ArrayList<>();
-        for (SurveyReference oneSurveyRef : compoundActivity.getSurveyList()) {
-            SurveyReference resolvedSurveyRef = resolveSurvey(context, surveyCache, oneSurveyRef);
-
-            if (resolvedSurveyRef != null) {
-                surveyList.add(resolvedSurveyRef);
-            }
-        }
-
-        // Make a new compound activity with the resolved schemas and surveys. This is cached in
-        // resolveCompoundActivities(), so this is okay.
-        return new CompoundActivity.Builder().copyOf(compoundActivity).withSchemaList(schemaList)
-                .withSurveyList(surveyList).build();
-    }
-
-    // Helper method to resolve a schema ref to the latest revision for the client.
-    private SchemaReference resolveSchema(CriteriaContext context, Map<String, SchemaReference> schemaCache,
-            SchemaReference schemaRef) {
-        if (schemaRef.getRevision() != null) {
-            // Already has a revision. No need to resolve. Return as is.
-            return schemaRef;
-        }
-
-        String schemaId = schemaRef.getId();
-        SchemaReference resolvedSchemaRef = schemaCache.get(schemaId);
-        if (resolvedSchemaRef == null) {
-            UploadSchema schema;
-            try {
-                schema = schemaService.getLatestUploadSchemaRevisionForAppVersion(context.getStudyIdentifier(),
-                        schemaId, context.getClientInfo());
-            } catch (EntityNotFoundException ex) {
-                LOG.error("Schedule references non-existent schema " + schemaId);
-                return null;
-            }
-            resolvedSchemaRef = new SchemaReference(schemaId, schema.getRevision());
-            schemaCache.put(schemaId, resolvedSchemaRef);
-        }
-        return resolvedSchemaRef;
-    }
-
-    // Helper method to resolve a published survey to a specific survey version.
-    private SurveyReference resolveSurvey(CriteriaContext context, Map<String, SurveyReference> surveyCache,
-            SurveyReference surveyRef) {
-        if (surveyRef.getCreatedOn() != null) {
-            return surveyRef;
-        }
-
-        String surveyGuid = surveyRef.getGuid();
-        SurveyReference resolvedSurveyRef = surveyCache.get(surveyGuid);
-        if (resolvedSurveyRef == null) {
-            Survey survey;
-            try {
-                survey = surveyService.getSurveyMostRecentlyPublishedVersion(context.getStudyIdentifier(), surveyGuid);
-            } catch (EntityNotFoundException ex) {
-                LOG.error("Schedule references non-existent survey " + surveyGuid);
-                return null;
-            }
-            resolvedSurveyRef = new SurveyReference(survey.getIdentifier(), surveyGuid,
-                    new DateTime(survey.getCreatedOn()));
-            surveyCache.put(surveyGuid, resolvedSurveyRef);
-        }
-        return resolvedSurveyRef;
-    }
 }

--- a/test/org/sagebionetworks/bridge/play/controllers/AppConfigControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/AppConfigControllerTest.java
@@ -76,7 +76,7 @@ public class AppConfigControllerTest {
     @Test
     public void getSelfAppConfig() throws Exception {
         mockPlayContext();
-        when(mockService.getAppConfigForUser(any())).thenReturn(appConfig);
+        when(mockService.getAppConfigForUser(any(), eq(true))).thenReturn(appConfig);
         
         Result result = controller.getSelfAppConfig();
         
@@ -84,7 +84,7 @@ public class AppConfigControllerTest {
         AppConfig found = getResponsePayload(result, AppConfig.class);
         assertEquals(appConfig.getGuid(), found.getGuid());
         
-        verify(mockService).getAppConfigForUser(contextCaptor.capture());
+        verify(mockService).getAppConfigForUser(contextCaptor.capture(), eq(true));
         
         CriteriaContext context = contextCaptor.getValue();
         assertEquals(TEST_STUDY, context.getStudyIdentifier());

--- a/test/org/sagebionetworks/bridge/services/AppConfigServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AppConfigServiceTest.java
@@ -140,7 +140,7 @@ public class AppConfigServiceTest {
         
         AppConfig appConfig2 = setupConfigsForUser();
         
-        AppConfig match = service.getAppConfigForUser(context);
+        AppConfig match = service.getAppConfigForUser(context, true);
         assertEquals(appConfig2, match);
     }
 
@@ -151,7 +151,7 @@ public class AppConfigServiceTest {
                 .withStudyIdentifier(TEST_STUDY).build();
         
         setupConfigsForUser();
-        service.getAppConfigForUser(context);
+        service.getAppConfigForUser(context, true);
     }
 
     @Test
@@ -161,7 +161,7 @@ public class AppConfigServiceTest {
                 .withStudyIdentifier(TEST_STUDY).build();
         
         setupConfigsForUser();
-        AppConfig appConfig = service.getAppConfigForUser(context);
+        AppConfig appConfig = service.getAppConfigForUser(context, true);
         assertEquals(EARLIER_TIMESTAMP, appConfig.getCreatedOn());
     }
     

--- a/test/org/sagebionetworks/bridge/services/AppConfigServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AppConfigServiceTest.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge.services;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.verify;
@@ -152,6 +153,17 @@ public class AppConfigServiceTest {
         
         setupConfigsForUser();
         service.getAppConfigForUser(context, true);
+    }
+    
+    @Test
+    public void getAppCOnfigForUserReturnsNull() {
+        CriteriaContext context = new CriteriaContext.Builder()
+                .withClientInfo(ClientInfo.fromUserAgentCache("app/21 (Motorola Flip-Phone; Android/14) BridgeJavaSDK/10"))
+                .withStudyIdentifier(TEST_STUDY).build();
+        
+        setupConfigsForUser();
+        AppConfig result = service.getAppConfigForUser(context, false);
+        assertNull(result);
     }
 
     @Test

--- a/test/org/sagebionetworks/bridge/services/ReferenceResolverTest.java
+++ b/test/org/sagebionetworks/bridge/services/ReferenceResolverTest.java
@@ -1,0 +1,329 @@
+package org.sagebionetworks.bridge.services;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
+import org.sagebionetworks.bridge.models.ClientInfo;
+import org.sagebionetworks.bridge.models.schedules.Activity;
+import org.sagebionetworks.bridge.models.schedules.CompoundActivity;
+import org.sagebionetworks.bridge.models.schedules.CompoundActivityDefinition;
+import org.sagebionetworks.bridge.models.schedules.ScheduledActivity;
+import org.sagebionetworks.bridge.models.schedules.SchemaReference;
+import org.sagebionetworks.bridge.models.schedules.SurveyReference;
+import org.sagebionetworks.bridge.models.schedules.TaskReference;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
+import org.sagebionetworks.bridge.models.surveys.Survey;
+import org.sagebionetworks.bridge.models.upload.UploadSchema;
+
+import com.google.common.collect.Lists;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ReferenceResolverTest {
+    
+    private static final ClientInfo CLIENT_INFO = ClientInfo.UNKNOWN_CLIENT;
+    private static final StudyIdentifier STUDY_ID = TestConstants.TEST_STUDY;
+    private static final String SURVEY_ID = "surveyId";
+    private static final String SURVEY_GUID = "guid";
+    private static final DateTime SURVEY_CREATED_ON = DateTime.now();
+    private static final String SCHEMA_ID = "schemaId";
+    private static final int SCHEMA_REVISION = 3;
+    private static final String TASK_ID = "taskId";
+    private static final SurveyReference RESOLVED_SURVEY_REF = new SurveyReference(SURVEY_ID, SURVEY_GUID, SURVEY_CREATED_ON);
+    private static final SchemaReference RESOLVED_SCHEMA_REF = new SchemaReference(SCHEMA_ID, SCHEMA_REVISION);
+    private static final TaskReference RESOLVED_TASK_REF = new TaskReference(TASK_ID, RESOLVED_SCHEMA_REF);
+    private static final SurveyReference UNRESOLVED_SURVEY_REF = new SurveyReference(SURVEY_ID, SURVEY_GUID, null);
+    private static final SchemaReference UNRESOLVED_SCHEMA_REF = new SchemaReference(SCHEMA_ID, null);
+    private static final TaskReference UNRESOLVED_TASK_REF = new TaskReference(TASK_ID, UNRESOLVED_SCHEMA_REF);
+    private static final CompoundActivity COMPOUND_ACTIVITY_SKINNY_REF = new CompoundActivity.Builder()
+            .withTaskIdentifier(TASK_ID).build();
+    private static final CompoundActivity RESOLVED_COMPOUND_ACTIVITY = new CompoundActivity.Builder()
+        .withSurveyList(Lists.newArrayList(RESOLVED_SURVEY_REF))
+        .withSchemaList(Lists.newArrayList(RESOLVED_SCHEMA_REF)).build();
+    private static final CompoundActivity UNRESOLVED_COMPOUND_ACTIVITY = new CompoundActivity.Builder()
+            .withSurveyList(Lists.newArrayList(UNRESOLVED_SURVEY_REF))
+            .withSchemaList(Lists.newArrayList(UNRESOLVED_SCHEMA_REF)).build();
+    private static final Survey SURVEY = Survey.create();
+    static {
+        SURVEY.setGuid(SURVEY_GUID);
+        SURVEY.setCreatedOn(SURVEY_CREATED_ON.getMillis());
+        SURVEY.setIdentifier(SURVEY_ID);
+    }
+    private static final UploadSchema SCHEMA = UploadSchema.create();
+    static {
+        SCHEMA.setSchemaId(SCHEMA_ID);
+        SCHEMA.setRevision(SCHEMA_REVISION);
+    }
+    private static final CompoundActivityDefinition RESOLVED_COMPOUND_ACTIVITY_DEF = CompoundActivityDefinition.create();
+    static {
+        RESOLVED_COMPOUND_ACTIVITY_DEF.setSurveyList(Lists.newArrayList(RESOLVED_SURVEY_REF));
+        RESOLVED_COMPOUND_ACTIVITY_DEF.setSchemaList(Lists.newArrayList(RESOLVED_SCHEMA_REF));
+    }
+
+    @Mock
+    CompoundActivityDefinitionService compoundActivityDefinitionService;
+    
+    @Mock
+    UploadSchemaService schemaService;
+    
+    @Mock
+    SurveyService surveyService;
+    
+    @Spy
+    private HashMap<String,SurveyReference> surveyReferences;
+    
+    @Spy
+    private HashMap<String,SchemaReference> schemaReferences;
+    
+    private ReferenceResolver resolver;
+    
+    private ScheduledActivity scheduledActivity;
+    
+    private Activity.Builder activityBuilder;
+    
+    @Before
+    public void before() {
+        // All the dependencies are mocks or mutable maps, and can be adjusted per test
+        resolver = new ReferenceResolver(compoundActivityDefinitionService, schemaService, surveyService,
+                surveyReferences, schemaReferences, CLIENT_INFO, STUDY_ID);
+        
+        scheduledActivity = ScheduledActivity.create();
+        
+        activityBuilder = new Activity.Builder();
+    }
+    
+    @Test
+    public void surveyAlreadyResolvedWithoutCalls() {
+        scheduledActivity.setActivity(activityBuilder.withSurvey(RESOLVED_SURVEY_REF).build());
+        
+        resolver.resolve(scheduledActivity);
+        
+        verifyNoMoreInteractions(surveyService);
+        verifyNoMoreInteractions(schemaService);
+        verifyNoMoreInteractions(surveyReferences);
+        verifyNoMoreInteractions(schemaReferences);
+    }
+    
+    @Test
+    public void schemaAlreadyResolvedWithoutCalls() {
+        scheduledActivity.setActivity(activityBuilder.withTask(RESOLVED_TASK_REF).build());
+        
+        resolver.resolve(scheduledActivity);
+        
+        verifyNoMoreInteractions(surveyService);
+        verifyNoMoreInteractions(schemaService);
+        verifyNoMoreInteractions(surveyReferences);
+        verifyNoMoreInteractions(schemaReferences);
+    }
+
+    @Test
+    public void compoundActivityAlreadyResolvedWithoutCalls() {
+        scheduledActivity.setActivity(activityBuilder.withCompoundActivity(RESOLVED_COMPOUND_ACTIVITY).build());
+        
+        resolver.resolve(scheduledActivity);
+        
+        verifyNoMoreInteractions(surveyService);
+        verifyNoMoreInteractions(schemaService);
+        verifyNoMoreInteractions(surveyReferences);
+        verifyNoMoreInteractions(schemaReferences);
+    }
+
+    @Test
+    public void surveyResolvedFromAppConfig() {
+        surveyReferences.put(SURVEY_GUID, RESOLVED_SURVEY_REF);
+        scheduledActivity.setActivity(activityBuilder.withSurvey(UNRESOLVED_SURVEY_REF).build());
+        
+        resolver.resolve(scheduledActivity);
+        
+        assertEquals(RESOLVED_SURVEY_REF, scheduledActivity.getActivity().getSurvey());
+        
+        verifyNoMoreInteractions(surveyService);
+        verifyNoMoreInteractions(schemaService);
+        verify(surveyReferences).get(SURVEY_GUID);
+        verifyNoMoreInteractions(schemaReferences);
+    }
+    
+    @Test
+    public void surveyResolvedFromServiceAndCached() {
+        scheduledActivity.setActivity(activityBuilder.withSurvey(UNRESOLVED_SURVEY_REF).build());
+        when(surveyService.getSurveyMostRecentlyPublishedVersion(STUDY_ID, SURVEY_GUID)).thenReturn(SURVEY);
+        
+        resolver.resolve(scheduledActivity);
+        
+        assertEquals(RESOLVED_SURVEY_REF, scheduledActivity.getActivity().getSurvey());
+        
+        resolver.resolve(scheduledActivity);
+        
+        verify(surveyService, times(1)).getSurveyMostRecentlyPublishedVersion(STUDY_ID, SURVEY_GUID);
+    }
+    
+    @Test
+    public void schemaResolvedFromAppConfig() {
+        schemaReferences.put(SCHEMA_ID, RESOLVED_SCHEMA_REF);
+        scheduledActivity.setActivity(activityBuilder.withTask(UNRESOLVED_TASK_REF).build());
+        
+        resolver.resolve(scheduledActivity);
+        
+        assertEquals(RESOLVED_SCHEMA_REF, scheduledActivity.getActivity().getTask().getSchema());
+        
+        verifyNoMoreInteractions(surveyService);
+        verifyNoMoreInteractions(schemaService);
+        verifyNoMoreInteractions(surveyReferences);
+        verify(schemaReferences).get(SCHEMA_ID);
+    }
+    
+    @Test
+    public void schemaResolvedFromServiceAndCached() {
+        scheduledActivity.setActivity(activityBuilder.withTask(UNRESOLVED_TASK_REF).build());
+        when(schemaService.getLatestUploadSchemaRevisionForAppVersion(STUDY_ID, SCHEMA_ID, CLIENT_INFO)).thenReturn(SCHEMA);
+        
+        resolver.resolve(scheduledActivity);
+        
+        assertEquals(RESOLVED_SCHEMA_REF, scheduledActivity.getActivity().getTask().getSchema());
+        
+        resolver.resolve(scheduledActivity);
+        
+        verify(schemaService, times(1)).getLatestUploadSchemaRevisionForAppVersion(STUDY_ID, SCHEMA_ID, CLIENT_INFO);
+    }
+    
+    @Test
+    public void compoundActivityReferenceFullyResolvedAndCached() {
+        scheduledActivity.setActivity(activityBuilder.withCompoundActivity(COMPOUND_ACTIVITY_SKINNY_REF).build());
+        when(compoundActivityDefinitionService.getCompoundActivityDefinition(STUDY_ID, TASK_ID))
+                .thenReturn(RESOLVED_COMPOUND_ACTIVITY_DEF);
+
+        resolver.resolve(scheduledActivity);
+        
+        CompoundActivity compoundActivity = scheduledActivity.getActivity().getCompoundActivity();
+        assertEquals(RESOLVED_SCHEMA_REF, compoundActivity.getSchemaList().get(0));
+        assertEquals(RESOLVED_SURVEY_REF, compoundActivity.getSurveyList().get(0));
+        
+        resolver.resolve(scheduledActivity);
+        
+        verify(compoundActivityDefinitionService, times(1)).getCompoundActivityDefinition(STUDY_ID, TASK_ID);
+    }
+    
+    @Test
+    public void compoundActivityFullyResolvedFromAppConfig() {
+        schemaReferences.put(SCHEMA_ID, RESOLVED_SCHEMA_REF);
+        surveyReferences.put(SURVEY_GUID, RESOLVED_SURVEY_REF);
+        scheduledActivity.setActivity(activityBuilder.withCompoundActivity(UNRESOLVED_COMPOUND_ACTIVITY).build());
+        
+        resolver.resolve(scheduledActivity);
+        
+        CompoundActivity compoundActivity = scheduledActivity.getActivity().getCompoundActivity();
+        assertEquals(RESOLVED_SCHEMA_REF, compoundActivity.getSchemaList().get(0));
+        assertEquals(RESOLVED_SURVEY_REF, compoundActivity.getSurveyList().get(0));
+        
+        verifyNoMoreInteractions(surveyService);
+        verifyNoMoreInteractions(schemaService);
+        verify(surveyReferences).get(SURVEY_GUID);
+        verify(schemaReferences).get(SCHEMA_ID);
+    }
+    
+    @Test
+    public void compoundActivityOnlySchemaResolvedFromAppConfig() {
+        // In this test, there is no resolved survey reference in the app config. The service will be called
+        // to fully resolve. 
+        schemaReferences.put(SCHEMA_ID, RESOLVED_SCHEMA_REF);
+        scheduledActivity.setActivity(activityBuilder.withCompoundActivity(UNRESOLVED_COMPOUND_ACTIVITY).build());
+        when(surveyService.getSurveyMostRecentlyPublishedVersion(STUDY_ID, SURVEY_GUID)).thenReturn(SURVEY);
+        
+        resolver.resolve(scheduledActivity);
+        
+        CompoundActivity compoundActivity = scheduledActivity.getActivity().getCompoundActivity();
+        assertEquals(RESOLVED_SCHEMA_REF, compoundActivity.getSchemaList().get(0));
+        assertEquals(RESOLVED_SURVEY_REF, compoundActivity.getSurveyList().get(0));
+        
+        verify(surveyService).getSurveyMostRecentlyPublishedVersion(STUDY_ID, SURVEY_GUID);
+        verifyNoMoreInteractions(schemaService);
+        verify(surveyReferences).get(SURVEY_GUID);
+        verify(schemaReferences).get(SCHEMA_ID);
+    }
+    
+    @Test
+    public void compoundActivityOnlySurveyResolvedFromAppConfig() {
+        // In this test, there is no resolved schema reference in the app config. The service will be called
+        // to fully resolve. 
+        surveyReferences.put(SURVEY_GUID, RESOLVED_SURVEY_REF);
+        scheduledActivity.setActivity(activityBuilder.withCompoundActivity(UNRESOLVED_COMPOUND_ACTIVITY).build());
+        when(schemaService.getLatestUploadSchemaRevisionForAppVersion(STUDY_ID, SCHEMA_ID, CLIENT_INFO)).thenReturn(SCHEMA);
+        
+        resolver.resolve(scheduledActivity);
+        
+        CompoundActivity compoundActivity = scheduledActivity.getActivity().getCompoundActivity();
+        assertEquals(RESOLVED_SCHEMA_REF, compoundActivity.getSchemaList().get(0));
+        assertEquals(RESOLVED_SURVEY_REF, compoundActivity.getSurveyList().get(0));
+        
+        verifyNoMoreInteractions(surveyService);
+        verify(schemaService).getLatestUploadSchemaRevisionForAppVersion(STUDY_ID, SCHEMA_ID, CLIENT_INFO);
+        verify(surveyReferences).get(SURVEY_GUID);
+        verify(schemaReferences).get(SCHEMA_ID);
+    }
+    
+    @Test
+    public void compoundActivityResolvedFromServiceAndCached() {
+        scheduledActivity.setActivity(activityBuilder.withCompoundActivity(UNRESOLVED_COMPOUND_ACTIVITY).build());
+        when(surveyService.getSurveyMostRecentlyPublishedVersion(STUDY_ID, SURVEY_GUID)).thenReturn(SURVEY);
+        when(schemaService.getLatestUploadSchemaRevisionForAppVersion(STUDY_ID, SCHEMA_ID, CLIENT_INFO)).thenReturn(SCHEMA);
+        
+        resolver.resolve(scheduledActivity);
+        
+        CompoundActivity compoundActivity = scheduledActivity.getActivity().getCompoundActivity();
+        assertEquals(RESOLVED_SCHEMA_REF, compoundActivity.getSchemaList().get(0));
+        assertEquals(RESOLVED_SURVEY_REF, compoundActivity.getSurveyList().get(0));
+        
+        resolver.resolve(scheduledActivity);
+        
+        verify(compoundActivityDefinitionService, never()).getCompoundActivityDefinition(STUDY_ID, TASK_ID);
+        verify(surveyService, times(1)).getSurveyMostRecentlyPublishedVersion(STUDY_ID, SURVEY_GUID);
+        verify(schemaService, times(1)).getLatestUploadSchemaRevisionForAppVersion(STUDY_ID, SCHEMA_ID, CLIENT_INFO);
+    }
+    
+    @Test
+    public void unresolvableSurveyReturnedAsIs() {
+        scheduledActivity.setActivity(activityBuilder.withSurvey(UNRESOLVED_SURVEY_REF).build());
+        when(surveyService.getSurveyMostRecentlyPublishedVersion(STUDY_ID, SURVEY_GUID)).thenThrow(new EntityNotFoundException(Survey.class));
+        
+        resolver.resolve(scheduledActivity);
+        
+        assertNull(scheduledActivity.getActivity().getSurvey().getCreatedOn());
+    }
+    
+    @Test
+    public void unresolvableSchemaReturnedAsIs() {
+        scheduledActivity.setActivity(activityBuilder.withTask(UNRESOLVED_TASK_REF).build());
+        when(schemaService.getLatestUploadSchemaRevisionForAppVersion(STUDY_ID, SCHEMA_ID, CLIENT_INFO)).thenThrow(new EntityNotFoundException(UploadSchema.class));
+        
+        resolver.resolve(scheduledActivity);
+        
+        assertNull(scheduledActivity.getActivity().getTask().getSchema().getRevision());
+    }
+    
+    @Test
+    public void unresolvableCompoundActivityReturnedAsIs() {
+        scheduledActivity.setActivity(activityBuilder.withCompoundActivity(COMPOUND_ACTIVITY_SKINNY_REF).build());
+        when(compoundActivityDefinitionService.getCompoundActivityDefinition(STUDY_ID, TASK_ID)).thenThrow(new EntityNotFoundException(CompoundActivityDefinition.class));
+        
+        resolver.resolve(scheduledActivity);
+        
+        assertTrue(scheduledActivity.getActivity().getCompoundActivity().getSchemaList().isEmpty());
+        assertTrue(scheduledActivity.getActivity().getCompoundActivity().getSurveyList().isEmpty());
+    }
+}

--- a/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceDuplicateTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceDuplicateTest.java
@@ -148,6 +148,9 @@ public class ScheduledActivityServiceDuplicateTest {
     @Mock
     SchedulePlanService schedulePlanService;
     
+    @Mock
+    AppConfigService appConfigService;
+    
     ScheduledActivityService service;
     
     ScheduleContext.Builder contextBuilder;
@@ -161,6 +164,7 @@ public class ScheduledActivityServiceDuplicateTest {
         service.setScheduledActivityDao(activityDao);
         service.setActivityEventService(activityEventService);
         service.setSchedulePlanService(schedulePlanService);
+        service.setAppConfigService(appConfigService);
         
         contextBuilder = new ScheduleContext.Builder()
                 .withClientInfo(ClientInfo.fromUserAgentCache("Lilly/25 (iPhone Simulator; iPhone OS/9.3) BridgeSDK/12"))

--- a/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceMockTest.java
@@ -113,6 +113,9 @@ public class ScheduledActivityServiceMockTest {
     private SurveyService surveyService;
     
     @Mock
+    private AppConfigService appConfigService;
+    
+    @Mock
     private Survey survey;
     
     @Captor
@@ -153,6 +156,7 @@ public class ScheduledActivityServiceMockTest {
         service.setScheduledActivityDao(activityDao);
         service.setActivityEventService(activityEventService);
         service.setSurveyService(surveyService);
+        service.setAppConfigService(appConfigService);
     }
     
     @After
@@ -864,7 +868,7 @@ public class ScheduledActivityServiceMockTest {
         DynamoSchedulePlan plan2 = new DynamoSchedulePlan();
         plan2.setStrategy(strategy);
         
-        doReturn(Lists.newArrayList(plan1,plan2)).when(schedulePlanService).getSchedulePlans(any(), any());
+        doReturn(Lists.newArrayList(plan1, plan2)).when(schedulePlanService).getSchedulePlans(any(), any());
         
         List<ScheduledActivity> schActivities = service.getScheduledActivities(context);
         

--- a/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceResolveLinksTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceResolveLinksTest.java
@@ -58,6 +58,7 @@ public class ScheduledActivityServiceResolveLinksTest {
     private UploadSchemaService mockSchemaService;
     private SurveyService mockSurveyService;
     private ScheduledActivityService scheduledActivityService;
+    private AppConfigService appConfigService;
 
     @Before
     public void setup() {
@@ -96,6 +97,8 @@ public class ScheduledActivityServiceResolveLinksTest {
         mockSurveyService = mock(SurveyService.class);
         when(mockSurveyService.getSurveyMostRecentlyPublishedVersion(TestConstants.TEST_STUDY, SURVEY_GUID))
                 .thenReturn(survey);
+        
+        appConfigService = mock(AppConfigService.class);
 
         // Set up scheduled activity service with the mocks.
         scheduledActivityService = new ScheduledActivityService();
@@ -103,6 +106,7 @@ public class ScheduledActivityServiceResolveLinksTest {
         scheduledActivityService.setSchedulePlanService(mockSchedulePlanService);
         scheduledActivityService.setSchemaService(mockSchemaService);
         scheduledActivityService.setSurveyService(mockSurveyService);
+        scheduledActivityService.setAppConfigService(appConfigService);
     }
 
     private void setupSchedulePlanServiceWithActivity(Activity activity) {


### PR DESCRIPTION
This finishes app configs by getting the app config for the request access scheduled activities, and referring to it before looking up the most recent schema/survey. Logic to resolve schedules was moved into separate class to make it easier to test (ReferenceResolver). I did not remove tests of reference resolution in the other tests, let me know if we should do this.