### PR TITLE
Phone lookup

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/AccountDao.java
+++ b/app/org/sagebionetworks/bridge/dao/AccountDao.java
@@ -6,14 +6,13 @@ import org.joda.time.DateTime;
 
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.AccountSummary;
-import org.sagebionetworks.bridge.models.accounts.Email;
 import org.sagebionetworks.bridge.models.accounts.EmailVerification;
 import org.sagebionetworks.bridge.models.accounts.PasswordReset;
 import org.sagebionetworks.bridge.models.accounts.Phone;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
 import org.sagebionetworks.bridge.models.studies.Study;
-import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 
 /**
  * DAO to retrieve personally identifiable account information, including authentication 
@@ -38,13 +37,13 @@ public interface AccountDao {
      * Sign up sends an email address with a link that includes a one-time token for verification. That email
      * can be resent by calling this method.
      */
-    void resendEmailVerificationToken(StudyIdentifier studyIdentifier, Email email);
+    void resendEmailVerificationToken(AccountId accountId);
     
     /**
      * Request that an email be sent to the account holder with a link to reset a password, including a 
      * one-time verification token. 
      */
-    void requestResetPassword(Study study, Email email);
+    void requestResetPassword(AccountId accountId);
     
     /**
      * Reset a password, supplying a new password and the one-time verification token that was sent via email 
@@ -73,7 +72,7 @@ public interface AccountDao {
     /**
      * Sign the user out of Bridge. This clears the user's reauthentication token.
      */
-    void signOut(StudyIdentifier studyId, String email);
+    void signOut(AccountId accountId);
     
     /**
      * Retrieve an account where authentication is handled outside of the DAO (If we
@@ -83,7 +82,7 @@ public interface AccountDao {
      * reauthorization token, the same as the authenticate and reauthenticate calls.
      * This method returns null if the Account does not exist.
      */
-    Account getAccountAfterAuthentication(Study study, String email);
+    Account getAccountAfterAuthentication(AccountId accountId);
     
     /**
      * A factory method to construct a valid Account object that will work with our
@@ -105,22 +104,16 @@ public interface AccountDao {
     void updateAccount(Account account);
     
     /**
-     * Get an account in the context of a study by the user's ID or by their email address. 
-     * Returns null if there is no account, it is up to callers to translate this into the 
-     * appropriate exception, if any. 
+     * Get an account in the context of a study by the user's ID, email address, or phone 
+     * number. Returns null if there is no account, it is up to callers to translate this 
+     * into the appropriate exception, if any. 
      */
-    Account getAccount(Study study, String id);
-    
-    /**
-     * Get an account in the context of a study by the email address used to register the study. Returns 
-     * null if there is no account.
-     */
-    Account getAccountWithEmail(Study study, String email);
+    Account getAccount(AccountId accountId);
     
     /**
      * Delete an account along with the authentication credentials.
      */
-    void deleteAccount(Study study, String id);
+    void deleteAccount(AccountId accountId);
     
     /**
      * Get all account summaries in all studies in a given environment.
@@ -157,8 +150,8 @@ public interface AccountDao {
     /**
      * For MailChimp, and other external systems, we need a way to get a healthCode for a given email.
      */
