### PR TITLE
Making pool much more aggressive in testing connections to make sure they still work.

### DIFF
--- a/app/org/sagebionetworks/bridge/config/BridgeProductionSpringConfig.java
+++ b/app/org/sagebionetworks/bridge/config/BridgeProductionSpringConfig.java
@@ -42,10 +42,10 @@ public class BridgeProductionSpringConfig {
         poolConfig.setMaxTotal(bridgeConfig.getPropertyAsInt("redis.max.total"));
         poolConfig.setMinIdle(bridgeConfig.getPropertyAsInt("redis.min.idle"));
         poolConfig.setMaxIdle(bridgeConfig.getPropertyAsInt("redis.max.idle"));
-        poolConfig.setTestOnCreate(true); // test threads when we create them (only)
-        poolConfig.setTestOnBorrow(false);
-        poolConfig.setTestOnReturn(false);
-        poolConfig.setTestWhileIdle(false);
+        poolConfig.setTestOnCreate(true);
+        poolConfig.setTestOnBorrow(true);
+        poolConfig.setTestOnReturn(true);
+        poolConfig.setTestWhileIdle(true);
         
         final String url = bridgeConfig.get(redisServerProperty);
         final JedisPool jedisPool = constructJedisPool(url, poolConfig);


### PR DESCRIPTION
We're still seeing this error after switching over entirely to ElastiCache in development:

"Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'defaultStudyBootstrapper': Invocation of init method failed; nested exception is org.sagebionetworks.bridge.exceptions.BridgeServiceException: redis.clients.jedis.exceptions.JedisConnectionException: Could not get a resource from the pool"

We had at one time turned off a lot of connection testing to try and make connections more stable with RedisCloud's Redis server, I'm turning that all back on to see if it helps eliminate this error.

BTW the server is up and running, and all integration tests pass. I don't know what the practical import of these errors is.