### PR TITLE
Remove new relic server

### DIFF
--- a/dist/.ebextensions/newrelic-server.config
+++ b/dist/.ebextensions/newrelic-server.config
@@ -1,19 +1,9 @@
-packages:
-  yum:
-    newrelic-sysmond: []
-  rpm:
-    newrelic: http://yum.newrelic.com/pub/newrelic/el5/x86_64/newrelic-repo-5-3.noarch.rpm
 container_commands:
-  "01SetLicenseKey":
-    command: "nrsysmond-config --set license_key=$NEW_RELIC_LICENSE_KEY"
-  "02SetNRServerInstanceId":
-    command: "export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo hostname=$INSTANCE_ID && echo hostname=$INSTANCE_ID >> /etc/newrelic/nrsysmond.cfg"
+# Setup NR APM config
   "03CopyNRApmAgent":
     command: "/bin/mkdir -p /usr/local/lib/newrelic && cp -rf /var/app/staging/lib/com.newrelic.agent.java.newrelic-agent-3.42.0.jar /usr/local/lib/newrelic/com.newrelic.agent.java.newrelic-agent.jar"
   "04SetNRJVMInstanceId":
     command: 'export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo -e "\n  process_host:\n    display_name: $INSTANCE_ID" >> /var/app/staging/newrelic/newrelic.yml'
-  "09StartMonitor":
-    command: "/etc/init.d/newrelic-sysmond start"
 # Setup NR infrastructure agent config
   "10CopyNRInfraConfig":
     command: "cp -rf /var/app/staging/newrelic/newrelic-infra.yml /etc/newrelic-infra.yml"


### PR DESCRIPTION
New relic server agent (newrelic-sysmond) is being replaced by
the new relic infrastructure[1] agent.  We already have infrastructure
agent setup and running so we no longer need the server agent.
The infrastructure agent reports both apm and infrastructure
metrics.

[1] https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/installation/transition-servers-new-relic-infrastructure