### PR TITLE
Deploy app using travis service account

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ branches:
   - uat
   - prod
 deploy:
+  matrix:
   - provider: elasticbeanstalk
     skip_cleanup: true
     bucket_name: org-sagebridge-bridgepf-deployment-bridgepf-$TRAVIS_BRANCH
@@ -43,6 +44,6 @@ deploy:
       prod: bridgepf-prod
     on:
       all_branches: true
-    access_key_id: AKIAIG6T67NMROEIMC7A
+    access_key_id: AKIAJ6YWVFOX3GHDXVRQ
     secret_access_key:
-      secure: gKFHd4igRV5NxvlaDAJFzoiGcr+TEulbd3GQU2vqHjGZmNveQ0ilbbA5ycDOekxfcK6ucnOJGroEOGpqJe9sRGnXmryZ3uptSGH4PiGELtBRF1X2CGsT0oJa629v5qKtkvwBScPz4/kSiukcKrZwMqlXYYQR1exhRskOoa1GEbw=
+      secure: Jod2Jr1sj/ZqoK32+xkUTSlFhQbtUGTXkGmETCr132nEcCFK71ecysXA/ZsjxsJJDYUAP+xzMqs/tH0xq5YldW96yI0yzq9RH4lHaYJBVxp5LwLlmlGlSQ+tVrUxt4VW6djV/GtmVDKHjin10PTUjQp9WiLOBOOaf69Y+JxJ26I=


### PR DESCRIPTION
We used Bridge-infra[1] repo to bootstrap a service user (travis) for
the purpose of deploying CF templates to our AWS bridge account.
This change sets up CF deployments using the travis service account.

[1] https://github.com/Sage-Bionetworks/Bridge-infra/blob/develop/cf_templates/bootstrap.yml