### PR TITLE
More Mutable Schemas

### DIFF
--- a/app/org/sagebionetworks/bridge/models/upload/UploadFieldType.java
+++ b/app/org/sagebionetworks/bridge/models/upload/UploadFieldType.java
@@ -76,4 +76,7 @@ public enum UploadFieldType {
     /** A set of upload field types that are considered attachment types. */
     public static final Set<UploadFieldType> ATTACHMENT_TYPE_SET = EnumSet.of(ATTACHMENT_BLOB, ATTACHMENT_CSV,
             ATTACHMENT_JSON_BLOB, ATTACHMENT_JSON_TABLE, ATTACHMENT_V2);
+
+    /* A set of upload field types that are freeform (or mostly freeform) strings. */
+    public static final Set<UploadFieldType> STRING_TYPE_SET = EnumSet.of(INLINE_JSON_BLOB, SINGLE_CHOICE, STRING);
 }

--- a/app/org/sagebionetworks/bridge/services/UploadSchemaService.java
+++ b/app/org/sagebionetworks/bridge/services/UploadSchemaService.java
@@ -735,22 +735,8 @@ public class UploadSchemaService {
         Map<String, UploadFieldDefinition> newFieldMap = getFieldsByName(schemaToUpdate);
         Set<String> newFieldNameSet = newFieldMap.keySet();
 
-        Set<String> addedFieldNameSet = Sets.difference(newFieldNameSet, oldFieldNameSet);
         Set<String> deletedFieldNameSet = Sets.difference(oldFieldNameSet, newFieldNameSet);
         Set<String> retainedFieldNameSet = Sets.intersection(oldFieldNameSet, newFieldNameSet);
-
-        // Added fields must be optional.
-        Set<String> invalidAddedFieldNameSet = new TreeSet<>();
-        for (String oneAddedFieldName : addedFieldNameSet) {
-            UploadFieldDefinition addedField = newFieldMap.get(oneAddedFieldName);
-            if (addedField.isRequired()) {
-                invalidAddedFieldNameSet.add(oneAddedFieldName);
-            }
-        }
-        if (!invalidAddedFieldNameSet.isEmpty()) {
-            errorMessageList.add("Added fields must be optional: " + BridgeUtils.COMMA_SPACE_JOINER
-                    .join(invalidAddedFieldNameSet));
-        }
 
         // Check deleted fields.
         if (!deletedFieldNameSet.isEmpty()) {
@@ -758,18 +744,18 @@ public class UploadSchemaService {
         }
 
         // Check retained fields, make sure none are modified.
-        Set<String> modifiedFieldNameSet = new TreeSet<>();
+        Set<String> incompatibleFieldNameSet = new TreeSet<>();
         for (String oneRetainedFieldName : retainedFieldNameSet) {
             UploadFieldDefinition oldFieldDef = oldFieldMap.get(oneRetainedFieldName);
             UploadFieldDefinition newFieldDef = newFieldMap.get(oneRetainedFieldName);
 
             if (!UploadUtil.isCompatibleFieldDef(oldFieldDef, newFieldDef)) {
-                modifiedFieldNameSet.add(oneRetainedFieldName);
+                incompatibleFieldNameSet.add(oneRetainedFieldName);
             }
         }
-        if (!modifiedFieldNameSet.isEmpty()) {
+        if (!incompatibleFieldNameSet.isEmpty()) {
             errorMessageList.add("Incompatible changes to fields: " + BridgeUtils.COMMA_SPACE_JOINER.join(
-                    modifiedFieldNameSet));
+                    incompatibleFieldNameSet));
         }
 
         // Can't modify schema types.

--- a/app/org/sagebionetworks/bridge/upload/UploadUtil.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadUtil.java
@@ -16,7 +16,10 @@ import com.fasterxml.jackson.databind.node.BigIntegerNode;
 import com.fasterxml.jackson.databind.node.BooleanNode;
 import com.fasterxml.jackson.databind.node.DecimalNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
@@ -58,6 +61,71 @@ public class UploadUtil {
             "periods, can't contain two or more non-alphanumeric characters in a row";
     public static final String INVALID_FIELD_NAME_ERROR_MESSAGE = INVALID_ANSWER_CHOICE_ERROR_MESSAGE +
             ", and can't be a reserved keyword";
+
+    // Misc constants
+    private static final int DEFAULT_MAX_LENGTH = 100;
+    private static final int MAX_MAX_LENGTH = 1000;
+
+    // Map of allowed field type changes. Key is the old type. Value is the new type.
+    //
+    // A few notes: This is largely based on whether the data can be converted in Synapse tables. Since booleans are
+    // stored as 0/1 and dates are stored as epoch milliseconds, converting these to strings means old values will be
+    // numeric types, but new values are likely to be "true"/"false" or ISO8601 timestamps. This leads to more
+    // confusion overall, so we've decided to block it.
+    //
+    // Additionally, multi-choice and timestamp fields create multiple columns in Synapse. Changing to single-column
+    // types may be confusing, so we prevent these as well.
+    private static final SetMultimap<UploadFieldType, UploadFieldType> ALLOWED_OLD_TYPE_TO_NEW_TYPE =
+            ImmutableSetMultimap.<UploadFieldType, UploadFieldType>builder()
+                    // All attachment types can be migrated to attachment_v2, but not the other way around.
+                    .put(UploadFieldType.ATTACHMENT_BLOB, UploadFieldType.ATTACHMENT_V2)
+                    .put(UploadFieldType.ATTACHMENT_CSV, UploadFieldType.ATTACHMENT_V2)
+                    .put(UploadFieldType.ATTACHMENT_JSON_BLOB, UploadFieldType.ATTACHMENT_V2)
+                    .put(UploadFieldType.ATTACHMENT_JSON_TABLE, UploadFieldType.ATTACHMENT_V2)
+                    // Numeric types can changed to types with more precision (bool to int to float), but not less
+                    // precision (float to int to bool).
+                    .put(UploadFieldType.BOOLEAN, UploadFieldType.INT)
+                    .put(UploadFieldType.BOOLEAN, UploadFieldType.FLOAT)
+                    .put(UploadFieldType.INT, UploadFieldType.FLOAT)
+                    // inline_json_blob values are parseable as JSON. This precludes string types, since JSON can't
+                    // parse unquoted strings. Numbers are fine.
+                    .put(UploadFieldType.FLOAT, UploadFieldType.INLINE_JSON_BLOB)
+                    .put(UploadFieldType.INT, UploadFieldType.INLINE_JSON_BLOB)
+                    // Anything can be converted to string types (except for attachments, multi-choice, and
+                    // timestamps), and single_choice is functionally equivalent to strings as far as data migration.
+                    .put(UploadFieldType.CALENDAR_DATE, UploadFieldType.SINGLE_CHOICE)
+                    .put(UploadFieldType.DURATION_V2, UploadFieldType.SINGLE_CHOICE)
+                    .put(UploadFieldType.FLOAT, UploadFieldType.SINGLE_CHOICE)
+                    .put(UploadFieldType.INLINE_JSON_BLOB, UploadFieldType.SINGLE_CHOICE)
+                    .put(UploadFieldType.INT, UploadFieldType.SINGLE_CHOICE)
+                    .put(UploadFieldType.STRING, UploadFieldType.SINGLE_CHOICE)
+                    .put(UploadFieldType.TIME_V2, UploadFieldType.SINGLE_CHOICE)
+                    .put(UploadFieldType.CALENDAR_DATE, UploadFieldType.STRING)
+                    .put(UploadFieldType.DURATION_V2, UploadFieldType.STRING)
+                    .put(UploadFieldType.FLOAT, UploadFieldType.STRING)
+                    .put(UploadFieldType.INLINE_JSON_BLOB, UploadFieldType.STRING)
+                    .put(UploadFieldType.INT, UploadFieldType.STRING)
+                    .put(UploadFieldType.SINGLE_CHOICE, UploadFieldType.STRING)
+                    .put(UploadFieldType.TIME_V2, UploadFieldType.STRING)
+                    // The only thing that can be turned into a timestamp is an int, which can be epoch milliseconds.
+                    .put(UploadFieldType.INT, UploadFieldType.TIMESTAMP)
+                    .build();
+
+    // When we determine if we're shrinking or growing fields, we use this to determine what the "length" of a field,
+    // based on the field type. For any type not in this list, we use DEFAULT_MAX_LENGTH.
+    private static final Map<UploadFieldType, Integer> MAX_LENGTH_BY_TYPE =
+            ImmutableMap.<UploadFieldType, Integer>builder()
+                    // YYYY-MM-DD
+                    .put(UploadFieldType.CALENDAR_DATE, 10)
+                    // See ISO8601 duration format
+                    .put(UploadFieldType.DURATION_V2, 24)
+                    // Empirically, the longest float in Synapse is 22 chars long
+                    .put(UploadFieldType.FLOAT, 22)
+                    // Synapse uses a bigint (signed long), which can be 20 chars long
+                    .put(UploadFieldType.INT, 20)
+                    // hh:mm:ss.sss
+                    .put(UploadFieldType.TIME_V2, 12)
+                    .build();
 
     // List of reserved SQL keywords and Synapse keywords that can't be used as field names.
     private static final Set<String> RESERVED_FIELD_NAME_LIST = ImmutableSet.<String>builder().add("access", "add",
@@ -407,11 +475,16 @@ public class UploadUtil {
         // fileExtension - This is just a hint to BridgeEX for serializing the values. It doesn't affect the columns or
         //   validation.
         // mimeType - Similarly, this is also just a serialization hint.
+        // required - This might break StrictValidation, but it doesn't impact the data in Synapse, so we should allow
+        //   it.
 
-        // Different types are obviously not compatible.
-        // This is the most likely reason fields are incompatible. Check this first.
+        // If types are different, check the table.
         if (oldFieldDef.getType() != newFieldDef.getType()) {
-            return false;
+            Set<UploadFieldType> allowedNewTypes = ALLOWED_OLD_TYPE_TO_NEW_TYPE.get(oldFieldDef
+                    .getType());
+            if (!allowedNewTypes.contains(newFieldDef.getType())) {
+                return false;
+            }
         }
 
         // allowOther - You can flip this to true (adds a field), but you can't flip it from true to false.
@@ -421,12 +494,37 @@ public class UploadUtil {
             return false;
         }
 
-        // Changing the maxLength will cause the Synapse column to be recreated, so we need to block this. (Strictly
-        // speaking, BridgeEX has code to prevent this by ignoring the new max length if it is different, for legacy
-        // reasons but this is confusing behavior, so we should just prevent this situation from happening to begin
-        // with.)
-        if (!Objects.equals(oldFieldDef.getMaxLength(), newFieldDef.getMaxLength())) {
-            return false;
+        // For string types, check max length. You can increase the max length, but you can't decrease it.
+        if (UploadFieldType.STRING_TYPE_SET.contains(newFieldDef.getType()) &&
+                !Objects.equals(oldFieldDef.getMaxLength(), newFieldDef.getMaxLength())) {
+            int oldMaxLength;
+            if (oldFieldDef.getMaxLength() != null) {
+                // If the old field def specified a max length, just use it.
+                oldMaxLength = oldFieldDef.getMaxLength();
+            } else if (MAX_LENGTH_BY_TYPE.containsKey(oldFieldDef.getType())) {
+                // The max length of the old field type is specified by its type.
+                oldMaxLength = MAX_LENGTH_BY_TYPE.get(oldFieldDef.getType());
+            } else {
+                // It's probably a string type with the default length.
+                oldMaxLength = DEFAULT_MAX_LENGTH;
+            }
+
+            // The new field is a string type. If the length isn't specified, it has the default max length.
+            // If max lengths aren't specified, Bridge treats the max length as 100.
+            int newMaxLength = (newFieldDef.getMaxLength() != null) ? newFieldDef.getMaxLength() : DEFAULT_MAX_LENGTH;
+
+            // Special case: if oldMaxLength is less than 1000, but newMaxLength is more than 1000, then Bridge
+            // converts this into an unbounded string (LargeText). There is a bug in Synapse that prevents this from
+            // working, so block this in Bridge.
+            // See also https://sagebionetworks.jira.com/browse/PLFM-4028
+            if (oldMaxLength <= MAX_MAX_LENGTH && newMaxLength > MAX_MAX_LENGTH) {
+                return false;
+            }
+
+            // You can't decrease max length.
+            if (newMaxLength < oldMaxLength) {
+                return false;
+            }
         }
 
         // Note: multiChoiceAnswerList can never be null.
@@ -448,17 +546,10 @@ public class UploadUtil {
             return false;
         }
 
-        // Going from required to optional is fine. Going from optional to required is okay only if you're adding a
-        // minAppVerison.
-        if (!oldFieldDef.isRequired() && newFieldDef.isRequired()) {
-            return false;
-        }
-
-        // isUnboundedText controls whether we use a String or LargeText in Synapse. So changing this is not
-        // compatible. (null defaults to false)
-        //noinspection ConstantConditions
+        // Converting from unbounded text may result in data loss, so it's not allowed.
+        // Converting to an unbounded text fails in Synapse due to a bug.
+        // See https://sagebionetworks.jira.com/browse/PLFM-4028
         boolean oldIsUnboundedText = oldFieldDef.isUnboundedText() != null ? oldFieldDef.isUnboundedText() : false;
-        //noinspection ConstantConditions
         boolean newIsUnboundedText = newFieldDef.isUnboundedText() != null ? newFieldDef.isUnboundedText() : false;
         if (oldIsUnboundedText != newIsUnboundedText) {
             return false;

--- a/app/org/sagebionetworks/bridge/upload/UploadUtil.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadUtil.java
@@ -73,6 +73,10 @@ public class UploadUtil {
     // numeric types, but new values are likely to be "true"/"false" or ISO8601 timestamps. This leads to more
     // confusion overall, so we've decided to block it.
     //
+    // Similarly, if you convert a bool to a numeric type (int, float), Synapse will convert the bools to 0s and 1s.
+    // However, old bools in DynamoDB are still using "true"/"false", which will no longer serialize to Synapse. To
+    // prevent this data loss, we're also not allowing bools to convert to numeric types.
+    //
     // Additionally, multi-choice and timestamp fields create multiple columns in Synapse. Changing to single-column
     // types may be confusing, so we prevent these as well.
     private static final SetMultimap<UploadFieldType, UploadFieldType> ALLOWED_OLD_TYPE_TO_NEW_TYPE =
@@ -82,10 +86,8 @@ public class UploadUtil {
                     .put(UploadFieldType.ATTACHMENT_CSV, UploadFieldType.ATTACHMENT_V2)
                     .put(UploadFieldType.ATTACHMENT_JSON_BLOB, UploadFieldType.ATTACHMENT_V2)
                     .put(UploadFieldType.ATTACHMENT_JSON_TABLE, UploadFieldType.ATTACHMENT_V2)
-                    // Numeric types can changed to types with more precision (bool to int to float), but not less
-                    // precision (float to int to bool).
-                    .put(UploadFieldType.BOOLEAN, UploadFieldType.INT)
-                    .put(UploadFieldType.BOOLEAN, UploadFieldType.FLOAT)
+                    // Numeric types can changed to types with more precision (int to float), but not less
+                    // precision (float to int).
                     .put(UploadFieldType.INT, UploadFieldType.FLOAT)
                     // inline_json_blob values are parseable as JSON. This precludes string types, since JSON can't
                     // parse unquoted strings. Numbers are fine.

--- a/test/org/sagebionetworks/bridge/services/UploadSchemaServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/UploadSchemaServiceTest.java
@@ -656,10 +656,9 @@ public class UploadSchemaServiceTest {
 
     @Test
     public void updateV4IncompatibleChange() {
-        // This update fails for 4 reasons
+        // This update fails for 3 reasons
         // - deleted fields
         // - modified non-compatible field
-        // - added required fields
         // - modified schema type
 
         // Make old schema - Only field def list and schema type matter for this test.
@@ -684,11 +683,7 @@ public class UploadSchemaServiceTest {
                 new UploadFieldDefinition.Builder().withName("modify-me-1").withType(UploadFieldType.STRING)
                         .withMaxLength(24).build(),
                 new UploadFieldDefinition.Builder().withName("modify-me-2").withType(UploadFieldType.FLOAT)
-                        .withMaxLength(24).build(),
-                new UploadFieldDefinition.Builder().withName("add-me-1").withType(UploadFieldType.BOOLEAN)
-                        .withRequired(true).build(),
-                new UploadFieldDefinition.Builder().withName("add-me-2").withType(UploadFieldType.BOOLEAN)
-                        .withRequired(true).build());
+                        .withMaxLength(24).build());
 
         UploadSchema newSchema = makeSimpleSchema();
         newSchema.setSchemaType(UploadSchemaType.IOS_SURVEY);
@@ -707,7 +702,6 @@ public class UploadSchemaServiceTest {
             errMsg = ex.getMessage();
         }
 
-        assertTrue(errMsg.contains("Added fields must be optional: add-me-1, add-me-2"));
         assertTrue(errMsg.contains("Can't delete fields: delete-me-1, delete-me-2"));
         assertTrue(errMsg.contains("Incompatible changes to fields: modify-me-1, modify-me-2"));
         assertTrue(errMsg.contains("Can't modify schema type, old=IOS_DATA, new=IOS_SURVEY"));
@@ -722,6 +716,7 @@ public class UploadSchemaServiceTest {
         // - unchanged field
         // - modified compatible field
         // - added optional field
+        // - added required field
 
         // Make old schema - Only field def list and schema type matter for this test.
         List<UploadFieldDefinition> oldFieldDefList = ImmutableList.of(
@@ -739,7 +734,9 @@ public class UploadSchemaServiceTest {
                 new UploadFieldDefinition.Builder().withName("modify-me").withType(UploadFieldType.MULTI_CHOICE)
                         .withMultiChoiceAnswerList("foo", "bar", "baz").withAllowOtherChoices(true).build(),
                 new UploadFieldDefinition.Builder().withName("added-optional-field")
-                        .withType(UploadFieldType.BOOLEAN).withRequired(false).build());
+                        .withType(UploadFieldType.BOOLEAN).withRequired(false).build(),
+                new UploadFieldDefinition.Builder().withName("added-required-field")
+                        .withType(UploadFieldType.INT).withRequired(true).build());
 
         UploadSchema newSchema = makeSimpleSchema();
         newSchema.setSchemaType(UploadSchemaType.IOS_SURVEY);

--- a/test/org/sagebionetworks/bridge/upload/UploadUtilTest.java
+++ b/test/org/sagebionetworks/bridge/upload/UploadUtilTest.java
@@ -426,6 +426,13 @@ public class UploadUtilTest {
                         false
                 },
                 {
+                        new UploadFieldDefinition.Builder().withName("field").withType(UploadFieldType.INT)
+                                .build(),
+                        new UploadFieldDefinition.Builder().withName("field").withType(UploadFieldType.STRING)
+                                .build(),
+                        true
+                },
+                {
                         new UploadFieldDefinition.Builder().withName("foo-field").withType(UploadFieldType.INT)
                                 .build(),
                         new UploadFieldDefinition.Builder().withName("bar-field").withType(UploadFieldType.INT)
@@ -484,10 +491,15 @@ public class UploadUtilTest {
         Object[][] testCases = {
                 { null, null, true },
                 { null, 10, false },
-                { 10, null, false },
+                { null, 200, true },
+                { 10, null, true },
+                { 200, null, false },
                 { 10, 10, true },
-                { 10, 15,  false },
+                { 10, 15,  true },
                 { 10, 5, false },
+                { 999, 1000, true },
+                { 1001, 1001, true },
+                { 1000, 1001, false },
         };
 
         for (Object[] oneTestCase : testCases) {
@@ -496,6 +508,32 @@ public class UploadUtilTest {
             UploadFieldDefinition newFieldDef = new UploadFieldDefinition.Builder().withName("field")
                     .withType(UploadFieldType.STRING).withMaxLength((Integer) oneTestCase[1]).build();
             assertEquals(oneTestCase[2], UploadUtil.isCompatibleFieldDef(oldFieldDef, newFieldDef));
+        }
+    }
+
+    @Test
+    public void isCompatibleFieldDefMaxLengthWithNonStrings() {
+        // { oldType, newType, newMaxLength, expected }
+        Object[][] testCases = {
+                { UploadFieldType.INT, UploadFieldType.FLOAT, null, true },
+                { UploadFieldType.CALENDAR_DATE, UploadFieldType.STRING, 9, false },
+                { UploadFieldType.CALENDAR_DATE, UploadFieldType.STRING, 11, true },
+                { UploadFieldType.DURATION_V2, UploadFieldType.STRING, 23, false },
+                { UploadFieldType.DURATION_V2, UploadFieldType.STRING, 25, true },
+                { UploadFieldType.FLOAT, UploadFieldType.STRING, 21, false },
+                { UploadFieldType.FLOAT, UploadFieldType.STRING, 23, true },
+                { UploadFieldType.INT, UploadFieldType.STRING, 19, false },
+                { UploadFieldType.INT, UploadFieldType.STRING, 21, true },
+                { UploadFieldType.TIME_V2, UploadFieldType.STRING, 11, false },
+                { UploadFieldType.TIME_V2, UploadFieldType.STRING, 13, true },
+        };
+
+        for (Object[] oneTestCase : testCases) {
+            UploadFieldDefinition oldFieldDef = new UploadFieldDefinition.Builder().withName("field")
+                    .withType((UploadFieldType) oneTestCase[0]).withMaxLength(null).build();
+            UploadFieldDefinition newFieldDef = new UploadFieldDefinition.Builder().withName("field")
+                    .withType((UploadFieldType) oneTestCase[1]).withMaxLength((Integer) oneTestCase[2]).build();
+            assertEquals(oneTestCase[3], UploadUtil.isCompatibleFieldDef(oldFieldDef, newFieldDef));
         }
     }
 
@@ -531,7 +569,7 @@ public class UploadUtilTest {
                 { false, false, true },
                 { true, true, true },
                 { true, false, true },
-                { false, true, false },
+                { false, true, true },
         };
 
         for (Object[] oneTestCase : testCases) {


### PR DESCRIPTION
Now that Synapse table columns are mutable, we should propagate that change to Bridge schemas. See https://sagebionetworks.jira.com/browse/BRIDGE-1863

This change allows certain field type changes and allows an increase in string lengths. The BridgePF change also allows flipping fields from optional to required and vice versa, and no longer requires that new fields are required.

Testing done:
* unit tests and integ tests
* see BridgeEX change for manual tests

The corresponding BridgeEX change https://github.com/Sage-Bionetworks/Bridge-Exporter/pull/58 should be merged and pushed to prod first, since pushing the BridgePF changes first may cause schema changes that BridgeEX doesn't yet accept.