-    default String getHealthCodeForEmail(Study study, String email) {
-        Account account = getAccountWithEmail(study, email);
+    default String getHealthCodeForAccount(AccountId accountId) {
+        Account account = getAccount(accountId);
         if (account != null) {
             return account.getHealthCode();
         } else {

--- a/app/org/sagebionetworks/bridge/dao/AccountDao.java
+++ b/app/org/sagebionetworks/bridge/dao/AccountDao.java
@@ -43,7 +43,7 @@ public interface AccountDao {
      * Request that an email be sent to the account holder with a link to reset a password, including a 
      * one-time verification token. 
      */
-    void requestResetPassword(AccountId accountId);
+    void requestResetPassword(Study study, AccountId accountId);
     
     /**
      * Reset a password, supplying a new password and the one-time verification token that was sent via email 

--- a/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
@@ -137,8 +137,8 @@ public class HibernateAccountDao implements AccountDao {
 
     /** {@inheritDoc} */
     @Override
-    public void requestResetPassword(AccountId accountId) {
-        accountWorkflowService.requestResetPassword(accountId);
+    public void requestResetPassword(Study study, AccountId accountId) {
+        accountWorkflowService.requestResetPassword(study, accountId);
     }
 
     /** {@inheritDoc} */
@@ -422,10 +422,12 @@ public class HibernateAccountDao implements AccountDao {
     /** {@inheritDoc} */
     @Override
     public void deleteAccount(AccountId accountId) {
-        HibernateAccount hibernateAccount = getHibernateAccount(accountId);
-        if (hibernateAccount != null) {
-            hibernateHelper.deleteById(HibernateAccount.class, hibernateAccount.getId());    
+        String userId = accountId.getUnguardedAccountId().getId();
+        if (userId == null) {
+            HibernateAccount hibernateAccount = getHibernateAccount(accountId);
+            userId = hibernateAccount.getId();
         }
+        hibernateHelper.deleteById(HibernateAccount.class, userId);    
     }
 
     /** {@inheritDoc} */

--- a/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
@@ -406,7 +406,7 @@ public class HibernateAccountDao implements AccountDao {
         if (unguarded.getEmail() != null) {
             query = String.format(EMAIL_QUERY, unguarded.getStudyId(), unguarded.getEmail());
         } else {
-            query = String.format(PHONE_QUERY, unguarded.getStudyId(), unguarded.getPhone());
+            query = String.format(PHONE_QUERY, unguarded.getStudyId(), unguarded.getPhone().getNumber());
         }
         List<HibernateAccount> accountList = hibernateHelper.queryGet(query, null, null, HibernateAccount.class);
         if (accountList.isEmpty()) {

--- a/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
@@ -34,9 +34,9 @@ import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.ResourceList;
 import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.AccountStatus;
 import org.sagebionetworks.bridge.models.accounts.AccountSummary;
-import org.sagebionetworks.bridge.models.accounts.Email;
 import org.sagebionetworks.bridge.models.accounts.EmailVerification;
 import org.sagebionetworks.bridge.models.accounts.GenericAccount;
 import org.sagebionetworks.bridge.models.accounts.HealthId;
@@ -62,6 +62,8 @@ public class HibernateAccountDao implements AccountDao {
 
     static final String ACCOUNT_SUMMARY_QUERY_PREFIX = "select new " + HibernateAccount.class.getCanonicalName() +
             "(createdOn, studyId, firstName, lastName, email, id, status) ";
+    static final String EMAIL_QUERY = "from HibernateAccount where studyId='%s' and email='%s'";
+    static final String PHONE_QUERY = "from HibernateAccount where studyId='%s' and phone='%s'";
     
     private AccountWorkflowService accountWorkflowService;
     private HealthCodeService healthCodeService;
@@ -129,14 +131,14 @@ public class HibernateAccountDao implements AccountDao {
 
     /** {@inheritDoc} */
     @Override
-    public void resendEmailVerificationToken(StudyIdentifier studyIdentifier, Email email) {
-        accountWorkflowService.resendEmailVerificationToken(studyIdentifier, email);
+    public void resendEmailVerificationToken(AccountId accountId) {
+        accountWorkflowService.resendEmailVerificationToken(accountId);
     }
 
     /** {@inheritDoc} */
     @Override
-    public void requestResetPassword(Study study, Email email) {
-        accountWorkflowService.requestResetPassword(study, email);
+    public void requestResetPassword(AccountId accountId) {
+        accountWorkflowService.requestResetPassword(accountId);
     }
 
     /** {@inheritDoc} */
@@ -190,18 +192,18 @@ public class HibernateAccountDao implements AccountDao {
         verifyCredential(hibernateAccount.getId(), credentialName, algorithm, hash, credentialValue);
 
         // Unmarshall account
-        validateHealthCode(new StudyIdentifierImpl(hibernateAccount.getStudyId()), hibernateAccount, false);
+        validateHealthCode(hibernateAccount, false);
         Account account = unmarshallAccount(hibernateAccount);
         updateReauthToken(hibernateAccount, account);
         return account;
     }
 
     @Override
-    public Account getAccountAfterAuthentication(Study study, String email) {
-        HibernateAccount hibernateAccount = getHibernateAccountByEmail(study, email);
+    public Account getAccountAfterAuthentication(AccountId accountId) {
+        HibernateAccount hibernateAccount = getHibernateAccount(accountId);
         
         if (hibernateAccount != null) {
-            validateHealthCode(study.getStudyIdentifier(), hibernateAccount, false);
+            validateHealthCode(hibernateAccount, false);
             Account account = unmarshallAccount(hibernateAccount);
             updateReauthToken(hibernateAccount, account);
             return account;
@@ -212,8 +214,8 @@ public class HibernateAccountDao implements AccountDao {
     }
 
     @Override
-    public void signOut(StudyIdentifier studyId, String email) {
-        HibernateAccount hibernateAccount = getHibernateAccountByEmail(studyId, email);
+    public void signOut(AccountId accountId) {
+        HibernateAccount hibernateAccount = getHibernateAccount(accountId);
         if (hibernateAccount != null) {
             hibernateAccount.setReauthTokenHash(null);
             hibernateAccount.setReauthTokenAlgorithm(null);
@@ -302,7 +304,7 @@ public class HibernateAccountDao implements AccountDao {
             hibernateHelper.create(hibernateAccount);
         } catch (ConcurrentModificationException ex) {
             // account exists, but we don't have the userId, load the account
-            HibernateAccount otherAccount = getHibernateAccountByEmail(study, account.getEmail());
+            HibernateAccount otherAccount = getHibernateAccount(AccountId.forEmail(study.getIdentifier(), account.getEmail()));
             if (otherAccount != null) {
                 throw new EntityAlreadyExistsException(Account.class, "userId", otherAccount.getId());
             } else {
@@ -340,10 +342,10 @@ public class HibernateAccountDao implements AccountDao {
 
     /** {@inheritDoc} */
     @Override
-    public Account getAccount(Study study, String id) {
-        HibernateAccount hibernateAccount = hibernateHelper.getById(HibernateAccount.class, id);
+    public Account getAccount(AccountId accountId) {
+        HibernateAccount hibernateAccount = getHibernateAccount(accountId);
         if (hibernateAccount != null) {
-            validateHealthCode(study.getStudyIdentifier(), hibernateAccount, true);
+            validateHealthCode(hibernateAccount, true);
             Account account = unmarshallAccount(hibernateAccount);
             return account;
         } else {
@@ -352,21 +354,9 @@ public class HibernateAccountDao implements AccountDao {
         }
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public Account getAccountWithEmail(Study study, String email) {
-        HibernateAccount hibernateAccount = getHibernateAccountByEmail(study.getStudyIdentifier(), email);
-        if (hibernateAccount != null) {
-            validateHealthCode(study.getStudyIdentifier(), hibernateAccount, true);
-            return unmarshallAccount(hibernateAccount);
-        } else {
-            return null;
-        }
-    }
-
     private HibernateAccount fetchHibernateAccount(Study study, SignIn signIn) {
         // Fetch account
-        HibernateAccount hibernateAccount = getHibernateAccountByEmail(study.getStudyIdentifier(), signIn.getEmail());
+        HibernateAccount hibernateAccount = getHibernateAccount(signIn.getAccountId());
         if (hibernateAccount == null || hibernateAccount.getStatus() == AccountStatus.UNVERIFIED) {
             throw new EntityNotFoundException(Account.class);
         }
@@ -403,27 +393,36 @@ public class HibernateAccountDao implements AccountDao {
         return hash;
     }
 
-    // Helper method to get a single account for a given study and email address.
-    private HibernateAccount getHibernateAccountByEmail(StudyIdentifier studyId, String email) {
-        List<HibernateAccount> accountList = hibernateHelper.queryGet("from HibernateAccount where studyId='" +
-                studyId.getIdentifier() + "' and email='" + email + "'", null, null, HibernateAccount.class);
+    // Helper method to get a single account for a given study and id, email address, or phone number.
+    private HibernateAccount getHibernateAccount(AccountId accountId) {
+        AccountId unguarded = accountId.getUnguardedAccountId();
+        if (unguarded.getId() != null) {
+            return hibernateHelper.getById(HibernateAccount.class, unguarded.getId());
+        }
+        String query = null;
+        if (unguarded.getEmail() != null) {
+            query = String.format(EMAIL_QUERY, unguarded.getStudyId(), unguarded.getEmail());
+        } else {
+            query = String.format(PHONE_QUERY, unguarded.getStudyId(), unguarded.getPhone());
+        }
+        List<HibernateAccount> accountList = hibernateHelper.queryGet(query, null, null, HibernateAccount.class);
         if (accountList.isEmpty()) {
             return null;
         }
         HibernateAccount hibernateAccount = accountList.get(0);
-
         if (accountList.size() > 1) {
-            LOG.warn("Multiple accounts found for the same study and email address; example accountId=" +
-                    hibernateAccount.getId());
+            LOG.warn("Multiple accounts found email/phone query; example accountId=" + hibernateAccount.getId());
         }
-
         return hibernateAccount;
     }
 
     /** {@inheritDoc} */
     @Override
-    public void deleteAccount(Study study, String id) {
-        hibernateHelper.deleteById(HibernateAccount.class, id);
+    public void deleteAccount(AccountId accountId) {
+        HibernateAccount hibernateAccount = getHibernateAccount(accountId);
+        if (hibernateAccount != null) {
+            hibernateHelper.deleteById(HibernateAccount.class, hibernateAccount.getId());    
+        }
     }
 
     /** {@inheritDoc} */
@@ -571,11 +570,11 @@ public class HibernateAccountDao implements AccountDao {
     // through the DAO will automatically have health code and ID populated, but accounts created in the DB directly
     // are left in a bad state. This method validates the health code mapping on a HibernateAccount and updates it as
     // is necessary.
-    private void validateHealthCode(StudyIdentifier studyId, HibernateAccount hibernateAccount, boolean doSave) {
+    private void validateHealthCode(HibernateAccount hibernateAccount, boolean doSave) {
         if (StringUtils.isBlank(hibernateAccount.getHealthCode()) ||
                 StringUtils.isBlank(hibernateAccount.getHealthId())) {
             // Generate health code mapping.
-            HealthId healthId = healthCodeService.createMapping(studyId);
+            HealthId healthId = healthCodeService.createMapping(new StudyIdentifierImpl(hibernateAccount.getStudyId()));
             hibernateAccount.setHealthCode(healthId.getCode());
             hibernateAccount.setHealthId(healthId.getId());
 

--- a/app/org/sagebionetworks/bridge/models/CriteriaContext.java
+++ b/app/org/sagebionetworks/bridge/models/CriteriaContext.java
@@ -6,6 +6,7 @@ import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
 
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 
 import com.google.common.collect.ImmutableSet;
@@ -28,6 +29,10 @@ public final class CriteriaContext {
         this.clientInfo = clientInfo;
         this.userDataGroups = (userDataGroups == null) ? ImmutableSet.of() : ImmutableSet.copyOf(userDataGroups);
         this.languages = (languages == null) ? new LinkedHashSet<>() : languages;
+    }
+    
+    public AccountId getAccountId() {
+        return AccountId.forId(studyId.getIdentifier(), userId);
     }
 
     /**

--- a/app/org/sagebionetworks/bridge/models/accounts/AccountId.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/AccountId.java
@@ -1,11 +1,8 @@
 package org.sagebionetworks.bridge.models.accounts;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Objects;
-
-import com.google.common.base.Preconditions;
 
 /**
  * An identifier that can be used to find an account (a study identifier with an ID, email, or phone number).
@@ -48,19 +45,27 @@ public final class AccountId {
     // the DAO where these values are checked to determine the type of database query.
     
     public String getStudyId() {
-        checkArgument(!usePreconditions || studyId != null);
+        if (usePreconditions && studyId == null) {
+            throw new NullPointerException("AccountId.studyId is null");
+        }
         return studyId;
     }
     public String getId() {
-        checkArgument(!usePreconditions || id != null);
+        if (usePreconditions && id == null) {
+            throw new NullPointerException("AccountId.id is null");
+        }
         return id;
     }
     public String getEmail() {
-        checkArgument(!usePreconditions || email != null);
+        if (usePreconditions && email == null) {
+            throw new NullPointerException("AccountId.email is null");
+        }
         return email;
     }
     public Phone getPhone() {
-        checkArgument(!usePreconditions || phone != null);
+        if (usePreconditions && phone == null) {
+            throw new NullPointerException("AccountId.phone is null");
+        }
         return phone;
     }
     public AccountId getUnguardedAccountId() {

--- a/app/org/sagebionetworks/bridge/models/accounts/AccountId.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/AccountId.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.models.accounts;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Objects;
@@ -47,30 +48,24 @@ public final class AccountId {
     // the DAO where these values are checked to determine the type of database query.
     
     public String getStudyId() {
-        //Preconditions.checkArgument(usePreconditions && studyId != null);
-        Preconditions.checkArgument( !(usePreconditions && studyId == null) );
+        checkArgument(!usePreconditions || studyId != null);
         return studyId;
     }
     public String getId() {
-        //Preconditions.checkArgument(usePreconditions && id != null);
-        Preconditions.checkArgument( !(usePreconditions && id == null) );
+        checkArgument(!usePreconditions || id != null);
         return id;
     }
     public String getEmail() {
-        //Preconditions.checkArgument(usePreconditions && email != null);
-        Preconditions.checkArgument( !(usePreconditions && email == null) );
+        checkArgument(!usePreconditions || email != null);
         return email;
     }
     public Phone getPhone() {
-        //Preconditions.checkArgument(usePreconditions && phone != null);
-        Preconditions.checkArgument( !(usePreconditions && phone == null) );
+        checkArgument(!usePreconditions || phone != null);
         return phone;
     }
-    
     public AccountId getUnguardedAccountId() {
         return new AccountId(this.studyId, this.id, this.email, this.phone, false);
     }
-    
     @Override
     public int hashCode() {
         return Objects.hash(studyId, email, id, phone, usePreconditions);

--- a/app/org/sagebionetworks/bridge/models/accounts/AccountId.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/AccountId.java
@@ -1,0 +1,93 @@
+package org.sagebionetworks.bridge.models.accounts;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Objects;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * An identifier that can be used to find an account (a study identifier with an ID, email, or phone number).
+ * Note that AccountId inequality does not indicate the objects represent two different accounts! 
+ */
+public final class AccountId {
+    
+    public final static AccountId forId(String studyId, String id) {
+        checkNotNull(studyId);
+        checkNotNull(id);
+        return new AccountId(studyId, id, null, null, true);
+    }
+    public final static AccountId forEmail(String studyId, String email) {
+        checkNotNull(studyId);
+        checkNotNull(email);
+        return new AccountId(studyId, null, email, null, true);
+    }
+    public final static AccountId forPhone(String studyId, Phone phone) {
+        checkNotNull(studyId);
+        checkNotNull(phone);
+        return new AccountId(studyId, null, null, phone, true);
+    }
+    
+    private final String studyId;
+    private final String id;
+    private final String email;
+    private final Phone phone;
+    private final boolean usePreconditions;
+    
+    private AccountId(String studyId, String id, String email, Phone phone, boolean usePreconditions) {
+        this.studyId = studyId;
+        this.id = id;
+        this.email = email;
+        this.phone = phone;
+        this.usePreconditions = usePreconditions;
+    }
+    
+    // It's important to guard against constructing AccountId with one of the identifying values, 
+    // then trying to retrieve a different value. Force a failue in this case until you get to 
+    // the DAO where these values are checked to determine the type of database query.
+    
+    public String getStudyId() {
+        //Preconditions.checkArgument(usePreconditions && studyId != null);
+        Preconditions.checkArgument( !(usePreconditions && studyId == null) );
+        return studyId;
+    }
+    public String getId() {
+        //Preconditions.checkArgument(usePreconditions && id != null);
+        Preconditions.checkArgument( !(usePreconditions && id == null) );
+        return id;
+    }
+    public String getEmail() {
+        //Preconditions.checkArgument(usePreconditions && email != null);
+        Preconditions.checkArgument( !(usePreconditions && email == null) );
+        return email;
+    }
+    public Phone getPhone() {
+        //Preconditions.checkArgument(usePreconditions && phone != null);
+        Preconditions.checkArgument( !(usePreconditions && phone == null) );
+        return phone;
+    }
+    
+    public AccountId getUnguardedAccountId() {
+        return new AccountId(this.studyId, this.id, this.email, this.phone, false);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(studyId, email, id, phone, usePreconditions);
+    }
+    
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null || getClass() != obj.getClass())
+            return false;
+        AccountId other = (AccountId) obj;
+        return Objects.equals(studyId, other.studyId) &&
+                Objects.equals(email, other.email) && 
+                Objects.equals(id, other.id) &&
+                Objects.equals(phone, other.phone) &&
+                Objects.equals(usePreconditions, other.usePreconditions);
+    }
+    
+}

--- a/app/org/sagebionetworks/bridge/models/accounts/Phone.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/Phone.java
@@ -2,6 +2,8 @@ package org.sagebionetworks.bridge.models.accounts;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.util.Objects;
+
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.Transient;
@@ -11,8 +13,11 @@ import com.google.i18n.phonenumbers.PhoneNumberUtil;
 import com.google.i18n.phonenumbers.PhoneNumberUtil.PhoneNumberFormat;
 import com.google.i18n.phonenumbers.Phonenumber.PhoneNumber;
 
+/**
+ * A phone number. Phone is mutable, do not use it as a key in a map.
+ */
 @Embeddable
-public class Phone {
+public final class Phone {
     
     public static final boolean isValid(Phone phone) {
         checkNotNull(phone);
@@ -69,5 +74,20 @@ public class Phone {
             }
         }
         return number;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getNumber(), regionCode);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null || getClass() != obj.getClass())
+            return false;
+        Phone other = (Phone) obj;
+        return Objects.equals(getNumber(), other.getNumber()) && Objects.equals(regionCode, other.regionCode);
     }
 }

--- a/app/org/sagebionetworks/bridge/models/accounts/SignIn.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/SignIn.java
@@ -53,7 +53,7 @@ public final class SignIn implements BridgeEntity {
         if (email != null) {
             return AccountId.forEmail(studyId, email);
         } else if (phone != null) {
-            return AccountId.forEmail(studyId, phone.getNumber());
+            return AccountId.forPhone(studyId, phone);
         }
         throw new IllegalArgumentException("SignIn not constructed with enough information to retrieve an account");
     }

--- a/app/org/sagebionetworks/bridge/models/accounts/SignIn.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/SignIn.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge.models.accounts;
 
 import org.sagebionetworks.bridge.models.BridgeEntity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize(builder = SignIn.Builder.class)
@@ -45,6 +46,16 @@ public final class SignIn implements BridgeEntity {
     
     public String getReauthToken() {
         return reauthToken;
+    }
+    
+    @JsonIgnore
+    public AccountId getAccountId() {
+        if (email != null) {
+            return AccountId.forEmail(studyId, email);
+        } else if (phone != null) {
+            return AccountId.forEmail(studyId, phone.getNumber());
+        }
+        throw new IllegalArgumentException("SignIn not constructed with enough information to retrieve an account");
     }
     
     public static class Builder {

--- a/app/org/sagebionetworks/bridge/play/controllers/EmailController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/EmailController.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.studies.Study;
 
 import org.apache.commons.lang3.StringUtils;
@@ -64,7 +65,8 @@ public class EmailController extends BaseController {
             }
             
             // This should always return a healthCode under normal circumstances.
-            String healthCode = accountDao.getHealthCodeForEmail(study, email);
+            AccountId accountId = AccountId.forEmail(study.getIdentifier(), email);
+            String healthCode = accountDao.getHealthCodeForAccount(accountId);
             if (healthCode == null) {
                 throw new BadRequestException("Email not found.");
             }

--- a/app/org/sagebionetworks/bridge/play/controllers/ParticipantReportController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ParticipantReportController.java
@@ -20,6 +20,7 @@ import org.sagebionetworks.bridge.models.DateRangeResourceList;
 import org.sagebionetworks.bridge.models.ForwardCursorPagedResourceList;
 import org.sagebionetworks.bridge.models.ReportTypeResourceList;
 import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.reports.ReportData;
 import org.sagebionetworks.bridge.models.reports.ReportIndex;
@@ -115,7 +116,7 @@ public class ParticipantReportController extends BaseController {
         LocalDate startDate = getLocalDateOrDefault(startDateString, null);
         LocalDate endDate = getLocalDateOrDefault(endDateString, null);
         
-        Account account = accountDao.getAccount(study, userId);
+        Account account = accountDao.getAccount(AccountId.forId(study.getIdentifier(), userId));
         
         DateRangeResourceList<? extends ReportData> results = reportService.getParticipantReport(
                 session.getStudyIdentifier(), identifier, account.getHealthCode(), startDate, endDate);
@@ -132,7 +133,7 @@ public class ParticipantReportController extends BaseController {
         DateTime endTime = getDateTimeOrDefault(endTimeString, null);
         int pageSize = getIntOrDefault(pageSizeString, BridgeConstants.API_DEFAULT_PAGE_SIZE);
         
-        Account account = accountDao.getAccount(study, userId);
+        Account account = accountDao.getAccount(AccountId.forId(study.getIdentifier(), userId));
         
         ForwardCursorPagedResourceList<ReportData> page = reportService.getParticipantReportV4(
                 session.getStudyIdentifier(), identifier, account.getHealthCode(), startTime, endTime, offsetKey,
@@ -149,7 +150,7 @@ public class ParticipantReportController extends BaseController {
         UserSession session = getAuthenticatedSession(DEVELOPER);
         Study study = studyService.getStudy(session.getStudyIdentifier());
         
-        Account account = accountDao.getAccount(study, userId);
+        Account account = accountDao.getAccount(AccountId.forId(study.getIdentifier(), userId));
         
         ReportData reportData = parseJson(request(), ReportData.class);
         reportData.setKey(null); // set in service, but just so no future use depends on it
@@ -191,7 +192,7 @@ public class ParticipantReportController extends BaseController {
         UserSession session = getAuthenticatedSession(DEVELOPER, WORKER);
         Study study = studyService.getStudy(session.getStudyIdentifier());
         
-        Account account = accountDao.getAccount(study, userId);
+        Account account = accountDao.getAccount(AccountId.forId(study.getIdentifier(), userId));
         
         reportService.deleteParticipantReport(session.getStudyIdentifier(), identifier, account.getHealthCode());
         
@@ -205,7 +206,7 @@ public class ParticipantReportController extends BaseController {
         UserSession session = getAuthenticatedSession(DEVELOPER, WORKER);
         Study study = studyService.getStudy(session.getStudyIdentifier());
         
-        Account account = accountDao.getAccount(study, userId);
+        Account account = accountDao.getAccount(AccountId.forId(study.getIdentifier(), userId));
         
         reportService.deleteParticipantReportRecord(session.getStudyIdentifier(), identifier, dateString, account.getHealthCode());
         

--- a/app/org/sagebionetworks/bridge/services/AccountWorkflowService.java
+++ b/app/org/sagebionetworks/bridge/services/AccountWorkflowService.java
@@ -15,12 +15,12 @@ import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.Email;
 import org.sagebionetworks.bridge.models.accounts.EmailVerification;
 import org.sagebionetworks.bridge.models.accounts.PasswordReset;
 import org.sagebionetworks.bridge.models.studies.EmailTemplate;
 import org.sagebionetworks.bridge.models.studies.Study;
-import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.services.email.BasicEmailProvider;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -115,14 +115,13 @@ public class AccountWorkflowService {
      * Send another email verification token. This creates and sends a new verification token 
      * starting with the user's email address.
      */
-    public void resendEmailVerificationToken(StudyIdentifier studyIdentifier, Email email) {
-        checkNotNull(studyIdentifier);
-        checkNotNull(email);
+    public void resendEmailVerificationToken(AccountId accountId) {
+        checkNotNull(accountId);
         
-        Study study = studyService.getStudy(studyIdentifier);
-        Account account = accountDao.getAccountWithEmail(study, email.getEmail());
+        Study study = studyService.getStudy(accountId.getStudyId());
+        Account account = accountDao.getAccount(accountId);
         if (account != null) {
-            sendEmailVerificationToken(study, account.getId(), email.getEmail());
+            sendEmailVerificationToken(study, account.getId(), account.getEmail());
         }
     }
     
@@ -143,7 +142,7 @@ public class AccountWorkflowService {
         }
         Study study = studyService.getStudy(data.getStudyId());
 
-        Account account = accountDao.getAccount(study, data.getUserId());
+        Account account = accountDao.getAccount(AccountId.forId(study.getIdentifier(), data.getUserId()));
         if (account == null) {
             throw new EntityNotFoundException(Account.class);
         }
@@ -159,7 +158,7 @@ public class AccountWorkflowService {
         checkNotNull(study);
         checkNotNull(email);
         
-        sendPasswordResetRelatedEmail(study, email, study.getAccountExistsTemplate());
+        sendPasswordResetRelatedEmail(study, email.getEmail(), study.getAccountExistsTemplate());
     }
     
     /**
@@ -168,21 +167,21 @@ public class AccountWorkflowService {
      * the email does not map to an account, in order to prevent account enumeration 
      * attacks.
      */
-    public void requestResetPassword(Study study, Email email) {
-        checkNotNull(study);
-        checkNotNull(email);
+    public void requestResetPassword(AccountId accountId) {
+        checkNotNull(accountId);
         
-        Account account = accountDao.getAccountWithEmail(study, email.getEmail());
+        Account account = accountDao.getAccount(accountId);
         if (account != null) {
-            sendPasswordResetRelatedEmail(study, email, study.getResetPasswordTemplate());    
+            Study study = studyService.getStudy(account.getStudyIdentifier());
+            sendPasswordResetRelatedEmail(study, account.getEmail(), study.getResetPasswordTemplate());    
         }
     }
 
-    private void sendPasswordResetRelatedEmail(Study study, Email email, EmailTemplate template) {
+    private void sendPasswordResetRelatedEmail(Study study, String email, EmailTemplate template) {
         String sptoken = createTimeLimitedToken();
         
         String cacheKey = sptoken + ":" + study.getIdentifier();
-        cacheProvider.setString(cacheKey, email.getEmail(), EXPIRE_IN_SECONDS);
+        cacheProvider.setString(cacheKey, email, EXPIRE_IN_SECONDS);
         
         String studyId = BridgeUtils.encodeURIComponent(study.getIdentifier());
         String url = String.format(RESET_PASSWORD_URL, BASE_URL, studyId, sptoken);
@@ -190,7 +189,7 @@ public class AccountWorkflowService {
         BasicEmailProvider provider = new BasicEmailProvider.Builder()
             .withStudy(study)
             .withEmailTemplate(template)
-            .withRecipientEmail(email.getEmail())
+            .withRecipientEmail(email)
             .withToken(URL_TOKEN, url)
             .withToken(EXP_WINDOW_TOKEN, Integer.toString(EXPIRE_IN_SECONDS/60/60)).build();
         sendMailService.sendEmail(provider);
@@ -213,7 +212,7 @@ public class AccountWorkflowService {
         cacheProvider.removeString(cacheKey);
         
         Study study = studyService.getStudy(passwordReset.getStudyIdentifier());
-        Account account = accountDao.getAccountWithEmail(study, email);
+        Account account = accountDao.getAccount(AccountId.forEmail(study.getIdentifier(), email));
         if (account == null) {
             throw new EntityNotFoundException(Account.class);
         }

--- a/app/org/sagebionetworks/bridge/services/AccountWorkflowService.java
+++ b/app/org/sagebionetworks/bridge/services/AccountWorkflowService.java
@@ -167,12 +167,12 @@ public class AccountWorkflowService {
      * the email does not map to an account, in order to prevent account enumeration 
      * attacks.
      */
-    public void requestResetPassword(AccountId accountId) {
+    public void requestResetPassword(Study study, AccountId accountId) {
         checkNotNull(accountId);
+        checkArgument(study.getIdentifier().equals(accountId.getStudyId()));
         
         Account account = accountDao.getAccount(accountId);
         if (account != null) {
-            Study study = studyService.getStudy(account.getStudyIdentifier());
             sendPasswordResetRelatedEmail(study, account.getEmail(), study.getResetPasswordTemplate());    
         }
     }

--- a/app/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -311,7 +311,7 @@ public class AuthenticationService {
         Validate.entityThrowingException(EmailValidator.INSTANCE, email);
         try {
             AccountId accountId = AccountId.forEmail(study.getIdentifier(), email.getEmail());
-            accountDao.requestResetPassword(accountId);    
+            accountDao.requestResetPassword(study, accountId);    
         } catch(EntityNotFoundException e) {
             // Suppress this. Otherwise it reveals if the account does not exist
             LOG.info("Request reset password request for unregistered email in study '"+study.getIdentifier()+"'");

--- a/app/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -23,6 +23,7 @@ import org.sagebionetworks.bridge.exceptions.LimitExceededException;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.AccountStatus;
 import org.sagebionetworks.bridge.models.accounts.Email;
 import org.sagebionetworks.bridge.models.accounts.EmailVerification;
@@ -128,7 +129,7 @@ public class AuthenticationService {
         }
         
         // check that email is in the study, if not, return quietly to prevent account enumeration attacks
-        if (accountDao.getAccountWithEmail(study, signIn.getEmail()) == null) {
+        if (accountDao.getAccount(signIn.getAccountId()) == null) {
             try {
                 // The not found case returns *much* faster than the normal case. To prevent account enumeration 
                 // attacks, measure time of a successful case and delay for that period before returning.
@@ -168,7 +169,7 @@ public class AuthenticationService {
         // Consume the key regardless of what happens
         cacheProvider.removeString(cacheKey);
         
-        Account account = accountDao.getAccountAfterAuthentication(study, signIn.getEmail());
+        Account account = accountDao.getAccountAfterAuthentication(signIn.getAccountId());
         if (account.getStatus() == AccountStatus.DISABLED) {
             throw new AccountDisabledException();
         } else if (account.getStatus() == AccountStatus.UNVERIFIED) {
@@ -214,7 +215,7 @@ public class AuthenticationService {
         checkNotNull(study);
         checkNotNull(context);
 
-        Account account = accountDao.getAccount(study, context.getUserId());
+        Account account = accountDao.getAccount(context.getAccountId());
         return getSessionFromAccount(study, context, account);
     }
 
@@ -256,7 +257,8 @@ public class AuthenticationService {
 
     public void signOut(final UserSession session) {
         if (session != null) {
-            accountDao.signOut(session.getStudyIdentifier(), session.getParticipant().getEmail());
+            AccountId accountId = AccountId.forId(session.getStudyIdentifier().getIdentifier(), session.getId());
+            accountDao.signOut(accountId);
             cacheProvider.removeSession(session);
         }
     }
@@ -294,7 +296,8 @@ public class AuthenticationService {
         
         Validate.entityThrowingException(EmailValidator.INSTANCE, email);
         try {
-            accountDao.resendEmailVerificationToken(studyIdentifier, email);    
+            AccountId accountId = AccountId.forEmail(studyIdentifier.getIdentifier(), email.getEmail());
+            accountDao.resendEmailVerificationToken(accountId);    
         } catch(EntityNotFoundException e) {
             // Suppress this. Otherwise it reveals if the account does not exist
             LOG.info("Resend email verification for unregistered email in study '"+studyIdentifier.getIdentifier()+"'");
@@ -307,7 +310,8 @@ public class AuthenticationService {
         
         Validate.entityThrowingException(EmailValidator.INSTANCE, email);
         try {
-            accountDao.requestResetPassword(study, email);    
+            AccountId accountId = AccountId.forEmail(study.getIdentifier(), email.getEmail());
+            accountDao.requestResetPassword(accountId);    
         } catch(EntityNotFoundException e) {
             // Suppress this. Otherwise it reveals if the account does not exist
             LOG.info("Request reset password request for unregistered email in study '"+study.getIdentifier()+"'");

--- a/app/org/sagebionetworks/bridge/services/ConsentService.java
+++ b/app/org/sagebionetworks/bridge/services/ConsentService.java
@@ -20,6 +20,7 @@ import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.Withdrawal;
@@ -53,7 +54,6 @@ public class ConsentService {
     private StudyConsentService studyConsentService;
     private ActivityEventService activityEventService;
     private SubpopulationService subpopService;
-    private StudyService studyService;
     private String consentTemplate;
     
     @Value("classpath:study-defaults/consent-page.xhtml")
@@ -86,10 +86,6 @@ public class ConsentService {
     final void setSubpopulationService(SubpopulationService subpopService) {
         this.subpopService = subpopService;
     }
-    @Autowired
-    final void setStudyService(StudyService studyService) {
-        this.studyService = studyService;
-    }
     
     /**
      * Get the user's active consent signature (a signature that has not been withdrawn).
@@ -107,7 +103,7 @@ public class ConsentService {
         // This will throw an EntityNotFoundException if the subpopulation is not in the user's study
         subpopService.getSubpopulation(study, subpopGuid);
         
-        Account account = accountDao.getAccount(study, userId);
+        Account account = accountDao.getAccount(AccountId.forId(study.getIdentifier(), userId));
         ConsentSignature signature = account.getActiveConsentSignature(subpopGuid);
         if (signature == null) {
             throw new EntityNotFoundException(ConsentSignature.class);    
@@ -151,7 +147,7 @@ public class ConsentService {
         
         // If there's a signature to the current and active consent, user cannot consent again. They can sign
         // any other consent, including more recent consents.
-        Account account = accountDao.getAccount(study, participant.getId());
+        Account account = accountDao.getAccount(AccountId.forId(study.getIdentifier(), participant.getId()));
         ConsentSignature active = account.getActiveConsentSignature(subpopGuid);
         if (active != null && active.getConsentCreatedOn() == studyConsent.getCreatedOn()) {
             throw new EntityAlreadyExistsException(ConsentSignature.class, null);
@@ -193,8 +189,7 @@ public class ConsentService {
     public Map<SubpopulationGuid,ConsentStatus> getConsentStatuses(CriteriaContext context) {
         checkNotNull(context);
         
-        Study study = studyService.getStudy(context.getStudyIdentifier());
-        Account account = accountDao.getAccount(study, context.getUserId());
+        Account account = accountDao.getAccount(context.getAccountId());
         
         ImmutableMap.Builder<SubpopulationGuid, ConsentStatus> builder = new ImmutableMap.Builder<>();
         for (Subpopulation subpop : subpopService.getSubpopulationForUser(context)) {
@@ -227,7 +222,7 @@ public class ConsentService {
         checkNotNull(withdrawal);
         checkArgument(withdrewOn > 0);
         
-        Account account = accountDao.getAccount(study, participant.getId());
+        Account account = accountDao.getAccount(context.getAccountId());
         
         String externalId = participant.getExternalId();
         
@@ -262,7 +257,7 @@ public class ConsentService {
         checkNotNull(withdrawal);
         checkArgument(withdrewOn > 0);
 
-        Account account = accountDao.getAccount(study, context.getUserId());
+        Account account = accountDao.getAccount(context.getAccountId());
         
         // Do this first, as it directly impacts the export of data, and if nothing else, we'd like this to succeed.
         optionsService.setEnum(study.getStudyIdentifier(), account.getHealthCode(), SHARING_SCOPE, SharingScope.NO_SHARING);

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -325,10 +325,10 @@ public class ParticipantService {
         checkNotNull(study);
         checkArgument(isNotBlank(userId));
 
-        // TODO: Loading account twice in this code path.
-        getAccountThrowingException(study, userId);
+        // Don't throw an exception here, you'd be exposing that an email/phone number is in the system.
+        AccountId accountId = AccountId.forId(study.getIdentifier(), userId);
 
-        accountDao.requestResetPassword(AccountId.forId(study.getIdentifier(), userId));
+        accountDao.requestResetPassword(accountId);
     }
 
     public ForwardCursorPagedResourceList<ScheduledActivity> getActivityHistory(Study study, String userId,

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -328,7 +328,7 @@ public class ParticipantService {
         // Don't throw an exception here, you'd be exposing that an email/phone number is in the system.
         AccountId accountId = AccountId.forId(study.getIdentifier(), userId);
 
-        accountDao.requestResetPassword(accountId);
+        accountDao.requestResetPassword(study, accountId);
     }
 
     public ForwardCursorPagedResourceList<ScheduledActivity> getActivityHistory(Study study, String userId,

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -43,8 +43,8 @@ import org.sagebionetworks.bridge.models.ForwardCursorPagedResourceList;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.RequestInfo;
 import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.AccountSummary;
-import org.sagebionetworks.bridge.models.accounts.Email;
 import org.sagebionetworks.bridge.models.accounts.IdentifierHolder;
 import org.sagebionetworks.bridge.models.accounts.ParticipantOptionsLookup;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
@@ -325,10 +325,10 @@ public class ParticipantService {
         checkNotNull(study);
         checkArgument(isNotBlank(userId));
 
-        Account account = getAccountThrowingException(study, userId);
+        // TODO: Loading account twice in this code path.
+        getAccountThrowingException(study, userId);
 
-        Email email = new Email(study.getIdentifier(), account.getEmail());
-        accountDao.requestResetPassword(study, email);
+        accountDao.requestResetPassword(AccountId.forId(study.getIdentifier(), userId));
     }
 
     public ForwardCursorPagedResourceList<ScheduledActivity> getActivityHistory(Study study, String userId,
@@ -367,8 +367,7 @@ public class ParticipantService {
         checkArgument(isNotBlank(userId));
 
         StudyParticipant participant = getParticipant(study, userId, false);
-        Email email = new Email(study.getIdentifier(), participant.getEmail());
-        accountDao.resendEmailVerificationToken(study.getStudyIdentifier(), email);
+        accountDao.resendEmailVerificationToken(AccountId.forEmail(study.getIdentifier(), participant.getEmail()));
     }
 
     public void withdrawAllConsents(Study study, String userId, Withdrawal withdrawal, long withdrewOn) {
@@ -509,7 +508,7 @@ public class ParticipantService {
     }
 
     private Account getAccountThrowingException(Study study, String id) {
-        Account account = accountDao.getAccount(study, id);
+        Account account = accountDao.getAccount(AccountId.forId(study.getIdentifier(), id));
         if (account == null) {
             throw new EntityNotFoundException(Account.class);
         }

--- a/app/org/sagebionetworks/bridge/services/UserAdminService.java
+++ b/app/org/sagebionetworks/bridge/services/UserAdminService.java
@@ -15,6 +15,7 @@ import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.accounts.IdentifierHolder;
 import org.sagebionetworks.bridge.models.accounts.ParticipantOptionsLookup;
@@ -175,7 +176,8 @@ public class UserAdminService {
         checkNotNull(study);
         checkArgument(StringUtils.isNotBlank(id));
         
-        Account account = accountDao.getAccount(study, id);
+        AccountId accountId = AccountId.forId(study.getIdentifier(), id);
+        Account account = accountDao.getAccount(accountId);
         if (account != null) {
             // remove this first so if account is partially deleted, re-authenticating will pick
             // up accurate information about the state of the account (as we can recover it)
@@ -196,7 +198,7 @@ public class UserAdminService {
                 externalIdService.unassignExternalId(study, externalId, healthCode);    
             }
             optionsService.deleteAllParticipantOptions(healthCode);
-            accountDao.deleteAccount(study, account.getId());
+            accountDao.deleteAccount(accountId);
         }
     }
 }

--- a/app/org/sagebionetworks/bridge/services/backfill/HealthCodeBackfill.java
+++ b/app/org/sagebionetworks/bridge/services/backfill/HealthCodeBackfill.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge.services.backfill;
 import java.util.Iterator;
 
 import org.sagebionetworks.bridge.dao.AccountDao;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.AccountSummary;
 import org.sagebionetworks.bridge.models.backfill.BackfillTask;
 import org.sagebionetworks.bridge.models.studies.Study;
@@ -41,7 +42,7 @@ public class HealthCodeBackfill extends AsyncBackfillTemplate {
             Study study = studyService.getStudy(summary.getStudyIdentifier());
             
             // getting the individual account is sufficient to create a mapping if it does not exist.
-            accountDao.getAccount(study, summary.getId());
+            accountDao.getAccount(AccountId.forId(study.getIdentifier(), summary.getId()));
         }
     }
 }

--- a/app/org/sagebionetworks/bridge/services/backfill/SignatureBackfill.java
+++ b/app/org/sagebionetworks/bridge/services/backfill/SignatureBackfill.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dao.StudyConsentDao;
 import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.AccountSummary;
 import org.sagebionetworks.bridge.models.backfill.BackfillTask;
 import org.sagebionetworks.bridge.models.studies.Study;
@@ -74,7 +75,7 @@ public class SignatureBackfill extends AsyncBackfillTemplate {
         while(summaries.hasNext()) {
             AccountSummary summary = summaries.next();
             
-            Account account = accountDao.getAccount(study, summary.getId());
+            Account account = accountDao.getAccount(AccountId.forId(study.getIdentifier(), summary.getId()));
             if (account == null) {
                 callback.newRecords(getBackfillRecordFactory().createOnly(task, "Account " + summary.getId() + " not found."));
             } else if (processAccount(task, callback, study, account)) {

--- a/app/org/sagebionetworks/bridge/services/backfill/StudyIdBackfill.java
+++ b/app/org/sagebionetworks/bridge/services/backfill/StudyIdBackfill.java
@@ -7,6 +7,7 @@ import java.util.Iterator;
 import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dao.HealthCodeDao;
 import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.AccountSummary;
 import org.sagebionetworks.bridge.models.backfill.BackfillTask;
 import org.sagebionetworks.bridge.models.studies.Study;
@@ -56,7 +57,8 @@ public class StudyIdBackfill extends AsyncBackfillTemplate  {
             // This ensures the healthCode is created.
             AccountSummary summary = i.next();
             Study study = studyService.getStudy(summary.getStudyIdentifier());
-            Account account = accountDao.getAccount(study, summary.getId());
+            AccountId accountId = AccountId.forId(study.getIdentifier(), summary.getId());
+            Account account = accountDao.getAccount(accountId);
             try {
                 String healthCode = account.getHealthCode();
                 final String studyId = healthCodeDao.getStudyIdentifier(healthCode);

--- a/test/org/sagebionetworks/bridge/TestConstants.java
+++ b/test/org/sagebionetworks/bridge/TestConstants.java
@@ -7,6 +7,7 @@ import org.joda.time.DateTime;
 import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
+import org.sagebionetworks.bridge.models.accounts.Phone;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
@@ -72,4 +73,6 @@ public class TestConstants {
     public static final Set<String> USER_DATA_GROUPS = Sets.newHashSet("group1","group2");
     
     public static final LinkedHashSet<String> LANGUAGES = TestUtils.newLinkedHashSet("en","fr");
+    
+    public static final Phone PHONE = new Phone("9174267643", "US");
 }

--- a/test/org/sagebionetworks/bridge/TestConstants.java
+++ b/test/org/sagebionetworks/bridge/TestConstants.java
@@ -24,7 +24,7 @@ public class TestConstants {
     public static final String TEST_STUDY_IDENTIFIER = "api";
     public static final StudyIdentifier TEST_STUDY = new StudyIdentifierImpl(TEST_STUDY_IDENTIFIER);
     public static final CriteriaContext TEST_CONTEXT = new CriteriaContext.Builder()
-            .withStudyIdentifier(TestConstants.TEST_STUDY).build();
+            .withUserId("user-id").withStudyIdentifier(TestConstants.TEST_STUDY).build();
 
     public static final int TIMEOUT = 10000;
     public static final String TEST_BASE_URL = "http://localhost:3333";

--- a/test/org/sagebionetworks/bridge/TestUserAdminHelper.java
+++ b/test/org/sagebionetworks/bridge/TestUserAdminHelper.java
@@ -7,6 +7,7 @@ import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 import java.util.Set;
 
 import org.sagebionetworks.bridge.models.CriteriaContext;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
@@ -75,6 +76,9 @@ public class TestUserAdminHelper {
         }
         public StudyIdentifier getStudyIdentifier() {
             return study.getStudyIdentifier();
+        }
+        public AccountId getAccountId() {
+            return AccountId.forId(study.getIdentifier(), getStudyParticipant().getId());
         }
         public CriteriaContext getCriteriaContext() {
             return new CriteriaContext.Builder()

--- a/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
+++ b/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
@@ -58,7 +58,7 @@ import org.sagebionetworks.bridge.services.AccountWorkflowService;
 import org.sagebionetworks.bridge.services.HealthCodeService;
 
 public class HibernateAccountDaoTest {
-    private static final String USER_ID = "account-id";
+    private static final String ACCOUNT_ID = "account-id";
     private static final DateTime CREATED_ON = DateTime.parse("2017-05-19T11:03:50.224-0700");
     private static final String DUMMY_PASSWORD = "Aa!Aa!Aa!Aa!1";
     private static final String DUMMY_PASSWORD_HASH = "dummy-password-hash";
@@ -73,7 +73,7 @@ public class HibernateAccountDaoTest {
     private static final String LAST_NAME = "McTester";
     private static final String REAUTH_TOKEN = "reauth-token";
     private static final int VERSION = 7;
-    private static final AccountId ACCOUNT_ID_WITH_ID = AccountId.forId(TestConstants.TEST_STUDY_IDENTIFIER, USER_ID);
+    private static final AccountId ACCOUNT_ID_WITH_ID = AccountId.forId(TestConstants.TEST_STUDY_IDENTIFIER, ACCOUNT_ID);
     private static final AccountId ACCOUNT_ID_WITH_EMAIL = AccountId.forEmail(TestConstants.TEST_STUDY_IDENTIFIER, EMAIL);
     
     private static final SignIn REAUTH_SIGNIN = new SignIn.Builder().withStudy(TestConstants.TEST_STUDY_IDENTIFIER)
@@ -123,12 +123,12 @@ public class HibernateAccountDaoTest {
         hibernateAccount.setEmailVerified(Boolean.FALSE);
         
         GenericAccount account = new GenericAccount();
-        account.setId(USER_ID);
+        account.setId(ACCOUNT_ID);
         account.setStatus(AccountStatus.UNVERIFIED);
         account.setEmailVerified(Boolean.FALSE);
         
         when(mockAccountWorkflowService.verifyEmail(any())).thenReturn(account);
-        when(mockHibernateHelper.getById(HibernateAccount.class, USER_ID)).thenReturn(hibernateAccount);
+        when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(hibernateAccount);
         
         EmailVerification verification = new EmailVerification(DUMMY_TOKEN);
         dao.verifyEmail(verification);
@@ -149,12 +149,12 @@ public class HibernateAccountDaoTest {
         hibernateAccount.setEmailVerified(Boolean.FALSE);
         
         GenericAccount account = new GenericAccount();
-        account.setId(USER_ID);
+        account.setId(ACCOUNT_ID);
         account.setStatus(AccountStatus.UNVERIFIED);
         account.setEmailVerified(Boolean.FALSE);
         
         when(mockAccountWorkflowService.verifyEmail(any())).thenReturn(account);
-        when(mockHibernateHelper.getById(HibernateAccount.class, USER_ID)).thenReturn(hibernateAccount);
+        when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(hibernateAccount);
         
         dao.verifyEmail(account);
         
@@ -173,12 +173,12 @@ public class HibernateAccountDaoTest {
         hibernateAccount.setEmailVerified(Boolean.TRUE);
         
         GenericAccount account = new GenericAccount();
-        account.setId(USER_ID);
+        account.setId(ACCOUNT_ID);
         account.setStatus(AccountStatus.ENABLED);
         account.setEmailVerified(Boolean.TRUE);
         
         when(mockAccountWorkflowService.verifyEmail(any())).thenReturn(account);
-        when(mockHibernateHelper.getById(HibernateAccount.class, USER_ID)).thenReturn(hibernateAccount);
+        when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(hibernateAccount);
         
         dao.verifyEmail(account);
         verify(mockHibernateHelper, never()).update(hibernateAccount);
@@ -197,11 +197,11 @@ public class HibernateAccountDaoTest {
     @Test
     public void verifyEmailFailsIfHibernateAccountNotFound() {
         GenericAccount account = new GenericAccount();
-        account.setId(USER_ID);
+        account.setId(ACCOUNT_ID);
         account.setStatus(AccountStatus.UNVERIFIED);
         account.setEmailVerified(null);
         
-        when(mockHibernateHelper.getById(HibernateAccount.class, USER_ID)).thenReturn(null);
+        when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(null);
         try {
             dao.verifyEmail(account);
             fail("Should have thrown an exception");
@@ -237,12 +237,12 @@ public class HibernateAccountDaoTest {
     public void changePasswordSuccess() throws Exception {
         // mock hibernate
         HibernateAccount hibernateAccount = new HibernateAccount();
-        hibernateAccount.setId(USER_ID);
-        when(mockHibernateHelper.getById(HibernateAccount.class, USER_ID)).thenReturn(hibernateAccount);
+        hibernateAccount.setId(ACCOUNT_ID);
+        when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(hibernateAccount);
 
         // Set up test account
         GenericAccount account = new GenericAccount();
-        account.setId(USER_ID);
+        account.setId(ACCOUNT_ID);
 
         // execute and verify
         dao.changePassword(account, DUMMY_PASSWORD);
@@ -250,7 +250,7 @@ public class HibernateAccountDaoTest {
         verify(mockHibernateHelper).update(updatedAccountCaptor.capture());
 
         HibernateAccount updatedAccount = updatedAccountCaptor.getValue();
-        assertEquals(USER_ID, updatedAccount.getId());
+        assertEquals(ACCOUNT_ID, updatedAccount.getId());
         assertEquals(MOCK_NOW_MILLIS, updatedAccount.getModifiedOn().longValue());
         assertEquals(PasswordAlgorithm.DEFAULT_PASSWORD_ALGORITHM, updatedAccount.getPasswordAlgorithm());
         assertEquals(MOCK_NOW_MILLIS, updatedAccount.getPasswordModifiedOn().longValue());
@@ -263,11 +263,11 @@ public class HibernateAccountDaoTest {
     @Test(expected = EntityNotFoundException.class)
     public void changePasswordAccountNotFound() {
         // mock hibernate
-        when(mockHibernateHelper.getById(HibernateAccount.class, USER_ID)).thenReturn(null);
+        when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(null);
 
         // Set up test account
         GenericAccount account = new GenericAccount();
-        account.setId(USER_ID);
+        account.setId(ACCOUNT_ID);
 
         // execute
         dao.changePassword(account, DUMMY_PASSWORD);
@@ -285,7 +285,7 @@ public class HibernateAccountDaoTest {
         
         // execute and verify - Verify just ID, study, and email, and health code mapping is enough.
         GenericAccount account = (GenericAccount) dao.authenticate(STUDY, PASSWORD_SIGNIN);
-        assertEquals(USER_ID, account.getId());
+        assertEquals(ACCOUNT_ID, account.getId());
         assertEquals(TestConstants.TEST_STUDY, account.getStudyIdentifier());
         assertEquals(EMAIL, account.getEmail());
         assertEquals("original-" + HEALTH_CODE, account.getHealthCode());
@@ -318,7 +318,7 @@ public class HibernateAccountDaoTest {
 
         // execute and verify - Verify just ID, study, and email, and health code mapping is enough.
         GenericAccount account = (GenericAccount) dao.authenticate(STUDY, PASSWORD_SIGNIN);
-        assertEquals(USER_ID, account.getId());
+        assertEquals(ACCOUNT_ID, account.getId());
         assertEquals(TestConstants.TEST_STUDY, account.getStudyIdentifier());
         assertEquals(EMAIL, account.getEmail());
         assertEquals(HEALTH_CODE, account.getHealthCode());
@@ -404,7 +404,7 @@ public class HibernateAccountDaoTest {
 
         // execute and verify - Verify just ID, study, and email, and health code mapping is enough.
         GenericAccount account = (GenericAccount) dao.reauthenticate(STUDY, REAUTH_SIGNIN);
-        assertEquals(USER_ID, account.getId());
+        assertEquals(ACCOUNT_ID, account.getId());
         assertEquals(TestConstants.TEST_STUDY, account.getStudyIdentifier());
         assertEquals(EMAIL, account.getEmail());
         assertNotEquals(originalReauthTokenHash, account.getReauthToken());
@@ -607,7 +607,7 @@ public class HibernateAccountDaoTest {
         // execute - We generate a new account ID.
         String daoOutputAcountId = dao.createAccount(STUDY, account, false);
         assertNotNull(daoOutputAcountId);
-        assertNotEquals(USER_ID, daoOutputAcountId);
+        assertNotEquals(ACCOUNT_ID, daoOutputAcountId);
 
         // verify hibernate call
         ArgumentCaptor<HibernateAccount> createdHibernateAccountCaptor = ArgumentCaptor.forClass(
@@ -645,7 +645,7 @@ public class HibernateAccountDaoTest {
     public void createAccountForMigration() {
         // Most of this is tested in createAccountSuccess(). Just test that account ID is correctly propagated and that
         // email workflow is *not* called despite the flag.
-        dao.createAccountForMigration(STUDY, makeValidGenericAccount(), USER_ID, true);
+        dao.createAccountForMigration(STUDY, makeValidGenericAccount(), ACCOUNT_ID, true);
         verify(mockAccountWorkflowService, never()).sendEmailVerificationToken(any(), any(), any());
 
         // created account has correct account ID account status unverified
@@ -654,7 +654,7 @@ public class HibernateAccountDaoTest {
         verify(mockHibernateHelper).create(createdHibernateAccountCaptor.capture());
 
         HibernateAccount createdHibernateAccount = createdHibernateAccountCaptor.getValue();
-        assertEquals(USER_ID, createdHibernateAccount.getId());
+        assertEquals(ACCOUNT_ID, createdHibernateAccount.getId());
         assertEquals(AccountStatus.UNVERIFIED, createdHibernateAccount.getStatus());
     }
 
@@ -705,7 +705,7 @@ public class HibernateAccountDaoTest {
         persistedAccount.setModifiedOn(5678L);
 
         // mock hibernate
-        when(mockHibernateHelper.getById(HibernateAccount.class, USER_ID)).thenReturn(persistedAccount);
+        when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(persistedAccount);
 
         // execute
         GenericAccount account = makeValidGenericAccount();
@@ -720,7 +720,7 @@ public class HibernateAccountDaoTest {
         verify(mockHibernateHelper).update(updatedHibernateAccountCaptor.capture());
 
         HibernateAccount updatedHibernateAccount = updatedHibernateAccountCaptor.getValue();
-        assertEquals(USER_ID, updatedHibernateAccount.getId());
+        assertEquals(ACCOUNT_ID, updatedHibernateAccount.getId());
         assertEquals("persisted-study", updatedHibernateAccount.getStudyId());
         assertEquals("persisted@example.com", updatedHibernateAccount.getEmail());
         assertEquals(PHONE.getNationalFormat(),
@@ -735,14 +735,14 @@ public class HibernateAccountDaoTest {
     @Test
     public void updateAccountNotFound() {
         // mock hibernate
-        when(mockHibernateHelper.getById(HibernateAccount.class, USER_ID)).thenReturn(null);
+        when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(null);
 
         // execute
         try {
             dao.updateAccount(makeValidGenericAccount());
             fail("expected exception");
         } catch (EntityNotFoundException ex) {
-            assertEquals("Account " + USER_ID + " not found", ex.getMessage());
+            assertEquals("Account " + ACCOUNT_ID + " not found", ex.getMessage());
         }
     }
 
@@ -752,11 +752,11 @@ public class HibernateAccountDaoTest {
         HibernateAccount hibernateAccount = makeValidHibernateAccount(false, false);
         hibernateAccount.setHealthCode("original-" + HEALTH_CODE);
         hibernateAccount.setHealthId("original-" + HEALTH_ID);
-        when(mockHibernateHelper.getById(HibernateAccount.class, USER_ID)).thenReturn(hibernateAccount);
+        when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(hibernateAccount);
 
         // execute and validate - just validate ID, study, and email, and health code mapping
         GenericAccount account = (GenericAccount) dao.getAccount(ACCOUNT_ID_WITH_ID);
-        assertEquals(USER_ID, account.getId());
+        assertEquals(ACCOUNT_ID, account.getId());
         assertEquals(TestConstants.TEST_STUDY, account.getStudyIdentifier());
         assertEquals(EMAIL, account.getEmail());
         assertEquals("original-" + HEALTH_CODE, account.getHealthCode());
@@ -770,12 +770,12 @@ public class HibernateAccountDaoTest {
     @Test
     public void getByIdSuccessCreateNewHealthCode() throws Exception {
         // mock hibernate
-        when(mockHibernateHelper.getById(HibernateAccount.class, USER_ID)).thenReturn(
+        when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(
                 makeValidHibernateAccount(false, false));
 
         // execute and validate - just validate ID, study, and email, and health code mapping
         GenericAccount account = (GenericAccount) dao.getAccount(ACCOUNT_ID_WITH_ID);
-        assertEquals(USER_ID, account.getId());
+        assertEquals(ACCOUNT_ID, account.getId());
         assertEquals(TestConstants.TEST_STUDY, account.getStudyIdentifier());
         assertEquals(EMAIL, account.getEmail());
         assertEquals(HEALTH_CODE, account.getHealthCode());
@@ -788,7 +788,7 @@ public class HibernateAccountDaoTest {
     @Test
     public void getByIdNotFound() {
         // mock hibernate
-        when(mockHibernateHelper.getById(HibernateAccount.class, USER_ID)).thenReturn(null);
+        when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(null);
 
         // execute and validate
         Account account = dao.getAccount(ACCOUNT_ID_WITH_ID);
@@ -805,7 +805,7 @@ public class HibernateAccountDaoTest {
 
         // execute and validate - just validate ID, study, and email, and health code mapping
         GenericAccount account = (GenericAccount) dao.getAccount(ACCOUNT_ID_WITH_EMAIL);
-        assertEquals(USER_ID, account.getId());
+        assertEquals(ACCOUNT_ID, account.getId());
         assertEquals(TestConstants.TEST_STUDY, account.getStudyIdentifier());
         assertEquals(EMAIL, account.getEmail());
         assertEquals("original-" + HEALTH_CODE, account.getHealthCode());
@@ -829,7 +829,7 @@ public class HibernateAccountDaoTest {
 
         // execute and validate - just validate ID, study, and email, and health code mapping
         GenericAccount account = (GenericAccount) dao.getAccount(ACCOUNT_ID_WITH_EMAIL);
-        assertEquals(USER_ID, account.getId());
+        assertEquals(ACCOUNT_ID, account.getId());
         assertEquals(TestConstants.TEST_STUDY, account.getStudyIdentifier());
         assertEquals(EMAIL, account.getEmail());
         assertEquals(HEALTH_CODE, account.getHealthCode());
@@ -857,11 +857,11 @@ public class HibernateAccountDaoTest {
     @Test
     public void delete() throws Exception {
         HibernateAccount hibernateAccount = makeValidHibernateAccount(false, false);
-        when(mockHibernateHelper.getById(HibernateAccount.class, USER_ID)).thenReturn(hibernateAccount);
+        when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(hibernateAccount);
         
         dao.deleteAccount(ACCOUNT_ID_WITH_ID);
         
-        verify(mockHibernateHelper).deleteById(HibernateAccount.class, USER_ID);
+        verify(mockHibernateHelper).deleteById(HibernateAccount.class, ACCOUNT_ID);
     }
 
     @Test
@@ -1038,7 +1038,7 @@ public class HibernateAccountDaoTest {
     public void marshallSuccess() {
         // create a fully populated GenericAccount
         GenericAccount genericAccount = new GenericAccount();
-        genericAccount.setId(USER_ID);
+        genericAccount.setId(ACCOUNT_ID);
         genericAccount.setStudyId(TestConstants.TEST_STUDY);
         genericAccount.setEmail(EMAIL);
         genericAccount.setPhone(PHONE);
@@ -1084,7 +1084,7 @@ public class HibernateAccountDaoTest {
 
         // marshall
         HibernateAccount hibernateAccount = HibernateAccountDao.marshallAccount(genericAccount);
-        assertEquals(USER_ID, hibernateAccount.getId());
+        assertEquals(ACCOUNT_ID, hibernateAccount.getId());
         assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, hibernateAccount.getStudyId());
         assertEquals(EMAIL, hibernateAccount.getEmail());
         assertEquals(PHONE, hibernateAccount.getPhone());
@@ -1141,7 +1141,7 @@ public class HibernateAccountDaoTest {
     public void unmarshallSuccess() {
         // create a fully populated HibernateAccount
         HibernateAccount hibernateAccount = new HibernateAccount();
-        hibernateAccount.setId(USER_ID);
+        hibernateAccount.setId(ACCOUNT_ID);
         hibernateAccount.setStudyId(TestConstants.TEST_STUDY_IDENTIFIER);
         hibernateAccount.setEmail(EMAIL);
         hibernateAccount.setPhone(PHONE);
@@ -1205,7 +1205,7 @@ public class HibernateAccountDaoTest {
 
         // unmarshall
         GenericAccount genericAccount = (GenericAccount) HibernateAccountDao.unmarshallAccount(hibernateAccount);
-        assertEquals(USER_ID, genericAccount.getId());
+        assertEquals(ACCOUNT_ID, genericAccount.getId());
         assertEquals(TestConstants.TEST_STUDY, genericAccount.getStudyIdentifier());
         assertEquals(EMAIL, genericAccount.getEmail());
         assertEquals(PHONE.getNationalFormat(), genericAccount.getPhone().getNationalFormat());
@@ -1257,7 +1257,7 @@ public class HibernateAccountDaoTest {
     public void unmarshallAccountSummarySuccess() {
         // Create HibernateAccount. Only fill in values needed for AccountSummary.
         HibernateAccount hibernateAccount = new HibernateAccount();
-        hibernateAccount.setId(USER_ID);
+        hibernateAccount.setId(ACCOUNT_ID);
         hibernateAccount.setStudyId(TestConstants.TEST_STUDY_IDENTIFIER);
         hibernateAccount.setEmail(EMAIL);
         hibernateAccount.setFirstName(FIRST_NAME);
@@ -1267,7 +1267,7 @@ public class HibernateAccountDaoTest {
 
         // Unmarshall
         AccountSummary accountSummary = HibernateAccountDao.unmarshallAccountSummary(hibernateAccount);
-        assertEquals(USER_ID, accountSummary.getId());
+        assertEquals(ACCOUNT_ID, accountSummary.getId());
         assertEquals(TestConstants.TEST_STUDY, accountSummary.getStudyIdentifier());
         assertEquals(EMAIL, accountSummary.getEmail());
         assertEquals(FIRST_NAME, accountSummary.getFirstName());
@@ -1322,7 +1322,7 @@ public class HibernateAccountDaoTest {
         verify(mockHibernateHelper).update(updatedAccountCaptor.capture());
 
         HibernateAccount updatedAccount = updatedAccountCaptor.getValue();
-        assertEquals(USER_ID, updatedAccount.getId());
+        assertEquals(ACCOUNT_ID, updatedAccount.getId());
         assertEquals(HEALTH_CODE, updatedAccount.getHealthCode());
         assertEquals(HEALTH_ID, updatedAccount.getHealthId());
         assertEquals(MOCK_NOW_MILLIS, updatedAccount.getModifiedOn().longValue());
@@ -1352,7 +1352,7 @@ public class HibernateAccountDaoTest {
     // Create minimal generic account for everything that will be used by HibernateAccountDao.
     private static GenericAccount makeValidGenericAccount() {
         GenericAccount genericAccount = new GenericAccount();
-        genericAccount.setId(USER_ID);
+        genericAccount.setId(ACCOUNT_ID);
         genericAccount.setStudyId(TestConstants.TEST_STUDY);
         genericAccount.setEmail(EMAIL);
         return genericAccount;
@@ -1361,7 +1361,7 @@ public class HibernateAccountDaoTest {
     // Create minimal Hibernate account for everything that will be used by HibernateAccountDao.
     private static HibernateAccount makeValidHibernateAccount(boolean generatePasswordHash, boolean generateReauthHash) throws Exception {
         HibernateAccount hibernateAccount = new HibernateAccount();
-        hibernateAccount.setId(USER_ID);
+        hibernateAccount.setId(ACCOUNT_ID);
         hibernateAccount.setStudyId(TestConstants.TEST_STUDY_IDENTIFIER);
         hibernateAccount.setEmail(EMAIL);
         hibernateAccount.setStatus(AccountStatus.ENABLED);

--- a/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
+++ b/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
@@ -918,6 +918,7 @@ public class HibernateAccountDaoTest {
         dao.deleteAccount(ACCOUNT_ID_WITH_ID);
         
         verify(mockHibernateHelper).deleteById(HibernateAccount.class, ACCOUNT_ID);
+        verify(mockHibernateHelper, never()).queryGet(any(), any(), any(), any());
     }
 
     @Test

--- a/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
+++ b/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
@@ -8,7 +8,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -223,8 +222,8 @@ public class HibernateAccountDaoTest {
 
     @Test
     public void requestResetPassword() {
-        dao.requestResetPassword(ACCOUNT_ID_WITH_EMAIL);
-        verify(mockAccountWorkflowService).requestResetPassword(ACCOUNT_ID_WITH_EMAIL);
+        dao.requestResetPassword(STUDY, ACCOUNT_ID_WITH_EMAIL);
+        verify(mockAccountWorkflowService).requestResetPassword(STUDY, ACCOUNT_ID_WITH_EMAIL);
     }
 
     @Test
@@ -903,10 +902,19 @@ public class HibernateAccountDaoTest {
     }
     
     @Test
-    public void delete() throws Exception {
+    public void deleteWithoutId() throws Exception {
+        // Can't use email, so it will do a lookup of the account
         HibernateAccount hibernateAccount = makeValidHibernateAccount(false, false);
-        when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(hibernateAccount);
+        when(mockHibernateHelper.queryGet(any(), any(), any(), any())).thenReturn(ImmutableList.of(hibernateAccount));
         
+        dao.deleteAccount(ACCOUNT_ID_WITH_EMAIL);
+        
+        verify(mockHibernateHelper).deleteById(HibernateAccount.class, ACCOUNT_ID);
+    }
+    
+    @Test
+    public void deleteWithId() throws Exception {
+        // Directly deletes with the ID it has
         dao.deleteAccount(ACCOUNT_ID_WITH_ID);
         
         verify(mockHibernateHelper).deleteById(HibernateAccount.class, ACCOUNT_ID);

--- a/test/org/sagebionetworks/bridge/models/CriteriaContextTest.java
+++ b/test/org/sagebionetworks/bridge/models/CriteriaContextTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -14,6 +15,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 public class CriteriaContextTest {
     
     private static final ClientInfo CLIENT_INFO = ClientInfo.parseUserAgentString("app/20");
+    private static final String USER_ID = "user-id";
     
     @Test
     public void equalsHashCode() {
@@ -23,6 +25,7 @@ public class CriteriaContextTest {
     @Test
     public void defaultsClientInfo() {
         CriteriaContext context = new CriteriaContext.Builder()
+                .withUserId(USER_ID)
                 .withStudyIdentifier(TestConstants.TEST_STUDY).build();
         assertEquals(ClientInfo.UNKNOWN_CLIENT, context.getClientInfo());
         assertEquals(ImmutableSet.of(), context.getLanguages());
@@ -30,13 +33,14 @@ public class CriteriaContextTest {
     
     @Test(expected = NullPointerException.class)
     public void requiresStudyIdentifier() {
-        new CriteriaContext.Builder().build();
+        new CriteriaContext.Builder().withUserId(USER_ID).build();
     }
     
     @Test
     public void builderWorks() {
         CriteriaContext context = new CriteriaContext.Builder()
                 .withStudyIdentifier(TestConstants.TEST_STUDY)
+                .withUserId(USER_ID)
                 .withClientInfo(CLIENT_INFO)
                 .withUserDataGroups(TestConstants.USER_DATA_GROUPS).build();
         
@@ -47,5 +51,16 @@ public class CriteriaContextTest {
         CriteriaContext copy = new CriteriaContext.Builder().withContext(context).build();
         assertEquals(CLIENT_INFO, copy.getClientInfo());
         assertEquals(TestConstants.USER_DATA_GROUPS, copy.getUserDataGroups());
+    }
+    
+    @Test
+    public void contextHasAccountId() {
+        CriteriaContext context = new CriteriaContext.Builder()
+                .withStudyIdentifier(TestConstants.TEST_STUDY)
+                .withUserId(USER_ID).build();
+        
+        AccountId accountId = context.getAccountId();
+        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, accountId.getStudyId());
+        assertEquals(USER_ID, accountId.getId());
     }
 }

--- a/test/org/sagebionetworks/bridge/models/accounts/AccountIdTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/AccountIdTest.java
@@ -1,0 +1,70 @@
+package org.sagebionetworks.bridge.models.accounts;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.sagebionetworks.bridge.TestConstants.PHONE;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
+
+import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+public class AccountIdTest {
+    
+    @Test
+    public void hashCodeEquals() {
+        EqualsVerifier.forClass(AccountId.class).allFieldsShouldBeUsed().verify();
+    }
+    
+    @Test
+    public void twoAccountIdsAreTheSameWithTheSameData() {
+        assertTrue(AccountId.forId(TEST_STUDY_IDENTIFIER, "id")
+                .equals(AccountId.forId(TEST_STUDY_IDENTIFIER, "id")));
+        
+        assertTrue(AccountId.forPhone(TEST_STUDY_IDENTIFIER, PHONE)
+                .equals(AccountId.forPhone(TEST_STUDY_IDENTIFIER, PHONE)));
+        
+        assertTrue(AccountId.forEmail(TEST_STUDY_IDENTIFIER, "email")
+                .equals(AccountId.forEmail(TEST_STUDY_IDENTIFIER, "email")));
+    }
+    
+    @Test
+    public void factoryMethodsWork() {
+        String number = PHONE.getNumber();
+        assertEquals("one", AccountId.forId(TEST_STUDY_IDENTIFIER, "one").getId());
+        assertEquals("one", AccountId.forEmail(TEST_STUDY_IDENTIFIER, "one").getEmail());
+        assertEquals(number, AccountId.forPhone(TEST_STUDY_IDENTIFIER, PHONE).getPhone().getNumber());
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void cannotCreateIdObjectWithNoEmail() {
+        AccountId.forEmail(TEST_STUDY_IDENTIFIER, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void cannotCreateIdObjectWithNoId() {
+        AccountId.forId(TEST_STUDY_IDENTIFIER, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void cannotCreateIdObjectWithNoPhone() {
+        AccountId.forPhone(TEST_STUDY_IDENTIFIER, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void cannotCreateIdObjectWithNoStudy() {
+        AccountId.forId(null, "id");
+    }
+    
+    @Test
+    public void getValuesWithoutGuards() {
+        AccountId id = AccountId.forId("test-study", "id");
+        
+        AccountId accountId = id.getUnguardedAccountId();
+        assertEquals("test-study", accountId.getStudyId());
+        assertEquals("id", accountId.getId());
+        assertNull(accountId.getEmail());
+        assertNull(accountId.getPhone());
+    }
+}

--- a/test/org/sagebionetworks/bridge/models/accounts/AccountIdTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/AccountIdTest.java
@@ -38,6 +38,21 @@ public class AccountIdTest {
     }
     
     @Test(expected = NullPointerException.class)
+    public void idAccessorThrows() {
+        AccountId.forEmail(TEST_STUDY_IDENTIFIER, "one").getId();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void emailAccessorThrows() {
+        AccountId.forId(TEST_STUDY_IDENTIFIER, "one").getEmail();
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void phoneAccessorThrows() {
+        AccountId.forId(TEST_STUDY_IDENTIFIER, "one").getPhone();
+    }
+    
+    @Test(expected = NullPointerException.class)
     public void cannotCreateIdObjectWithNoEmail() {
         AccountId.forEmail(TEST_STUDY_IDENTIFIER, null);
     }
@@ -55,6 +70,21 @@ public class AccountIdTest {
     @Test(expected = NullPointerException.class)
     public void cannotCreateIdObjectWithNoStudy() {
         AccountId.forId(null, "id");
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void cannotCreateIdObjectWithNoStudyOrEmail() {
+        AccountId.forEmail(null, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void cannotCreateIdObjectWithNoStudyOrId() {
+        AccountId.forId(null, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void cannotCreateIdObjectWithNoStudyOrPhone() {
+        AccountId.forPhone(null, null);
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/models/accounts/PhoneTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/PhoneTest.java
@@ -9,8 +9,16 @@ import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+
 public class PhoneTest {
 
+    @Test
+    public void hashCodeEquals() {
+        EqualsVerifier.forClass(Phone.class).suppress(Warning.NONFINAL_FIELDS).allFieldsShouldBeUsed().verify();
+    }
+    
     @Test
     public void canSerialize() throws Exception {
         Phone phone = new Phone("408.258.8569", "US");

--- a/test/org/sagebionetworks/bridge/models/accounts/SignInTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/SignInTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.models.accounts;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import org.junit.Test;
 import org.sagebionetworks.bridge.TestConstants;
@@ -116,7 +117,8 @@ public class SignInTest {
         // SignIn should be validated to hold either email or phone before we 
         // retrieve accountId 
         try {
-            signIn.getAccountId();    
+            signIn.getAccountId();
+            fail("Should have thrown an exception");
         } catch(IllegalArgumentException e) {
             assertEquals("SignIn not constructed with enough information to retrieve an account", e.getMessage());
         }

--- a/test/org/sagebionetworks/bridge/models/accounts/SignInTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/SignInTest.java
@@ -108,4 +108,17 @@ public class SignInTest {
         assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, accountId.getStudyId());
         assertEquals(TestConstants.PHONE.getNumber(), accountId.getPhone().getNumber());
     }
+    
+    @Test
+    public void signInAccountIncomplete() {
+        SignIn signIn = new SignIn.Builder().withStudy(TestConstants.TEST_STUDY_IDENTIFIER)
+                .withPassword("password").build();
+        // SignIn should be validated to hold either email or phone before we 
+        // retrieve accountId 
+        try {
+            signIn.getAccountId();    
+        } catch(IllegalArgumentException e) {
+            assertEquals("SignIn not constructed with enough information to retrieve an account", e.getMessage());
+        }
+    }
 }

--- a/test/org/sagebionetworks/bridge/models/accounts/SignInTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/SignInTest.java
@@ -3,7 +3,7 @@ package org.sagebionetworks.bridge.models.accounts;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
-
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 
@@ -89,5 +89,23 @@ public class SignInTest {
         assertEquals("studyValue", signIn.getStudyId());
         assertEquals("tokenValue", signIn.getToken());
         assertEquals("reauthTokenValue", signIn.getReauthToken());
-    }  
+    }
+    
+    @Test
+    public void signInAccountIdWithEmail() {
+        SignIn signIn = new SignIn.Builder().withStudy(TestConstants.TEST_STUDY_IDENTIFIER).withEmail("email")
+                .withPassword("password").build();
+        AccountId accountId = signIn.getAccountId();
+        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, accountId.getStudyId());
+        assertEquals("email", accountId.getEmail());
+    }
+    
+    @Test
+    public void signInAccountIdWithPhone() {
+        SignIn signIn = new SignIn.Builder().withStudy(TestConstants.TEST_STUDY_IDENTIFIER)
+                .withPhone(TestConstants.PHONE).withPassword("password").build();
+        AccountId accountId = signIn.getAccountId();
+        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, accountId.getStudyId());
+        assertEquals(TestConstants.PHONE.getNumber(), accountId.getPhone().getNumber());
+    }
 }

--- a/test/org/sagebionetworks/bridge/play/controllers/EmailControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/EmailControllerTest.java
@@ -9,6 +9,7 @@ import static org.sagebionetworks.bridge.dao.ParticipantOption.EMAIL_NOTIFICATIO
 import static org.mockito.Mockito.verify;
 
 import org.junit.Test;
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.config.BridgeConfig;
 import org.sagebionetworks.bridge.dao.AccountDao;
@@ -23,6 +24,7 @@ import play.test.Helpers;
 import java.util.Map;
 
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.studies.Study;
 
 import com.google.common.collect.Maps;
@@ -35,8 +37,9 @@ public class EmailControllerTest {
     private static final String UNSUBSCRIBE_TOKEN = "unsubscribeToken";
     private static final String TOKEN = "token";
     private static final String STUDY2 = "study";
-    private static final String API = "api";
+    private static final String API = TestConstants.TEST_STUDY_IDENTIFIER;
     private static final String EMAIL_ADDRESS = "bridge-testing@sagebase.org";
+    private static final AccountId ACCOUNT_ID = AccountId.forEmail(API, EMAIL_ADDRESS);
 
     private ParticipantOptionsService optionsService;
 
@@ -73,7 +76,7 @@ public class EmailControllerTest {
         study.setIdentifier(API);
 
         accountDao = mock(AccountDao.class);
-        when(accountDao.getHealthCodeForEmail(study, EMAIL_ADDRESS)).thenReturn(HEALTH_CODE);
+        when(accountDao.getHealthCodeForAccount(ACCOUNT_ID)).thenReturn(HEALTH_CODE);
 
         StudyService studyService = mock(StudyService.class);
         when(studyService.getStudy(API)).thenReturn(study);
@@ -155,7 +158,7 @@ public class EmailControllerTest {
     public void noAccountThrowsException() throws Exception {
         mockContext(map(DATA_BRACKET_EMAIL, EMAIL_ADDRESS, STUDY2, API, TOKEN, UNSUBSCRIBE_TOKEN), null);
         EmailController controller = createController();
-        doReturn(null).when(accountDao).getHealthCodeForEmail(study, EMAIL_ADDRESS);
+        doReturn(null).when(accountDao).getHealthCodeForAccount(ACCOUNT_ID);
 
         Result result = controller.unsubscribeFromEmail();
         assertEquals(200, result.status());

--- a/test/org/sagebionetworks/bridge/play/controllers/ParticipantReportControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ParticipantReportControllerTest.java
@@ -2,7 +2,6 @@ package org.sagebionetworks.bridge.play.controllers;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.spy;
@@ -36,13 +35,13 @@ import org.sagebionetworks.bridge.models.ForwardCursorPagedResourceList;
 import org.sagebionetworks.bridge.models.ReportTypeResourceList;
 import org.sagebionetworks.bridge.models.ResourceList;
 import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.reports.ReportData;
 import org.sagebionetworks.bridge.models.reports.ReportIndex;
 import org.sagebionetworks.bridge.models.reports.ReportType;
-import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 import org.sagebionetworks.bridge.services.ReportService;
 import org.sagebionetworks.bridge.services.StudyService;
@@ -70,6 +69,8 @@ public class ParticipantReportControllerTest {
     private static final String OTHER_PARTICIPANT_HEALTH_CODE = "ABC";
 
     private static final String OTHER_PARTICIPANT_ID = "userId";
+    
+    private static final AccountId OTHER_ACCOUNT_ID = AccountId.forId(TEST_STUDY_IDENTIFIER, OTHER_PARTICIPANT_ID);
 
     private static final String HEALTH_CODE = "healthCode";
     
@@ -123,7 +124,7 @@ public class ParticipantReportControllerTest {
         StudyParticipant participant = new StudyParticipant.Builder().withHealthCode(HEALTH_CODE)
                 .withRoles(Sets.newHashSet(Roles.DEVELOPER)).build();
         
-        doReturn(mockOtherAccount).when(mockAccountDao).getAccount(study, OTHER_PARTICIPANT_ID);
+        doReturn(mockOtherAccount).when(mockAccountDao).getAccount(OTHER_ACCOUNT_ID);
         
         ConsentStatus status = new ConsentStatus.Builder().withName("Name").withGuid(SubpopulationGuid.create("GUID"))
                 .withConsented(true).withRequired(true).withSignedMostRecentConsent(true).build();
@@ -241,7 +242,7 @@ public class ParticipantReportControllerTest {
                 .withRoles(Sets.newHashSet(Roles.RESEARCHER)).build();
         session.setParticipant(participant);
         
-        doReturn(mockAccount).when(mockAccountDao).getAccount(any(Study.class), eq(OTHER_PARTICIPANT_ID));
+        doReturn(mockAccount).when(mockAccountDao).getAccount(OTHER_ACCOUNT_ID);
         
         doReturn(makePagedResults()).when(mockReportService).getParticipantReportV4(session.getStudyIdentifier(),
                 REPORT_ID, HEALTH_CODE, START_TIME, END_TIME, OFFSET_KEY, Integer.parseInt(PAGE_SIZE));
@@ -268,7 +269,7 @@ public class ParticipantReportControllerTest {
                 .withRoles(Sets.newHashSet(Roles.RESEARCHER)).build();
         session.setParticipant(participant);
         
-        doReturn(mockAccount).when(mockAccountDao).getAccount(any(Study.class), eq(OTHER_PARTICIPANT_ID));
+        doReturn(mockAccount).when(mockAccountDao).getAccount(OTHER_ACCOUNT_ID);
         
         doReturn(makeResults(START_DATE, END_DATE)).when(mockReportService).getParticipantReport(session.getStudyIdentifier(),
                 REPORT_ID, HEALTH_CODE, START_DATE, END_DATE);

--- a/test/org/sagebionetworks/bridge/play/controllers/StudyReportControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/StudyReportControllerTest.java
@@ -35,6 +35,7 @@ import org.sagebionetworks.bridge.models.ForwardCursorPagedResourceList;
 import org.sagebionetworks.bridge.models.ReportTypeResourceList;
 import org.sagebionetworks.bridge.models.ResourceList;
 import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
@@ -72,6 +73,8 @@ public class StudyReportControllerTest {
     private static final String OTHER_PARTICIPANT_HEALTH_CODE = "ABC";
 
     private static final String OTHER_PARTICIPANT_ID = "userId";
+    
+    private static final AccountId OTHER_ACCOUNT_ID = AccountId.forId(TEST_STUDY_IDENTIFIER, OTHER_PARTICIPANT_ID);
 
     private static final String HEALTH_CODE = "healthCode";
     
@@ -128,7 +131,7 @@ public class StudyReportControllerTest {
         StudyParticipant participant = new StudyParticipant.Builder().withHealthCode(HEALTH_CODE)
                 .withRoles(Sets.newHashSet(Roles.DEVELOPER)).build();
         
-        doReturn(mockOtherAccount).when(mockAccountDao).getAccount(study, OTHER_PARTICIPANT_ID);
+        doReturn(mockOtherAccount).when(mockAccountDao).getAccount(OTHER_ACCOUNT_ID);
         
         ConsentStatus status = new ConsentStatus.Builder().withName("Name").withGuid(SubpopulationGuid.create("GUID"))
                 .withConsented(true).withRequired(true).withSignedMostRecentConsent(true).build();

--- a/test/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
@@ -26,6 +26,7 @@ import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.Email;
 import org.sagebionetworks.bridge.models.accounts.EmailVerification;
 import org.sagebionetworks.bridge.models.accounts.PasswordReset;
@@ -43,6 +44,8 @@ public class AccountWorkflowServiceTest {
     private static final String SPTOKEN = "sptoken";
     private static final String USER_ID = "userId";
     private static final String EMAIL = "email@email.com";
+    private static final AccountId ACCOUNT_ID_WITH_ID = AccountId.forId(TEST_STUDY_IDENTIFIER, USER_ID);
+    private static final AccountId ACCOUNT_ID_WITH_EMAIL = AccountId.forEmail(TEST_STUDY_IDENTIFIER, EMAIL);
 
     @Mock
     private StudyService mockStudyService;
@@ -111,27 +114,24 @@ public class AccountWorkflowServiceTest {
     
     @Test
     public void resendEmailVerificationToken() {
-        when(mockStudyService.getStudy(TEST_STUDY)).thenReturn(study);
-        when(mockAccountDao.getAccountWithEmail(study, EMAIL)).thenReturn(mockAccount);
+        when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
+        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(mockAccount);
         when(mockAccount.getId()).thenReturn(USER_ID);
+        when(mockAccount.getEmail()).thenReturn(EMAIL);
         
-        Email email = new Email(TEST_STUDY_IDENTIFIER, EMAIL);
-        
-        service.resendEmailVerificationToken(TEST_STUDY, email);
+        service.resendEmailVerificationToken(ACCOUNT_ID_WITH_EMAIL);
         
         verify(service).sendEmailVerificationToken(study, USER_ID, EMAIL);
     }
     
     @Test
     public void resendEmailVerificationTokenFailsWithMissingStudy() {
-        when(mockStudyService.getStudy(TEST_STUDY)).thenThrow(new EntityNotFoundException(Study.class));
-        when(mockAccountDao.getAccountWithEmail(study, EMAIL)).thenReturn(mockAccount);
+        when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenThrow(new EntityNotFoundException(Study.class));
+        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(mockAccount);
         when(mockAccount.getId()).thenReturn(USER_ID);
         
-        Email email = new Email(TEST_STUDY_IDENTIFIER, EMAIL);
-        
         try {
-            service.resendEmailVerificationToken(TEST_STUDY, email);
+            service.resendEmailVerificationToken(ACCOUNT_ID_WITH_EMAIL);
             fail("Should have thrown exception");
         } catch(EntityNotFoundException e) {
         }
@@ -141,12 +141,10 @@ public class AccountWorkflowServiceTest {
     @Test
     public void resendEmailVerificationTokenFailsQuietlyWithMissingAccount() {
         when(mockStudyService.getStudy(TEST_STUDY)).thenReturn(study);
-        when(mockAccountDao.getAccountWithEmail(study, EMAIL)).thenReturn(null);
+        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(null);
         when(mockAccount.getId()).thenReturn(USER_ID);
         
-        Email email = new Email(TEST_STUDY_IDENTIFIER, EMAIL);
-        
-        service.resendEmailVerificationToken(TEST_STUDY, email);
+        service.resendEmailVerificationToken(ACCOUNT_ID_WITH_EMAIL);
         
         verify(service, never()).sendEmailVerificationToken(study, USER_ID, EMAIL);
     }
@@ -156,7 +154,7 @@ public class AccountWorkflowServiceTest {
         when(mockCacheProvider.getString(SPTOKEN)).thenReturn(
             TestUtils.createJson("{'studyId':'api','userId':'userId'}"));
         when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
-        when(mockAccountDao.getAccount(study, "userId")).thenReturn(mockAccount);
+        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_ID)).thenReturn(mockAccount);
         when(mockAccount.getId()).thenReturn("accountId");
         
         EmailVerification verification = new EmailVerification(SPTOKEN);
@@ -198,11 +196,12 @@ public class AccountWorkflowServiceTest {
     @Test
     public void requestResetPassword() throws Exception {
         when(service.createTimeLimitedToken()).thenReturn("ABC");
-        when(mockAccountDao.getAccountWithEmail(study, EMAIL)).thenReturn(mockAccount);
+        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(mockAccount);
+        when(mockStudyService.getStudy(TEST_STUDY)).thenReturn(study);
+        when(mockAccount.getEmail()).thenReturn(EMAIL);
+        when(mockAccount.getStudyIdentifier()).thenReturn(TEST_STUDY);
         
-        Email emailObj = new Email(TEST_STUDY_IDENTIFIER, EMAIL);
-        
-        service.requestResetPassword(study, emailObj);
+        service.requestResetPassword(ACCOUNT_ID_WITH_EMAIL);
         
         verify(mockCacheProvider).setString("ABC:api", EMAIL, 60*60*2);
         verify(mockSendMailService).sendEmail(emailProviderCaptor.capture());
@@ -220,11 +219,9 @@ public class AccountWorkflowServiceTest {
     @Test
     public void requestResetPasswordInvalidEmailFailsQuietly() throws Exception {
         when(service.createTimeLimitedToken()).thenReturn("ABC");
-        when(mockAccountDao.getAccountWithEmail(study, EMAIL)).thenReturn(null);
+        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(null);
         
-        Email emailObj = new Email(TEST_STUDY_IDENTIFIER, EMAIL);
-        
-        service.requestResetPassword(study, emailObj);
+        service.requestResetPassword(ACCOUNT_ID_WITH_EMAIL);
         
         verify(mockCacheProvider, never()).setString("ABC:api", EMAIL, 60*5);
         verify(mockSendMailService, never()).sendEmail(emailProviderCaptor.capture());
@@ -234,7 +231,7 @@ public class AccountWorkflowServiceTest {
     public void resetPassword() {
         when(mockCacheProvider.getString("sptoken:api")).thenReturn(EMAIL);
         when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
-        when(mockAccountDao.getAccountWithEmail(study, EMAIL)).thenReturn(mockAccount);
+        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(mockAccount);
 
         PasswordReset passwordReset = new PasswordReset("newPassword", "sptoken", TEST_STUDY_IDENTIFIER);
         
@@ -265,7 +262,7 @@ public class AccountWorkflowServiceTest {
     public void resetPasswordInvalidAccount() {
         when(mockCacheProvider.getString("sptoken:api")).thenReturn(EMAIL);
         when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
-        when(mockAccountDao.getAccountWithEmail(study, EMAIL)).thenReturn(null);
+        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(null);
 
         PasswordReset passwordReset = new PasswordReset("newPassword", "sptoken", TEST_STUDY_IDENTIFIER);
         

--- a/test/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
@@ -201,7 +201,7 @@ public class AccountWorkflowServiceTest {
         when(mockAccount.getEmail()).thenReturn(EMAIL);
         when(mockAccount.getStudyIdentifier()).thenReturn(TEST_STUDY);
         
-        service.requestResetPassword(ACCOUNT_ID_WITH_EMAIL);
+        service.requestResetPassword(study, ACCOUNT_ID_WITH_EMAIL);
         
         verify(mockCacheProvider).setString("ABC:api", EMAIL, 60*60*2);
         verify(mockSendMailService).sendEmail(emailProviderCaptor.capture());
@@ -221,7 +221,7 @@ public class AccountWorkflowServiceTest {
         when(service.createTimeLimitedToken()).thenReturn("ABC");
         when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(null);
         
-        service.requestResetPassword(ACCOUNT_ID_WITH_EMAIL);
+        service.requestResetPassword(study, ACCOUNT_ID_WITH_EMAIL);
         
         verify(mockCacheProvider, never()).setString("ABC:api", EMAIL, 60*5);
         verify(mockSendMailService, never()).sendEmail(emailProviderCaptor.capture());

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
@@ -43,6 +43,7 @@ import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.accounts.Email;
 import org.sagebionetworks.bridge.models.accounts.IdentifierHolder;
@@ -274,7 +275,7 @@ public class AuthenticationServiceTest {
 
         IdentifierHolder holder = authService.signUp(study, participant);
         
-        Account account = accountDao.getAccount(study, holder.getIdentifier());
+        Account account = accountDao.getAccount(AccountId.forId(study.getIdentifier(), holder.getIdentifier()));
         
         Set<String> persistedGroups = optionsService.getOptions(account.getHealthCode()).getStringSet(DATA_GROUPS);
         assertEquals(groups, persistedGroups);

--- a/test/org/sagebionetworks/bridge/services/ConsentServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ConsentServiceTest.java
@@ -299,7 +299,7 @@ public class ConsentServiceTest {
             assertEquals("ConsentSignature not found.", e.getMessage());
         }
         
-        Account account = accountDao.getAccount(testUser.getStudy(), testUser.getId());
+        Account account = accountDao.getAccount(testUser.getAccountId());
         assertEquals(1, account.getConsentSignatureHistory(defaultSubpopulation.getGuid()).size());
         ConsentSignature historicalSignature = account.getConsentSignatureHistory(defaultSubpopulation.getGuid()).get(0);
         
@@ -465,7 +465,7 @@ public class ConsentServiceTest {
         assertFalse(ConsentStatus.isUserConsented(map));
         
         assertFalse(testUser.getSession().doesConsent());
-        Account account = accountDao.getAccount(study, testUser.getId());
+        Account account = accountDao.getAccount(testUser.getAccountId());
         assertNull(account.getActiveConsentSignature(subpopGuid));
     }
     

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -730,11 +730,7 @@ public class ParticipantServiceTest {
         
         participantService.requestResetPassword(STUDY, ID);
         
-        verify(accountDao).requestResetPassword(accountIdCaptor.capture());
-        
-        AccountId accountId = accountIdCaptor.getValue();
-        assertEquals(STUDY.getIdentifier(), accountId.getStudyId());
-        assertEquals(ID, accountId.getId());
+        verify(accountDao).requestResetPassword(eq(STUDY), eq(ACCOUNT_ID));
     }
     
     public void requestResetPasswordNoAccountIsSilent() {

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -737,9 +737,10 @@ public class ParticipantServiceTest {
         assertEquals(ID, accountId.getId());
     }
     
-    @Test(expected = EntityNotFoundException.class)
-    public void requestResetPasswordNoUserThrowsCorrectException() {
+    public void requestResetPasswordNoAccountIsSilent() {
         participantService.requestResetPassword(STUDY, ID);
+        
+        verifyNoMoreInteractions(accountDao);
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -44,6 +44,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.Roles;
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.config.Environment;
@@ -60,6 +61,7 @@ import org.sagebionetworks.bridge.exceptions.LimitExceededException;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.AccountStatus;
 import org.sagebionetworks.bridge.models.accounts.AccountSummary;
 import org.sagebionetworks.bridge.models.accounts.Email;
@@ -91,7 +93,7 @@ public class ParticipantServiceTest {
     private static final Study STUDY = new DynamoStudy();
     private static final Phone PHONE = new Phone("4082585869", "US");
     static {
-        STUDY.setIdentifier("test-study");
+        STUDY.setIdentifier(TestConstants.TEST_STUDY_IDENTIFIER);
         STUDY.setHealthCodeExportEnabled(true);
         STUDY.setUserProfileAttributes(STUDY_PROFILE_ATTRS);
         STUDY.setDataGroups(STUDY_DATA_GROUPS);
@@ -114,6 +116,7 @@ public class ParticipantServiceTest {
     private static final DateTimeZone USER_TIME_ZONE = DateTimeZone.forOffsetHours(-3);
     private static final Map<String,String> ATTRS = new ImmutableMap.Builder<String,String>().put("can_be_recontacted","true").build();
     private static final SubpopulationGuid SUBPOP_GUID = SubpopulationGuid.create(STUDY.getIdentifier());
+    private static final AccountId ACCOUNT_ID = AccountId.forId(TestConstants.TEST_STUDY_IDENTIFIER, ID);
     private static final StudyParticipant PARTICIPANT = new StudyParticipant.Builder()
             .withFirstName(FIRST_NAME)
             .withLastName(LAST_NAME)
@@ -200,6 +203,9 @@ public class ParticipantServiceTest {
     @Captor
     ArgumentCaptor<CriteriaContext> contextCaptor;
     
+    @Captor
+    ArgumentCaptor<AccountId> accountIdCaptor;
+    
     @Mock
     private ExternalIdService externalIdService;
     
@@ -225,7 +231,7 @@ public class ParticipantServiceTest {
         when(account.getId()).thenReturn(ID);
         when(accountDao.constructAccount(STUDY, EMAIL, PHONE, PASSWORD)).thenReturn(account);
         when(accountDao.createAccount(same(STUDY), same(account), anyBoolean())).thenReturn(ID);
-        when(accountDao.getAccount(STUDY, ID)).thenReturn(account);
+        when(accountDao.getAccount(ACCOUNT_ID)).thenReturn(account);
         when(account.getHealthCode()).thenReturn(HEALTH_CODE);
         when(account.getEmail()).thenReturn(EMAIL);
         when(optionsService.getOptions(HEALTH_CODE)).thenReturn(lookup);
@@ -361,7 +367,7 @@ public class ParticipantServiceTest {
     
     @Test(expected = EntityNotFoundException.class)
     public void getParticipantEmailDoesNotExist() {
-        when(accountDao.getAccount(STUDY, ID)).thenReturn(null);
+        when(accountDao.getAccount(ACCOUNT_ID)).thenReturn(null);
         
         participantService.getParticipant(STUDY, ID, false);
     }
@@ -447,19 +453,19 @@ public class ParticipantServiceTest {
     
     @Test(expected = EntityNotFoundException.class)
     public void signOutUserWhoDoesNotExist() {
-        when(accountDao.getAccount(STUDY, ID)).thenReturn(null);
+        when(accountDao.getAccount(ACCOUNT_ID)).thenReturn(null);
         
         participantService.signUserOut(STUDY, ID);
     }
     
     @Test
     public void signOutUser() {
-        when(accountDao.getAccount(STUDY, ID)).thenReturn(account);
+        when(accountDao.getAccount(ACCOUNT_ID)).thenReturn(account);
         when(account.getId()).thenReturn("userId");
         
         participantService.signUserOut(STUDY, ID);
         
-        verify(accountDao).getAccount(STUDY, ID);
+        verify(accountDao).getAccount(ACCOUNT_ID);
         verify(cacheProvider).removeSessionByUserId("userId");
     }
     
@@ -517,7 +523,7 @@ public class ParticipantServiceTest {
     
     @Test
     public void updateParticipantWithNoAccount() {
-        doThrow(new EntityNotFoundException(Account.class)).when(accountDao).getAccount(STUDY, ID);
+        doThrow(new EntityNotFoundException(Account.class)).when(accountDao).getAccount(ACCOUNT_ID);
         try {
             participantService.updateParticipant(STUDY, CALLER_ROLES, PARTICIPANT);
             fail("Should have thrown exception.");
@@ -724,11 +730,11 @@ public class ParticipantServiceTest {
         
         participantService.requestResetPassword(STUDY, ID);
         
-        verify(accountDao).requestResetPassword(eq(STUDY), emailCaptor.capture());
+        verify(accountDao).requestResetPassword(accountIdCaptor.capture());
         
-        Email email = emailCaptor.getValue();
-        assertEquals(STUDY.getStudyIdentifier(), email.getStudyIdentifier());
-        assertEquals(EMAIL, email.getEmail());
+        AccountId accountId = accountIdCaptor.getValue();
+        assertEquals(STUDY.getIdentifier(), accountId.getStudyId());
+        assertEquals(ID, accountId.getId());
     }
     
     @Test(expected = EntityNotFoundException.class)
@@ -780,11 +786,11 @@ public class ParticipantServiceTest {
         
         participantService.resendEmailVerification(STUDY, ID);
         
-        verify(accountDao).resendEmailVerificationToken(eq(STUDY.getStudyIdentifier()), emailCaptor.capture());
+        verify(accountDao).resendEmailVerificationToken(accountIdCaptor.capture());
         
-        Email email = emailCaptor.getValue();
-        assertEquals(STUDY.getStudyIdentifier(), email.getStudyIdentifier());
-        assertEquals(EMAIL, email.getEmail());
+        AccountId accountId = accountIdCaptor.getValue();
+        assertEquals(STUDY.getIdentifier(), accountId.getStudyId());
+        assertEquals(EMAIL, accountId.getEmail());
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/services/UserAdminServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/UserAdminServiceMockTest.java
@@ -29,6 +29,7 @@ import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dao.ParticipantOption.SharingScope;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.accounts.IdentifierHolder;
 import org.sagebionetworks.bridge.models.accounts.ParticipantOptionsLookup;
@@ -177,9 +178,11 @@ public class UserAdminServiceMockTest {
     public void deleteUser() {
         Study study = TestUtils.getValidStudy(UserAdminServiceMockTest.class);
         
+        AccountId accountId = AccountId.forId(study.getIdentifier(),  "userId");
+        
         doReturn("userId").when(account).getId();
         doReturn("healthCode").when(account).getHealthCode();
-        doReturn(account).when(accountDao).getAccount(study, "userId");
+        doReturn(account).when(accountDao).getAccount(accountId);
         
         doReturn(lookup).when(participantOptionsService).getOptions("healthCode");
         doReturn("externalId").when(lookup).getString(EXTERNAL_IDENTIFIER);
@@ -195,7 +198,7 @@ public class UserAdminServiceMockTest {
         verify(activityEventService).deleteActivityEvents("healthCode");
         verify(externalIdService).unassignExternalId(study, "externalId", "healthCode");
         verify(participantOptionsService).deleteAllParticipantOptions("healthCode");
-        verify(accountDao).deleteAccount(study, "userId");
+        verify(accountDao).deleteAccount(accountId);
     }
     
 }


### PR DESCRIPTION
Introduces an AccountId object which is used by AccountDao to retrieve accounts. It contains a study ID and one of: an ID, email or phone number. You still can't sign in using a phone #, that'll come next.

Once you start tugging at this thread you realize we have many, many methods that take a studyIdentifier, and then a userId, email, or eventually a phone number. So I just stopped at a place where everything compiles, calling AccountDao and the related AccountWorflowService. This is already a lot of files.

The only functional change was one place where we were returning a 404 if someone requested a password reset email. We should not do this, it allows you to determine which emails are in the study. It also fit better with a refactor to use AccountId.

The AccountId will throw an exception if you use a getter on the object for a field that has not been initialized. This should make it easier to verify that it's not being constructed with one identifier, then being called to retrieve a different identifier (e.g. made with a userId, then called later to retrieve an email address). The only place this isn't relevant is in the private getHibernateAccount() method where we'll query the DB based on what we find in AccountId. There's an accessor on AccountId to get a version that doesn't have these precondition checks.