### PR TITLE
Large Text Attachments

### DIFF
--- a/app/org/sagebionetworks/bridge/models/upload/UploadFieldType.java
+++ b/app/org/sagebionetworks/bridge/models/upload/UploadFieldType.java
@@ -58,6 +58,13 @@ public enum UploadFieldType {
     /** An integer value, generally represented as a long in Java (64-bit signed integer) */
     INT,
 
+    /**
+     * A value that is written to Synapse as a LargeText (unbounded String), but stored in Bridge as an attachment.
+     * This allows us to have inline strings larger than ~10kb without hitting DynamoDB's 400kb record limit. This is
+     * frequently used to upload large JSON blobs, like accelerometer data.
+     */
+    LARGE_TEXT_ATTACHMENT,
+
     /** Multiple choice question with multiple answers. */
     MULTI_CHOICE,
 
@@ -75,8 +82,11 @@ public enum UploadFieldType {
 
     /** A set of upload field types that are considered attachment types. */
     public static final Set<UploadFieldType> ATTACHMENT_TYPE_SET = EnumSet.of(ATTACHMENT_BLOB, ATTACHMENT_CSV,
-            ATTACHMENT_JSON_BLOB, ATTACHMENT_JSON_TABLE, ATTACHMENT_V2);
+            ATTACHMENT_JSON_BLOB, ATTACHMENT_JSON_TABLE, ATTACHMENT_V2, LARGE_TEXT_ATTACHMENT);
 
-    /* A set of upload field types that are freeform (or mostly freeform) strings. */
+    /**
+     * A set of upload field types that are freeform (or mostly freeform) strings. This is used to make calculations
+     * related to max length. As such, this doesn't include attachment types.
+     */
     public static final Set<UploadFieldType> STRING_TYPE_SET = EnumSet.of(INLINE_JSON_BLOB, SINGLE_CHOICE, STRING);
 }

--- a/app/org/sagebionetworks/bridge/upload/UploadUtil.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadUtil.java
@@ -181,7 +181,8 @@ public class UploadUtil {
             case ATTACHMENT_JSON_BLOB:
             case ATTACHMENT_JSON_TABLE:
             case ATTACHMENT_V2:
-            case INLINE_JSON_BLOB: {
+            case INLINE_JSON_BLOB:
+            case LARGE_TEXT_ATTACHMENT: {
                 // always valid, always canonical
                 return CanonicalizationResult.makeResult(valueNode);
             }

--- a/test/org/sagebionetworks/bridge/upload/UploadUtilTest.java
+++ b/test/org/sagebionetworks/bridge/upload/UploadUtilTest.java
@@ -83,6 +83,9 @@ public class UploadUtilTest {
                 // inline json
                 { new TextNode("dummy inline JSON"), UploadFieldType.INLINE_JSON_BLOB,
                         new TextNode("dummy inline JSON"), true },
+                // large text attachment
+                { new TextNode("dummy large text"), UploadFieldType.LARGE_TEXT_ATTACHMENT,
+                        new TextNode("dummy large text"), true },
                 // boolean zero false
                 { new IntNode(0), UploadFieldType.BOOLEAN, BooleanNode.FALSE, true },
                 // boolean positive true


### PR DESCRIPTION
See https://sagebionetworks.jira.com/browse/BRIDGE-1760

We want to be able to use LargeText to have accelerometer data (and other large JSON blobs) inline in Synapse tables. This will allow researchers to download the data within a single table instead of making downloads for hundreds of relatively small files.

Previously, our limitation was DynamoDB's 400kb limit. In this change, we add a new type that stores the data in S3 like an attachment, but uploads it to Synapse as a LargeText.

Testing done:
* Not much testing was done on the BridgePF side, since in BridgePF, this just looks like a normal attachment.
* End-to-end integ tests in BridgeExporterIntegrationTests tests using the Synchronous Health Data API.
* Upload ZIP files (both V1 Legacy and V2 Generic) were manually tested, as these are pain to add to unit tests.