### PR TITLE
Ensure that finished tasks remain finished in v4 API.

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/ScheduledActivityDao.java
+++ b/app/org/sagebionetworks/bridge/dao/ScheduledActivityDao.java
@@ -27,7 +27,7 @@ public interface ScheduledActivityDao {
     /**
      * Load an individual activity.
      */
-    ScheduledActivity getActivity(String healthCode, String guid);
+    ScheduledActivity getActivity(String healthCode, String guid, boolean throwException);
    
     /**
      * Get a list of activities for a user. The list is derived from the scheduler.

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDao.java
@@ -247,13 +247,13 @@ public class DynamoScheduledActivityDao implements ScheduledActivityDao {
     
     /** {@inheritDoc} */
     @Override
-    public ScheduledActivity getActivity(String healthCode, String guid) {
+    public ScheduledActivity getActivity(String healthCode, String guid, boolean throwException) {
         DynamoScheduledActivity hashKey = new DynamoScheduledActivity();
         hashKey.setHealthCode(healthCode);
         hashKey.setGuid(guid);
         
         ScheduledActivity dbActivity = mapper.load(hashKey);
-        if (dbActivity == null) {
+        if (throwException && dbActivity == null) {
             throw new EntityNotFoundException(ScheduledActivity.class);
         }
         return dbActivity;

--- a/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
+++ b/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
@@ -261,7 +261,7 @@ public class ScheduledActivityService {
         
         Map<String,ScheduledActivity> dbMap = Maps.newHashMap();
         // IA-545: If a schedule has an identical activity but a new GUID (say if we change the schedule on the user), the user can 
-        // lose existing activities. So during the time window the user is looking at, we will return any activities that exist.x`
+        // lose existing activities. So during the time window the user is looking at, we will return any activities that exist.
         for (String activityGuid : activityGuids) {
             ForwardCursorPagedResourceList<ScheduledActivity> list = activityDao.getActivityHistoryV2(
                     context.getCriteriaContext().getHealthCode(), activityGuid,

--- a/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
+++ b/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
@@ -261,7 +261,7 @@ public class ScheduledActivityService {
         
         Map<String,ScheduledActivity> dbMap = Maps.newHashMap();
         // IA-545: If a schedule has an identical activity but a new GUID (say if we change the schedule on the user), the user can 
-        // lose existing activities. So during the time window the user is looking at, we will return any activities that exist.
+        // lose existing activities. So during the time window the user is looking at, we will return any activities that exist.x`
         for (String activityGuid : activityGuids) {
             ForwardCursorPagedResourceList<ScheduledActivity> list = activityDao.getActivityHistoryV2(
                     context.getCriteriaContext().getHealthCode(), activityGuid,

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -293,12 +293,12 @@ public class TestUtils {
     }
     
     public static Activity getActivity1() {
-        return new Activity.Builder().withGuid(BridgeUtils.generateGuid()).withLabel("Activity1")
+        return new Activity.Builder().withGuid("activity1guid").withLabel("Activity1")
                 .withPublishedSurvey("identifier1", "AAA").build();
     }
     
     public static Activity getActivity2() {
-        return new Activity.Builder().withGuid(BridgeUtils.generateGuid()).withLabel("Activity2")
+        return new Activity.Builder().withGuid("activity2guid").withLabel("Activity2")
                 .withPublishedSurvey("identifier2", "BBB").build();
     }
     

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDaoMockTest.java
@@ -118,7 +118,7 @@ public class DynamoScheduledActivityDaoMockTest {
     
     @Test
     public void getScheduledActivities() throws Exception {
-        ScheduledActivity activity = activityDao.getActivity("AAA", "BBB");
+        ScheduledActivity activity = activityDao.getActivity("AAA", "BBB", true);
         assertEquals(testSchActivity, activity);
         
     }
@@ -127,7 +127,7 @@ public class DynamoScheduledActivityDaoMockTest {
     public void getActivityThrowsException() throws Exception {
         when(mapper.load(any(DynamoScheduledActivity.class))).thenReturn(null);
         
-        activityDao.getActivity("AAA", "BBB");
+        activityDao.getActivity("AAA", "BBB", true);
     }
 
     /**

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityDaoTest.java
@@ -355,7 +355,7 @@ public class DynamoScheduledActivityDaoTest {
         
         // Verify getActivity() works
         ScheduledActivity savedActivity = activityDao.getActivity(context.getCriteriaContext().getHealthCode(),
-                savedActivities.get(0).getGuid());
+                savedActivities.get(0).getGuid(), true);
         savedActivity.setTimeZone(MSK); // for equality check
         assertEquals(savedActivities.get(0), savedActivity);
         assertEquals(context.getInitialTimeZone(), savedActivity.getTimeZone());

--- a/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceMockTest.java
@@ -1261,10 +1261,8 @@ public class ScheduledActivityServiceMockTest {
         Map<String,DateTime> events = Maps.newHashMap();
         events.put("enrollment", ENROLLMENT);
         
-        DateTimeZone zone = DateTimeZone.forOffsetHours(-7); // zone of the original times
-        // Initial time zone and the time zone of enrollment should be the same. They are in reality.
-        return new ScheduleContext.Builder().withStudyIdentifier(TEST_STUDY).withInitialTimeZone(zone)
-                .withStartsOn(NOW).withAccountCreatedOn(ENROLLMENT.minusHours(2).withZone(zone)).withEndsOn(endsOn)
+        return new ScheduleContext.Builder().withStudyIdentifier(TEST_STUDY).withInitialTimeZone(DateTimeZone.UTC)
+                .withStartsOn(NOW).withAccountCreatedOn(ENROLLMENT.minusHours(2)).withEndsOn(endsOn)
                 .withHealthCode(HEALTH_CODE).withUserId(USER_ID).withEvents(events);
     }
     

--- a/test/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceConsentTest.java
+++ b/test/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceConsentTest.java
@@ -118,7 +118,6 @@ public class SendMailViaAmazonServiceConsentTest {
 
         // Validate message content. MIME message must be ASCII
         String rawMessage = new String(req.getRawMessage().getData().array(), Charsets.US_ASCII);
-        System.out.println(rawMessage);
         assertTrue("Contains consent content", rawMessage.contains("Had this been a real study"));
         assertTrue("Name transposed to document", rawMessage.contains("Test 2"));
         assertTrue("Email transposed to document", rawMessage.contains("test-user@sagebase.org"));


### PR DESCRIPTION
This was changed to ensure that users see all the activities that are scheduled in the period they are looking for. This change removed functionality to attempt to load all the scheduled activities from the database.

The problem is that once these tasks fall outside the time range, they are not retrieved and their state is reset. This is a problem for one-time tasks that sit around for awhile... or any other task with a long periodicity (longer than the query window for activities when scheduling).