### PR TITLE
Setup new relic logs to file

### DIFF
--- a/dist/newrelic/newrelic-infra.yml
+++ b/dist/newrelic/newrelic-infra.yml
@@ -42,7 +42,7 @@
 #          different than the default (for example, with troubleshooting).
 # Default: Typical default location for standard log files
 #
-log_file: /var/log/newrelic/newrelic-infra.log
+log_file: /var/log/newrelic-infra.log
 
 # Option : log_to_stdout
 # Value  : If you have a log file set through the log_file option, the

--- a/dist/newrelic/newrelic.yml
+++ b/dist/newrelic/newrelic.yml
@@ -16,7 +16,7 @@ common: &default_settings
   # Set the name of your application as you'd like it show up in New Relic.
   # If enable_auto_app_naming is false, the agent reports all data to this application.
   # Otherwise, the agent reports only background tasks (transactions for non-web applications)
-  # to this application. To report data to more than one application 
+  # to this application. To report data to more than one application
   # (useful for rollup reporting), separate the application names with ";".
   # For example, to report data to "My Application" and "My Application 2" use this:
   # app_name: My Application;My Application 2
@@ -45,10 +45,18 @@ common: &default_settings
   # Default is info.
   log_level: info
 
+  # The name of the log file.
+  # Default is newrelic_agent.log.
+  log_file_name: newrelic-apm.log
+
+  # The log file path.
+  # Default same directory as newrelic.jar
+  log_file_path: /var/log
+
   # New Relic Real User Monitoring gives you insight into the performance real users are
   # experiencing with your website. This is accomplished by measuring the time it takes for
   # your users' browsers to download and render your web pages by injecting a small amount
-  # of JavaScript code into the header and footer of each page. 
+  # of JavaScript code into the header and footer of each page.
   browser_monitoring:
 
     # By default the agent automatically inserts API calls in compiled JSPs to


### PR DESCRIPTION
Older NR agents only supported loging to std out.  NR agent 3.42.0
supports logging to file.  With the recent upgrade[1] we can now
send NR logs to file.

This will also require removing the NewRelicLog[2] parameter from
BridgePF-infra.

[1] https://github.com/Sage-Bionetworks/BridgePF/pull/1563
[2] https://github.com/Sage-Bionetworks/BridgePF-infra/blob/develop/update_cf_stack.sh#L71