### PR TITLE
remove schema publish workflow

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchema.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchema.java
@@ -55,7 +55,6 @@ public class DynamoUploadSchema implements UploadSchema {
     private Long surveyCreatedOn;
     private String studyId;
     private Long version;
-    private boolean published;
 
     /** {@inheritDoc} */
     @DynamoDBIgnore
@@ -315,18 +314,6 @@ public class DynamoUploadSchema implements UploadSchema {
     @Override
     public void setStudyId(String studyId) {
         this.studyId = studyId;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public boolean getPublished() {
-        return this.published;
-    }
-
-    /** @see #getPublished */
-    @Override
-    public void setPublished(boolean published) {
-        this.published = published;
     }
 
     /**

--- a/app/org/sagebionetworks/bridge/models/upload/UploadSchema.java
+++ b/app/org/sagebionetworks/bridge/models/upload/UploadSchema.java
@@ -133,12 +133,4 @@ public interface UploadSchema extends BridgeEntity {
 
     /** @see #getStudyId */
     void setStudyId(String studyId);
-
-    /**
-     * return if this upload schema is published: if it is, updating it will throw exception
-     */
-    boolean getPublished();
-
-    /** @see #getPublished */
-    void setPublished(boolean published);
 }

--- a/app/org/sagebionetworks/bridge/services/SharedModuleService.java
+++ b/app/org/sagebionetworks/bridge/services/SharedModuleService.java
@@ -106,8 +106,7 @@ public class SharedModuleService {
             UploadSchema schema = schemaService.getUploadSchemaByIdAndRev(BridgeConstants.SHARED_STUDY_ID, schemaId,
                     schemaRev);
 
-            // also make the schema published and annotate with module ID and version
-            schema.setPublished(true);
+            // annotate with module ID and version
             schema.setModuleId(moduleId);
             schema.setModuleVersion(moduleVersion);
 

--- a/app/org/sagebionetworks/bridge/services/UploadSchemaService.java
+++ b/app/org/sagebionetworks/bridge/services/UploadSchemaService.java
@@ -713,9 +713,10 @@ public class UploadSchemaService {
         // doesn't exist.
         UploadSchema oldSchema = getUploadSchemaByIdAndRev(studyId, schemaId, revision);
 
-        // published schema cannot be modified
-        if (oldSchema.getPublished()) {
-            throw new BadRequestException("Published upload schema " + oldSchema.getSchemaId() + " cannot be modified.");
+        // Schemas associated with shared module can't be modified.
+        if (StringUtils.isNotBlank(oldSchema.getModuleId())) {
+            throw new BadRequestException("Schema " + oldSchema.getSchemaId() + " was imported from a shared module " +
+                    "and cannot be modified.");
         }
 
         // Set study ID, schema ID, and revision. This ensures we are updating the correct schema in the correct study.

--- a/test/org/sagebionetworks/bridge/models/upload/UploadSchemaTest.java
+++ b/test/org/sagebionetworks/bridge/models/upload/UploadSchemaTest.java
@@ -213,7 +213,6 @@ public class UploadSchemaTest {
                 "   \"moduleVersion\":" + MODULE_VERSION + ",\n" +
                 "   \"name\":\"Test Schema\",\n" +
                 "   \"revision\":3,\n" +
-                "   \"published\":true,\n" +
                 "   \"schemaId\":\"test-schema\",\n" +
                 "   \"schemaType\":\"ios_survey\",\n" +
                 "   \"studyId\":\"test-study\",\n" +
@@ -246,7 +245,6 @@ public class UploadSchemaTest {
         assertEquals("survey-guid", uploadSchema.getSurveyGuid());
         assertEquals(surveyCreatedOnMillis, uploadSchema.getSurveyCreatedOn().longValue());
         assertEquals(6, ((DynamoUploadSchema) uploadSchema).getVersion().longValue());
-        assertEquals(true, uploadSchema.getPublished());
 
         assertEquals(ImmutableSet.of("iOS", "Android"), uploadSchema.getAppVersionOperatingSystems());
         assertEquals(13, uploadSchema.getMinAppVersion("iOS").intValue());
@@ -273,7 +271,7 @@ public class UploadSchemaTest {
         // for consistency in tests, we should do it the same way every time.
         String convertedJson = BridgeObjectMapper.get().writeValueAsString(uploadSchema);
         JsonNode jsonNode = BridgeObjectMapper.get().readTree(convertedJson);
-        assertEquals(15, jsonNode.size());
+        assertEquals(14, jsonNode.size());
         assertEquals(MODULE_ID, jsonNode.get("moduleId").textValue());
         assertEquals(MODULE_VERSION, jsonNode.get("moduleVersion").intValue());
         assertEquals("Test Schema", jsonNode.get("name").textValue());
@@ -284,7 +282,6 @@ public class UploadSchemaTest {
         assertEquals("survey-guid", jsonNode.get("surveyGuid").textValue());
         assertEquals("UploadSchema", jsonNode.get("type").textValue());
         assertEquals(6,  jsonNode.get("version").intValue());
-        assertTrue(jsonNode.get("published").booleanValue());
 
         JsonNode maxAppVersionMap = jsonNode.get("maxAppVersions");
         assertEquals(2, maxAppVersionMap.size());

--- a/test/org/sagebionetworks/bridge/services/SharedModuleServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SharedModuleServiceTest.java
@@ -1,8 +1,6 @@
 package org.sagebionetworks.bridge.services;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -95,7 +93,6 @@ public class SharedModuleServiceTest {
 
         // mock schema service
         UploadSchema sharedSchema = UploadSchema.create();
-        assertFalse(sharedSchema.getPublished());
         when(mockSchemaService.getUploadSchemaByIdAndRev(BridgeConstants.SHARED_STUDY_ID, SCHEMA_ID, SCHEMA_REV))
                 .thenReturn(sharedSchema);
 
@@ -107,7 +104,6 @@ public class SharedModuleServiceTest {
         assertEquals(SCHEMA_REV, status.getSchemaRevision().intValue());
 
         UploadSchema modifiedSchema = schemaArgumentCaptor.getValue();
-        assertTrue(modifiedSchema.getPublished());
         assertEquals(MODULE_ID, modifiedSchema.getModuleId());
         assertEquals(MODULE_VERSION, modifiedSchema.getModuleVersion().intValue());
 
@@ -184,7 +180,6 @@ public class SharedModuleServiceTest {
 
         // mock schema service
         UploadSchema sharedSchema = UploadSchema.create();
-        assertFalse(sharedSchema.getPublished());
         when(mockSchemaService.getUploadSchemaByIdAndRev(BridgeConstants.SHARED_STUDY_ID, SCHEMA_ID, SCHEMA_REV))
                 .thenReturn(sharedSchema);
 
@@ -196,7 +191,6 @@ public class SharedModuleServiceTest {
         assertEquals(SCHEMA_REV, status.getSchemaRevision().intValue());
 
         UploadSchema modifiedSchema = schemaArgumentCaptor.getValue();
-        assertTrue(modifiedSchema.getPublished());
         assertEquals(MODULE_ID, modifiedSchema.getModuleId());
         assertEquals(MODULE_VERSION, modifiedSchema.getModuleVersion().intValue());
 

--- a/test/org/sagebionetworks/bridge/services/UploadSchemaServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/UploadSchemaServiceTest.java
@@ -630,13 +630,21 @@ public class UploadSchemaServiceTest {
         svc.updateSchemaRevisionV4(TestConstants.TEST_STUDY, SCHEMA_ID, SCHEMA_REV, svcInputSchema);
     }
 
-    @Test(expected = BadRequestException.class)
-    public void updateV4PublishedSchema() {
-        // mock as published schema
-        svcInputSchema.setPublished(true);
-        when(dao.getUploadSchemaByIdAndRevision(TestConstants.TEST_STUDY, SCHEMA_ID, SCHEMA_REV)).thenReturn(svcInputSchema);
+    @Test
+    public void updateV4SchemaFromSharedModule() {
+        // schema is annotated with shared module
+        svcInputSchema.setModuleId("test-module");
+        svcInputSchema.setModuleVersion(2);
+        when(dao.getUploadSchemaByIdAndRevision(TestConstants.TEST_STUDY, SCHEMA_ID, SCHEMA_REV)).thenReturn(
+                svcInputSchema);
 
-        svc.updateSchemaRevisionV4(TestConstants.TEST_STUDY, SCHEMA_ID, SCHEMA_REV, svcInputSchema);
+        try {
+            svc.updateSchemaRevisionV4(TestConstants.TEST_STUDY, SCHEMA_ID, SCHEMA_REV, svcInputSchema);
+            fail("expected exception");
+        } catch (BadRequestException ex) {
+            assertEquals("Schema " + SCHEMA_ID + " was imported from a shared module and cannot be modified.",
+                    ex.getMessage());
+        }
     }
 
     @Test


### PR DESCRIPTION
Having a publish workflow just encourages study developers to publish everything. This locks down the schema to make it not editable. This flies in the face of our design philosophy, which is that schemas should be easy to change. As such, we're removing the publish workflow. Instead, we'll simply check the shared module ID and version to lock down imported schemas.

Testing done: updated unit tests and integ tests