### PR TITLE
Upload API Synchronous Mode

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -170,7 +170,7 @@ POST   /v4/activities                              @org.sagebionetworks.bridge.p
 
 # Uploads
 POST   /v3/uploads                     @org.sagebionetworks.bridge.play.controllers.UploadController.upload
-POST   /v3/uploads/:uploadId/complete  @org.sagebionetworks.bridge.play.controllers.UploadController.uploadComplete(uploadId: String)
+POST   /v3/uploads/:uploadId/complete  @org.sagebionetworks.bridge.play.controllers.UploadController.uploadComplete(uploadId: String, synchronous: String ?= "false")
 GET    /v3/uploadstatuses/:uploadId    @org.sagebionetworks.bridge.play.controllers.UploadController.getValidationStatus(uploadId: String)
 
 # Upload Schemas
@@ -307,7 +307,7 @@ POST   /api/v2/consent/dataSharing           @org.sagebionetworks.bridge.play.co
 
 # API - Upload
 POST   /api/v1/upload                  @org.sagebionetworks.bridge.play.controllers.UploadController.upload
-POST   /api/v1/upload/:id/complete     @org.sagebionetworks.bridge.play.controllers.UploadController.uploadComplete(id: String)
+POST   /api/v1/upload/:id/complete     @org.sagebionetworks.bridge.play.controllers.UploadController.uploadComplete(id: String, synchronous: String ?= "false")
 GET    /api/v1/upload/:id/status       @org.sagebionetworks.bridge.play.controllers.UploadController.getValidationStatus(id: String)
 
 # Assets, there are only two, a robots file and a favicon.ico

--- a/test/org/sagebionetworks/bridge/services/UploadServicePollStatusTest.java
+++ b/test/org/sagebionetworks/bridge/services/UploadServicePollStatusTest.java
@@ -1,0 +1,70 @@
+package org.sagebionetworks.bridge.services;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
+import org.sagebionetworks.bridge.models.upload.UploadStatus;
+import org.sagebionetworks.bridge.models.upload.UploadValidationStatus;
+
+public class UploadServicePollStatusTest {
+    private static final String UPLOAD_ID = "test-upload";
+
+    private UploadService svc;
+
+    @Before
+    public void setup() {
+        // Spy service, so we can mock a call to getValidationStatus() instead of tightly coupling to that logic.
+        svc = spy(new UploadService());
+
+        // Set sleep time to 10ms and max iterations to 2, so we don't have to wait that long.
+        svc.setPollValidationStatusMaxIterations(2);
+        svc.setPollValidationStatusSleepMillis(10);
+    }
+
+    @Test
+    public void firstTry() {
+        doReturn(makeValidationStatus(UploadStatus.SUCCEEDED)).when(svc).getUploadValidationStatus(UPLOAD_ID);
+        UploadValidationStatus validationStatus = svc.pollUploadValidationStatusUntilComplete(UPLOAD_ID);
+        assertEquals(UploadStatus.SUCCEEDED, validationStatus.getStatus());
+        verify(svc, times(1)).getUploadValidationStatus(UPLOAD_ID);
+    }
+
+    @Test
+    public void secondTry() {
+        UploadValidationStatus inProgressStatus = makeValidationStatus(UploadStatus.VALIDATION_IN_PROGRESS);
+        UploadValidationStatus succeededStatus = makeValidationStatus(UploadStatus.SUCCEEDED);
+
+        doReturn(inProgressStatus).doReturn(succeededStatus).when(svc).getUploadValidationStatus(UPLOAD_ID);
+        UploadValidationStatus validationStatus = svc.pollUploadValidationStatusUntilComplete(UPLOAD_ID);
+        assertEquals(UploadStatus.SUCCEEDED, validationStatus.getStatus());
+        verify(svc, times(2)).getUploadValidationStatus(UPLOAD_ID);
+    }
+
+    @Test
+    public void timeout() {
+        doReturn(makeValidationStatus(UploadStatus.VALIDATION_IN_PROGRESS)).when(svc).getUploadValidationStatus(
+                UPLOAD_ID);
+
+        try {
+            svc.pollUploadValidationStatusUntilComplete(UPLOAD_ID);
+            fail("expected exception");
+        } catch (BridgeServiceException ex) {
+            assertEquals("Timeout polling validation status for upload " + UPLOAD_ID, ex.getMessage());
+        }
+        verify(svc, times(2)).getUploadValidationStatus(UPLOAD_ID);
+    }
+
+    private UploadValidationStatus makeValidationStatus(UploadStatus uploadStatus) {
+        return new UploadValidationStatus.Builder().withId(UPLOAD_ID).withMessageList(ImmutableList.of())
+                .withStatus(uploadStatus).build();
+    }
+}


### PR DESCRIPTION
Added a synchronous mode to the Upload Complete API, intended for use in app development. This allows app developers to call the upload complete API and synchronously validate their uploads in a single call, as opposed to the asynchronous call and polling until the upload is complete. (While this *can* be used for released apps, it's not recommended as the Synchronous Upload Complete call can take up to 10 seconds, even longer for large uploads.)

This also changes the async API to return a Validation Status (that probably just says "validation_in_pgoress") instead of a plain text message saying "Upload complete!"

Updated unit tests and integ tests.

Manual test cases:
* Asynchronous API
* Synchronous API
* Calling Synchronous Upload Complete for an already completed upload.
* Calling Synchronous Upload Complete for a concurrent modification. (Injected a 5-second sleep into the DAO to enable testing. This sleep was removed before checkin.)