### PR TITLE
Improve Upload Validation

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataRecord.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataRecord.java
@@ -45,6 +45,7 @@ public class DynamoHealthDataRecord implements HealthDataRecord {
     private ParticipantOption.SharingScope userSharingScope;
     private String userExternalId;
     private Set<String> userDataGroups;
+    private String validationErrors;
     private Long version;
     private ExporterStatus synapseExporterStatus;
 
@@ -281,7 +282,19 @@ public class DynamoHealthDataRecord implements HealthDataRecord {
         // DDB doesn't support empty sets, use null reference for empty set. This is also enforced by the builder.
         this.userDataGroups = (userDataGroups != null && !userDataGroups.isEmpty()) ? userDataGroups : null;
     }
-    
+
+    /** {@inheritDoc} */
+    @Override
+    public String getValidationErrors() {
+        return validationErrors;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setValidationErrors(String validationErrors) {
+        this.validationErrors = validationErrors;
+    }
+
     /** {@inheritDoc} */
     @DynamoDBVersionAttribute
     @Override

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
@@ -24,6 +24,7 @@ import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
+import org.sagebionetworks.bridge.models.upload.UploadValidationStrictness;
 
 @DynamoDBTable(tableName = "Study")
 @BridgeTypeName("Study")
@@ -39,6 +40,7 @@ public final class DynamoStudy implements Study {
     private String technicalEmail;
     private boolean usesCustomExportSchedule;
     private List<UploadFieldDefinition> uploadMetadataFieldDefinitions;
+    private UploadValidationStrictness uploadValidationStrictness;
     private String consentNotificationEmail;
     private int minAgeOfConsent;
     private int accountLimit;
@@ -219,6 +221,19 @@ public final class DynamoStudy implements Study {
     public void setUploadMetadataFieldDefinitions(List<UploadFieldDefinition> uploadMetadataFieldDefinitions) {
         this.uploadMetadataFieldDefinitions = (uploadMetadataFieldDefinitions == null) ? new ArrayList<>() :
                 uploadMetadataFieldDefinitions;
+    }
+
+    /** {@inheritDoc} */
+    @DynamoDBTypeConverted(converter=EnumMarshaller.class)
+    @Override
+    public UploadValidationStrictness getUploadValidationStrictness() {
+        return uploadValidationStrictness;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setUploadValidationStrictness(UploadValidationStrictness uploadValidationStrictness) {
+        this.uploadValidationStrictness = uploadValidationStrictness;
     }
 
     /** {@inheritDoc} */
@@ -467,7 +482,7 @@ public final class DynamoStudy implements Study {
     public int hashCode() {
         return Objects.hash(name, sponsorName, identifier, studyIdExcludedInExport, supportEmail, synapseDataAccessTeamId,
                 synapseProjectId, technicalEmail, usesCustomExportSchedule, uploadMetadataFieldDefinitions,
-                consentNotificationEmail, minAgeOfConsent,
+                uploadValidationStrictness, consentNotificationEmail, minAgeOfConsent,
                 accountLimit, version, active, profileAttributes, taskIdentifiers, activityEventKeys, dataGroups,
                 passwordPolicy, verifyEmailTemplate, resetPasswordTemplate, emailSignInTemplate, accountExistsTemplate,
                 strictUploadValidationEnabled, healthCodeExportEnabled, emailVerificationEnabled,
@@ -487,6 +502,7 @@ public final class DynamoStudy implements Study {
                 && Objects.equals(studyIdExcludedInExport, other.studyIdExcludedInExport)
                 && Objects.equals(supportEmail, other.supportEmail)
                 && Objects.equals(uploadMetadataFieldDefinitions, other.uploadMetadataFieldDefinitions)
+                && Objects.equals(uploadValidationStrictness, other.uploadValidationStrictness)
                 && Objects.equals(minAgeOfConsent, other.minAgeOfConsent) && Objects.equals(name, other.name)
                 && Objects.equals(passwordPolicy, other.passwordPolicy) && Objects.equals(active, other.active))
                 && Objects.equals(verifyEmailTemplate, other.verifyEmailTemplate)
@@ -521,14 +537,14 @@ public final class DynamoStudy implements Study {
         return String.format(
             "DynamoStudy [name=%s, active=%s, sponsorName=%s, identifier=%s, minAgeOfConsent=%s, studyIdExcludedInExport=%b, "
                         + "supportEmail=%s, synapseDataAccessTeamId=%s, synapseProjectId=%s, technicalEmail=%s, "
-                        + "consentNotificationEmail=%s, version=%s, userProfileAttributes=%s, taskIdentifiers=%s, "
+                        + "uploadValidationStrictness=%s, consentNotificationEmail=%s, version=%s, userProfileAttributes=%s, taskIdentifiers=%s, "
                         + "activityEventKeys=%s, dataGroups=%s, passwordPolicy=%s, verifyEmailTemplate=%s, "
                         + "resetPasswordTemplate=%s, strictUploadValidationEnabled=%s, healthCodeExportEnabled=%s, "
                         + "emailVerificationEnabled=%s, externalIdValidationEnabled=%s, externalIdRequiredOnSignup=%s, "
                         + "minSupportedAppVersions=%s, usesCustomExportSchedule=%s, pushNotificationARNs=%s, "
                         + "disableExport=%s, emailSignInTemplate=%s, emailSignInEnabled=%s, accountLimit=%s]",
                 name, active, sponsorName, identifier, minAgeOfConsent, studyIdExcludedInExport, supportEmail,
-                synapseDataAccessTeamId, synapseProjectId, technicalEmail, consentNotificationEmail, version,
+                synapseDataAccessTeamId, synapseProjectId, technicalEmail, uploadValidationStrictness, consentNotificationEmail, version,
                 profileAttributes, taskIdentifiers, activityEventKeys, dataGroups, passwordPolicy, verifyEmailTemplate,
                 resetPasswordTemplate, strictUploadValidationEnabled, healthCodeExportEnabled, emailVerificationEnabled,
                 externalIdValidationEnabled, externalIdRequiredOnSignup, minSupportedAppVersions,

--- a/app/org/sagebionetworks/bridge/models/healthdata/HealthDataRecord.java
+++ b/app/org/sagebionetworks/bridge/models/healthdata/HealthDataRecord.java
@@ -159,7 +159,13 @@ public interface HealthDataRecord extends BridgeEntity {
 
     /** @see #getUserDataGroups() */
     void setUserDataGroups(Set<String> userDataGroups);
-    
+
+    /** Error messages related to upload validation. Only generated if UploadValidationStrictness is set to REPORT. */
+    String getValidationErrors();
+
+    /** @see #getValidationErrors */
+    void setValidationErrors(String validationErrors);
+
     /**
      * Record version. This is used to detect concurrency conflicts. For creating new health data records, this field
      * should be left unspecified. For updating records, this field should match the version of the most recent GET

--- a/app/org/sagebionetworks/bridge/models/studies/Study.java
+++ b/app/org/sagebionetworks/bridge/models/studies/Study.java
@@ -8,6 +8,7 @@ import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.BridgeEntity;
 import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
+import org.sagebionetworks.bridge.models.upload.UploadValidationStrictness;
 
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -152,6 +153,15 @@ public interface Study extends BridgeEntity, StudyIdentifier {
 
     /** @see #getUploadMetadataFieldDefinitions */
     void setUploadMetadataFieldDefinitions(List<UploadFieldDefinition> uploadMetadataFieldDefinitions);
+
+    /**
+     * How strictly to validate health data and uploads. If this and {@link #isStrictUploadValidationEnabled} are
+     * specified, this enum takes precedence.
+     */
+    UploadValidationStrictness getUploadValidationStrictness();
+
+    /** @see #getUploadValidationStrictness */
+    void setUploadValidationStrictness(UploadValidationStrictness uploadValidationStrictness);
 
     /**
      * Copies of all consent agreements, as well as rosters of all participants in a study, or any 

--- a/app/org/sagebionetworks/bridge/models/upload/UploadValidationStrictness.java
+++ b/app/org/sagebionetworks/bridge/models/upload/UploadValidationStrictness.java
@@ -1,0 +1,16 @@
+package org.sagebionetworks.bridge.models.upload;
+
+/** Enumeration of upload validation strictness settings. */
+public enum UploadValidationStrictness {
+    /** The default setting, which is to log a warning into the Bridge Server logs. */
+    WARNING,
+
+    /**
+     * In addition to logging a warning, this writes a validation message back into the health data record and exports
+     * that message to Synapse.
+     */
+    REPORT,
+
+    /** Throws an error if validation fails. */
+    STRICT,
+}

--- a/app/org/sagebionetworks/bridge/services/StudyService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyService.java
@@ -64,6 +64,7 @@ import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyAndUsers;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
+import org.sagebionetworks.bridge.models.upload.UploadValidationStrictness;
 import org.sagebionetworks.bridge.validators.StudyParticipantValidator;
 import org.sagebionetworks.bridge.validators.StudyValidator;
 import org.sagebionetworks.bridge.validators.Validate;
@@ -325,11 +326,16 @@ public class StudyService {
         }
 
         study.setActive(true);
-        study.setStrictUploadValidationEnabled(true);
         study.setStudyIdExcludedInExport(true);
         study.getDataGroups().add(BridgeConstants.TEST_USER_GROUP);
         setDefaultsIfAbsent(study);
         sanitizeHTML(study);
+
+        // If validation strictness isn't set on study creation, set it to a reasonable default.
+        if (study.getUploadValidationStrictness() == null) {
+            study.setUploadValidationStrictness(UploadValidationStrictness.REPORT);
+        }
+
         Validate.entityThrowingException(validator, study);
 
         if (studyDao.doesIdentifierExist(study.getIdentifier())) {
@@ -450,7 +456,6 @@ public class StudyService {
             study.setExternalIdRequiredOnSignup(originalStudy.isExternalIdRequiredOnSignup());
             study.setEmailSignInEnabled(originalStudy.isEmailSignInEnabled());
             study.setAccountLimit(originalStudy.getAccountLimit());
-            study.setStrictUploadValidationEnabled(originalStudy.isStrictUploadValidationEnabled());
             study.setStudyIdExcludedInExport(originalStudy.isStudyIdExcludedInExport());
         }
 

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -63,6 +63,7 @@ import org.sagebionetworks.bridge.models.studies.MimeType;
 import org.sagebionetworks.bridge.models.studies.PasswordPolicy;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
+import org.sagebionetworks.bridge.models.upload.UploadValidationStrictness;
 import org.sagebionetworks.bridge.validators.Validate;
 
 public class TestUtils {
@@ -386,6 +387,7 @@ public class TestUtils {
         study.setSynapseDataAccessTeamId(1234L);
         study.setSynapseProjectId("test-synapse-project-id");
         study.setTechnicalEmail("bridge-testing+technical@sagebase.org");
+        study.setUploadValidationStrictness(UploadValidationStrictness.REPORT);
         study.setUsesCustomExportSchedule(true);
         study.setSupportEmail("bridge-testing+support@sagebase.org");
         study.setUserProfileAttributes(Sets.newHashSet("a", "b"));

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
@@ -80,6 +80,8 @@ public class DynamoStudyTest {
         assertEqualsAndNotNull(study.getSynapseDataAccessTeamId(), node.get("synapseDataAccessTeamId").longValue());
         assertEqualsAndNotNull(study.getSynapseProjectId(), node.get("synapseProjectId").textValue());
         assertEqualsAndNotNull(study.getTechnicalEmail(), node.get("technicalEmail").asText());
+        assertEqualsAndNotNull(study.getUploadValidationStrictness().toString().toLowerCase(),
+                node.get("uploadValidationStrictness").textValue());
         assertTrue(node.get("usesCustomExportSchedule").asBoolean());
         assertEqualsAndNotNull(study.getSponsorName(), node.get("sponsorName").asText());
         assertEqualsAndNotNull(study.getName(), node.get("name").asText());

--- a/test/org/sagebionetworks/bridge/models/healthdata/HealthDataRecordTest.java
+++ b/test/org/sagebionetworks/bridge/models/healthdata/HealthDataRecordTest.java
@@ -78,6 +78,7 @@ public class HealthDataRecordTest {
         record.setUploadedOn(uploadedOn);
         record.setUserExternalId("optional external ID");
         record.setUserMetadata(DUMMY_USER_METADATA);
+        record.setValidationErrors("dummy validation errors");
         record.setVersion(42L);
 
         // validate
@@ -92,6 +93,7 @@ public class HealthDataRecordTest {
         assertEquals(uploadedOn, record.getUploadedOn().longValue());
         assertEquals("optional external ID", record.getUserExternalId());
         assertSame(DUMMY_USER_METADATA, record.getUserMetadata());
+        assertEquals("dummy validation errors", record.getValidationErrors());
         assertEquals(42, record.getVersion().longValue());
     }
     
@@ -280,6 +282,7 @@ public class HealthDataRecordTest {
                 "   \"userMetadata\":{\"userMetadata\":\"userMetaValue\"},\n" +
                 "   \"userSharingScope\":\"all_qualified_researchers\",\n" +
                 "   \"userExternalId\":\"ABC-123-XYZ\",\n" +
+                "   \"validationErrors\":\"dummy validation errors\",\n" +
                 "   \"version\":42\n" +
                 "}";
         long measuredTimeMillis = new DateTime(2014, 2, 12, 13, 45, BridgeConstants.LOCAL_TIME_ZONE).getMillis();
@@ -301,6 +304,7 @@ public class HealthDataRecordTest {
         assertEquals(uploadedOn, record.getUploadedOn().longValue());
         assertEquals(ParticipantOption.SharingScope.ALL_QUALIFIED_RESEARCHERS, record.getUserSharingScope());
         assertEquals("ABC-123-XYZ", record.getUserExternalId());
+        assertEquals("dummy validation errors", record.getValidationErrors());
         assertEquals(42, record.getVersion().longValue());
 
         assertEquals(1, record.getData().size());
@@ -317,7 +321,7 @@ public class HealthDataRecordTest {
 
         // then convert to a map so we can validate the raw JSON
         Map<String, Object> jsonMap = BridgeObjectMapper.get().readValue(convertedJson, JsonUtils.TYPE_REF_RAW_MAP);
-        assertEquals(20, jsonMap.size());
+        assertEquals(21, jsonMap.size());
         assertEquals(APP_VERSION, jsonMap.get("appVersion"));
         assertEquals("-0800", jsonMap.get("createdOnTimeZone"));
         assertEquals("json healthcode", jsonMap.get("healthCode"));
@@ -332,6 +336,7 @@ public class HealthDataRecordTest {
         assertEquals(uploadedOn, DateTime.parse((String) jsonMap.get("uploadedOn")).getMillis());
         assertEquals("all_qualified_researchers", jsonMap.get("userSharingScope"));
         assertEquals("ABC-123-XYZ", jsonMap.get("userExternalId"));
+        assertEquals("dummy validation errors", jsonMap.get("validationErrors"));
         assertEquals(42, jsonMap.get("version"));
         assertEquals("HealthData", jsonMap.get("type"));
 
@@ -355,7 +360,7 @@ public class HealthDataRecordTest {
 
         // Convert back to map again. Only validate a few key fields are present and the filtered fields are absent.
         Map<String, Object> publicJsonMap = BridgeObjectMapper.get().readValue(publicJson, JsonUtils.TYPE_REF_RAW_MAP);
-        assertEquals(19, publicJsonMap.size());
+        assertEquals(20, publicJsonMap.size());
         assertFalse(publicJsonMap.containsKey("healthCode"));
         assertEquals("json record ID", publicJsonMap.get("id"));
     }

--- a/test/org/sagebionetworks/bridge/upload/StrictValidationHandlerGetValidationStrictnessTest.java
+++ b/test/org/sagebionetworks/bridge/upload/StrictValidationHandlerGetValidationStrictnessTest.java
@@ -1,0 +1,90 @@
+package org.sagebionetworks.bridge.upload;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.upload.UploadValidationStrictness;
+import org.sagebionetworks.bridge.services.StudyService;
+
+public class StrictValidationHandlerGetValidationStrictnessTest {
+    private StrictValidationHandler handler;
+    private StudyService mockStudyService;
+
+    @Before
+    public void setup() {
+        mockStudyService = mock(StudyService.class);
+        handler = new StrictValidationHandler();
+        handler.setStudyService(mockStudyService);
+    }
+
+    @Test
+    public void enumStrict() {
+        // mock study
+        Study study = Study.create();
+        study.setUploadValidationStrictness(UploadValidationStrictness.STRICT);
+        study.setStrictUploadValidationEnabled(false);
+        when(mockStudyService.getStudy(TestConstants.TEST_STUDY)).thenReturn(study);
+
+        // execute and validate
+        UploadValidationStrictness retVal = handler.getUploadValidationStrictnessForStudy(TestConstants.TEST_STUDY);
+        assertEquals(UploadValidationStrictness.STRICT, retVal);
+    }
+
+    @Test
+    public void enumReport() {
+        // mock study
+        Study study = Study.create();
+        study.setUploadValidationStrictness(UploadValidationStrictness.REPORT);
+        study.setStrictUploadValidationEnabled(false);
+        when(mockStudyService.getStudy(TestConstants.TEST_STUDY)).thenReturn(study);
+
+        // execute and validate
+        UploadValidationStrictness retVal = handler.getUploadValidationStrictnessForStudy(TestConstants.TEST_STUDY);
+        assertEquals(UploadValidationStrictness.REPORT, retVal);
+    }
+
+    @Test
+    public void enumWarn() {
+        // mock study
+        Study study = Study.create();
+        study.setUploadValidationStrictness(UploadValidationStrictness.WARNING);
+        study.setStrictUploadValidationEnabled(true);
+        when(mockStudyService.getStudy(TestConstants.TEST_STUDY)).thenReturn(study);
+
+        // execute and validate
+        UploadValidationStrictness retVal = handler.getUploadValidationStrictnessForStudy(TestConstants.TEST_STUDY);
+        assertEquals(UploadValidationStrictness.WARNING, retVal);
+    }
+
+    @Test
+    public void booleanTrue() {
+        // mock study
+        Study study = Study.create();
+        study.setUploadValidationStrictness(null);
+        study.setStrictUploadValidationEnabled(true);
+        when(mockStudyService.getStudy(TestConstants.TEST_STUDY)).thenReturn(study);
+
+        // execute and validate
+        UploadValidationStrictness retVal = handler.getUploadValidationStrictnessForStudy(TestConstants.TEST_STUDY);
+        assertEquals(UploadValidationStrictness.STRICT, retVal);
+    }
+
+    @Test
+    public void booleanFalse() {
+        // mock study
+        Study study = Study.create();
+        study.setUploadValidationStrictness(null);
+        study.setStrictUploadValidationEnabled(false);
+        when(mockStudyService.getStudy(TestConstants.TEST_STUDY)).thenReturn(study);
+
+        // execute and validate
+        UploadValidationStrictness retVal = handler.getUploadValidationStrictnessForStudy(TestConstants.TEST_STUDY);
+        assertEquals(UploadValidationStrictness.WARNING, retVal);
+    }
+}


### PR DESCRIPTION
See https://sagebionetworks.jira.com/browse/BRIDGE-1865

Strict Validation as originally intended to filter out unusable data, such as Walking Activity with no accelerometer data, and to aid in app development by having missing (or incorrectly named) fields be rejected.

In practice, we just ended up setting most fields to required=false, which defeats the whole purpose of Strict Validation. In addition, researchers have asked for incomplete data, so they can do data quality analysis.

Our solution is to change the boolean Strict Validation into a three-state enum, and the default option will be to permit everything, but write the validation errors to Synapse so incomplete data is properly marked as such.

Testing done: updated unit tests and integ tests

Next steps: Update BridgeEX to read record.validationErrors and write it to Synapse.