### PR TITLE
Phone-only accounts; phone-only sign-ins

### DIFF
--- a/app/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/app/org/sagebionetworks/bridge/BridgeConstants.java
@@ -94,6 +94,12 @@ public class BridgeConstants {
     
     /**
      * This whitelist adds a few additional tags and attributes that are used by the CKEDITOR options we have 
+     * Limited to 140 characters (Java is UTF-16, so two bytes per character, assuming for now that 
+     * SNS converts these to ASCII.
+     */
+    public static final int SMS_CHARACTER_LIMIT = 140;
+
+    /**
      * displayed in the UI.
      */
     public static final Whitelist CKEDITOR_WHITELIST = Whitelist.relaxed()

--- a/app/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/app/org/sagebionetworks/bridge/BridgeConstants.java
@@ -93,14 +93,14 @@ public class BridgeConstants {
     public static final Set<Roles> NO_CALLER_ROLES = ImmutableSet.of();
     
     /**
-     * This whitelist adds a few additional tags and attributes that are used by the CKEDITOR options we have 
      * Limited to 140 characters (Java is UTF-16, so two bytes per character, assuming for now that 
      * SNS converts these to ASCII.
      */
     public static final int SMS_CHARACTER_LIMIT = 140;
 
     /**
-     * displayed in the UI.
+     * This whitelist adds a few additional tags and attributes that are used by the CKEDITOR options 
+     * we have displayed in the UI.
      */
     public static final Whitelist CKEDITOR_WHITELIST = Whitelist.relaxed()
             .addTags("hr", "s", "caption")

--- a/app/org/sagebionetworks/bridge/DefaultStudyBootstrapper.java
+++ b/app/org/sagebionetworks/bridge/DefaultStudyBootstrapper.java
@@ -54,6 +54,7 @@ public class DefaultStudyBootstrapper {
         } catch (EntityNotFoundException e) {
             Study study = Study.create();
             study.setName("Test Study");
+            study.setShortName("TestStudy");
             study.setIdentifier(BridgeConstants.API_STUDY_ID_STRING);
             study.setSponsorName("Sage Bionetworks");
             study.setMinAgeOfConsent(18);
@@ -74,6 +75,7 @@ public class DefaultStudyBootstrapper {
         } catch (EntityNotFoundException e) {
             Study study = Study.create();
             study.setName("Shared Module Library");
+            study.setShortName("SharedLib");
             study.setSponsorName("Sage Bionetworks");
             study.setIdentifier(BridgeConstants.SHARED_STUDY_ID_STRING);
             study.setSupportEmail("bridgeit@sagebridge.org");

--- a/app/org/sagebionetworks/bridge/SecureTokenGenerator.java
+++ b/app/org/sagebionetworks/bridge/SecureTokenGenerator.java
@@ -14,6 +14,8 @@ public class SecureTokenGenerator {
 
     public static final SecureTokenGenerator INSTANCE = new SecureTokenGenerator();
     
+    public static final SecureTokenGenerator PHONE_CODE_INSTANCE = new SecureTokenGenerator(6, new SecureRandom(), "0123456789");
+    
     private static final String ALPHANUMERIC = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 
     private final Random random;

--- a/app/org/sagebionetworks/bridge/dao/AccountDao.java
+++ b/app/org/sagebionetworks/bridge/dao/AccountDao.java
@@ -13,6 +13,7 @@ import org.sagebionetworks.bridge.models.accounts.PasswordReset;
 import org.sagebionetworks.bridge.models.accounts.Phone;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
 import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.services.AuthenticationService;
 
 /**
  * DAO to retrieve personally identifiable account information, including authentication 
@@ -28,10 +29,9 @@ public interface AccountDao {
     void verifyEmail(EmailVerification verification);
     
     /**
-     * Set the emailVerified flag to true and enable the account (if needed). Called from  
-     * <code>AuthenticationService.emailSignIn</code>. 
+     * Set the verified flag for the channel (email or phone) to true, and enable the account (if needed).
      */
-    void verifyEmail(Account account);
+    void verifyChannel(AuthenticationService.ChannelType channelType, Account account);
     
     /**
      * Sign up sends an email address with a link that includes a one-time token for verification. That email

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
@@ -31,6 +31,7 @@ import org.sagebionetworks.bridge.models.upload.UploadValidationStrictness;
 @JsonFilter("filter")
 public final class DynamoStudy implements Study {
     private String name;
+    private String shortName;
     private String sponsorName;
     private String identifier;
     private boolean studyIdExcludedInExport;
@@ -97,6 +98,17 @@ public final class DynamoStudy implements Study {
         this.name = name;
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public String getShortName() {
+        return shortName;
+    }
+
+    @Override
+    public void setShortName(String shortName) {
+        this.shortName = shortName;
+    }
+    
     /** {@inheritDoc} */
     @Override
     @DynamoDBHashKey
@@ -480,9 +492,9 @@ public final class DynamoStudy implements Study {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, sponsorName, identifier, studyIdExcludedInExport, supportEmail, synapseDataAccessTeamId,
-                synapseProjectId, technicalEmail, usesCustomExportSchedule, uploadMetadataFieldDefinitions,
-                uploadValidationStrictness, consentNotificationEmail, minAgeOfConsent,
+        return Objects.hash(name, shortName, sponsorName, identifier, studyIdExcludedInExport, supportEmail,
+                synapseDataAccessTeamId, synapseProjectId, technicalEmail, usesCustomExportSchedule,
+                uploadMetadataFieldDefinitions, uploadValidationStrictness, consentNotificationEmail, minAgeOfConsent,
                 accountLimit, version, active, profileAttributes, taskIdentifiers, activityEventKeys, dataGroups,
                 passwordPolicy, verifyEmailTemplate, resetPasswordTemplate, emailSignInTemplate, accountExistsTemplate,
                 strictUploadValidationEnabled, healthCodeExportEnabled, emailVerificationEnabled,
@@ -503,8 +515,11 @@ public final class DynamoStudy implements Study {
                 && Objects.equals(supportEmail, other.supportEmail)
                 && Objects.equals(uploadMetadataFieldDefinitions, other.uploadMetadataFieldDefinitions)
                 && Objects.equals(uploadValidationStrictness, other.uploadValidationStrictness)
-                && Objects.equals(minAgeOfConsent, other.minAgeOfConsent) && Objects.equals(name, other.name)
-                && Objects.equals(passwordPolicy, other.passwordPolicy) && Objects.equals(active, other.active))
+                && Objects.equals(minAgeOfConsent, other.minAgeOfConsent) 
+                && Objects.equals(name, other.name)
+                && Objects.equals(shortName, other.shortName)
+                && Objects.equals(passwordPolicy, other.passwordPolicy) 
+                && Objects.equals(active, other.active))
                 && Objects.equals(verifyEmailTemplate, other.verifyEmailTemplate)
                 && Objects.equals(consentNotificationEmail, other.consentNotificationEmail)
                 && Objects.equals(resetPasswordTemplate, other.resetPasswordTemplate)
@@ -535,7 +550,7 @@ public final class DynamoStudy implements Study {
     @Override
     public String toString() {
         return String.format(
-            "DynamoStudy [name=%s, active=%s, sponsorName=%s, identifier=%s, minAgeOfConsent=%s, studyIdExcludedInExport=%b, "
+            "DynamoStudy [name=%s, shortName=%s, active=%s, sponsorName=%s, identifier=%s, minAgeOfConsent=%s, studyIdExcludedInExport=%b, "
                         + "supportEmail=%s, synapseDataAccessTeamId=%s, synapseProjectId=%s, technicalEmail=%s, "
                         + "uploadValidationStrictness=%s, consentNotificationEmail=%s, version=%s, userProfileAttributes=%s, taskIdentifiers=%s, "
                         + "activityEventKeys=%s, dataGroups=%s, passwordPolicy=%s, verifyEmailTemplate=%s, "
@@ -543,7 +558,7 @@ public final class DynamoStudy implements Study {
                         + "emailVerificationEnabled=%s, externalIdValidationEnabled=%s, externalIdRequiredOnSignup=%s, "
                         + "minSupportedAppVersions=%s, usesCustomExportSchedule=%s, pushNotificationARNs=%s, "
                         + "disableExport=%s, emailSignInTemplate=%s, emailSignInEnabled=%s, accountLimit=%s]",
-                name, active, sponsorName, identifier, minAgeOfConsent, studyIdExcludedInExport, supportEmail,
+                name, shortName, active, sponsorName, identifier, minAgeOfConsent, studyIdExcludedInExport, supportEmail,
                 synapseDataAccessTeamId, synapseProjectId, technicalEmail, uploadValidationStrictness, consentNotificationEmail, version,
                 profileAttributes, taskIdentifiers, activityEventKeys, dataGroups, passwordPolicy, verifyEmailTemplate,
                 resetPasswordTemplate, strictUploadValidationEnabled, healthCodeExportEnabled, emailVerificationEnabled,

--- a/app/org/sagebionetworks/bridge/hibernate/HibernateAccount.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateAccount.java
@@ -68,12 +68,13 @@ public class HibernateAccount {
      * specifying a constructor.
      */
     public HibernateAccount(Long createdOn, String studyId, String firstName, String lastName, String email,
-            String id, AccountStatus status) {
+            Phone phone, String id, AccountStatus status) {
         this.createdOn = createdOn;
         this.studyId = studyId;
         this.firstName = firstName;
         this.lastName = lastName;
         this.email = email;
+        this.phone = phone;
         this.id = id;
         this.status = status;
     }

--- a/app/org/sagebionetworks/bridge/models/ClientInfo.java
+++ b/app/org/sagebionetworks/bridge/models/ClientInfo.java
@@ -246,7 +246,8 @@ public final class ClientInfo {
      * @return
      */
     public static ClientInfo fromUserAgentCache(String userAgent) {
-        if (!StringUtils.isBlank(userAgent)) {
+        // The "null" string comes up in tests, and there's no point in parsing it
+        if (!StringUtils.isBlank(userAgent) && !"null".equals(userAgent)) {
             try {
                 return userAgents.get(userAgent);    
             } catch(ExecutionException e) {

--- a/app/org/sagebionetworks/bridge/models/accounts/AccountSummary.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/AccountSummary.java
@@ -14,6 +14,7 @@ public final class AccountSummary {
     private final String firstName;
     private final String lastName;
     private final String email;
+    private final Phone phone;
     private final String id;
     private final DateTime createdOn;
     private final AccountStatus status;
@@ -21,12 +22,13 @@ public final class AccountSummary {
     
     @JsonCreator
     public AccountSummary(@JsonProperty("firstName") String firstName, @JsonProperty("lastName") String lastName,
-            @JsonProperty("email") String email, @JsonProperty("id") String id,
+            @JsonProperty("email") String email, @JsonProperty("phone") Phone phone, @JsonProperty("id") String id,
             @JsonProperty("createdOn") DateTime createdOn, @JsonProperty("status") AccountStatus status,
             @JsonProperty("studyIdentifier") StudyIdentifier studyIdentifier) {
         this.firstName = firstName;
         this.lastName = lastName;
         this.email = email;
+        this.phone = phone;
         this.id = id;
         this.createdOn = (createdOn == null) ? null : createdOn.withZone(DateTimeZone.UTC);
         this.status = status;
@@ -43,6 +45,10 @@ public final class AccountSummary {
     
     public String getEmail() {
         return email;
+    }
+    
+    public Phone getPhone() {
+        return phone;
     }
     
     public String getId() {
@@ -63,7 +69,7 @@ public final class AccountSummary {
 
     @Override
     public int hashCode() {
-        return Objects.hash(firstName, lastName, email, id, createdOn, status, studyIdentifier);
+        return Objects.hash(firstName, lastName, email, phone, id, createdOn, status, studyIdentifier);
     }
 
     @Override
@@ -74,9 +80,9 @@ public final class AccountSummary {
             return false;
         AccountSummary other = (AccountSummary) obj;
         return Objects.equals(firstName, other.firstName) && Objects.equals(lastName, other.lastName)
-                && Objects.equals(email, other.email) && Objects.equals(createdOn, other.createdOn)
-                && Objects.equals(status, other.status) && Objects.equals(id, other.id)
-                && Objects.equals(studyIdentifier, other.studyIdentifier);
+                && Objects.equals(email, other.email) && Objects.equals(phone, other.phone)
+                && Objects.equals(createdOn, other.createdOn) && Objects.equals(status, other.status)
+                && Objects.equals(id, other.id) && Objects.equals(studyIdentifier, other.studyIdentifier);
     }
     
     // no toString() method as the information is sensitive.

--- a/app/org/sagebionetworks/bridge/models/accounts/SignIn.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/SignIn.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge.models.accounts;
 import org.sagebionetworks.bridge.models.BridgeEntity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize(builder = SignIn.Builder.class)
@@ -24,6 +25,9 @@ public final class SignIn implements BridgeEntity {
         this.reauthToken = reauthToken;
     }
     
+    // Serializing this property as study allows us to use SignIn to construct the JSON payload that we 
+    // are accepting from clients, which is useful for tests to avoid manually constructing the JSON string.
+    @JsonProperty("study")
     public String getStudyId() {
         return studyId;
     }

--- a/app/org/sagebionetworks/bridge/models/studies/Study.java
+++ b/app/org/sagebionetworks/bridge/models/studies/Study.java
@@ -40,6 +40,12 @@ public interface Study extends BridgeEntity, StudyIdentifier {
     void setName(String name);
 
     /**
+     * A short display name for SMS messages and other highly constrained UIs. 10 characters of less. 
+     */
+    String getShortName();
+    void setShortName(String shortName);
+    
+    /**
      * The name of the institution or research group conducting the study. 
      */
     String getSponsorName();

--- a/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
@@ -182,8 +182,8 @@ public class AuthenticationController extends BaseController {
                 }
                 throw e;
             }
-            logAuthenticationSuccess(session);
         }
+        logAuthenticationSuccess(session);
 
         // You can proceed if 1) you're some kind of system administrator (developer, researcher), or 2)
         // you've consented to research.
@@ -194,7 +194,7 @@ public class AuthenticationController extends BaseController {
     }
 
     private void logAuthenticationSuccess(UserSession session) {
-        writeSessionInfoToMetrics(session);
+        writeSessionInfoToMetrics(session);  
         // We have removed the cookie in the past, only to find out that clients were unknowingly
         // depending on the cookie to preserve the session token. So it remains.
         response().setCookie(BridgeConstants.SESSION_TOKEN_HEADER, session.getSessionToken(),

--- a/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
@@ -52,10 +52,36 @@ public class AuthenticationController extends BaseController {
         CriteriaContext context = getCriteriaContext(study.getStudyIdentifier());
         
         UserSession session = authenticationService.emailSignIn(context, signInRequest);
-        
+        logAuthenticationSuccess(session);
+
         return okResult(UserSessionInfo.toJSON(session));
     }
 
+    public Result requestPhoneSignIn() {
+        SignIn signInRequest = parseJson(request(), SignIn.class);
+        
+        authenticationService.requestPhoneSignIn(signInRequest);
+
+        return acceptedResult("Message sent.");
+    }
+
+    public Result phoneSignIn() {
+        SignIn signInRequest = parseJson(request(), SignIn.class);
+
+        if (isBlank(signInRequest.getStudyId())) {
+            throw new BadRequestException("Study identifier is required.");
+        }
+        Study study = studyService.getStudy(signInRequest.getStudyId());
+        verifySupportedVersionOrThrowException(study);
+        
+        CriteriaContext context = getCriteriaContext(study.getStudyIdentifier());
+        
+        UserSession session = authenticationService.phoneSignIn(context, signInRequest);
+        logAuthenticationSuccess(session);
+
+        return okResult(UserSessionInfo.toJSON(session));
+    }
+    
     public Result signIn() throws Exception {
         return signInWithRetry(5);
     }
@@ -73,13 +99,7 @@ public class AuthenticationController extends BaseController {
         
         UserSession session = authenticationService.reauthenticate(study, context, signInRequest);
         
-        writeSessionInfoToMetrics(session);
-        response().setCookie(BridgeConstants.SESSION_TOKEN_HEADER, session.getSessionToken(),
-                BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS, "/");
-        
-        RequestInfo requestInfo = getRequestInfoBuilder(session)
-                .withSignedInOn(DateUtils.getCurrentDateTime()).build();
-        cacheProvider.updateRequestInfo(requestInfo);
+        logAuthenticationSuccess(session);
         
         return okResult(UserSessionInfo.toJSON(session));
     }
@@ -120,12 +140,14 @@ public class AuthenticationController extends BaseController {
     }
 
     public Result requestResetPassword() throws Exception {
-        JsonNode json = requestToJSON(request());
-        Email email = parseJson(request(), Email.class);
-        Study study = getStudyOrThrowException(json);
-        authenticationService.requestResetPassword(study, email);
+        SignIn signIn = parseJson(request(), SignIn.class);
+        
+        Study study = studyService.getStudy(signIn.getStudyId());
+        verifySupportedVersionOrThrowException(study);
+        
+        authenticationService.requestResetPassword(study, signIn);
 
-        return okResult("If registered with the study, we'll email you instructions on how to change your password.");
+        return okResult("If registered with the study, we'll send you instructions on how to change your password.");
     }
 
     public Result resetPassword() throws Exception {
@@ -160,13 +182,7 @@ public class AuthenticationController extends BaseController {
                 }
                 throw e;
             }
-            writeSessionInfoToMetrics(session);
-            response().setCookie(BridgeConstants.SESSION_TOKEN_HEADER, session.getSessionToken(),
-                    BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS, "/");
-            
-            RequestInfo requestInfo = getRequestInfoBuilder(session)
-                    .withSignedInOn(DateUtils.getCurrentDateTime()).build();
-            cacheProvider.updateRequestInfo(requestInfo);
+            logAuthenticationSuccess(session);
         }
 
         // You can proceed if 1) you're some kind of system administrator (developer, researcher), or 2)
@@ -175,6 +191,18 @@ public class AuthenticationController extends BaseController {
             throw new ConsentRequiredException(session);
         }
         return okResult(UserSessionInfo.toJSON(session));
+    }
+
+    private void logAuthenticationSuccess(UserSession session) {
+        writeSessionInfoToMetrics(session);
+        // We have removed the cookie in the past, only to find out that clients were unknowingly
+        // depending on the cookie to preserve the session token. So it remains.
+        response().setCookie(BridgeConstants.SESSION_TOKEN_HEADER, session.getSessionToken(),
+                BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS, "/");
+        
+        RequestInfo requestInfo = getRequestInfoBuilder(session)
+                .withSignedInOn(DateUtils.getCurrentDateTime()).build();
+        cacheProvider.updateRequestInfo(requestInfo);
     }
 
     /**

--- a/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
@@ -214,7 +214,7 @@ public abstract class BaseController extends Controller {
         Integer minVersionForOs = study.getMinSupportedAppVersions().get(osName);
         
         if (!clientInfo.isSupportedAppVersion(minVersionForOs)) {
-        	throw new UnsupportedVersionException(clientInfo);
+            throw new UnsupportedVersionException(clientInfo);
         }
     }
 

--- a/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
@@ -275,9 +275,8 @@ public abstract class BaseController extends Controller {
         if (info.equals(ClientInfo.UNKNOWN_CLIENT)) {
             addWarningMessage(BridgeConstants.WARN_NO_USER_AGENT);
         }
-
-        LOG.debug("User-Agent: '"+userAgentHeader+"' converted to " + info);
-    	return info;
+        LOG.debug("User-Agent: '"+userAgentHeader+"' converted to " + info);    
+    	    return info;
     }
 
     CriteriaContext getCriteriaContext(StudyIdentifier studyId) {

--- a/app/org/sagebionetworks/bridge/play/controllers/UserDataDownloadController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/UserDataDownloadController.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import play.mvc.Result;
 
+import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.models.DateRange;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
@@ -32,6 +33,11 @@ public class UserDataDownloadController extends BaseController {
     public Result requestUserData(String startDate, String endDate) throws JsonProcessingException {
         UserSession session = getAuthenticatedAndConsentedSession();
         StudyIdentifier studyIdentifier = session.getStudyIdentifier();
+        
+        // At least for now, if the user does not have an email address, do not allow this service.
+        if (session.getParticipant().getEmail() == null) {
+            throw new BadRequestException("Cannot request user data, account has no email address.");
+        }
         
         DateRange dateRange;
         if (isNotBlank(startDate) && isNotBlank(endDate)) {

--- a/app/org/sagebionetworks/bridge/play/controllers/UserDataDownloadController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/UserDataDownloadController.java
@@ -11,6 +11,7 @@ import play.mvc.Result;
 
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.models.DateRange;
+import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.services.UserDataDownloadService;
@@ -34,9 +35,10 @@ public class UserDataDownloadController extends BaseController {
         UserSession session = getAuthenticatedAndConsentedSession();
         StudyIdentifier studyIdentifier = session.getStudyIdentifier();
         
-        // At least for now, if the user does not have an email address, do not allow this service.
-        if (session.getParticipant().getEmail() == null) {
-            throw new BadRequestException("Cannot request user data, account has no email address.");
+        // At least for now, if the user does not have a verified email address, do not allow this service.
+        StudyParticipant participant = session.getParticipant();
+        if (participant.getEmail() == null || participant.getEmailVerified() != Boolean.TRUE) {
+            throw new BadRequestException("Cannot request user data, account has no verified email address.");
         }
         
         DateRange dateRange;

--- a/app/org/sagebionetworks/bridge/services/AccountWorkflowService.java
+++ b/app/org/sagebionetworks/bridge/services/AccountWorkflowService.java
@@ -41,7 +41,7 @@ public class AccountWorkflowService {
     private static final String BASE_URL = BridgeConfigFactory.getConfig().get("webservices.url");
     private static final String EXP_WINDOW_TOKEN = "expirationWindow";
     private static final String URL_TOKEN = "url";
-    private static final int EXPIRE_IN_SECONDS = 60*60*2;
+    static final int EXPIRE_IN_SECONDS = 60*60*2;
     
     private static class VerificationData {
         private final String studyId;
@@ -204,7 +204,7 @@ public class AccountWorkflowService {
     private void sendPasswordResetRelatedEmail(Study study, String email, EmailTemplate template) {
         String sptoken = createTimeLimitedToken();
         
-        String cacheKey = sptoken + ":email:" + study.getIdentifier();
+        String cacheKey = sptoken + ":" + study.getIdentifier();
         cacheProvider.setString(cacheKey, email, EXPIRE_IN_SECONDS);
         
         String studyId = BridgeUtils.encodeURIComponent(study.getIdentifier());
@@ -239,7 +239,7 @@ public class AccountWorkflowService {
         checkNotNull(passwordReset);
         
         // This pathway is unusual as the account may have an email address or a phone number, so test for both.
-        String emailCacheKey = passwordReset.getSptoken() + ":email:" + passwordReset.getStudyIdentifier();
+        String emailCacheKey = passwordReset.getSptoken() + ":" + passwordReset.getStudyIdentifier();
         String phoneCacheKey = passwordReset.getSptoken() + ":phone:" + passwordReset.getStudyIdentifier();
         
         String email = cacheProvider.getString(emailCacheKey);

--- a/app/org/sagebionetworks/bridge/services/AccountWorkflowService.java
+++ b/app/org/sagebionetworks/bridge/services/AccountWorkflowService.java
@@ -99,11 +99,11 @@ public class AccountWorkflowService {
      * verified. We assume that an account has been created and that email verification should be sent
      * (neither is verified in this method).
      */
-    public void sendEmailVerificationToken(Study study, String userId, String email) {
+    public void sendEmailVerificationToken(Study study, String userId, String recipientEmail) {
         checkNotNull(study);
         checkArgument(isNotBlank(userId));
         
-        if (email != null) {
+        if (recipientEmail != null) {
             String sptoken = createTimeLimitedToken();
             
             saveVerification(sptoken, new VerificationData(study.getIdentifier(), userId));
@@ -114,7 +114,7 @@ public class AccountWorkflowService {
             BasicEmailProvider provider = new BasicEmailProvider.Builder()
                 .withStudy(study)
                 .withEmailTemplate(study.getVerifyEmailTemplate())
-                .withRecipientEmail(email)
+                .withRecipientEmail(recipientEmail)
                 .withToken(URL_TOKEN, url).build();
             sendMailService.sendEmail(provider);         
         }
@@ -171,7 +171,8 @@ public class AccountWorkflowService {
         if (account.getEmail() != null && account.getEmailVerified()) {
             sendPasswordResetRelatedEmail(study, account.getEmail(), study.getAccountExistsTemplate());    
         } else if (account.getPhone() != null && account.getPhoneVerified()) {
-            String message = "Account for " + study.getShortName() + " already exists. Reset password: ";
+            String appName = (study.getShortName() != null) ? study.getShortName() : "Bridge";
+            String message = "Account for " + appName + " already exists. Reset password: ";
             sendPasswordResetRelatedSMS(study, account.getPhone(), message);
         }
     }
@@ -191,7 +192,8 @@ public class AccountWorkflowService {
             if (account.getEmail() != null && account.getEmailVerified()) {
                 sendPasswordResetRelatedEmail(study, account.getEmail(), study.getResetPasswordTemplate());    
             } else if (account.getPhone() != null && account.getPhoneVerified()) {
-                String message = "Reset " + study.getShortName() + " password: ";
+                String appName = (study.getShortName() != null) ? study.getShortName() : "Bridge";
+                String message = "Reset " + appName + " password: ";
                 sendPasswordResetRelatedSMS(study, account.getPhone(), message);
             }
         }

--- a/app/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -394,6 +394,7 @@ public class AuthenticationService {
         if (account.getStatus() == AccountStatus.DISABLED) {
             throw new AccountDisabledException();
         }
+        // Update account state before we create the session, so it's accurate...
         accountDao.verifyChannel(channelType, account);
 
         UserSession session = getSessionFromAccount(study, context, account);

--- a/app/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -21,7 +21,6 @@ import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.exceptions.ConsentRequiredException;
 import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
-import org.sagebionetworks.bridge.exceptions.LimitExceededException;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.accounts.Account;

--- a/app/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -6,6 +6,8 @@ import static org.sagebionetworks.bridge.dao.ParticipantOption.LANGUAGES;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.Roles;
@@ -29,6 +31,7 @@ import org.sagebionetworks.bridge.models.accounts.Email;
 import org.sagebionetworks.bridge.models.accounts.EmailVerification;
 import org.sagebionetworks.bridge.models.accounts.IdentifierHolder;
 import org.sagebionetworks.bridge.models.accounts.PasswordReset;
+import org.sagebionetworks.bridge.models.accounts.Phone;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
@@ -46,13 +49,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.validation.Validator;
 
 @Component("authenticationService")
 public class AuthenticationService {
-
     private static final Logger LOG = LoggerFactory.getLogger(AuthenticationService.class);
-    private static final String SESSION_SIGNIN_CACHE_KEY = "%s:%s:signInRequest";
-    private static final int SESSION_SIGNIN_TIMEOUT = 60;
+    
+    public static enum ChannelType {
+        EMAIL,
+        PHONE;
+    }
+    
+    private static final String EMAIL_SIGNIN_REQUEST_KEY = "%s:%s:signInRequest";
+    private static final String PHONE_SIGNIN_REQUEST_KEY = "%s:%s:phoneSignInRequest";
+    private static final int SESSION_SIGNIN_TIMEOUT = 60*5; // 5 minutes
     
     private CacheProvider cacheProvider;
     private BridgeConfig config;
@@ -64,7 +74,9 @@ public class AuthenticationService {
     private StudyService studyService;
     private PasswordResetValidator passwordResetValidator;
     private AccountWorkflowService accountWorkflowService;
+    private NotificationsService notificationsService;
     private final AtomicLong emailSignInRequestInMillis = new AtomicLong(200L);
+    private final AtomicLong phoneSignInRequestInMillis = new AtomicLong(200L);
 
     @Autowired
     final void setCacheProvider(CacheProvider cache) {
@@ -106,82 +118,73 @@ public class AuthenticationService {
     final void setAccountWorkflowService(AccountWorkflowService accountWorkflowService) {
         this.accountWorkflowService = accountWorkflowService;
     }
+    @Autowired
+    final void setNotificationsService(NotificationsService notificationsService) {
+        this.notificationsService = notificationsService;
+    }
     final AtomicLong getEmailSignInRequestInMillis() {
         return emailSignInRequestInMillis;
-    }    
-    
-    public void requestEmailSignIn(SignIn signIn) {
-        long startTime = System.currentTimeMillis();
-        Validate.entityThrowingException(SignInValidator.EMAIL_SIGNIN_REQUEST, signIn);
-        
-        // We use the study so it's existence is verified. We retrieve the account so we verify it
-        // exists as well. If the token is returned to the server, we can safely use the credentials 
-        // in the persisted SignIn object.        
-        Study study = studyService.getStudy(signIn.getStudyId());
-        if (!study.isEmailSignInEnabled()) {
-            throw new UnauthorizedException("Email-based sign in not enabled for study: " + study.getName());
-        }
-        
-        // check that email is not already locked
-        String cacheKey = getEmailSignInCacheKey(study, signIn.getEmail());
-        if (cacheProvider.getString(cacheKey) != null) {
-            throw new LimitExceededException("Email currently pending confirmation.");
-        }
-        
-        // check that email is in the study, if not, return quietly to prevent account enumeration attacks
-        if (accountDao.getAccount(signIn.getAccountId()) == null) {
-            try {
-                // The not found case returns *much* faster than the normal case. To prevent account enumeration 
-                // attacks, measure time of a successful case and delay for that period before returning.
-                TimeUnit.MILLISECONDS.sleep(emailSignInRequestInMillis.get());            
-            } catch(InterruptedException e) {
-                // Just return, the thread was killed by the connection, the server died, etc.
-            }
-            return;
-        }
-        
-        // set a time-limited token
-        String token = getVerificationToken();
-        cacheProvider.setString(cacheKey, token, SESSION_SIGNIN_TIMEOUT);
-        
-        // email the user the token
-        BasicEmailProvider provider = new BasicEmailProvider.Builder()
-            .withEmailTemplate(study.getEmailSignInTemplate())
-            .withStudy(study)
-            .withRecipientEmail(signIn.getEmail())
-            .withToken("email", BridgeUtils.encodeURIComponent(signIn.getEmail()))
-            .withToken("token", token).build();
-        sendMailService.sendEmail(provider);
-        
-        this.emailSignInRequestInMillis.set(System.currentTimeMillis()-startTime);
+    }
+    final AtomicLong getPhoneSignInRequestInMillis() {
+        return phoneSignInRequestInMillis;
     }
     
-    public UserSession emailSignIn(CriteriaContext context, SignIn signIn) {
-        Validate.entityThrowingException(SignInValidator.EMAIL_SIGNIN, signIn);
-        
-        Study study = studyService.getStudy(signIn.getStudyId());
-        String cacheKey = getEmailSignInCacheKey(study, signIn.getEmail());
-        
-        String storedToken = cacheProvider.getString(cacheKey);
-        if (storedToken == null || !storedToken.equals(signIn.getToken())) {
-            throw new AuthenticationFailedException();
-        }
-        // Consume the key regardless of what happens
-        cacheProvider.removeString(cacheKey);
-        
-        Account account = accountDao.getAccountAfterAuthentication(signIn.getAccountId());
-        if (account.getStatus() == AccountStatus.DISABLED) {
-            throw new AccountDisabledException();
-        } else if (account.getStatus() == AccountStatus.UNVERIFIED) {
-            accountDao.verifyEmail(account);
-        }
-
-        UserSession session = getSessionFromAccount(study, context, account);
-
-        if (!session.doesConsent() && !session.isInRole(Roles.ADMINISTRATIVE_ROLES)) {
-            throw new ConsentRequiredException(session);
-        }
-        return session;
+    /**
+     * Request a token to be sent via SMS to the user, that can be used to start a session on the Bridge server.
+     */
+    public void requestPhoneSignIn(final SignIn signIn) {
+        requestChannelSignIn(ChannelType.PHONE, signIn, SignInValidator.PHONE_SIGNIN_REQUEST, phoneSignInRequestInMillis, () -> {
+            return getPhoneSignInCacheKey(signIn.getPhone(), signIn.getStudyId());
+        }, () -> {
+            return getPhoneToken();
+        }, (study, token) -> {
+            // Put a space in the token so it's easier to enter into the UI
+            String formattedToken = token.substring(0,3) + "-" + token.substring(3,6); 
+            String appName = (study.getShortName() != null) ? study.getShortName() : "Bridge";
+            String message = "Enter " + formattedToken + " to sign in to " + appName;
+            
+            notificationsService.sendSMSMessage(study.getStudyIdentifier(), signIn.getPhone(), message);
+        });
+    }
+    
+    /**
+     * Sign in using a phone number and a token that was sent to that phone number via SMS. 
+     */
+    public UserSession phoneSignIn(CriteriaContext context, final SignIn signIn) {
+        return channelSignIn(ChannelType.PHONE, context, signIn, SignInValidator.PHONE_SIGNIN, () -> {
+            return getPhoneSignInCacheKey(signIn.getPhone(), signIn.getStudyId());
+        });
+    }
+    
+    /**
+     * Request a token to be sent via a link in an email message, that can be used to start a session on the Bridge server. 
+     * The installed application should intercept this link in order to complete the transaction within the app, where the 
+     * returned session can be captured. If the link is not captured, it retrieves a test page on the Bridge server as 
+     * configured by default. That test page will complete the transaction and return a session token.
+     */
+    public void requestEmailSignIn(final SignIn signIn) {
+        requestChannelSignIn(ChannelType.EMAIL, signIn, SignInValidator.EMAIL_SIGNIN_REQUEST, emailSignInRequestInMillis, () -> {
+            return getEmailSignInCacheKey(signIn.getEmail(), signIn.getStudyId());
+        }, () -> {
+            return getEmailToken();
+        }, (study, token) -> {
+            BasicEmailProvider provider = new BasicEmailProvider.Builder()
+                .withEmailTemplate(study.getEmailSignInTemplate())
+                .withStudy(study)
+                .withRecipientEmail(signIn.getEmail())
+                .withToken("email", BridgeUtils.encodeURIComponent(signIn.getEmail()))
+                .withToken("token", token).build();
+            sendMailService.sendEmail(provider);
+        });
+    }
+    
+    /**
+     * Sign in using an email address and a token that was supplied via a message to that email address. 
+     */
+    public UserSession emailSignIn(CriteriaContext context, final SignIn signIn) {
+        return channelSignIn(ChannelType.EMAIL, context, signIn, SignInValidator.EMAIL_SIGNIN, () -> {
+            return getEmailSignInCacheKey(signIn.getEmail(), signIn.getStudyId());
+        });
     }
     
     /**
@@ -276,8 +279,8 @@ public class AuthenticationService {
             // Suppress this and send an email to notify the user that the account already exists. From 
             // this call, we simply return a 200 the same as any other sign up. Otherwise the response 
             // reveals that the email has been taken.
-            Email email = new Email(study.getIdentifier(), participant.getEmail());
-            accountWorkflowService.notifyAccountExists(study, email);
+            AccountId accountId = AccountId.forId(study.getIdentifier(), (String) e.getEntityKeys().get("userId"));
+            accountWorkflowService.notifyAccountExists(study, accountId);
             LOG.info("Sign up attempt for existing email address in study '"+study.getIdentifier()+"'");
         }
         return null;
@@ -304,17 +307,17 @@ public class AuthenticationService {
         }
     }
 
-    public void requestResetPassword(Study study, Email email) throws BridgeServiceException {
+    public void requestResetPassword(Study study, SignIn signIn) throws BridgeServiceException {
         checkNotNull(study);
-        checkNotNull(email);
+        checkNotNull(signIn);
         
-        Validate.entityThrowingException(EmailValidator.INSTANCE, email);
+        // validate the data in signIn, then convert it to an account ID which we know will be valid.
+        Validate.entityThrowingException(SignInValidator.REQUEST_RESET_PASSWORD, signIn);
         try {
-            AccountId accountId = AccountId.forEmail(study.getIdentifier(), email.getEmail());
-            accountDao.requestResetPassword(study, accountId);    
+            accountDao.requestResetPassword(study, signIn.getAccountId());    
         } catch(EntityNotFoundException e) {
             // Suppress this. Otherwise it reveals if the account does not exist
-            LOG.info("Request reset password request for unregistered email in study '"+study.getIdentifier()+"'");
+            LOG.info("Request reset password request for unregistered email in study '"+signIn.getStudyId()+"'");
         }
     }
 
@@ -324,6 +327,81 @@ public class AuthenticationService {
         Validate.entityThrowingException(passwordResetValidator, passwordReset);
         
         accountDao.resetPassword(passwordReset);
+    }
+    
+    protected String getEmailToken() {
+        return SecureTokenGenerator.INSTANCE.nextToken();
+    }
+    
+    protected String getPhoneToken() {
+        return SecureTokenGenerator.PHONE_CODE_INSTANCE.nextToken();
+    }
+
+    private void requestChannelSignIn(ChannelType channelType, SignIn signIn, Validator validator,
+            AtomicLong atomicLong, Supplier<String> cacheKeySupplier, Supplier<String> tokenSupplier,
+            BiConsumer<Study, String> messageSender) {
+        long startTime = System.currentTimeMillis();
+        Validate.entityThrowingException(validator, signIn);
+
+        // We use the study so it's existence is verified. We retrieve the account so we verify it
+        // exists as well. If the token is returned to the server, we can safely use the credentials 
+        // in the persisted SignIn object.        
+        Study study = studyService.getStudy(signIn.getStudyId());
+
+        // Do we want the same flag for phone? Do we want to eliminate this flag?
+        if (channelType == ChannelType.EMAIL && !study.isEmailSignInEnabled()) {
+            throw new UnauthorizedException("Email-based sign in not enabled for study: " + study.getName());
+        }
+
+        String cacheKey = cacheKeySupplier.get();
+        if (cacheProvider.getString(cacheKey) != null) {
+            throw new LimitExceededException("Sign in currently pending confirmation.");
+        }
+        
+        // check that the account exists, return quietly if not to prevent account enumeration attacks
+        if (accountDao.getAccount(signIn.getAccountId()) == null) {
+            try {
+                // The not found case returns *much* faster than the normal case. To prevent account enumeration 
+                // attacks, measure time of a successful case and delay for that period before returning.
+                TimeUnit.MILLISECONDS.sleep(atomicLong.get());            
+            } catch(InterruptedException e) {
+                // Just return, the thread was killed by the connection, the server died, etc.
+            }
+            return;
+        }
+        String token = tokenSupplier.get();
+        cacheProvider.setString(cacheKey, token, SESSION_SIGNIN_TIMEOUT);
+
+        messageSender.accept(study, token);
+        atomicLong.set(System.currentTimeMillis()-startTime);
+    }
+    
+    private UserSession channelSignIn(ChannelType channelType, CriteriaContext context, SignIn signIn,
+            Validator validator, Supplier<String> cacheKeySupplier) {
+        Validate.entityThrowingException(validator, signIn);
+        
+        Study study = studyService.getStudy(signIn.getStudyId());
+        String cacheKey = cacheKeySupplier.get();
+        
+        String storedToken = cacheProvider.getString(cacheKey);
+        if (storedToken == null || !storedToken.equals(signIn.getToken())) {
+            throw new AuthenticationFailedException();
+        }
+        // Consume the key regardless of what happens
+        cacheProvider.removeString(cacheKey);
+        
+        Account account = accountDao.getAccountAfterAuthentication(signIn.getAccountId());
+        if (account.getStatus() == AccountStatus.DISABLED) {
+            throw new AccountDisabledException();
+        }
+        accountDao.verifyChannel(channelType, account);
+
+        UserSession session = getSessionFromAccount(study, context, account);
+
+        if (!session.doesConsent() && !session.isInRole(Roles.ADMINISTRATIVE_ROLES)) {
+            throw new ConsentRequiredException(session);
+        }
+        return session;
     }
     
     private UserSession getSessionFromAccount(Study study, CriteriaContext context, Account account) {
@@ -367,11 +445,11 @@ public class AuthenticationService {
         return session;
     }
     
-    private String getVerificationToken() {
-        return SecureTokenGenerator.INSTANCE.nextToken();
+    private String getPhoneSignInCacheKey(Phone phone, String studyId) {
+        return String.format(PHONE_SIGNIN_REQUEST_KEY, phone.getNumber(), studyId);
     }
     
-    private String getEmailSignInCacheKey(Study study, String email) {
-        return String.format(SESSION_SIGNIN_CACHE_KEY, email, study.getIdentifier());
+    private String getEmailSignInCacheKey(String email, String studyId) {
+        return String.format(EMAIL_SIGNIN_REQUEST_KEY, email, studyId);
     }
 }

--- a/app/org/sagebionetworks/bridge/services/ConsentService.java
+++ b/app/org/sagebionetworks/bridge/services/ConsentService.java
@@ -170,7 +170,7 @@ public class ConsentService {
         optionsService.setEnum(study, participant.getHealthCode(), SHARING_SCOPE, sharingScope);
         
         // Send email, if required.
-        if (sendEmail) {
+        if (sendEmail && participant.getEmail() != null) {
             MimeTypeEmailProvider consentEmail = new ConsentEmailProvider(study, participant.getTimeZone(),
                     participant.getEmail(), withConsentCreatedOnSignature, sharingScope,
                     studyConsent.getDocumentContent(), consentTemplate);
@@ -231,9 +231,11 @@ public class ConsentService {
         }
         accountDao.updateAccount(account);
         
-        MimeTypeEmailProvider consentEmail = new WithdrawConsentEmailProvider(study, externalId, account, withdrawal,
-                withdrewOn);
-        sendMailService.sendEmail(consentEmail);
+        if (account.getEmail() != null) {
+            MimeTypeEmailProvider consentEmail = new WithdrawConsentEmailProvider(study, externalId, account, withdrawal,
+                    withdrewOn);
+            sendMailService.sendEmail(consentEmail);
+        }
         
         Map<SubpopulationGuid,ConsentStatus> statuses = getConsentStatuses(context);
         
@@ -268,9 +270,12 @@ public class ConsentService {
         accountDao.updateAccount(account);
         
         String externalId = optionsService.getOptions(account.getHealthCode()).getString(EXTERNAL_IDENTIFIER);
-        MimeTypeEmailProvider consentEmail = new WithdrawConsentEmailProvider(study, externalId, account, withdrawal,
-                withdrewOn);
-        sendMailService.sendEmail(consentEmail);
+        
+        if (account.getEmail() != null) {
+            MimeTypeEmailProvider consentEmail = new WithdrawConsentEmailProvider(study, externalId, account, withdrawal,
+                    withdrewOn);
+            sendMailService.sendEmail(consentEmail);
+        }
         
         // But we don't need to query, we know these are all withdraw.
         return getConsentStatuses(context);
@@ -293,9 +298,11 @@ public class ConsentService {
         
         String htmlTemplate = studyConsentService.getActiveConsent(subpop).getDocumentContent();
         
-        MimeTypeEmailProvider consentEmail = new ConsentEmailProvider(study, participant.getTimeZone(),
-                participant.getEmail(), consentSignature, sharingScope, htmlTemplate, consentTemplate);
-        sendMailService.sendEmail(consentEmail);
+        if (participant.getEmail() != null) {
+            MimeTypeEmailProvider consentEmail = new ConsentEmailProvider(study, participant.getTimeZone(),
+                    participant.getEmail(), consentSignature, sharingScope, htmlTemplate, consentTemplate);
+            sendMailService.sendEmail(consentEmail);
+        }
     }
 
     private boolean withdrawSignatures(Account account, SubpopulationGuid subpopGuid, long withdrewOn) {

--- a/app/org/sagebionetworks/bridge/services/NotificationsService.java
+++ b/app/org/sagebionetworks/bridge/services/NotificationsService.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge.services;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.sagebionetworks.bridge.BridgeUtils.SEMICOLON_SPACE_JOINER;
 
+import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
 
@@ -190,9 +191,9 @@ public class NotificationsService {
         checkNotNull(phone);
         checkNotNull(message);
         
-        // Limited to 140 characters (Java is UTF-16, so two bytes per character, assuming for now that 
-        // SNS converts these to ASCII, requires integration testing
-        if (message.length() > BridgeConstants.SMS_CHARACTER_LIMIT) {
+        // Limited to 140 bytes in GSM. We can test the length in ASCII (GSM is not a supported encoding in the 
+        // JDK) and this is a rough approximation as both are 7-bit encodings.
+        if (message.getBytes(Charset.forName("US-ASCII")).length > BridgeConstants.SMS_CHARACTER_LIMIT) {
             throw new BridgeServiceException("SMS message cannot be longer than 140 UTF-8/ASCII characters.");
         }
         

--- a/app/org/sagebionetworks/bridge/services/NotificationsService.java
+++ b/app/org/sagebionetworks/bridge/services/NotificationsService.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.sagebionetworks.bridge.BridgeUtils.SEMICOLON_SPACE_JOINER;
 
 import java.util.List;
+import java.util.Map;
 
 import javax.annotation.Resource;
 
@@ -12,11 +13,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
+import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.dao.NotificationRegistrationDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
+import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.exceptions.NotImplementedException;
 import org.sagebionetworks.bridge.models.OperatingSystem;
+import org.sagebionetworks.bridge.models.accounts.Phone;
 import org.sagebionetworks.bridge.models.notifications.NotificationMessage;
 import org.sagebionetworks.bridge.models.notifications.NotificationRegistration;
 import org.sagebionetworks.bridge.models.studies.Study;
@@ -27,9 +30,11 @@ import org.sagebionetworks.bridge.validators.Validate;
 
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.sns.AmazonSNSClient;
+import com.amazonaws.services.sns.model.MessageAttributeValue;
 import com.amazonaws.services.sns.model.PublishRequest;
 import com.amazonaws.services.sns.model.PublishResult;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 
 /**
  * Service for managing client registration to receive push notifications, integrated into the 
@@ -38,6 +43,17 @@ import com.google.common.collect.Lists;
 @Component
 public class NotificationsService {
     private static Logger LOG = LoggerFactory.getLogger(NotificationsService.class);
+        
+    static final String SMS_TYPE_TRANSACTIONAL = "Transactional";
+    /**
+     * 11 character label as to who sent the SMS message. Only in some supported countries (not US):
+     * https://support.twilio.com/hc/en-us/articles/223133767-International-support-for-Alphanumeric-Sender-ID
+     */
+    static final String SENDER_ID = "AWS.SNS.SMS.SenderID";
+    /**
+     * SMS type (Promotional or Transactional).
+     */
+    static final String SMS_TYPE = "AWS.SNS.SMS.SMSType";
     
     private StudyService studyService;
     
@@ -167,6 +183,35 @@ public class NotificationsService {
             throw new BadRequestException("Error sending push notification: " + 
                 SEMICOLON_SPACE_JOINER.join(errorMessages) + ".");
         }
+    }
+    
+    public void sendSMSMessage(StudyIdentifier studyId, Phone phone, String message) {
+        checkNotNull(studyId);
+        checkNotNull(phone);
+        checkNotNull(message);
+        
+        // Limited to 140 characters (Java is UTF-16, so two bytes per character, assuming for now that 
+        // SNS converts these to ASCII, requires integration testing
+        if (message.length() > BridgeConstants.SMS_CHARACTER_LIMIT) {
+            throw new BridgeServiceException("SMS message cannot be longer than 140 UTF-8/ASCII characters.");
+        }
+        
+        Map<String, MessageAttributeValue> smsAttributes = Maps.newHashMap();
+        smsAttributes.put(SENDER_ID, attribute("Bridge"));
+        smsAttributes.put(SMS_TYPE, attribute(SMS_TYPE_TRANSACTIONAL));
+        // Costs seem too low to worry about this, but if need be, this is how we'd cap it.
+        // smsAttributes.put("AWS.SNS.SMS.MaxPrice", attribute("0.50")); max price set to $.50
+        
+        PublishResult result = snsClient.publish(new PublishRequest()
+                .withMessage(message)
+                .withPhoneNumber(phone.getNumber())
+                .withMessageAttributes(smsAttributes));
+
+        LOG.debug("Sent SMS message, study=" + studyId.getIdentifier() + ", message ID=" + result.getMessageId());
+    }
+
+    private MessageAttributeValue attribute(String value) {
+        return new MessageAttributeValue().withStringValue(value).withDataType("String");
     }
 
     private String getPlatformARN(Study study, NotificationRegistration registration) {

--- a/app/org/sagebionetworks/bridge/services/UserAdminService.java
+++ b/app/org/sagebionetworks/bridge/services/UserAdminService.java
@@ -12,8 +12,6 @@ import org.apache.commons.lang3.StringUtils;
 
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.cache.CacheProvider;
-import org.sagebionetworks.bridge.config.BridgeConfigFactory;
-import org.sagebionetworks.bridge.config.Environment;
 import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.json.DateUtils;
 import org.sagebionetworks.bridge.models.CriteriaContext;
@@ -25,13 +23,10 @@ import org.sagebionetworks.bridge.models.accounts.ParticipantOptionsLookup;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
-import org.sagebionetworks.bridge.models.accounts.UserSessionInfo;
 import org.sagebionetworks.bridge.models.studies.Study;
-import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 
 import org.springframework.beans.factory.annotation.Autowired;

--- a/app/org/sagebionetworks/bridge/validators/SignInValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/SignInValidator.java
@@ -34,6 +34,9 @@ public class SignInValidator implements Validator {
     /** Request a reset password link via email or SMS. */
     public static final SignInValidator REQUEST_RESET_PASSWORD = new SignInValidator(EnumSet.of(STUDY, EMAIL_OR_PHONE));
     
+    /** The basics of a sign in that must be present for the admin create user API. */
+    public static final SignInValidator MINIMAL = new SignInValidator(EnumSet.of(STUDY, EMAIL_OR_PHONE));
+    
     /** Sign in using an email and password. */
     public static final SignInValidator PASSWORD_SIGNIN = new SignInValidator(EnumSet.of(STUDY, EMAIL_OR_PHONE, PASSWORD));
     /** Reauthentication. */

--- a/app/org/sagebionetworks/bridge/validators/SignInValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/SignInValidator.java
@@ -2,12 +2,14 @@ package org.sagebionetworks.bridge.validators;
 
 import static org.sagebionetworks.bridge.validators.SignInValidator.RequiredFields.STUDY;
 import static org.sagebionetworks.bridge.validators.SignInValidator.RequiredFields.EMAIL;
+import static org.sagebionetworks.bridge.validators.SignInValidator.RequiredFields.EMAIL_OR_PHONE;
 import static org.sagebionetworks.bridge.validators.SignInValidator.RequiredFields.PASSWORD;
 import static org.sagebionetworks.bridge.validators.SignInValidator.RequiredFields.PHONE;
 import static org.sagebionetworks.bridge.validators.SignInValidator.RequiredFields.TOKEN;
 import static org.sagebionetworks.bridge.validators.SignInValidator.RequiredFields.REAUTH;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.util.EnumSet;
 
@@ -29,14 +31,18 @@ public class SignInValidator implements Validator {
     /** Sign in using token sent through SMS. */
     public static final SignInValidator PHONE_SIGNIN = new SignInValidator(EnumSet.of(STUDY, PHONE, TOKEN));
 
+    /** Request a reset password link via email or SMS. */
+    public static final SignInValidator REQUEST_RESET_PASSWORD = new SignInValidator(EnumSet.of(STUDY, EMAIL_OR_PHONE));
+    
     /** Sign in using an email and password. */
-    public static final SignInValidator PASSWORD_SIGNIN = new SignInValidator(EnumSet.of(STUDY, EMAIL, PASSWORD));
+    public static final SignInValidator PASSWORD_SIGNIN = new SignInValidator(EnumSet.of(STUDY, EMAIL_OR_PHONE, PASSWORD));
     /** Reauthentication. */
-    public static final SignInValidator REAUTH_SIGNIN = new SignInValidator(EnumSet.of(STUDY, EMAIL, REAUTH));
+    public static final SignInValidator REAUTH_SIGNIN = new SignInValidator(EnumSet.of(STUDY, EMAIL_OR_PHONE, REAUTH));
     
     static enum RequiredFields {
         STUDY,
         EMAIL,
+        EMAIL_OR_PHONE,
         PASSWORD,
         PHONE,
         TOKEN,
@@ -66,6 +72,16 @@ public class SignInValidator implements Validator {
         }
         if (requiredFields.contains(PASSWORD) && isBlank(signIn.getPassword())) {
             errors.rejectValue("password", "is required");
+        }
+        if (requiredFields.contains(EMAIL_OR_PHONE)) {
+            if (isBlank(signIn.getEmail()) && signIn.getPhone() == null) {
+                errors.reject("email or phone is required");
+            } else if (isNotBlank(signIn.getEmail()) && signIn.getPhone() != null) {
+                errors.reject("email or phone is required, but not both");
+            }
+            if (signIn.getPhone() != null && !Phone.isValid(signIn.getPhone())) {
+                errors.rejectValue("phone", "does not appear to be a phone number");
+            }
         }
         if (requiredFields.contains(TOKEN) && isBlank(signIn.getToken())) {
             errors.rejectValue("token", "is required");

--- a/app/org/sagebionetworks/bridge/validators/StudyValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/StudyValidator.java
@@ -69,9 +69,7 @@ public class StudyValidator implements Validator {
         if (StringUtils.isBlank(study.getName())) {
             errors.rejectValue("name", "is required");
         }
-        if (StringUtils.isBlank(study.getShortName())) {
-            errors.rejectValue("shortName", "is required");
-        } else if (study.getShortName().length() > 10) {
+        if (study.getShortName() != null && study.getShortName().length() > 10) {
             errors.rejectValue("shortName", "must be 10 characters or less");
         }
         if (StringUtils.isBlank(study.getSponsorName())) {

--- a/app/org/sagebionetworks/bridge/validators/StudyValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/StudyValidator.java
@@ -69,6 +69,11 @@ public class StudyValidator implements Validator {
         if (StringUtils.isBlank(study.getName())) {
             errors.rejectValue("name", "is required");
         }
+        if (StringUtils.isBlank(study.getShortName())) {
+            errors.rejectValue("shortName", "is required");
+        } else if (study.getShortName().length() > 10) {
+            errors.rejectValue("shortName", "must be 10 characters or less");
+        }
         if (StringUtils.isBlank(study.getSponsorName())) {
             errors.rejectValue("sponsorName", "is required");
         }

--- a/conf/routes
+++ b/conf/routes
@@ -16,6 +16,9 @@ POST   /v3/auth/verifyEmail             @org.sagebionetworks.bridge.play.control
 POST   /v3/auth/resendEmailVerification @org.sagebionetworks.bridge.play.controllers.AuthenticationController.resendEmailVerification
 POST   /v3/auth/email                   @org.sagebionetworks.bridge.play.controllers.AuthenticationController.requestEmailSignIn
 POST   /v3/auth/email/signIn            @org.sagebionetworks.bridge.play.controllers.AuthenticationController.emailSignIn
+POST   /v3/auth/phone                   @org.sagebionetworks.bridge.play.controllers.AuthenticationController.requestPhoneSignIn
+POST   /v3/auth/phone/signIn            @org.sagebionetworks.bridge.play.controllers.AuthenticationController.phoneSignIn
+
 
 # Compound Activity Definitions
 GET    /v3/compoundactivitydefinitions @org.sagebionetworks.bridge.play.controllers.CompoundActivityDefinitionController.getAllCompoundActivityDefinitionsInStudy
@@ -175,24 +178,24 @@ POST   /v3/uploads/:uploadId/complete  @org.sagebionetworks.bridge.play.controll
 GET    /v3/uploadstatuses/:uploadId    @org.sagebionetworks.bridge.play.controllers.UploadController.getValidationStatus(uploadId: String)
 
 # Upload Schemas
-GET    /v3/uploadschemas                           @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getUploadSchemasForStudy
-POST   /v3/uploadschemas                           @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.createOrUpdateUploadSchema
-POST   /v4/uploadschemas                           @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.createSchemaRevisionV4
+GET    /v3/uploadschemas                               @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getUploadSchemasForStudy
+POST   /v3/uploadschemas                               @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.createOrUpdateUploadSchema
+POST   /v4/uploadschemas                               @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.createSchemaRevisionV4
 POST   /v4/uploadschemas/:schemaId/revisions/:revision @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.updateSchemaRevisionV4(schemaId: String, revision: Int)
-GET    /v3/uploadschemas/:schemaId                 @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getUploadSchemaAllRevisions(schemaId: String)
-GET    /v3/uploadschemas/:schemaId/recent          @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getUploadSchema(schemaId: String)
-GET    /v3/uploadschemas/:schemaId/revisions/:rev  @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getUploadSchemaByIdAndRev(schemaId: String, rev: Int)
+GET    /v3/uploadschemas/:schemaId                     @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getUploadSchemaAllRevisions(schemaId: String)
+GET    /v3/uploadschemas/:schemaId/recent              @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getUploadSchema(schemaId: String)
+GET    /v3/uploadschemas/:schemaId/revisions/:rev      @org.sagebionetworks.bridge.play.controllers.UploadSchemaController.getUploadSchemaByIdAndRev(schemaId: String, rev: Int)
 
 # Schedule Plans
-GET    /v3/scheduleplans                  @org.sagebionetworks.bridge.play.controllers.SchedulePlanController.getSchedulePlans
-POST   /v3/scheduleplans                  @org.sagebionetworks.bridge.play.controllers.SchedulePlanController.createSchedulePlan
-GET    /v3/scheduleplans/:guid            @org.sagebionetworks.bridge.play.controllers.SchedulePlanController.getSchedulePlan(guid: String)
-POST   /v3/scheduleplans/:guid            @org.sagebionetworks.bridge.play.controllers.SchedulePlanController.updateSchedulePlan(guid: String)
-DELETE /v3/scheduleplans/:guid            @org.sagebionetworks.bridge.play.controllers.SchedulePlanController.deleteSchedulePlan(guid: String)
+GET    /v3/scheduleplans        @org.sagebionetworks.bridge.play.controllers.SchedulePlanController.getSchedulePlans
+POST   /v3/scheduleplans        @org.sagebionetworks.bridge.play.controllers.SchedulePlanController.createSchedulePlan
+GET    /v3/scheduleplans/:guid  @org.sagebionetworks.bridge.play.controllers.SchedulePlanController.getSchedulePlan(guid: String)
+POST   /v3/scheduleplans/:guid  @org.sagebionetworks.bridge.play.controllers.SchedulePlanController.updateSchedulePlan(guid: String)
+DELETE /v3/scheduleplans/:guid  @org.sagebionetworks.bridge.play.controllers.SchedulePlanController.deleteSchedulePlan(guid: String)
 
 # Activity Events
-GET    /v1/activityevents               @org.sagebionetworks.bridge.play.controllers.ActivityEventController.getSelfActivityEvents
-POST   /v1/activityevents              @org.sagebionetworks.bridge.play.controllers.ActivityEventController.createCustomActivityEvent
+GET    /v1/activityevents  @org.sagebionetworks.bridge.play.controllers.ActivityEventController.getSelfActivityEvents
+POST   /v1/activityevents  @org.sagebionetworks.bridge.play.controllers.ActivityEventController.createCustomActivityEvent
 
 # Notifications
 GET    /v3/notifications                      @org.sagebionetworks.bridge.play.controllers.NotificationRegistrationController.getAllRegistrations
@@ -220,8 +223,8 @@ POST   /v3/appconfigs/:guid  @org.sagebionetworks.bridge.play.controllers.AppCon
 DELETE /v3/appconfigs/:guid  @org.sagebionetworks.bridge.play.controllers.AppConfigController.deleteAppConfig(guid: String)
 
 # Bridge Exporter
-POST /v3/recordexportstatuses      @org.sagebionetworks.bridge.play.controllers.HealthDataController.updateRecordsStatus
-POST /v3/recordExportStatuses      @org.sagebionetworks.bridge.play.controllers.HealthDataController.updateRecordsStatus
+POST /v3/recordexportstatuses  @org.sagebionetworks.bridge.play.controllers.HealthDataController.updateRecordsStatus
+POST /v3/recordExportStatuses  @org.sagebionetworks.bridge.play.controllers.HealthDataController.updateRecordsStatus
 
 # Studies
 GET    /v3/studies                     @org.sagebionetworks.bridge.play.controllers.StudyController.getAllStudies(format: String ?= null, summary: String ?= null)

--- a/test/org/sagebionetworks/bridge/DefaultStudyBootstrapperTest.java
+++ b/test/org/sagebionetworks/bridge/DefaultStudyBootstrapperTest.java
@@ -57,6 +57,7 @@ public class DefaultStudyBootstrapperTest {
         assertEquals("Test Study", study.getName());
         assertEquals(BridgeConstants.API_STUDY_ID_STRING, study.getIdentifier());
         assertEquals("Sage Bionetworks", study.getSponsorName());
+        assertEquals("TestStudy", study.getShortName());
         assertEquals(18, study.getMinAgeOfConsent());
         assertEquals("bridge-testing+consent@sagebase.org", study.getConsentNotificationEmail());
         assertEquals("bridge-testing+technical@sagebase.org", study.getTechnicalEmail());

--- a/test/org/sagebionetworks/bridge/SecureTokenGeneratorTest.java
+++ b/test/org/sagebionetworks/bridge/SecureTokenGeneratorTest.java
@@ -2,20 +2,15 @@ package org.sagebionetworks.bridge;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-
-import java.security.SecureRandom;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public class StringIdGeneratorTest {
+public class SecureTokenGeneratorTest {
 
-    @Mock
-    private SecureRandom random;
-    
     @Test
     public void testNoArgConstructor() {
         String value = SecureTokenGenerator.INSTANCE.nextToken();
@@ -27,6 +22,13 @@ public class StringIdGeneratorTest {
     @Test
     public void nextStringDifferent() {
         assertNotEquals(SecureTokenGenerator.INSTANCE.nextToken(), SecureTokenGenerator.INSTANCE.nextToken());
+    }
+    
+    @Test
+    public void phoneCodeString() {
+        String token = SecureTokenGenerator.PHONE_CODE_INSTANCE.nextToken();
+        assertEquals(6, token.length());
+        assertTrue(token.matches("^\\d+$")); // composed only of digits
     }
     
 }

--- a/test/org/sagebionetworks/bridge/TestConstants.java
+++ b/test/org/sagebionetworks/bridge/TestConstants.java
@@ -74,5 +74,5 @@ public class TestConstants {
     
     public static final LinkedHashSet<String> LANGUAGES = TestUtils.newLinkedHashSet("en","fr");
     
-    public static final Phone PHONE = new Phone("9174267643", "US");
+    public static final Phone PHONE = new Phone("9712486796", "US");
 }

--- a/test/org/sagebionetworks/bridge/TestUserAdminHelper.java
+++ b/test/org/sagebionetworks/bridge/TestUserAdminHelper.java
@@ -111,11 +111,11 @@ public class TestUserAdminHelper {
     public void deleteUser(TestUser testUser) {
         checkNotNull(testUser);
         
+        String userId = testUser.getId();
         if (testUser.getSession() != null) {
-            String userId = testUser.getId();
             authService.signOut(testUser.getSession());
-            deleteUser(testUser.getStudy(), userId);
         }
+        deleteUser(testUser.getStudy(), userId);
     }
 
     public void deleteUser(Study study, String id) {

--- a/test/org/sagebionetworks/bridge/TestUserAdminHelper.java
+++ b/test/org/sagebionetworks/bridge/TestUserAdminHelper.java
@@ -112,9 +112,10 @@ public class TestUserAdminHelper {
         checkNotNull(testUser);
         
         if (testUser.getSession() != null) {
+            String userId = testUser.getId();
             authService.signOut(testUser.getSession());
+            deleteUser(testUser.getStudy(), userId);
         }
-        deleteUser(testUser.getStudy(), testUser.getId());
     }
 
     public void deleteUser(Study study, String id) {

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -117,11 +117,8 @@ public class TestUtils {
             Validate.entityThrowingException(validator, object);
             fail("Should have thrown exception");
         } catch(InvalidEntityException e) {
-            for (int i=0; i < e.getErrors().get(fieldName).size(); i++) {
-                String msg = e.getErrors().get(fieldName).get(i);
-                if ((fieldNameAsLabel+error).equals(msg)) {
-                    return;
-                }
+            if (e.getErrors().get(fieldName).contains(fieldNameAsLabel+error)) {
+                return;
             }
             fail("Did not find error message in errors object");
         }
@@ -207,13 +204,13 @@ public class TestUtils {
     /**
      * In the rare case where you need the context, you can use <code>Http.Context.current.get()</code>;
      */
-    public static void mockPlayContext() throws Exception {
+    public static Http.Response mockPlayContext() throws Exception {
         Http.RequestBody body = mock(Http.RequestBody.class);
         when(body.asJson()).thenReturn(null);
         
         Http.Request request = mock(Http.Request.class);
         when(request.body()).thenReturn(body);
-        mockPlayContext(request);
+        return mockPlayContext(request);
     }
     
     public static String randomName(Class<?> clazz) {

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -117,7 +117,13 @@ public class TestUtils {
             Validate.entityThrowingException(validator, object);
             fail("Should have thrown exception");
         } catch(InvalidEntityException e) {
-            assertEquals(fieldNameAsLabel+error, e.getErrors().get(fieldName).get(0));
+            for (int i=0; i < e.getErrors().get(fieldName).size(); i++) {
+                String msg = e.getErrors().get(fieldName).get(i);
+                if ((fieldNameAsLabel+error).equals(msg)) {
+                    return;
+                }
+            }
+            fail("Did not find error message in errors object");
         }
     }
     
@@ -177,6 +183,11 @@ public class TestUtils {
     public static Http.Response mockPlayContextWithJson(Object object) throws Exception {
         String json = BridgeObjectMapper.get().writeValueAsString(object);
         return mockPlayContextWithJson(json, Maps.newHashMap());
+    }
+    
+    public static Http.Response mockPlayContextWithJson(Object object, Map<String, String[]> headers) throws Exception {
+        String json = BridgeObjectMapper.get().writeValueAsString(object);
+        return mockPlayContextWithJson(json, headers);
     }
     
     /**
@@ -376,6 +387,7 @@ public class TestUtils {
         // This study will save without further modification.
         DynamoStudy study = new DynamoStudy();
         study.setName("Test Study ["+clazz.getSimpleName()+"]");
+        study.setShortName("ShortName");
         study.setPasswordPolicy(PasswordPolicy.DEFAULT_PASSWORD_POLICY);
         study.setStudyIdExcludedInExport(true);
         study.setVerifyEmailTemplate(new EmailTemplate("verifyEmail subject", "body with ${url}", MimeType.TEXT));

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
@@ -85,6 +85,7 @@ public class DynamoStudyTest {
         assertTrue(node.get("usesCustomExportSchedule").asBoolean());
         assertEqualsAndNotNull(study.getSponsorName(), node.get("sponsorName").asText());
         assertEqualsAndNotNull(study.getName(), node.get("name").asText());
+        assertEqualsAndNotNull(study.getShortName(), node.get("shortName").textValue());
         assertEqualsAndNotNull(study.isActive(), node.get("active").asBoolean());
         assertEqualsAndNotNull(study.getIdentifier(), node.get("identifier").asText());
         assertEqualsAndNotNull(study.getMinAgeOfConsent(), node.get("minAgeOfConsent").asInt());

--- a/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
+++ b/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
@@ -65,7 +65,7 @@ public class HibernateAccountDaoTest {
     private static final String DUMMY_PASSWORD_HASH = "dummy-password-hash";
     private static final String DUMMY_TOKEN = "dummy-token";
     private static final String EMAIL = "eggplant@example.com";
-    private static final Phone PHONE = new Phone("+14082588569", "US");
+    private static final Phone PHONE = TestConstants.PHONE;
     private static final Phone OTHER_PHONE = new Phone("+12065881469", "US");
     private static final String HEALTH_CODE = "health-code";
     private static final String HEALTH_ID = "health-id";
@@ -799,7 +799,7 @@ public class HibernateAccountDaoTest {
             fail("expected exception");
         } catch (EntityAlreadyExistsException ex) {
             assertEquals(otherAccountId, ex.getEntity().get("userId"));
-            assertTrue(queryCaptor.getValue().contains("phone.number='+19174267643' and phone.regionCode='US'"));
+            assertTrue(queryCaptor.getValue().contains("phone.number='+19712486796' and phone.regionCode='US'"));
         }
     }
     

--- a/test/org/sagebionetworks/bridge/hibernate/HibernateAccountTest.java
+++ b/test/org/sagebionetworks/bridge/hibernate/HibernateAccountTest.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import org.junit.Test;
 
 import org.sagebionetworks.bridge.Roles;
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.models.accounts.AccountStatus;
 
 public class HibernateAccountTest {
@@ -120,13 +121,14 @@ public class HibernateAccountTest {
     @Test
     public void accountSummaryConstructor() {
         HibernateAccount account = new HibernateAccount(new Long(123), "studyId", "firstName", "lastName", "email",
-                "id", AccountStatus.UNVERIFIED);
+                TestConstants.PHONE, "id", AccountStatus.UNVERIFIED);
 
         assertEquals(new Long(123), account.getCreatedOn());
         assertEquals("studyId", account.getStudyId());
         assertEquals("firstName", account.getFirstName());
         assertEquals("lastName", account.getLastName());
         assertEquals("email", account.getEmail());
+        assertEquals(TestConstants.PHONE, account.getPhone());
         assertEquals("id", account.getId());
         assertEquals(AccountStatus.UNVERIFIED, account.getStatus());
     }

--- a/test/org/sagebionetworks/bridge/models/ForwardCursorPagedResourceListTest.java
+++ b/test/org/sagebionetworks/bridge/models/ForwardCursorPagedResourceListTest.java
@@ -26,10 +26,10 @@ public class ForwardCursorPagedResourceListTest {
     @Test
     public void canSerialize() throws Exception {
         List<AccountSummary> accounts = Lists.newArrayListWithCapacity(2);
-        accounts.add(new AccountSummary("firstName1", "lastName1", "email1@email.com", "id", DateTime.now(),
-                AccountStatus.DISABLED, TestConstants.TEST_STUDY));
-        accounts.add(new AccountSummary("firstName2", "lastName2", "email2@email.com", "id2", DateTime.now(),
-                AccountStatus.ENABLED, TestConstants.TEST_STUDY));
+        accounts.add(new AccountSummary("firstName1", "lastName1", "email1@email.com", TestConstants.PHONE, "id",
+                DateTime.now(), AccountStatus.DISABLED, TestConstants.TEST_STUDY));
+        accounts.add(new AccountSummary("firstName2", "lastName2", "email2@email.com", TestConstants.PHONE, "id2",
+                DateTime.now(), AccountStatus.ENABLED, TestConstants.TEST_STUDY));
         
         DateTime startTime = DateTime.parse("2016-02-03T10:10:10.000-08:00");
         DateTime endTime = DateTime.parse("2016-02-23T14:14:14.000-08:00");

--- a/test/org/sagebionetworks/bridge/models/PagedResourceListTest.java
+++ b/test/org/sagebionetworks/bridge/models/PagedResourceListTest.java
@@ -24,10 +24,10 @@ public class PagedResourceListTest {
     @Test
     public void canSerialize() throws Exception {
         List<AccountSummary> accounts = Lists.newArrayListWithCapacity(2);
-        accounts.add(new AccountSummary("firstName1", "lastName1", "email1@email.com", "id", DateTime.now(),
-                AccountStatus.DISABLED, TestConstants.TEST_STUDY));
-        accounts.add(new AccountSummary("firstName2", "lastName2", "email2@email.com", "id2", DateTime.now(),
-                AccountStatus.ENABLED, TestConstants.TEST_STUDY));
+        accounts.add(new AccountSummary("firstName1", "lastName1", "email1@email.com", TestConstants.PHONE, "id",
+                DateTime.now(), AccountStatus.DISABLED, TestConstants.TEST_STUDY));
+        accounts.add(new AccountSummary("firstName2", "lastName2", "email2@email.com", TestConstants.PHONE, "id2",
+                DateTime.now(), AccountStatus.ENABLED, TestConstants.TEST_STUDY));
 
         DateTime startTime = DateTime.parse("2016-02-03T10:10:10.000-08:00");
         DateTime endTime = DateTime.parse("2016-02-23T14:14:14.000-08:00");

--- a/test/org/sagebionetworks/bridge/models/accounts/AccountSummaryTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/AccountSummaryTest.java
@@ -24,14 +24,17 @@ public class AccountSummaryTest {
         // Set the time zone so it's not UTC, it should be converted to UTC so the strings are 
         // equal below (to demonstrate the ISO 8601 string is in UTC time zone).
         DateTime dateTime = DateTime.now().withZone(DateTimeZone.forOffsetHours(-8));
-        AccountSummary summary = new AccountSummary("firstName", "lastName", "email@email.com", "ABC", dateTime,
-                AccountStatus.UNVERIFIED, TestConstants.TEST_STUDY);
+        AccountSummary summary = new AccountSummary("firstName", "lastName", "email@email.com", TestConstants.PHONE,
+                "ABC", dateTime, AccountStatus.UNVERIFIED, TestConstants.TEST_STUDY);
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(summary);
         assertEquals("firstName", node.get("firstName").textValue());
         assertEquals("lastName", node.get("lastName").textValue());
         assertEquals("email@email.com", node.get("email").textValue());
         assertEquals("ABC", node.get("id").textValue());
+        assertEquals(TestConstants.PHONE.getNumber(), node.get("phone").get("number").textValue());
+        assertEquals(TestConstants.PHONE.getRegionCode(), node.get("phone").get("regionCode").textValue());
+        assertEquals(TestConstants.PHONE.getNationalFormat(), node.get("phone").get("nationalFormat").textValue());
         assertEquals(dateTime.withZone(DateTimeZone.UTC).toString(), node.get("createdOn").textValue());
         assertEquals("unverified", node.get("status").textValue());
         assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, node.get("studyIdentifier").get("identifier").textValue());

--- a/test/org/sagebionetworks/bridge/models/accounts/PhoneTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/PhoneTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -21,20 +22,20 @@ public class PhoneTest {
     
     @Test
     public void canSerialize() throws Exception {
-        Phone phone = new Phone("408.258.8569", "US");
-        assertEquals("+14082588569", phone.getNumber());
+        Phone phone = new Phone(TestConstants.PHONE.getNationalFormat(), TestConstants.PHONE.getRegionCode());
+        assertEquals(TestConstants.PHONE.getNumber(), phone.getNumber());
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(phone);
-        assertEquals("+14082588569", node.get("number").textValue());
-        assertEquals("US", node.get("regionCode").textValue());
-        assertEquals("(408) 258-8569", node.get("nationalFormat").textValue());
+        assertEquals(TestConstants.PHONE.getNumber(), node.get("number").textValue());
+        assertEquals(TestConstants.PHONE.getRegionCode(), node.get("regionCode").textValue());
+        assertEquals(TestConstants.PHONE.getNationalFormat(), node.get("nationalFormat").textValue());
         assertEquals("Phone", node.get("type").textValue());
         assertEquals(4, node.size());
         
         Phone deser = BridgeObjectMapper.get().readValue(node.toString(), Phone.class);
         assertEquals(phone.getNumber(), deser.getNumber());
         assertEquals(phone.getRegionCode(), deser.getRegionCode());
-        assertEquals("(408) 258-8569", deser.getNationalFormat());
+        assertEquals(TestConstants.PHONE.getNationalFormat(), deser.getNationalFormat());
     }
     
     @Test
@@ -50,10 +51,10 @@ public class PhoneTest {
     @Test
     public void hibernateConstructionPathWorks() {
         Phone phone = new Phone();
-        phone.setNumber("408-258-8569");
+        phone.setNumber(TestConstants.PHONE.getNationalFormat());
         phone.setRegionCode("US");
-        assertEquals("+14082588569", phone.getNumber());
-        assertEquals("(408) 258-8569", phone.getNationalFormat());
+        assertEquals(TestConstants.PHONE.getNumber(), phone.getNumber());
+        assertEquals(TestConstants.PHONE.getNationalFormat(), phone.getNationalFormat());
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/models/accounts/SignInTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/SignInTest.java
@@ -35,6 +35,24 @@ public class SignInTest {
     }
     
     @Test
+    public void canSerialize() throws Exception {
+        // We set up tests with this object so verify it creates the correct JSON
+        SignIn signIn = new SignIn.Builder().withEmail("email@email.com")
+                .withPassword("password").withPhone(TestConstants.PHONE)
+                .withReauthToken("reauthToken").withStudy("study-key")
+                .withToken("token").build();
+        
+        JsonNode node = BridgeObjectMapper.get().valueToTree(signIn);
+        assertEquals("email@email.com", node.get("email").textValue());
+        assertEquals("password", node.get("password").textValue());
+        assertEquals(TestConstants.PHONE.getNumber(), node.get("phone").get("number").textValue());
+        assertEquals(TestConstants.PHONE.getRegionCode(), node.get("phone").get("regionCode").textValue());
+        assertEquals("reauthToken", node.get("reauthToken").textValue());
+        assertEquals("study-key", node.get("study").textValue());
+        assertEquals("token", node.get("token").textValue());
+    }
+    
+    @Test
     public void preferUsernameOverEmailForBackwardsCompatibility() throws Exception {
         String json = "{\"username\":\"aName\",\"email\":\"email@email.com\",\"password\":\"password\"}";
 

--- a/test/org/sagebionetworks/bridge/models/accounts/SignInTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/SignInTest.java
@@ -61,7 +61,8 @@ public class SignInTest {
                 "'password':'passwordValue',"+
                 "'study':'studyValue',"+
                 "'token':'tokenValue',"+
-                "'phone':{'number':'4082588569','regionCode':'US'},"+
+                "'phone':{'number':'"+TestConstants.PHONE.getNumber()+"',"+
+                    "'regionCode':'"+TestConstants.PHONE.getRegionCode()+"'},"+
                 "'reauthToken':'reauthTokenValue'"+
                 "}"));
         
@@ -70,8 +71,8 @@ public class SignInTest {
         assertEquals("passwordValue", signIn.getPassword());
         assertEquals("studyValue", signIn.getStudyId());
         assertEquals("tokenValue", signIn.getToken());
-        assertEquals("+14082588569", signIn.getPhone().getNumber());
-        assertEquals("US", signIn.getPhone().getRegionCode());
+        assertEquals(TestConstants.PHONE.getNumber(), signIn.getPhone().getNumber());
+        assertEquals(TestConstants.PHONE.getRegionCode(), signIn.getPhone().getRegionCode());
         assertEquals("reauthTokenValue", signIn.getReauthToken());
     }
     

--- a/test/org/sagebionetworks/bridge/models/accounts/StudyParticipantTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/StudyParticipantTest.java
@@ -40,7 +40,7 @@ public class StudyParticipantTest {
     private static final String ACCOUNT_ID = "6278uk74xoQkXkrbh9vJnh";
     private static final DateTime CREATED_ON = DateTime.now();
     private static final DateTime CREATED_ON_UTC = CREATED_ON.withZone(DateTimeZone.UTC);
-    private static final Phone PHONE = new Phone("4082588569", "US");
+    private static final Phone PHONE = TestConstants.PHONE;
     private static final Set<Roles> ROLES = Sets.newHashSet(Roles.ADMIN, Roles.WORKER);
     private static final LinkedHashSet<String> LANGS = TestUtils.newLinkedHashSet("en","fr");
     private static final Set<String> DATA_GROUPS = Sets.newHashSet("group1","group2");

--- a/test/org/sagebionetworks/bridge/play/controllers/AuthenticationControllerMockTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/AuthenticationControllerMockTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.spy;
@@ -15,6 +16,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.TestConstants.TEST_CONTEXT;
 import static org.sagebionetworks.bridge.TestUtils.assertResult;
+import static org.sagebionetworks.bridge.TestUtils.mockPlayContext;
 import static org.sagebionetworks.bridge.TestUtils.mockPlayContextWithJson;
 
 import java.util.Map;
@@ -27,6 +29,7 @@ import com.google.common.collect.Sets;
 import org.apache.http.HttpStatus;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -71,13 +74,12 @@ import play.test.Helpers;
 @RunWith(MockitoJUnitRunner.class)
 public class AuthenticationControllerMockTest {
     
+    private static final DateTime NOW = DateTime.now();
     private static final String REAUTH_TOKEN = "reauthToken";
-    private static final String SESSION_TOKEN = "sessionToken";
     private static final String TEST_INTERNAL_SESSION_ID = "internal-session-id";
     private static final String TEST_PASSWORD = "password";
     private static final String TEST_ACCOUNT_ID = "spId";
     private static final String TEST_EMAIL = "email@email.com";
-    private static final String TEST_REQUEST_ID = "request-id";
     private static final String TEST_SESSION_TOKEN = "session-token";
     private static final String TEST_STUDY_ID_STRING = "study-key";
     private static final StudyIdentifier TEST_STUDY_ID = new StudyIdentifierImpl(TEST_STUDY_ID_STRING);
@@ -120,15 +122,26 @@ public class AuthenticationControllerMockTest {
     
     UserSession userSession;
     
+    // This is manually mocked along with a request payload and captured in some tests
+    // for verification
+    Http.Response response;
+    
+    @Mock
+    Metrics metrics;
+    
     @Before
     public void before() {
+        DateTimeUtils.setCurrentMillisFixed(NOW.getMillis());
+        
         controller = spy(new AuthenticationController());
         controller.setAuthenticationService(authenticationService);
         controller.setCacheProvider(cacheProvider);
         
         userSession = new UserSession();
         userSession.setReauthToken(REAUTH_TOKEN);
-        userSession.setSessionToken(SESSION_TOKEN);
+        userSession.setSessionToken(TEST_SESSION_TOKEN);
+        userSession.setParticipant(new StudyParticipant.Builder().withId(TEST_ACCOUNT_ID).build());
+        userSession.setInternalSessionToken(TEST_INTERNAL_SESSION_ID);
         userSession.setStudyIdentifier(TEST_STUDY_ID);
         
         study = new DynamoStudy();
@@ -138,6 +151,13 @@ public class AuthenticationControllerMockTest {
         when(studyService.getStudy(TEST_STUDY_ID)).thenReturn(study);
         
         controller.setStudyService(studyService);
+        
+        doReturn(metrics).when(controller).getMetrics();
+    }
+    
+    @After
+    public void after() {
+        DateTimeUtils.setCurrentMillisSystem();
     }
     
     @Test
@@ -154,16 +174,11 @@ public class AuthenticationControllerMockTest {
     
     @Test
     public void emailSignIn() throws Exception {
-        StudyParticipant participant = new StudyParticipant.Builder().build();
-        mockPlayContextWithJson(TestUtils.createJson("{'study':'study-key','email':'email@email.com','token':'ABC'}"));
-        userSession.setParticipant(participant);
+        response = mockPlayContextWithJson(TestUtils.createJson("{'study':'study-key','email':'email@email.com','token':'ABC'}"));
         userSession.setAuthenticated(true);
         study.setIdentifier("study-test");
         doReturn(study).when(studyService).getStudy("study-test");
         doReturn(userSession).when(authenticationService).emailSignIn(any(CriteriaContext.class), any(SignIn.class));
-        
-        Metrics metrics = new Metrics(TEST_REQUEST_ID);
-        doReturn(metrics).when(controller).getMetrics();
         
         Result result = controller.emailSignIn();
         assertEquals(200, result.status());
@@ -176,6 +191,8 @@ public class AuthenticationControllerMockTest {
         assertEquals(TEST_EMAIL, captured.getEmail());
         assertEquals("study-key", captured.getStudyId());
         assertEquals("ABC", captured.getToken());
+        
+        verifyCommonLoggingForSignIns();
     }
     
     @Test(expected = BadRequestException.class)
@@ -197,10 +214,9 @@ public class AuthenticationControllerMockTest {
         long timestamp = DateTime.now().getMillis();
         DateTimeUtils.setCurrentMillisFixed(timestamp);
         try {
-            Http.Response response = mockPlayContextWithJson(TestUtils.createJson(
+            response = mockPlayContextWithJson(TestUtils.createJson(
                     "{'study':'study-key','email':'email@email.com','reauthToken':'abc'}"));
             when(authenticationService.reauthenticate(any(), any(), any())).thenReturn(userSession);
-            doReturn(new Metrics("abcd")).when(controller).getMetrics();
             
             Result result = controller.reauthenticate();
             assertEquals(200, result.status());
@@ -211,17 +227,12 @@ public class AuthenticationControllerMockTest {
             assertEquals("email@email.com", signIn.getEmail());
             assertEquals("abc", signIn.getReauthToken());
             
-            verify(controller).getMetrics();
-            
-            verify(response).setCookie(BridgeConstants.SESSION_TOKEN_HEADER, SESSION_TOKEN,
-                    BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS, "/");
-            
-            verify(cacheProvider).updateRequestInfo(requestInfoCaptor.capture());
-            RequestInfo requestInfo = requestInfoCaptor.getValue();
-            assertEquals(timestamp, requestInfo.getSignedInOn().getMillis());
+            verifyCommonLoggingForSignIns();
             
             JsonNode node = BridgeObjectMapper.get().readTree(Helpers.contentAsString(result));
             assertEquals(REAUTH_TOKEN, node.get("reauthToken").textValue());
+            
+            verifyCommonLoggingForSignIns();
         } finally {
             DateTimeUtils.setCurrentMillisSystem();
         }
@@ -246,21 +257,18 @@ public class AuthenticationControllerMockTest {
     }
 
     @Test
-    public void getSessionIfItExistsSuccess() {
+    public void getSessionIfItExistsSuccess() throws Exception {
+        mockPlayContext(); 
         // mock getSessionToken and getMetrics
         doReturn(TEST_SESSION_TOKEN).when(controller).getSessionToken();
 
-        Metrics metrics = new Metrics(TEST_REQUEST_ID);
-        doReturn(metrics).when(controller).getMetrics();
-
         // mock AuthenticationService
-        UserSession session = createSession(TestConstants.REQUIRED_SIGNED_CURRENT, null);
-        when(authenticationService.getSession(TEST_SESSION_TOKEN)).thenReturn(session);
+        when(authenticationService.getSession(TEST_SESSION_TOKEN)).thenReturn(userSession);
 
         // execute and validate
         UserSession retVal = controller.getSessionIfItExists();
-        assertSame(session, retVal);
-        assertSessionInfoInMetrics(metrics);
+        assertSame(userSession, retVal);
+        verifyMetrics();
     }
 
     @Test(expected = NotAuthenticatedException.class)
@@ -286,9 +294,6 @@ public class AuthenticationControllerMockTest {
         // mock getSessionToken and getMetrics
         doReturn(TEST_SESSION_TOKEN).when(controller).getSessionToken();
 
-        Metrics metrics = new Metrics(TEST_REQUEST_ID);
-        doReturn(metrics).when(controller).getMetrics();
-
         // mock AuthenticationService
         when(authenticationService.getSession(TEST_SESSION_TOKEN)).thenReturn(null);
 
@@ -301,9 +306,6 @@ public class AuthenticationControllerMockTest {
         // mock getSessionToken and getMetrics
         doReturn(TEST_SESSION_TOKEN).when(controller).getSessionToken();
 
-        Metrics metrics = new Metrics(TEST_REQUEST_ID);
-        doReturn(metrics).when(controller).getMetrics();
-
         // mock AuthenticationService
         UserSession session = createSession(TestConstants.REQUIRED_SIGNED_CURRENT, null);
         session.setAuthenticated(false);
@@ -314,12 +316,10 @@ public class AuthenticationControllerMockTest {
     }
 
     @Test
-    public void getAuthenticatedSessionSuccess() {
+    public void getAuthenticatedSessionSuccess() throws Exception {
+        TestUtils.mockPlayContext();
         // mock getSessionToken and getMetrics
         doReturn(TEST_SESSION_TOKEN).when(controller).getSessionToken();
-
-        Metrics metrics = new Metrics(TEST_REQUEST_ID);
-        doReturn(metrics).when(controller).getMetrics();
 
         // mock AuthenticationService
         UserSession session = createSession(TestConstants.REQUIRED_SIGNED_CURRENT, null);
@@ -328,7 +328,7 @@ public class AuthenticationControllerMockTest {
         // execute and validate
         UserSession retVal = controller.getAuthenticatedSession();
         assertSame(session, retVal);
-        assertSessionInfoInMetrics(metrics);
+        verifyMetrics();
     }
 
     @Test
@@ -339,10 +339,10 @@ public class AuthenticationControllerMockTest {
         ObjectNode node = BridgeObjectMapper.get().valueToTree(originalParticipant);
         node.put("study", TEST_STUDY_ID_STRING);
         
-        TestUtils.mockPlayContextWithJson(node.toString());
+        mockPlayContextWithJson(node.toString());
         
         Result result = controller.signUp();
-        TestUtils.assertResult(result, 201, "Signed up.");
+        assertResult(result, 201, "Signed up.");
         
         verify(authenticationService).signUp(eq(study), participantCaptor.capture());
         
@@ -374,7 +374,7 @@ public class AuthenticationControllerMockTest {
         study.getMinSupportedAppVersions().put(OperatingSystem.IOS, 20);
 
         // Setup and execute. This will throw.
-        TestUtils.mockPlayContextWithJson(node.toString(), headers);
+        response = TestUtils.mockPlayContextWithJson(node.toString(), headers);
         controller.signUp();
     }
 
@@ -385,16 +385,14 @@ public class AuthenticationControllerMockTest {
         ObjectNode node = BridgeObjectMapper.get().valueToTree(originalParticipant);
 
         // Setup and execute. This will throw.
-        TestUtils.mockPlayContextWithJson(node.toString());
+        mockPlayContextWithJson(node.toString());
         controller.signUp();
     }
 
     private void signInExistingSession(boolean isConsented, Roles role, boolean shouldThrow) throws Exception {
+        response = mockPlayContext();
         // mock getSessionToken and getMetrics
         doReturn(TEST_SESSION_TOKEN).when(controller).getSessionToken();
-
-        Metrics metrics = new Metrics(TEST_REQUEST_ID);
-        doReturn(metrics).when(controller).getMetrics();
 
         // mock AuthenticationService
         ConsentStatus consentStatus = (isConsented) ? TestConstants.REQUIRED_SIGNED_CURRENT : null;
@@ -413,7 +411,7 @@ public class AuthenticationControllerMockTest {
                 throw ex;
             }
         }
-        assertSessionInfoInMetrics(metrics);
+        verifyCommonLoggingForSignIns();    
     }
     @Test
     public void signInExistingSession() throws Exception {
@@ -457,9 +455,6 @@ public class AuthenticationControllerMockTest {
 
         doReturn(TEST_CONTEXT).when(controller).getCriteriaContext(any(StudyIdentifier.class));
 
-        Metrics metrics = new Metrics(TEST_REQUEST_ID);
-        doReturn(metrics).when(controller).getMetrics();
-
         // mock request
         String requestJsonString = "{\n" +
                 "   \"email\":\"" + TEST_EMAIL + "\",\n" +
@@ -467,7 +462,7 @@ public class AuthenticationControllerMockTest {
                 "   \"study\":\"" + TEST_STUDY_ID_STRING + "\"\n" +
                 "}";
 
-        TestUtils.mockPlayContextWithJson(requestJsonString);
+        response = TestUtils.mockPlayContextWithJson(requestJsonString);
 
         // mock AuthenticationService
         ConsentStatus consentStatus = (isConsented) ? TestConstants.REQUIRED_SIGNED_CURRENT : null;
@@ -502,7 +497,7 @@ public class AuthenticationControllerMockTest {
                 throw ex;
             }
         }
-        assertSessionInfoInMetrics(metrics);
+        verifyCommonLoggingForSignIns();
 
         // validate signIn
         SignIn signIn = signInCaptor.getValue();
@@ -547,13 +542,10 @@ public class AuthenticationControllerMockTest {
 
     @Test
     public void signOut() throws Exception {
-        TestUtils.mockPlayContext();
+        mockPlayContext();
         
         // mock getSessionToken and getMetrics
         doReturn(TEST_SESSION_TOKEN).when(controller).getSessionToken();
-
-        Metrics metrics = new Metrics(TEST_REQUEST_ID);
-        doReturn(metrics).when(controller).getMetrics();
 
         // mock AuthenticationService
         UserSession session = createSession(TestConstants.REQUIRED_SIGNED_CURRENT, null);
@@ -562,7 +554,6 @@ public class AuthenticationControllerMockTest {
         // execute and validate
         Result result = controller.signOut();
         assertEquals(HttpStatus.SC_OK, result.status());
-        assertSessionInfoInMetrics(metrics);
         
         @SuppressWarnings("static-access")
         Http.Response mockResponse = controller.response();
@@ -576,9 +567,6 @@ public class AuthenticationControllerMockTest {
         // mock getSessionToken and getMetrics
         doReturn(null).when(controller).getSessionToken();
 
-        Metrics metrics = new Metrics(TEST_REQUEST_ID);
-        doReturn(metrics).when(controller).getMetrics();
-
         // execute and validate
         Result result = controller.signOut();
         assertEquals(HttpStatus.SC_OK, result.status());
@@ -588,17 +576,13 @@ public class AuthenticationControllerMockTest {
 
     @Test
     public void verifyEmail() throws Exception {
-        // mock getMetrics
-        Metrics metrics = new Metrics(TEST_REQUEST_ID);
-        doReturn(metrics).when(controller).getMetrics();
-        
         // mock request
         String requestJsonString = "{\n" +
                 "   \"sptoken\":\"" + TEST_TOKEN + "\",\n" +
                 "   \"study\":\"" + TEST_STUDY_ID_STRING + "\"\n" +
                 "}";
 
-        TestUtils.mockPlayContextWithJson(requestJsonString);
+        mockPlayContextWithJson(requestJsonString);
 
         // mock AuthenticationService
         ArgumentCaptor<EmailVerification> emailVerifyCaptor = ArgumentCaptor.forClass(EmailVerification.class);
@@ -620,12 +604,9 @@ public class AuthenticationControllerMockTest {
         String json = TestUtils.createJson(
                 "{'study':'" + TEST_STUDY_ID_STRING + 
                 "','email':'email@email.com','password':'bar'}");
-        TestUtils.mockPlayContextWithJson(json, headers);
+        mockPlayContextWithJson(json, headers);
         study.getMinSupportedAppVersions().put(OperatingSystem.IOS, 20);
         
-        Metrics metrics = new Metrics(TEST_REQUEST_ID);
-        doReturn(metrics).when(controller).getMetrics();
-
         controller.signIn();
     }
     
@@ -636,13 +617,23 @@ public class AuthenticationControllerMockTest {
         String json = TestUtils.createJson(
                 "{'study':'" + TEST_STUDY_ID_STRING + 
                 "','email':'email@email.com','password':'bar'}");
-        TestUtils.mockPlayContextWithJson(json, headers);
+        mockPlayContextWithJson(json, headers);
         study.getMinSupportedAppVersions().put(OperatingSystem.IOS, 20);
         
-        Metrics metrics = new Metrics(TEST_REQUEST_ID);
-        doReturn(metrics).when(controller).getMetrics();
-
         controller.emailSignIn();
+    }
+    
+    @Test(expected = UnsupportedVersionException.class)
+    public void phoneSignInBlockedByVersionKillSwitch() throws Exception {
+        Map<String,String[]> headers = new ImmutableMap.Builder<String,String[]>()
+                .put("User-Agent", new String[]{"App/14 (Unknown iPhone; iOS/9.0.2) BridgeSDK/4"}).build();
+        String json = TestUtils.createJson(
+                "{'study':'" + TEST_STUDY_ID_STRING + 
+                "','email':'email@email.com','password':'bar'}");
+        mockPlayContextWithJson(json, headers);
+        study.getMinSupportedAppVersions().put(OperatingSystem.IOS, 20);
+        
+        controller.phoneSignIn();
     }
     
     @Test
@@ -668,7 +659,7 @@ public class AuthenticationControllerMockTest {
 
     @Test(expected = EntityNotFoundException.class)
     public void resendEmailVerificationNoStudy() throws Exception {
-        TestUtils.mockPlayContextWithJson(new Email((StudyIdentifier) null, TEST_EMAIL));
+        mockPlayContextWithJson(new Email((StudyIdentifier) null, TEST_EMAIL));
         controller.resendEmailVerification();
     }
 
@@ -697,7 +688,7 @@ public class AuthenticationControllerMockTest {
 
     @Test(expected = EntityNotFoundException.class)
     public void resetPasswordNoStudy() throws Exception {
-        TestUtils.mockPlayContextWithJson(new PasswordReset("aPassword", "aSpToken", null));
+        mockPlayContextWithJson(new PasswordReset("aPassword", "aSpToken", null));
         controller.resetPassword();
     }
 
@@ -706,7 +697,7 @@ public class AuthenticationControllerMockTest {
                 .put("User-Agent", new String[]{"App/14 (Unknown iPhone; iOS/9.0.2) BridgeSDK/4"}).build();
         String json = TestUtils.createJson("{'study':'" + TEST_STUDY_ID_STRING + 
             "','sptoken':'aSpToken','password':'aPassword'}");
-        TestUtils.mockPlayContextWithJson(json, headers);
+        mockPlayContextWithJson(json, headers);
     }
     
     @Test
@@ -746,16 +737,16 @@ public class AuthenticationControllerMockTest {
     @Test(expected = EntityNotFoundException.class)
     public void requestResetPasswordNoStudy() throws Exception {
         when(studyService.getStudy((String)any())).thenThrow(new EntityNotFoundException(Study.class));
-        TestUtils.mockPlayContextWithJson(new SignIn.Builder().withEmail(TEST_EMAIL).build());
+        mockPlayContextWithJson(new SignIn.Builder().withEmail(TEST_EMAIL).build());
         controller.requestResetPassword();
     }
     
     @Test
     public void requestPhoneSignIn() throws Exception {
-        TestUtils.mockPlayContextWithJson(PHONE_SIGN_IN_REQUEST);
+        mockPlayContextWithJson(PHONE_SIGN_IN_REQUEST);
         
         Result result = controller.requestPhoneSignIn();
-        TestUtils.assertResult(result, 202, "Message sent.");
+        assertResult(result, 202, "Message sent.");
         
         verify(authenticationService).requestPhoneSignIn(signInCaptor.capture());
         
@@ -766,15 +757,17 @@ public class AuthenticationControllerMockTest {
     
     @Test
     public void phoneSignIn() throws Exception {
-        TestUtils.mockPlayContextWithJson(PHONE_SIGN_IN);
-        
-        Metrics metrics = new Metrics(TEST_REQUEST_ID);
-        doReturn(metrics).when(controller).getMetrics();
+        response = mockPlayContextWithJson(PHONE_SIGN_IN);
         
         when(authenticationService.phoneSignIn(any(), any())).thenReturn(userSession);
         
         Result result = controller.phoneSignIn();
         assertEquals(200, result.status());
+        
+        // Returns user session.
+        JsonNode node = TestUtils.getJson(result);
+        assertEquals(TEST_SESSION_TOKEN, node.get("sessionToken").textValue());
+        assertEquals("UserSessionInfo", node.get("type").textValue());
         
         verify(authenticationService).phoneSignIn(contextCaptor.capture(), signInCaptor.capture());
         
@@ -785,13 +778,15 @@ public class AuthenticationControllerMockTest {
         assertEquals(TEST_STUDY_ID_STRING, captured.getStudyId());
         assertEquals(TEST_TOKEN, captured.getToken());
         assertEquals(TestConstants.PHONE.getNumber(), captured.getPhone().getNumber());
+        
+        verifyCommonLoggingForSignIns();
     }
     
     @Test(expected = BadRequestException.class)
     public void phoneSignInMissingStudy() throws Exception {
         SignIn badPhoneSignIn = new SignIn.Builder().withStudy(null)
                 .withPhone(TestConstants.PHONE).withToken(TEST_TOKEN).build();
-        TestUtils.mockPlayContextWithJson(badPhoneSignIn);
+        mockPlayContextWithJson(badPhoneSignIn);
         
         controller.phoneSignIn();
     }
@@ -800,7 +795,7 @@ public class AuthenticationControllerMockTest {
     public void phoneSignInBadStudy() throws Exception {
         SignIn badPhoneSignIn = new SignIn.Builder().withStudy("bad-study")
                 .withPhone(TestConstants.PHONE).withToken(TEST_TOKEN).build();
-        TestUtils.mockPlayContextWithJson(badPhoneSignIn);
+        mockPlayContextWithJson(badPhoneSignIn);
         when(authenticationService.phoneSignIn(any(), any())).thenReturn(userSession);
         when(studyService.getStudy((String)any())).thenThrow(new EntityNotFoundException(Study.class));
         
@@ -811,14 +806,14 @@ public class AuthenticationControllerMockTest {
         Map<String, String[]> headers = new ImmutableMap.Builder<String, String[]>()
                 .put("User-Agent", new String[] { "App/14 (Unknown iPhone; iOS/9.0.2) BridgeSDK/4" }).build();
         SignIn signIn = new SignIn.Builder().withStudy(TEST_STUDY_ID_STRING).withEmail(TEST_EMAIL).build();
-        TestUtils.mockPlayContextWithJson(signIn, headers);
+        mockPlayContextWithJson(signIn, headers);
     }
 
     private void mockSignInWithPhonePayload() throws Exception {
         Map<String, String[]> headers = new ImmutableMap.Builder<String, String[]>()
                 .put("User-Agent", new String[] { "App/14 (Unknown iPhone; iOS/9.0.2) BridgeSDK/4" }).build();
         SignIn signIn = new SignIn.Builder().withStudy(TEST_STUDY_ID_STRING).withPhone(TestConstants.PHONE).build();
-        TestUtils.mockPlayContextWithJson(signIn, headers);
+        mockPlayContextWithJson(signIn, headers);
     }
 
     private static void assertSessionInPlayResult(Result result) throws Exception {
@@ -829,13 +824,6 @@ public class AuthenticationControllerMockTest {
         JsonNode resultNode = BridgeObjectMapper.get().readTree(resultString);
         assertTrue(resultNode.get("authenticated").booleanValue());
         assertEquals(TEST_SESSION_TOKEN, resultNode.get("sessionToken").textValue());
-    }
-
-    private static void assertSessionInfoInMetrics(Metrics metrics) {
-        ObjectNode metricsJsonNode = metrics.getJson();
-        assertEquals(TEST_INTERNAL_SESSION_ID, metricsJsonNode.get("session_id").textValue());
-        assertEquals(TEST_STUDY_ID_STRING, metricsJsonNode.get("study").textValue());
-        assertEquals(TEST_ACCOUNT_ID, metricsJsonNode.get("user_id").textValue());
     }
 
     private UserSession createSession(ConsentStatus status, Roles role) {
@@ -855,6 +843,25 @@ public class AuthenticationControllerMockTest {
             session.setConsentStatuses(TestUtils.toMap(status));    
         }
         return session;
+    }
+    
+    private void verifyMetrics() {
+        verify(controller, atLeastOnce()).getMetrics();
+        
+        verify(metrics, atLeastOnce()).setSessionId(TEST_INTERNAL_SESSION_ID);
+        verify(metrics, atLeastOnce()).setUserId(TEST_ACCOUNT_ID);
+        verify(metrics, atLeastOnce()).setStudy(TEST_STUDY_ID_STRING);
+    }
+    
+    private void verifyCommonLoggingForSignIns() throws Exception {
+        verifyMetrics();
+        
+        verify(response).setCookie(BridgeConstants.SESSION_TOKEN_HEADER, TEST_SESSION_TOKEN,
+                BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS, "/");
+        
+        verify(cacheProvider).updateRequestInfo(requestInfoCaptor.capture());
+        RequestInfo info = requestInfoCaptor.getValue();
+        assertEquals(NOW.getMillis(), info.getSignedInOn().getMillis());
     }
     
 }

--- a/test/org/sagebionetworks/bridge/play/controllers/AuthenticationControllerMockTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/AuthenticationControllerMockTest.java
@@ -560,6 +560,7 @@ public class AuthenticationControllerMockTest {
 
         verify(authenticationService).signOut(session);
         verify(mockResponse).discardCookie(BridgeConstants.SESSION_TOKEN_HEADER);
+        verifyMetrics();
     }
 
     @Test

--- a/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
@@ -104,8 +104,8 @@ public class ParticipantControllerTest {
     
     private static final DateTime END_TIME = DateTime.now();
     
-    private static final AccountSummary SUMMARY = new AccountSummary("firstName", "lastName", "email", "id",
-            DateTime.now(), AccountStatus.ENABLED, TestConstants.TEST_STUDY);
+    private static final AccountSummary SUMMARY = new AccountSummary("firstName", "lastName", "email",
+            TestConstants.PHONE, "id", DateTime.now(), AccountStatus.ENABLED, TestConstants.TEST_STUDY);
     
     @Spy
     private ParticipantController controller;

--- a/test/org/sagebionetworks/bridge/play/controllers/UserDataDownloadControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/UserDataDownloadControllerTest.java
@@ -51,7 +51,8 @@ public class UserDataDownloadControllerTest {
     
     @Test
     public void test() throws Exception {
-        StudyParticipant participant = new StudyParticipant.Builder().withId(USER_ID).withEmail(EMAIL).build();
+        StudyParticipant participant = new StudyParticipant.Builder().withId(USER_ID).withEmail(EMAIL)
+                .withEmailVerified(Boolean.TRUE).build();
         doReturn(STUDY_ID).when(mockSession).getStudyIdentifier();
         doReturn(participant).when(mockSession).getParticipant();
         
@@ -77,7 +78,8 @@ public class UserDataDownloadControllerTest {
     
     @Test
     public void testQueryParameters() throws Exception {
-        StudyParticipant participant = new StudyParticipant.Builder().withId(USER_ID).withEmail(EMAIL).build();
+        StudyParticipant participant = new StudyParticipant.Builder().withId(USER_ID).withEmail(EMAIL)
+                .withEmailVerified(Boolean.TRUE).build();
         doReturn(STUDY_ID).when(mockSession).getStudyIdentifier();
         doReturn(participant).when(mockSession).getParticipant();
         
@@ -101,6 +103,13 @@ public class UserDataDownloadControllerTest {
         controller.requestUserData("2015-08-15", "2015-08-19");
     }
     
-    
-    
+    @Test(expected = BadRequestException.class)
+    public void throwExceptionIfAccountEmailUnverified() throws Exception {
+        StudyParticipant participant = new StudyParticipant.Builder().withId(USER_ID)
+                .withEmail(EMAIL).withEmailVerified(Boolean.FALSE).build();
+        doReturn(STUDY_ID).when(mockSession).getStudyIdentifier();
+        doReturn(participant).when(mockSession).getParticipant();
+
+        controller.requestUserData("2015-08-15", "2015-08-19");
+    }
 }

--- a/test/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
@@ -3,8 +3,11 @@ package org.sagebionetworks.bridge.services;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
@@ -19,7 +22,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
-
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.dao.AccountDao;
@@ -27,7 +30,6 @@ import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
-import org.sagebionetworks.bridge.models.accounts.Email;
 import org.sagebionetworks.bridge.models.accounts.EmailVerification;
 import org.sagebionetworks.bridge.models.accounts.PasswordReset;
 import org.sagebionetworks.bridge.models.studies.EmailTemplate;
@@ -46,12 +48,16 @@ public class AccountWorkflowServiceTest {
     private static final String EMAIL = "email@email.com";
     private static final AccountId ACCOUNT_ID_WITH_ID = AccountId.forId(TEST_STUDY_IDENTIFIER, USER_ID);
     private static final AccountId ACCOUNT_ID_WITH_EMAIL = AccountId.forEmail(TEST_STUDY_IDENTIFIER, EMAIL);
+    private static final AccountId ACCOUNT_ID_WITH_PHONE = AccountId.forPhone(TEST_STUDY_IDENTIFIER, TestConstants.PHONE);
 
     @Mock
     private StudyService mockStudyService;
     
     @Mock
     private SendMailService mockSendMailService;
+    
+    @Mock
+    private NotificationsService mockNotificationsService;
     
     @Mock
     private AccountDao mockAccountDao;
@@ -68,6 +74,9 @@ public class AccountWorkflowServiceTest {
     @Captor
     private ArgumentCaptor<Account> accountCaptor;
     
+    @Captor
+    private ArgumentCaptor<String> stringCaptor;
+    
     private Study study;
     
     @Spy
@@ -82,6 +91,7 @@ public class AccountWorkflowServiceTest {
         study = Study.create();
         study.setIdentifier(TEST_STUDY_IDENTIFIER);
         study.setName("This study name");
+        study.setShortName("ShortName");
         study.setSupportEmail(SUPPORT_EMAIL);
         study.setVerifyEmailTemplate(verifyEmailTemplate);
         study.setResetPasswordTemplate(resetPasswordTemplate);
@@ -91,6 +101,7 @@ public class AccountWorkflowServiceTest {
         service.setCacheProvider(mockCacheProvider);
         service.setSendMailService(mockSendMailService);
         service.setStudyService(mockStudyService);
+        service.setNotificationsService(mockNotificationsService);
     }
     
     @Test
@@ -110,6 +121,12 @@ public class AccountWorkflowServiceTest {
         MimeBodyPart body = email.getMessageParts().get(0);
         String bodyString = (String)body.getContent();
         assertTrue(bodyString.contains("/mobile/verifyEmail.html?study=api&sptoken=ABC"));
+    }
+    
+    @Test
+    public void sendEmailVerificationTokenNoEmail() throws Exception {
+        service.sendEmailVerificationToken(study, USER_ID, null);
+        verify(mockSendMailService, never()).sendEmail(any());
     }
     
     @Test
@@ -173,12 +190,14 @@ public class AccountWorkflowServiceTest {
     }
     
     @Test
-    public void notifyAccountExists() throws Exception {
+    public void notifyAccountExistsForEmail() throws Exception {
+        AccountId accountId = AccountId.forId(TEST_STUDY_IDENTIFIER, USER_ID);
         when(service.createTimeLimitedToken()).thenReturn("ABC");
+        when(mockAccount.getEmail()).thenReturn(EMAIL);
+        when(mockAccount.getEmailVerified()).thenReturn(Boolean.TRUE);
+        when(mockAccountDao.getAccount(accountId)).thenReturn(mockAccount);
         
-        Email emailObj = new Email(TEST_STUDY_IDENTIFIER, EMAIL);
-        
-        service.notifyAccountExists(study, emailObj);
+        service.notifyAccountExists(study, accountId);
         
         verify(mockCacheProvider).setString("ABC:api", EMAIL, 60*60*2);
         verify(mockSendMailService).sendEmail(emailProviderCaptor.capture());
@@ -194,11 +213,29 @@ public class AccountWorkflowServiceTest {
     }
     
     @Test
-    public void requestResetPassword() throws Exception {
+    public void notifyAccountExistsForPhone() throws Exception {
+        AccountId accountId = AccountId.forPhone(TEST_STUDY_IDENTIFIER, TestConstants.PHONE);
+        when(service.createTimeLimitedToken()).thenReturn("ABC");
+        when(mockAccount.getPhone()).thenReturn(TestConstants.PHONE);
+        when(mockAccount.getPhoneVerified()).thenReturn(Boolean.TRUE);
+        when(mockAccountDao.getAccount(accountId)).thenReturn(mockAccount);
+        
+        service.notifyAccountExists(study, accountId);
+        
+        verify(mockNotificationsService).sendSMSMessage(eq(study.getStudyIdentifier()), 
+                eq(TestConstants.PHONE), stringCaptor.capture());
+        String message = stringCaptor.getValue();
+        assertTrue(message.contains("Account for ShortName already exists. Reset password: "));
+        assertTrue(message.contains("/mobile/resetPassword.html?study=api&sptoken=ABC"));
+    }
+    
+    @Test
+    public void requestResetPasswordWithEmail() throws Exception {
         when(service.createTimeLimitedToken()).thenReturn("ABC");
         when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(mockAccount);
         when(mockStudyService.getStudy(TEST_STUDY)).thenReturn(study);
         when(mockAccount.getEmail()).thenReturn(EMAIL);
+        when(mockAccount.getEmailVerified()).thenReturn(Boolean.TRUE);        
         when(mockAccount.getStudyIdentifier()).thenReturn(TEST_STUDY);
         
         service.requestResetPassword(study, ACCOUNT_ID_WITH_EMAIL);
@@ -217,6 +254,54 @@ public class AccountWorkflowServiceTest {
     }
     
     @Test
+    public void requestResetPasswordWithPhone() throws Exception {
+        when(service.createTimeLimitedToken()).thenReturn("ABC");
+        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
+        when(mockStudyService.getStudy(TEST_STUDY)).thenReturn(study);
+        when(mockAccount.getPhone()).thenReturn(TestConstants.PHONE);
+        when(mockAccount.getPhoneVerified()).thenReturn(Boolean.TRUE);        
+        when(mockAccount.getStudyIdentifier()).thenReturn(TEST_STUDY);
+        
+        service.requestResetPassword(study, ACCOUNT_ID_WITH_PHONE);
+        
+        verify(mockCacheProvider).setString("ABC:api", TestConstants.PHONE.getNumber(), 60*60*2);
+        
+        verify(mockNotificationsService).sendSMSMessage(eq(TEST_STUDY), eq(TestConstants.PHONE), stringCaptor.capture());
+        
+        String message = stringCaptor.getValue();
+        assertTrue(message.contains("Reset ShortName password: "));
+        assertTrue(message.contains("/mobile/resetPassword.html?study=api&sptoken=ABC"));
+    }
+
+    @Test
+    public void requestResetPasswordFailsQuietlyIfEmailPhoneUnverifiedUsingEmail() {
+        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
+        when(mockAccount.getEmail()).thenReturn(EMAIL);
+        when(mockAccount.getPhoneVerified()).thenReturn(Boolean.FALSE);
+        when(mockAccount.getEmailVerified()).thenReturn(Boolean.FALSE);
+        when(mockAccount.getStudyIdentifier()).thenReturn(TEST_STUDY);
+
+        service.requestResetPassword(study, ACCOUNT_ID_WITH_PHONE);
+        
+        verify(mockCacheProvider, never()).setString("ABC:api", TestConstants.PHONE.getNumber(), 60*60*2);
+        verify(mockNotificationsService, never()).sendSMSMessage(eq(TEST_STUDY), eq(TestConstants.PHONE), any());
+    }
+
+    @Test
+    public void requestResetPasswordFailsQuietlyIfEmailPhoneUnverifiedUsingPhone() {
+        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
+        when(mockAccount.getPhone()).thenReturn(TestConstants.PHONE);
+        when(mockAccount.getPhoneVerified()).thenReturn(Boolean.FALSE);
+        when(mockAccount.getEmailVerified()).thenReturn(Boolean.FALSE);
+        when(mockAccount.getStudyIdentifier()).thenReturn(TEST_STUDY);
+        
+        service.requestResetPassword(study, ACCOUNT_ID_WITH_PHONE);
+        
+        verify(mockCacheProvider, never()).setString("ABC:api", TestConstants.PHONE.getNumber(), 60*60*2);
+        verify(mockNotificationsService, never()).sendSMSMessage(eq(TEST_STUDY), eq(TestConstants.PHONE), any());
+    }
+    
+    @Test
     public void requestResetPasswordInvalidEmailFailsQuietly() throws Exception {
         when(service.createTimeLimitedToken()).thenReturn("ABC");
         when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(null);
@@ -227,6 +312,30 @@ public class AccountWorkflowServiceTest {
         verify(mockSendMailService, never()).sendEmail(emailProviderCaptor.capture());
     }
 
+    @Test
+    public void requestRestPasswordUnverifiedEmailFailsQuietly() throws Exception {
+        when(service.createTimeLimitedToken()).thenReturn("ABC");
+        when(mockAccount.getEmail()).thenReturn(EMAIL);
+        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(mockAccount);
+        
+        service.requestResetPassword(study, ACCOUNT_ID_WITH_EMAIL);
+        
+        verifyNoMoreInteractions(mockSendMailService);
+        verifyNoMoreInteractions(mockNotificationsService);
+    }
+    
+    @Test
+    public void requestRestPasswordUnverifiedPhoneFailsQuietly() throws Exception {
+        when(service.createTimeLimitedToken()).thenReturn("ABC");
+        when(mockAccount.getPhone()).thenReturn(TestConstants.PHONE);
+        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
+        
+        service.requestResetPassword(study, ACCOUNT_ID_WITH_PHONE);
+        
+        verifyNoMoreInteractions(mockSendMailService);
+        verifyNoMoreInteractions(mockNotificationsService);
+    }
+    
     @Test
     public void resetPassword() {
         when(mockCacheProvider.getString("sptoken:api")).thenReturn(EMAIL);

--- a/test/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
@@ -79,6 +79,9 @@ public class AccountWorkflowServiceTest {
     @Captor
     private ArgumentCaptor<String> stringCaptor;
     
+    @Captor
+    private ArgumentCaptor<String> secondStringCaptor;
+    
     private Study study;
     
     @Spy
@@ -270,12 +273,12 @@ public class AccountWorkflowServiceTest {
         service.requestResetPassword(study, ACCOUNT_ID_WITH_PHONE);
         
         verify(mockCacheProvider).setString(eq("ABC:phone:api"), stringCaptor.capture(), eq(60*60*2));
-        verify(mockNotificationsService).sendSMSMessage(eq(TEST_STUDY), eq(TestConstants.PHONE), stringCaptor.capture());
+        verify(mockNotificationsService).sendSMSMessage(eq(TEST_STUDY), eq(TestConstants.PHONE), secondStringCaptor.capture());
         
-        Phone captured = BridgeObjectMapper.get().readValue(stringCaptor.getAllValues().get(0), Phone.class);
+        Phone captured = BridgeObjectMapper.get().readValue(stringCaptor.getValue(), Phone.class);
         assertEquals(TestConstants.PHONE, captured); 
         
-        String message = stringCaptor.getAllValues().get(1);
+        String message = secondStringCaptor.getValue();
         assertTrue(message.contains("Reset ShortName password: "));
         assertTrue(message.contains("/mobile/resetPassword.html?study=api&sptoken=ABC"));
     }

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
@@ -212,11 +212,17 @@ public class AuthenticationServiceMockTest {
         service.requestEmailSignIn(SIGN_IN_REQUEST_WITH_EMAIL);
     }
     
-    @Test(expected = LimitExceededException.class)
-    public void requestEmailSignInLimitExceeded() {
+    @Test
+    public void requestEmailSignInTwiceReturnsSameToken() {
+        // In this case, where there is a value and an account, we do't generate a new one,
+        // we just send the message again.
         doReturn("something").when(cacheProvider).getString(CACHE_KEY);
+        doReturn(account).when(accountDao).getAccount(any());
         
         service.requestEmailSignIn(SIGN_IN_REQUEST_WITH_EMAIL);
+        
+        verify(cacheProvider, never()).setString(any(), any(), anyInt());
+        verify(sendMailService).sendEmail(any());
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
@@ -508,13 +508,21 @@ public class AuthenticationServiceMockTest {
     
     @Test
     public void phoneSignIn() {
+        // Put some stuff in participant to verify session is initialized
+        StudyParticipant participant = new StudyParticipant.Builder()
+                .withEmail(RECIPIENT_EMAIL).withFirstName("Test").withLastName("Tester").build();
+        
         String cacheKey = TestConstants.PHONE.getNumber() + ":api:phoneSignInRequest";
         when(cacheProvider.getString(cacheKey)).thenReturn(TOKEN);
         when(accountDao.getAccountAfterAuthentication(ACCOUNT_ID_WITH_PHONE)).thenReturn(account);
-        when(participantService.getParticipant(study, account, false)).thenReturn(PARTICIPANT);
+        when(participantService.getParticipant(study, account, false)).thenReturn(participant);
         when(consentService.getConsentStatuses(any())).thenReturn(CONSENTED_STATUS_MAP);
         
-        service.phoneSignIn(CONTEXT, SIGN_IN_WITH_PHONE);
+        UserSession session = service.phoneSignIn(CONTEXT, SIGN_IN_WITH_PHONE);
+        
+        assertEquals(RECIPIENT_EMAIL, session.getParticipant().getEmail());
+        assertEquals("Test", session.getParticipant().getFirstName());
+        assertEquals("Tester", session.getParticipant().getLastName());
         
         // this doesn't pass if our mock calls above aren't executed, but verify these:
         verify(cacheProvider).removeString(cacheKey);

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
@@ -33,7 +33,6 @@ import org.sagebionetworks.bridge.exceptions.AuthenticationFailedException;
 import org.sagebionetworks.bridge.exceptions.ConsentRequiredException;
 import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
-import org.sagebionetworks.bridge.exceptions.LimitExceededException;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.accounts.Account;

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
@@ -4,10 +4,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.sagebionetworks.bridge.BridgeConstants.NO_CALLER_ROLES;
 
 import java.util.Map;
 
@@ -17,6 +21,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import org.sagebionetworks.bridge.TestConstants;
@@ -26,6 +31,7 @@ import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.exceptions.AccountDisabledException;
 import org.sagebionetworks.bridge.exceptions.AuthenticationFailedException;
 import org.sagebionetworks.bridge.exceptions.ConsentRequiredException;
+import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.exceptions.LimitExceededException;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
@@ -40,10 +46,12 @@ import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.studies.EmailTemplate;
 import org.sagebionetworks.bridge.models.studies.MimeType;
+import org.sagebionetworks.bridge.models.studies.PasswordPolicy;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
+import org.sagebionetworks.bridge.services.AuthenticationService.ChannelType;
 import org.sagebionetworks.bridge.services.email.BasicEmailProvider;
 import org.sagebionetworks.bridge.validators.PasswordResetValidator;
 
@@ -60,13 +68,20 @@ public class AuthenticationServiceMockTest {
     private static final String TOKEN = "ABC-DEF";
     private static final String REAUTH_TOKEN = "GHI-JKL";
     private static final String USER_ID = "user-id";
-    private static final String PASSWORD = "password";
-    private static final SignIn SIGN_IN_REQUEST = new SignIn.Builder().withStudy(STUDY_ID).withEmail(RECIPIENT_EMAIL)
-            .build();
-    private static final SignIn SIGN_IN = new SignIn.Builder().withStudy(STUDY_ID).withEmail(RECIPIENT_EMAIL)
+    private static final String PASSWORD = "Password~!1";
+    private static final SignIn SIGN_IN_REQUEST_WITH_EMAIL = new SignIn.Builder().withStudy(STUDY_ID)
+            .withEmail(RECIPIENT_EMAIL).build();
+    private static final SignIn SIGN_IN_WITH_EMAIL = new SignIn.Builder().withStudy(STUDY_ID).withEmail(RECIPIENT_EMAIL)
             .withToken(TOKEN).build();
-    private static final SignIn PASSWORD_SIGN_IN = new SignIn.Builder().withStudy(STUDY_ID).withEmail(RECIPIENT_EMAIL)
+    private static final SignIn SIGN_IN_REQUEST_WITH_PHONE = new SignIn.Builder().withStudy(STUDY_ID)
+            .withPhone(TestConstants.PHONE).build();
+    private static final SignIn SIGN_IN_WITH_PHONE = new SignIn.Builder().withStudy(STUDY_ID)
+            .withPhone(TestConstants.PHONE).withToken(TOKEN).build();
+    
+    private static final SignIn EMAIL_PASSWORD_SIGN_IN = new SignIn.Builder().withStudy(STUDY_ID).withEmail(RECIPIENT_EMAIL)
             .withPassword(PASSWORD).build();
+    private static final SignIn PHONE_PASSWORD_SIGN_IN = new SignIn.Builder().withStudy(STUDY_ID)
+            .withPhone(TestConstants.PHONE).withPassword(PASSWORD).build();
     private static final SignIn REAUTH_REQUEST = new SignIn.Builder().withStudy(STUDY_ID).withEmail(RECIPIENT_EMAIL)
             .withReauthToken(TOKEN).build();
     
@@ -83,6 +98,7 @@ public class AuthenticationServiceMockTest {
             .withStudyIdentifier(TestConstants.TEST_STUDY).build();
     private static final StudyParticipant PARTICIPANT = new StudyParticipant.Builder().build();
     private static final AccountId ACCOUNT_ID = AccountId.forId(STUDY_ID, USER_ID);
+    private static final AccountId ACCOUNT_ID_WITH_PHONE = AccountId.forPhone(STUDY_ID, TestConstants.PHONE);
 
     @Mock
     private CacheProvider cacheProvider;
@@ -102,18 +118,24 @@ public class AuthenticationServiceMockTest {
     private StudyService studyService;
     @Mock
     private PasswordResetValidator passwordResetValidator;
+    @Mock
+    private AccountWorkflowService accountWorkflowService;
+    @Mock
+    private NotificationsService notificationsService; 
     @Captor
     private ArgumentCaptor<String> stringCaptor;
     @Captor
     private ArgumentCaptor<BasicEmailProvider> providerCaptor;
     @Captor
     private ArgumentCaptor<UserSession> sessionCaptor;
+    @Captor
+    private ArgumentCaptor<StudyParticipant> participantCaptor;
+    @Spy
+    private AuthenticationService service;
 
     private Study study;
 
     private Account account;
-    
-    private AuthenticationService service;
 
     @Before
     public void before() {
@@ -126,7 +148,6 @@ public class AuthenticationServiceMockTest {
         
         account = new GenericAccount();
         
-        service = new AuthenticationService();
         service.setCacheProvider(cacheProvider);
         service.setBridgeConfig(config);
         service.setConsentService(consentService);
@@ -136,32 +157,44 @@ public class AuthenticationServiceMockTest {
         service.setParticipantService(participantService);
         service.setSendMailService(sendMailService);
         service.setStudyService(studyService);
+        service.setAccountWorkflowService(accountWorkflowService);
+        service.setNotificationsService(notificationsService);
 
         doReturn(study).when(studyService).getStudy(STUDY_ID);
     }
     
     @Test
-    public void signIn() throws Exception {
+    public void signInWithEmail() throws Exception {
         account.setReauthToken(REAUTH_TOKEN);
-        doReturn(account).when(accountDao).authenticate(study, PASSWORD_SIGN_IN);
+        doReturn(account).when(accountDao).authenticate(study, EMAIL_PASSWORD_SIGN_IN);
         doReturn(PARTICIPANT).when(participantService).getParticipant(study, account, false);
         
-        UserSession retrieved = service.signIn(study, CONTEXT, PASSWORD_SIGN_IN);
+        UserSession retrieved = service.signIn(study, CONTEXT, EMAIL_PASSWORD_SIGN_IN);
+        assertEquals(REAUTH_TOKEN, retrieved.getReauthToken());
+    }
+    
+    @Test
+    public void signInWithPhone() throws Exception {
+        account.setReauthToken(REAUTH_TOKEN);
+        doReturn(account).when(accountDao).authenticate(study, PHONE_PASSWORD_SIGN_IN);
+        doReturn(PARTICIPANT).when(participantService).getParticipant(study, account, false);
+        
+        UserSession retrieved = service.signIn(study, CONTEXT, PHONE_PASSWORD_SIGN_IN);
         assertEquals(REAUTH_TOKEN, retrieved.getReauthToken());
     }
     
     @Test
     public void requestEmailSignIn() throws Exception {
-        doReturn(account).when(accountDao).getAccount(SIGN_IN_REQUEST.getAccountId());
+        doReturn(account).when(accountDao).getAccount(SIGN_IN_REQUEST_WITH_EMAIL.getAccountId());
         
-        service.requestEmailSignIn(SIGN_IN_REQUEST);
+        service.requestEmailSignIn(SIGN_IN_REQUEST_WITH_EMAIL);
         
         verify(cacheProvider).getString(stringCaptor.capture());
         assertEquals(CACHE_KEY, stringCaptor.getValue());
         
-        verify(accountDao).getAccount(SIGN_IN_REQUEST.getAccountId());
+        verify(accountDao).getAccount(SIGN_IN_REQUEST_WITH_EMAIL.getAccountId());
         
-        verify(cacheProvider).setString(eq(CACHE_KEY), stringCaptor.capture(), eq(60));
+        verify(cacheProvider).setString(eq(CACHE_KEY), stringCaptor.capture(), eq(300));
         assertNotNull(stringCaptor.getValue());
 
         verify(sendMailService).sendEmail(providerCaptor.capture());
@@ -176,14 +209,14 @@ public class AuthenticationServiceMockTest {
     public void requestEmailSignInDisabled() {
         study.setEmailSignInEnabled(false);
         
-        service.requestEmailSignIn(SIGN_IN_REQUEST);
+        service.requestEmailSignIn(SIGN_IN_REQUEST_WITH_EMAIL);
     }
     
     @Test(expected = LimitExceededException.class)
     public void requestEmailSignInLimitExceeded() {
         doReturn("something").when(cacheProvider).getString(CACHE_KEY);
         
-        service.requestEmailSignIn(SIGN_IN_REQUEST);
+        service.requestEmailSignIn(SIGN_IN_REQUEST_WITH_EMAIL);
     }
     
     @Test
@@ -211,7 +244,7 @@ public class AuthenticationServiceMockTest {
     public void requestEmailSignInEmailNotRegistered() {
         doReturn(null).when(accountDao).getAccount(ACCOUNT_ID);
         
-        service.requestEmailSignIn(SIGN_IN_REQUEST);
+        service.requestEmailSignIn(SIGN_IN_REQUEST_WITH_EMAIL);
 
         verify(cacheProvider, never()).setString(eq(CACHE_KEY), any(), eq(60));
         verify(sendMailService, never()).sendEmail(any());
@@ -222,17 +255,17 @@ public class AuthenticationServiceMockTest {
         account.setReauthToken(REAUTH_TOKEN);
         account.setStatus(AccountStatus.UNVERIFIED);
         doReturn(TOKEN).when(cacheProvider).getString(CACHE_KEY);
-        doReturn(account).when(accountDao).getAccountAfterAuthentication(SIGN_IN.getAccountId());
+        doReturn(account).when(accountDao).getAccountAfterAuthentication(SIGN_IN_WITH_EMAIL.getAccountId());
         doReturn(PARTICIPANT).when(participantService).getParticipant(study, account, false);
         doReturn(CONSENTED_STATUS_MAP).when(consentService).getConsentStatuses(any());
         
-        UserSession retSession = service.emailSignIn(CONTEXT, SIGN_IN);
+        UserSession retSession = service.emailSignIn(CONTEXT, SIGN_IN_WITH_EMAIL);
         
         assertNotNull(retSession);
         assertEquals(REAUTH_TOKEN, retSession.getReauthToken());
         verify(accountDao, never()).changePassword(eq(account), any());
-        verify(accountDao).getAccountAfterAuthentication(SIGN_IN.getAccountId());
-        verify(accountDao).verifyEmail(account);
+        verify(accountDao).getAccountAfterAuthentication(SIGN_IN_WITH_EMAIL.getAccountId());
+        verify(accountDao).verifyChannel(AuthenticationService.ChannelType.EMAIL, account);
         verify(cacheProvider).removeString(CACHE_KEY);
     }
     
@@ -266,7 +299,7 @@ public class AuthenticationServiceMockTest {
         doReturn(null).when(accountDao).getAccount(any());
                  
         long start = System.currentTimeMillis();
-        service.requestEmailSignIn(SIGN_IN_REQUEST);
+        service.requestEmailSignIn(SIGN_IN_REQUEST_WITH_EMAIL);
         long total = System.currentTimeMillis()-start;
         assertTrue(total >= 1000);
         service.getEmailSignInRequestInMillis().set(0);
@@ -302,7 +335,7 @@ public class AuthenticationServiceMockTest {
     
     @Test(expected = InvalidEntityException.class)
     public void emailSignInMissingToken() {
-        service.emailSignIn(CONTEXT, SIGN_IN_REQUEST); // not SIGN_IN which has the token
+        service.emailSignIn(CONTEXT, SIGN_IN_REQUEST_WITH_EMAIL); // not SIGN_IN which has the token
     }
     
     @Test(expected = AccountDisabledException.class)
@@ -314,10 +347,10 @@ public class AuthenticationServiceMockTest {
         study.setIdentifier(STUDY_ID);
         doReturn(TOKEN).when(cacheProvider).getString(CACHE_KEY);
         doReturn(study).when(studyService).getStudy(STUDY_ID);
-        doReturn(account).when(accountDao).getAccountAfterAuthentication(SIGN_IN.getAccountId());
+        doReturn(account).when(accountDao).getAccountAfterAuthentication(SIGN_IN_WITH_EMAIL.getAccountId());
         account.setStatus(AccountStatus.DISABLED);
         
-        service.emailSignIn(CONTEXT, SIGN_IN);
+        service.emailSignIn(CONTEXT, SIGN_IN_WITH_EMAIL);
     }
     
     @Test(expected = ConsentRequiredException.class)
@@ -329,9 +362,9 @@ public class AuthenticationServiceMockTest {
         study.setIdentifier(STUDY_ID);
         doReturn(TOKEN).when(cacheProvider).getString(CACHE_KEY);
         doReturn(study).when(studyService).getStudy(STUDY_ID);
-        doReturn(account).when(accountDao).getAccountAfterAuthentication(SIGN_IN.getAccountId());
+        doReturn(account).when(accountDao).getAccountAfterAuthentication(SIGN_IN_WITH_EMAIL.getAccountId());
         
-        service.emailSignIn(CONTEXT, SIGN_IN);
+        service.emailSignIn(CONTEXT, SIGN_IN_WITH_EMAIL);
     }
     
     @Test
@@ -359,7 +392,7 @@ public class AuthenticationServiceMockTest {
     
     @Test(expected = InvalidEntityException.class)
     public void reauthTokenRequired() {
-        service.reauthenticate(study, CONTEXT, SIGN_IN); // doesn't have reauth token
+        service.reauthenticate(study, CONTEXT, SIGN_IN_WITH_EMAIL); // doesn't have reauth token
     }
     
     @Test(expected = ConsentRequiredException.class)
@@ -373,4 +406,113 @@ public class AuthenticationServiceMockTest {
         service.reauthenticate(study, CONTEXT, REAUTH_REQUEST);
     }
     
+    @Test(expected = InvalidEntityException.class)
+    public void requestResetInvalid() throws Exception {
+        SignIn signIn = new SignIn.Builder().withStudy(STUDY_ID).withPhone(TestConstants.PHONE)
+                .withEmail(RECIPIENT_EMAIL).build();
+        service.requestResetPassword(study, signIn);
+    }
+    
+    @Test
+    public void requestResetPassword() throws Exception {
+        SignIn signIn = new SignIn.Builder().withStudy(STUDY_ID).withEmail(RECIPIENT_EMAIL).build();
+        
+        service.requestResetPassword(study, signIn);
+        
+        verify(accountDao).requestResetPassword(study, signIn.getAccountId());
+    }
+    
+    @Test
+    public void signUpWithEmailOK() throws Exception {
+        study.setPasswordPolicy(PasswordPolicy.DEFAULT_PASSWORD_POLICY);
+        StudyParticipant participant = new StudyParticipant.Builder().withEmail(RECIPIENT_EMAIL).withPassword(PASSWORD)
+                .build();
+        
+        service.signUp(study, participant);
+        
+        verify(participantService).createParticipant(eq(study), eq(NO_CALLER_ROLES), participantCaptor.capture(), eq(true));
+        StudyParticipant captured = participantCaptor.getValue();
+        assertEquals(RECIPIENT_EMAIL, captured.getEmail());
+        assertEquals(PASSWORD, captured.getPassword());
+    }
+
+    @Test
+    public void signUpWithPhoneOK() throws Exception {
+        study.setPasswordPolicy(PasswordPolicy.DEFAULT_PASSWORD_POLICY);
+        StudyParticipant participant = new StudyParticipant.Builder().withPhone(TestConstants.PHONE)
+                .withPassword(PASSWORD).build();
+        
+        service.signUp(study, participant);
+        
+        verify(participantService).createParticipant(eq(study), eq(NO_CALLER_ROLES), participantCaptor.capture(), eq(true));
+        StudyParticipant captured = participantCaptor.getValue();
+        assertEquals(TestConstants.PHONE.getNumber(), captured.getPhone().getNumber());
+        assertEquals(PASSWORD, captured.getPassword());
+    }
+    
+    @Test
+    public void signUpExistingAccount() throws Exception {
+        study.setPasswordPolicy(PasswordPolicy.DEFAULT_PASSWORD_POLICY);
+        StudyParticipant participant = new StudyParticipant.Builder().withEmail(RECIPIENT_EMAIL).withPassword(PASSWORD)
+                .build();
+        doThrow(new EntityAlreadyExistsException(StudyParticipant.class, "userId", "AAA")).when(participantService)
+                .createParticipant(study, NO_CALLER_ROLES, participant, true);
+        
+        service.signUp(study, participant);
+        
+        ArgumentCaptor<AccountId> accountIdCaptor = ArgumentCaptor.forClass(AccountId.class);
+        
+        verify(participantService).createParticipant(eq(study), eq(NO_CALLER_ROLES), any(), eq(true));
+        verify(accountWorkflowService).notifyAccountExists(eq(study), accountIdCaptor.capture());
+        
+        AccountId captured = accountIdCaptor.getValue();
+        assertEquals("AAA", captured.getId());
+        assertEquals(STUDY_ID, captured.getStudyId());
+    }
+    
+    @Test
+    public void requestPhoneSignIn() { 
+        study.setShortName("AppName");
+        String cacheKey = TestConstants.PHONE.getNumber() + ":api:phoneSignInRequest";
+        when(accountDao.getAccount(SIGN_IN_WITH_PHONE.getAccountId())).thenReturn(account);
+        when(service.getPhoneToken()).thenReturn("123456");
+        
+        service.requestPhoneSignIn(SIGN_IN_REQUEST_WITH_PHONE);
+        
+        verify(cacheProvider).getString(cacheKey);
+        verify(cacheProvider).setString(eq(cacheKey), stringCaptor.capture(), eq(300));
+        verify(notificationsService).sendSMSMessage(eq(study.getStudyIdentifier()), eq(TestConstants.PHONE),
+                stringCaptor.capture());
+        assertEquals("123456", stringCaptor.getAllValues().get(0));
+        assertEquals("Enter 123-456 to sign in to AppName", stringCaptor.getAllValues().get(1));
+    }
+    
+    @Test
+    public void requestPhoneSignInFails() {
+        // This should fail silently, or we risk giving away information about accounts in the system.
+        service.requestPhoneSignIn(SIGN_IN_REQUEST_WITH_PHONE);
+        
+        verify(cacheProvider, never()).setString(any(), any(), anyInt());
+        verify(notificationsService, never()).sendSMSMessage(any(), any(), any());
+    }    
+    
+    @Test
+    public void phoneSignIn() {
+        String cacheKey = TestConstants.PHONE.getNumber() + ":api:phoneSignInRequest";
+        when(cacheProvider.getString(cacheKey)).thenReturn(TOKEN);
+        when(accountDao.getAccountAfterAuthentication(ACCOUNT_ID_WITH_PHONE)).thenReturn(account);
+        when(participantService.getParticipant(study, account, false)).thenReturn(PARTICIPANT);
+        when(consentService.getConsentStatuses(any())).thenReturn(CONSENTED_STATUS_MAP);
+        
+        service.phoneSignIn(CONTEXT, SIGN_IN_WITH_PHONE);
+        
+        // this doesn't pass if our mock calls above aren't executed, but verify these:
+        verify(cacheProvider).removeString(cacheKey);
+        verify(accountDao).verifyChannel(ChannelType.PHONE, account);
+    }
+
+    @Test(expected = AuthenticationFailedException.class)
+    public void phoneSignInFails() {
+        service.phoneSignIn(CONTEXT, SIGN_IN_WITH_PHONE);
+    }
 }

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
@@ -183,8 +183,8 @@ public class AuthenticationServiceTest {
 
     @Test(expected = InvalidEntityException.class)
     public void requestPasswordResetFailsOnEmptyString() throws Exception {
-        Email email = new Email(TEST_STUDY_IDENTIFIER, "");
-        authService.requestResetPassword(study, email);
+        SignIn signIn = new SignIn.Builder().withStudy(TEST_STUDY_IDENTIFIER).build();
+        authService.requestResetPassword(study, signIn);
     }
     
     @Test(expected = BadRequestException.class)
@@ -315,10 +315,10 @@ public class AuthenticationServiceTest {
         // Second sign up
         authService.signUp(testUser.getStudy(), testUser.getStudyParticipant());
         
-        ArgumentCaptor<Email> emailCaptor = ArgumentCaptor.forClass(Email.class);
-        verify(accountWorkflowServiceSpy).notifyAccountExists(eq(testUser.getStudy()), emailCaptor.capture());
-        assertEquals(testUser.getStudyIdentifier(), emailCaptor.getValue().getStudyIdentifier());
-        assertEquals(testUser.getEmail(), emailCaptor.getValue().getEmail());
+        ArgumentCaptor<AccountId> accountIdCaptor = ArgumentCaptor.forClass(AccountId.class);
+        verify(accountWorkflowServiceSpy).notifyAccountExists(eq(testUser.getStudy()), accountIdCaptor.capture());
+        assertEquals(testUser.getStudyIdentifier().getIdentifier(), accountIdCaptor.getValue().getStudyId());
+        assertEquals(testUser.getId(), accountIdCaptor.getValue().getId());
     }
     
     @Test
@@ -329,8 +329,9 @@ public class AuthenticationServiceTest {
     
     @Test
     public void requestResetPasswordLooksSuccessfulWhenNoAccount() throws Exception {
-        Email email = new Email(TEST_STUDY_IDENTIFIER, "notarealaccount@sagebase.org");
-        authService.requestResetPassword(study, email);
+        SignIn signIn = new SignIn.Builder().withStudy(TEST_STUDY_IDENTIFIER).withEmail("notarealaccount@sagebase.org")
+                .build();
+        authService.requestResetPassword(study, signIn);
     }
     
     // Consent statuses passed on to sessionInfo

--- a/test/org/sagebionetworks/bridge/services/ConsentServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/ConsentServiceMockTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -59,6 +60,9 @@ public class ConsentServiceMockTest {
     private static final SubpopulationGuid SUBPOP_GUID = SubpopulationGuid.create("GUID");
     private static final long SIGNED_ON = 1446044925219L;
     private static final long CONSENT_CREATED_ON = 1446044814108L;
+    private static final String ID = "user-id";
+    private static final String HEALTH_CODE = "health-code";
+    private static final String EMAIL = "email@email.com";
     
     private ConsentService consentService;
 
@@ -94,10 +98,7 @@ public class ConsentServiceMockTest {
         
         study = TestUtils.getValidStudy(ConsentServiceMockTest.class);
         
-        participant = new StudyParticipant.Builder()
-                .withHealthCode("BBB")
-                .withId("user-id")
-                .withEmail("bbb@bbb.com").build();
+        participant = new StudyParticipant.Builder().withHealthCode(HEALTH_CODE).withId(ID).withEmail(EMAIL).build();
         
         consentSignature = new ConsentSignature.Builder().withName("Test User").withBirthdate("1990-01-01")
                 .withSignedOn(SIGNED_ON).build();
@@ -221,7 +222,7 @@ public class ConsentServiceMockTest {
     
     @Test
     public void withdrawConsentWithParticipant() throws Exception {
-        account.setEmail("bbb@bbb.com");
+        account.setEmail(EMAIL);
         
         Map<String,String> optionsMap = Maps.newHashMap();
         optionsMap.put(EXTERNAL_IDENTIFIER.name(), participant.getExternalId());
@@ -230,8 +231,7 @@ public class ConsentServiceMockTest {
         doReturn(account).when(accountDao).getAccount(AccountId.forId(study.getIdentifier(), participant.getId()));
         doReturn(new ParticipantOptionsLookup(optionsMap)).when(optionsService).getOptions(participant.getHealthCode());
         
-        CriteriaContext context = new CriteriaContext.Builder()
-                .withUserId(participant.getId())
+        CriteriaContext context = new CriteriaContext.Builder().withUserId(participant.getId())
                 .withStudyIdentifier(study.getStudyIdentifier()).build();
 
         // Add two consents to the account, one withdrawn, one active. This tests to make sure we're not accidentally
@@ -276,12 +276,13 @@ public class ConsentServiceMockTest {
         assertEquals("\"Test Study [ConsentServiceMockTest]\" <bridge-testing+support@sagebase.org>", email.getSenderAddress());
         assertEquals("bridge-testing+consent@sagebase.org", email.getRecipientAddresses().get(0));
         assertEquals("Notification of consent withdrawal for Test Study [ConsentServiceMockTest]", email.getSubject());
-        assertEquals("<p>User   &lt;bbb@bbb.com&gt; withdrew from the study on October 28, 2015. </p><p>Reason:</p><p>For reasons.</p>", 
+        assertEquals("<p>User   &lt;"+EMAIL+"&gt; withdrew from the study on October 28, 2015. </p><p>Reason:</p><p>For reasons.</p>", 
                     email.getMessageParts().get(0).getContent());
     }
     
     @Test
     public void withdrawConsentWithAccount() throws Exception {
+        account.setEmail(EMAIL);
         Map<String,String> optionsMap = Maps.newHashMap();
         optionsMap.put(ParticipantOption.EXTERNAL_IDENTIFIER.name(), participant.getExternalId());
 
@@ -319,4 +320,40 @@ public class ConsentServiceMockTest {
         verifyNoMoreInteractions(sendMailService);
     }
 
+    @Test
+    public void consentToResearchWithoutEmail() {
+        StudyParticipant noEmail = new StudyParticipant.Builder().copyOf(participant).withEmail(null).build();
+        
+        consentService.consentToResearch(study, SUBPOP_GUID, noEmail, consentSignature, SharingScope.NO_SHARING, true);
+        
+        verify(sendMailService, never()).sendEmail(any());
+    }
+    
+    @Test
+    public void withdrawConsentWithoutEmail() {
+        doReturn(account).when(accountDao).getAccount(any());
+        doReturn(ImmutableList.of(consentSignature)).when(account).getConsentSignatureHistory(any());
+        doReturn(consentSignature).when(account).getActiveConsentSignature(any());
+
+        StudyParticipant noEmail = new StudyParticipant.Builder().copyOf(participant).withEmail(null).build();
+        Withdrawal withdrawal = new Withdrawal("reason");
+        CriteriaContext context = new CriteriaContext.Builder().withUserId(ID)
+                .withStudyIdentifier(study.getStudyIdentifier()).build();
+        
+        consentService.withdrawConsent(study, SUBPOP_GUID, noEmail, context, withdrawal, SIGNED_ON);
+        
+        verify(sendMailService, never()).sendEmail(any());
+    }
+    
+    @Test
+    public void emailConsentAgreementWithoutEmail() {
+        doReturn(account).when(accountDao).getAccount(any());
+        doReturn(consentSignature).when(account).getActiveConsentSignature(any());
+        
+        StudyParticipant noEmail = new StudyParticipant.Builder().copyOf(participant).withEmail(null).build();
+        
+        consentService.emailConsentAgreement(study, SUBPOP_GUID, noEmail);
+        
+        verify(sendMailService, never()).sendEmail(any());
+    }
 }

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -4,9 +4,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
@@ -179,6 +179,9 @@ public class ParticipantServiceTest {
     @Mock
     private PagedResourceList<AccountSummary> accountSummaries;
     
+    @Mock
+    private ExternalIdService externalIdService;
+    
     @Captor
     ArgumentCaptor<StudyParticipant> participantCaptor;
     
@@ -205,9 +208,6 @@ public class ParticipantServiceTest {
     
     @Captor
     ArgumentCaptor<AccountId> accountIdCaptor;
-    
-    @Mock
-    private ExternalIdService externalIdService;
     
     @Before
     public void before() {
@@ -931,7 +931,7 @@ public class ParticipantServiceTest {
         when(accountDao.getPagedAccountSummaries(STUDY, 0, BridgeConstants.API_MINIMUM_PAGE_SIZE, null, null, null))
                 .thenReturn(accountSummaries);
         
-        participantService.createParticipant(STUDY,  CALLER_ROLES, PARTICIPANT, false);
+        participantService.createParticipant(STUDY, CALLER_ROLES, PARTICIPANT, false);
     }
     
     private void verifyStatusCreate(Set<Roles> callerRoles) {

--- a/test/org/sagebionetworks/bridge/services/UserAdminServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/UserAdminServiceMockTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyObject;
 import static org.mockito.Mockito.anySet;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
@@ -124,6 +125,8 @@ public class UserAdminServiceMockTest {
         doReturn(new IdentifierHolder("ABC")).when(participantService).createParticipant(anyObject(), anySet(),
                 anyObject(), anyBoolean());
         doReturn(session).when(authenticationService).getSession(anyObject(), anyObject());
+        doReturn(new StudyParticipant.Builder().withId("ABC").build()).when(participantService).getParticipant(any(),
+                anyString(), anyBoolean());
     }
     
     private void addConsentStatus(Map<SubpopulationGuid,ConsentStatus> statuses, String guid) {
@@ -137,7 +140,7 @@ public class UserAdminServiceMockTest {
         Study study = TestUtils.getValidStudy(UserAdminServiceMockTest.class);
         StudyParticipant participant = new StudyParticipant.Builder().withEmail("email@email.com").withPassword("password").build();
 
-        UserSession session = service.createUser(study, participant, null, true, true);
+        service.createUser(study, participant, null, true, true);
         
         verify(participantService).createParticipant(study, Sets.newHashSet(Roles.ADMIN), participant, false);
         verify(authenticationService).signIn(eq(study), contextCaptor.capture(), signInCaptor.capture());
@@ -149,9 +152,7 @@ public class UserAdminServiceMockTest {
         assertEquals(participant.getEmail(), signIn.getEmail());
         assertEquals(participant.getPassword(), signIn.getPassword());
         
-        for (SubpopulationGuid guid : session.getConsentStatuses().keySet()) {
-            verify(consentService).consentToResearch(eq(study), eq(guid), any(StudyParticipant.class), any(), eq(SharingScope.NO_SHARING), eq(false));
-        }
+        verify(consentService).getConsentStatuses(context);
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/services/UserAdminServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/UserAdminServiceMockTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.dao.ParticipantOption.EXTERNAL_IDENTIFIER;
@@ -24,10 +25,12 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import org.sagebionetworks.bridge.Roles;
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dao.ParticipantOption.SharingScope;
+import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
@@ -139,6 +142,37 @@ public class UserAdminServiceMockTest {
     public void creatingUserConsentsToAllRequiredConsents() {
         Study study = TestUtils.getValidStudy(UserAdminServiceMockTest.class);
         StudyParticipant participant = new StudyParticipant.Builder().withEmail("email@email.com").withPassword("password").build();
+        
+        Map<SubpopulationGuid,ConsentStatus> statuses = Maps.newHashMap();
+        statuses.put(SubpopulationGuid.create("foo1"), TestConstants.REQUIRED_SIGNED_CURRENT);
+        statuses.put(SubpopulationGuid.create("foo2"), TestConstants.REQUIRED_SIGNED_OBSOLETE);
+        when(consentService.getConsentStatuses(any())).thenReturn(statuses);
+        
+        service.createUser(study, participant, null, true, true);
+        
+        verify(participantService).createParticipant(study, Sets.newHashSet(Roles.ADMIN), participant, false);
+        verify(authenticationService).signIn(eq(study), contextCaptor.capture(), signInCaptor.capture());
+        
+        CriteriaContext context = contextCaptor.getValue();
+        assertEquals(study.getStudyIdentifier(), context.getStudyIdentifier());
+        
+        verify(consentService).consentToResearch(eq(study), eq(SubpopulationGuid.create("foo1")), any(StudyParticipant.class), any(),
+                eq(SharingScope.NO_SHARING), eq(false));
+        verify(consentService).consentToResearch(eq(study), eq(SubpopulationGuid.create("foo2")), any(StudyParticipant.class), any(),
+                eq(SharingScope.NO_SHARING), eq(false));
+
+        SignIn signIn = signInCaptor.getValue();
+        assertEquals(participant.getEmail(), signIn.getEmail());
+        assertEquals(participant.getPassword(), signIn.getPassword());
+        
+        verify(consentService).getConsentStatuses(context);
+    }
+    
+    @Test
+    public void creatingUserWithPhone() {
+        Study study = TestUtils.getValidStudy(UserAdminServiceMockTest.class);
+        StudyParticipant participant = new StudyParticipant.Builder().withPhone(TestConstants.PHONE)
+                .withPassword("password").build();
 
         service.createUser(study, participant, null, true, true);
         
@@ -149,10 +183,18 @@ public class UserAdminServiceMockTest {
         assertEquals(study.getStudyIdentifier(), context.getStudyIdentifier());
         
         SignIn signIn = signInCaptor.getValue();
-        assertEquals(participant.getEmail(), signIn.getEmail());
+        assertEquals(participant.getPhone(), signIn.getPhone());
         assertEquals(participant.getPassword(), signIn.getPassword());
         
         verify(consentService).getConsentStatuses(context);
+    }
+    
+    @Test(expected = InvalidEntityException.class)
+    public void creatingUserWithoutEmailOrPhoneProhibited() {
+        Study study = TestUtils.getValidStudy(UserAdminServiceMockTest.class);
+        StudyParticipant participant = new StudyParticipant.Builder().withPassword("password").build();
+
+        service.createUser(study, participant, null, true, true);
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/validators/SignInValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/SignInValidatorTest.java
@@ -118,4 +118,30 @@ public class SignInValidatorTest {
         assertValidatorMessage(SignInValidator.REAUTH_SIGNIN, EMPTY_SIGNIN, "study", "is required");
         assertValidatorMessage(SignInValidator.REAUTH_SIGNIN, EMPTY_SIGNIN, "reauthToken", "is required");
     }
+    @Test
+    public void requestResetPasswordOK() {
+        SignIn signIn = new SignIn.Builder().withStudy(TEST_STUDY_IDENTIFIER).withEmail(EMAIL).build();
+        Validate.entityThrowingException(SignInValidator.REQUEST_RESET_PASSWORD, signIn);
+
+        signIn = new SignIn.Builder().withStudy(TEST_STUDY_IDENTIFIER).withPhone(TestConstants.PHONE).build();
+        Validate.entityThrowingException(SignInValidator.REQUEST_RESET_PASSWORD, signIn);
+    }
+    @Test
+    public void requestResetPassword() {
+        assertValidatorMessage(SignInValidator.REQUEST_RESET_PASSWORD, EMPTY_SIGNIN, "SignIn", "email or phone is required");
+        assertValidatorMessage(SignInValidator.REQUEST_RESET_PASSWORD, EMPTY_SIGNIN, "study", "is required");
+    }
+    @Test
+    public void minimalOK() {
+        SignIn signIn = new SignIn.Builder().withStudy(TEST_STUDY_IDENTIFIER).withEmail(EMAIL).build();
+        Validate.entityThrowingException(SignInValidator.MINIMAL, signIn);
+
+        signIn = new SignIn.Builder().withStudy(TEST_STUDY_IDENTIFIER).withPhone(TestConstants.PHONE).build();
+        Validate.entityThrowingException(SignInValidator.MINIMAL, signIn);
+    }
+    @Test
+    public void minimal() {
+        assertValidatorMessage(SignInValidator.MINIMAL, EMPTY_SIGNIN, "SignIn", "email or phone is required");
+        assertValidatorMessage(SignInValidator.MINIMAL, EMPTY_SIGNIN, "study", "is required");
+    }
 }

--- a/test/org/sagebionetworks/bridge/validators/SignInValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/SignInValidatorTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.validators;
 
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 
 import org.junit.Test;
 
@@ -10,17 +11,15 @@ import org.sagebionetworks.bridge.models.accounts.SignIn;
 
 public class SignInValidatorTest {
     
-    private static final String STUDY_ID = TestConstants.TEST_STUDY_IDENTIFIER;
     private static final String TOKEN = "token";
     private static final String PASSWORD = "password";
     private static final String EMAIL = "email@email.com";
     private static final String REAUTH_TOKEN = "reauthToken";
-    private static final Phone PHONE = new Phone("4082588569","US");
     private static final SignIn EMPTY_SIGNIN = new SignIn.Builder().build();
 
     @Test
     public void emailSignInRequestOK() {
-        SignIn signIn = new SignIn.Builder().withStudy(STUDY_ID).withEmail(EMAIL).build();
+        SignIn signIn = new SignIn.Builder().withStudy(TEST_STUDY_IDENTIFIER).withEmail(EMAIL).build();
         Validate.entityThrowingException(SignInValidator.EMAIL_SIGNIN_REQUEST, signIn);
     }
     @Test
@@ -30,7 +29,7 @@ public class SignInValidatorTest {
     }
     @Test
     public void emailSignInOK() {
-        SignIn signIn = new SignIn.Builder().withStudy(STUDY_ID).withEmail(EMAIL).withToken(TOKEN).build();
+        SignIn signIn = new SignIn.Builder().withStudy(TEST_STUDY_IDENTIFIER).withEmail(EMAIL).withToken(TOKEN).build();
         Validate.entityThrowingException(SignInValidator.EMAIL_SIGNIN, signIn);
     }
     @Test
@@ -41,7 +40,7 @@ public class SignInValidatorTest {
     }
     @Test
     public void phoneSignInRequestOK() {
-        SignIn signIn = new SignIn.Builder().withStudy(STUDY_ID).withPhone(PHONE).build();
+        SignIn signIn = new SignIn.Builder().withStudy(TEST_STUDY_IDENTIFIER).withPhone(TestConstants.PHONE).build();
         Validate.entityThrowingException(SignInValidator.PHONE_SIGNIN_REQUEST, signIn);
     }
     @Test
@@ -51,7 +50,7 @@ public class SignInValidatorTest {
     }
     @Test
     public void phoneSignInOK() {
-        SignIn signIn = new SignIn.Builder().withStudy(STUDY_ID).withPhone(PHONE).withToken(TOKEN).build();
+        SignIn signIn = new SignIn.Builder().withStudy(TEST_STUDY_IDENTIFIER).withPhone(TestConstants.PHONE).withToken(TOKEN).build();
         Validate.entityThrowingException(SignInValidator.PHONE_SIGNIN, signIn);
     }
     @Test
@@ -68,25 +67,55 @@ public class SignInValidatorTest {
         assertValidatorMessage(SignInValidator.PHONE_SIGNIN, missingPhoneFields, "token", "is required");
     }
     @Test
-    public void passwordSignInOK() {
-        SignIn signIn = new SignIn.Builder().withStudy(STUDY_ID).withEmail(EMAIL).withPassword(PASSWORD).build();
+    public void passwordSignInWithEmailOK() {
+        SignIn signIn = new SignIn.Builder().withStudy(TEST_STUDY_IDENTIFIER).withEmail(EMAIL).withPassword(PASSWORD).build();
         Validate.entityThrowingException(SignInValidator.PASSWORD_SIGNIN, signIn);
     }
     @Test
+    public void passwordSignInWithPhoneOK() {
+        SignIn signIn = new SignIn.Builder().withStudy(TEST_STUDY_IDENTIFIER).withPhone(TestConstants.PHONE).withPassword(PASSWORD).build();
+        Validate.entityThrowingException(SignInValidator.PASSWORD_SIGNIN, signIn);
+    }
+    @Test
+    public void passwordSignInWithEmailAndPhoneInvalid() {
+        SignIn signIn = new SignIn.Builder().withEmail(EMAIL).withPhone(TestConstants.PHONE).build();
+        assertValidatorMessage(SignInValidator.PASSWORD_SIGNIN, signIn, "SignIn", "email or phone is required, but not both");
+    }
+    @Test
+    public void passwordSignInWithInvalidPhoneInvalid() {
+        SignIn signIn = new SignIn.Builder().withPhone(new Phone("xxxxxxxxxx", "US")).build();
+        assertValidatorMessage(SignInValidator.PASSWORD_SIGNIN, signIn, "phone", "does not appear to be a phone number");
+    }
+    @Test
     public void passwordSignInInvalid() {
+        assertValidatorMessage(SignInValidator.PASSWORD_SIGNIN, EMPTY_SIGNIN, "SignIn", "email or phone is required");
         assertValidatorMessage(SignInValidator.PASSWORD_SIGNIN, EMPTY_SIGNIN, "study", "is required");
-        assertValidatorMessage(SignInValidator.PASSWORD_SIGNIN, EMPTY_SIGNIN, "email", "is required");
         assertValidatorMessage(SignInValidator.PASSWORD_SIGNIN, EMPTY_SIGNIN, "password", "is required");
     }
     @Test
-    public void reauthOK() {
-        SignIn signIn = new SignIn.Builder().withStudy(STUDY_ID).withEmail(EMAIL).withReauthToken(REAUTH_TOKEN).build();
+    public void reauthWithEmailOK() {
+        SignIn signIn = new SignIn.Builder().withStudy(TEST_STUDY_IDENTIFIER).withEmail(EMAIL).withReauthToken(REAUTH_TOKEN).build();
         Validate.entityThrowingException(SignInValidator.REAUTH_SIGNIN, signIn);
     }
     @Test
+    public void reauthWithPhoneOK() {
+        SignIn signIn = new SignIn.Builder().withStudy(TEST_STUDY_IDENTIFIER).withPhone(TestConstants.PHONE).withReauthToken(REAUTH_TOKEN).build();
+        Validate.entityThrowingException(SignInValidator.REAUTH_SIGNIN, signIn);
+    }
+    @Test
+    public void reauthWithEmailAndPhoneInvalid() {
+        SignIn signIn = new SignIn.Builder().withEmail(EMAIL).withPhone(TestConstants.PHONE).build();
+        assertValidatorMessage(SignInValidator.REAUTH_SIGNIN, signIn, "SignIn", "email or phone is required, but not both");
+    }
+    @Test
+    public void reauthWithInvalidPhoneInvalid() {
+        SignIn signIn = new SignIn.Builder().withPhone(new Phone("xxxxxxxxxx", "US")).build();
+        assertValidatorMessage(SignInValidator.REAUTH_SIGNIN, signIn, "phone", "does not appear to be a phone number");
+    }
+    @Test
     public void reauthInvalid() {
+        assertValidatorMessage(SignInValidator.REAUTH_SIGNIN, EMPTY_SIGNIN, "SignIn", "email or phone is required");
         assertValidatorMessage(SignInValidator.REAUTH_SIGNIN, EMPTY_SIGNIN, "study", "is required");
-        assertValidatorMessage(SignInValidator.REAUTH_SIGNIN, EMPTY_SIGNIN, "email", "is required");
         assertValidatorMessage(SignInValidator.REAUTH_SIGNIN, EMPTY_SIGNIN, "reauthToken", "is required");
     }
 }

--- a/test/org/sagebionetworks/bridge/validators/StudyParticipantValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/StudyParticipantValidatorTest.java
@@ -86,8 +86,6 @@ public class StudyParticipantValidatorTest {
             assertNull(e.getErrors().get("email"));
             assertNull(e.getErrors().get("externalId"));
             assertNull(e.getErrors().get("password"));
-            //assertError(e, "dataGroups", 0, " 'badGroup' is not defined for study (use group1, group2, bluebell)");
-            //assertError(e, "attributes", 0, " 'badValue' is not defined for study (use attr1, attr2, phone)");
         }
         assertValidatorMessage(validator, participant, "dataGroups", "'badGroup' is not defined for study (use group1, group2, bluebell)");
         assertValidatorMessage(validator, participant, "attributes", "'badValue' is not defined for study (use attr1, attr2, phone)");
@@ -121,9 +119,15 @@ public class StudyParticipantValidatorTest {
     }
     
     @Test
-    public void passwordRequired() {
+    public void emptyStringPasswordRequired() {
         validator = new StudyParticipantValidator(study, true);
         assertValidatorMessage(validator, withPassword(""), "password", "is required");
+    }
+    
+    @Test
+    public void nullPasswordOK() {
+        validator = new StudyParticipantValidator(study, true);
+        Validate.entityThrowingException(validator, withPassword(null));
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/validators/StudyParticipantValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/StudyParticipantValidatorTest.java
@@ -10,6 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.models.accounts.Phone;
@@ -195,7 +196,7 @@ public class StudyParticipantValidatorTest {
     public void validatePhone() {
         validator = new StudyParticipantValidator(study, true);
         StudyParticipant participant = new StudyParticipant.Builder().withEmail("email@email.com")
-                .withPassword("pAssword1@").withPhone(new Phone("4082588569","US")).build();
+                .withPassword("pAssword1@").withPhone(TestConstants.PHONE).build();
         Validate.entityThrowingException(validator, participant);
     }
     

--- a/test/org/sagebionetworks/bridge/validators/StudyParticipantValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/StudyParticipantValidatorTest.java
@@ -1,11 +1,8 @@
 package org.sagebionetworks.bridge.validators;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -58,19 +55,14 @@ public class StudyParticipantValidatorTest {
                 .withAttributes(attrs)
                 .withPassword("bad")
                 .build();
-        
-        try {
-            Validate.entityThrowingException(validator, participant);
-        } catch(InvalidEntityException e) {
-            assertError(e, "email", 0, " is required");
-            assertError(e, "externalId", 0, " is required");
-            assertError(e, "dataGroups", 0, " 'badGroup' is not defined for study (use group1, group2, bluebell)");
-            assertError(e, "attributes", 0, " 'badValue' is not defined for study (use attr1, attr2, phone)");
-            assertError(e, "password", 0, " must be at least 8 characters");
-            assertError(e, "password", 1, " must contain at least one number (0-9)");
-            assertError(e, "password", 2, " must contain at least one symbol ( !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~ )");
-            assertError(e, "password", 3, " must contain at least one uppercase letter (A-Z)");
-        }
+        assertValidatorMessage(validator, participant, "StudyParticipant", "email or phone is required");
+        assertValidatorMessage(validator, participant, "externalId", "is required");
+        assertValidatorMessage(validator, participant, "dataGroups", "'badGroup' is not defined for study (use group1, group2, bluebell)");
+        assertValidatorMessage(validator, participant, "attributes", "'badValue' is not defined for study (use attr1, attr2, phone)");
+        assertValidatorMessage(validator, participant, "password", "must be at least 8 characters");
+        assertValidatorMessage(validator, participant, "password", "must contain at least one number (0-9)");
+        assertValidatorMessage(validator, participant, "password", "must contain at least one symbol ( !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~ )");
+        assertValidatorMessage(validator, participant, "password", "must contain at least one uppercase letter (A-Z)");
     }
     
     // Password, email address, and externalId (if being validated) cannot be updated, so these don't need to be validated.
@@ -93,9 +85,11 @@ public class StudyParticipantValidatorTest {
             assertNull(e.getErrors().get("email"));
             assertNull(e.getErrors().get("externalId"));
             assertNull(e.getErrors().get("password"));
-            assertError(e, "dataGroups", 0, " 'badGroup' is not defined for study (use group1, group2, bluebell)");
-            assertError(e, "attributes", 0, " 'badValue' is not defined for study (use attr1, attr2, phone)");
+            //assertError(e, "dataGroups", 0, " 'badGroup' is not defined for study (use group1, group2, bluebell)");
+            //assertError(e, "attributes", 0, " 'badValue' is not defined for study (use attr1, attr2, phone)");
         }
+        assertValidatorMessage(validator, participant, "dataGroups", "'badGroup' is not defined for study (use group1, group2, bluebell)");
+        assertValidatorMessage(validator, participant, "attributes", "'badValue' is not defined for study (use attr1, attr2, phone)");
     }
     
     @Test
@@ -120,82 +114,81 @@ public class StudyParticipantValidatorTest {
     }
     
     @Test
-    public void emailRequired() {
+    public void emailOrPhoneRequired() {
         validator = new StudyParticipantValidator(study, true);
-        assertCorrectMessage(withEmail(null), "email", "email is required");
+        assertValidatorMessage(validator, withEmail(null), "StudyParticipant", "email or phone is required");
     }
     
     @Test
     public void passwordRequired() {
         validator = new StudyParticipantValidator(study, true);
-        assertCorrectMessage(withPassword(""), "password", "password is required");
+        assertValidatorMessage(validator, withPassword(""), "password", "is required");
     }
     
     @Test
     public void validEmail() {
         validator = new StudyParticipantValidator(study, true);
-        assertCorrectMessage(withEmail("belgium"), "email", "email must be a valid email address");
+        assertValidatorMessage(validator, withEmail("belgium"), "email", "does not appear to be an email address");
     }
     
     @Test
     public void minLength() {
         validator = new StudyParticipantValidator(study, true);
-        assertCorrectMessage(withPassword("a1A~"), "password", "password must be at least 8 characters");
+        assertValidatorMessage(validator, withPassword("a1A~"), "password", "must be at least 8 characters");
     }
     
     @Test
     public void numberRequired() {
         validator = new StudyParticipantValidator(study, true);
-        assertCorrectMessage(withPassword("aaaaaaaaA~"), "password", "password must contain at least one number (0-9)");
+        assertValidatorMessage(validator, withPassword("aaaaaaaaA~"), "password", "must contain at least one number (0-9)");
     }
     
     @Test
     public void symbolRequired() {
         validator = new StudyParticipantValidator(study, true);
-        assertCorrectMessage(withPassword("aaaaaaaaA1"), "password", 
-            "password must contain at least one symbol ( !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~ )");
+        assertValidatorMessage(validator, withPassword("aaaaaaaaA1"), "password", "must contain at least one symbol ( !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~ )");
     }
     
     @Test
     public void lowerCaseRequired() {
         validator = new StudyParticipantValidator(study, true);
-        assertCorrectMessage(withPassword("AAAAA!A1"), "password", "password must contain at least one lowercase letter (a-z)");
+        assertValidatorMessage(validator, withPassword("AAAAA!A1"), "password", "must contain at least one lowercase letter (a-z)");
     }
     
     @Test
     public void upperCaseRequired() {
         validator = new StudyParticipantValidator(study, true);
-        assertCorrectMessage(withPassword("aaaaa!a1"), "password", "password must contain at least one uppercase letter (A-Z)");
+        assertValidatorMessage(validator, withPassword("aaaaa!a1"), "password", "must contain at least one uppercase letter (A-Z)");
     }
     
     @Test
     public void validatesDataGroupsValidIfSupplied() {
         validator = new StudyParticipantValidator(study, true);
-        assertCorrectMessage(withDataGroup("squirrel"), "dataGroups", "dataGroups 'squirrel' is not defined for study (use group1, group2, bluebell)");
+        assertValidatorMessage(validator, withDataGroup("squirrel"), "dataGroups", "'squirrel' is not defined for study (use group1, group2, bluebell)");
     }
     
     @Test
     public void validatePhoneRegionRequired() {
         validator = new StudyParticipantValidator(study, true);
-        assertCorrectMessage(withPhone("1234567890", null), "phone", "phone does not appear to be a phone number");
+        assertValidatorMessage(validator, withPhone("1234567890", null), "phone", "does not appear to be a phone number");
     }
     
     @Test
     public void validatePhoneRegionIsCode() {
         validator = new StudyParticipantValidator(study, true);
-        assertCorrectMessage(withPhone("1234567890", "esg"), "phone", "phone does not appear to be a phone number");
+        assertValidatorMessage(validator, withPhone("1234567890", "esg"), "phone", "does not appear to be a phone number");
     }
     
     @Test
     public void validatePhoneRequired() {
         validator = new StudyParticipantValidator(study, true);
-        assertCorrectMessage(withPhone(null, "US"), "phone", "phone does not appear to be a phone number");
+        assertValidatorMessage(validator, withPhone(null, "US"), "phone", "does not appear to be a phone number");
     }
     
     @Test
     public void validatePhonePattern() {
         validator = new StudyParticipantValidator(study, true);
-        assertCorrectMessage(withPhone("234567890", "US"), "phone", "phone does not appear to be a phone number");
+        assertValidatorMessage(validator, withPhone("234567890", "US"), "phone", "does not appear to be a phone number");
     }
     
     @Test
@@ -209,19 +202,7 @@ public class StudyParticipantValidatorTest {
     @Test
     public void validateTotallyWrongPhone() {
         validator = new StudyParticipantValidator(study, true);
-        assertCorrectMessage(withPhone("this isn't a phone number", "US"), "phone", "phone does not appear to be a phone number");
-    }
-    
-    private void assertCorrectMessage(StudyParticipant participant, String fieldName, String message) {
-        try {
-            Validate.entityThrowingException(validator, participant);
-            fail("should have thrown exception");
-        } catch(InvalidEntityException e) {
-            List<String> errors = e.getErrors().get(fieldName);
-            assertFalse(errors == null || errors.isEmpty());
-            String error = errors.get(0);
-            assertEquals(message, error);
-        }
+        assertValidatorMessage(validator, withPhone("this isn't a phone number", "US"), "phone", "does not appear to be a phone number");
     }
     
     private StudyParticipant withPhone(String phone, String phoneRegion) {
@@ -240,10 +221,4 @@ public class StudyParticipantValidatorTest {
         return new StudyParticipant.Builder().withEmail("email@email.com").withPassword("aAz1%_aAz1%")
                 .withDataGroups(Sets.newHashSet(dataGroup)).build();
     }
-    
-    private void assertError(InvalidEntityException e, String fieldName, int index, String errorMsg) {
-        assertEquals(fieldName+errorMsg, e.getErrors().get(fieldName).get(index));
-    }
-    
-    
 }

--- a/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
@@ -1,22 +1,15 @@
 package org.sagebionetworks.bridge.validators;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
-
-import java.util.List;
 
 import com.google.common.collect.ImmutableList;
 import org.junit.Before;
 import org.junit.Test;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
-import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.models.studies.EmailTemplate;
 import org.sagebionetworks.bridge.models.studies.MimeType;
 import org.sagebionetworks.bridge.models.studies.PasswordPolicy;
-import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
 import org.sagebionetworks.bridge.models.upload.UploadFieldType;
 
@@ -25,23 +18,12 @@ import com.google.common.collect.Sets;
 
 public class StudyValidatorTest {
 
+    private static final StudyValidator INSTANCE = StudyValidator.INSTANCE;
     private DynamoStudy study;
     
     @Before
     public void createValidStudy() {
         study = TestUtils.getValidStudy(StudyValidatorTest.class);
-    }
-    
-    public void assertCorrectMessage(Study study, String fieldName, String message) {
-        try {
-            Validate.entityThrowingException(StudyValidator.INSTANCE, study);
-            fail("should have thrown an exception");
-        } catch(InvalidEntityException e) {
-            List<String> errors = e.getErrors().get(fieldName);
-            assertFalse(errors == null || errors.isEmpty());
-            String error = errors.get(0);
-            assertEquals(message, error);
-        }
     }
     
     @Test
@@ -53,43 +35,55 @@ public class StudyValidatorTest {
     @Test
     public void minLengthCannotBeLessThan2() {
         study.setPasswordPolicy(new PasswordPolicy(1, false, false, false, false));
-        assertCorrectMessage(study, "passwordPolicy.minLength", "passwordPolicy.minLength must be 2-999 characters");
+        assertValidatorMessage(INSTANCE, study, "passwordPolicy.minLength", "must be 2-999 characters");
+    }
+    
+    @Test
+    public void shortNameRequired() {
+        study.setShortName("");
+        assertValidatorMessage(INSTANCE, study, "shortName", "is required");
+    }
+    
+    @Test
+    public void shortNameTooLong() {
+        study.setShortName("ThisNameIsOverTenCharactersLong");
+        assertValidatorMessage(INSTANCE, study, "shortName", "must be 10 characters or less");
     }
     
     @Test
     public void sponsorNameRequired() {
         study.setSponsorName("");
-        assertCorrectMessage(study, "sponsorName", "sponsorName is required");
+        assertValidatorMessage(INSTANCE, study, "sponsorName", "is required");
     }
     
     @Test
     public void minLengthCannotBeMoreThan999() {
         study.setPasswordPolicy(new PasswordPolicy(1000, false, false, false, false));
-        assertCorrectMessage(study, "passwordPolicy.minLength", "passwordPolicy.minLength must be 2-999 characters");
+        assertValidatorMessage(INSTANCE, study, "passwordPolicy.minLength", "must be 2-999 characters");
     }
     
     @Test
     public void resetPasswordMustHaveUrlVariable() {
         study.setResetPasswordTemplate(new EmailTemplate("subject", "no url variable", MimeType.TEXT));
-        assertCorrectMessage(study, "resetPasswordTemplate.body", "resetPasswordTemplate.body must contain the ${url} template variable");
+        assertValidatorMessage(INSTANCE, study, "resetPasswordTemplate.body", "must contain the ${url} template variable");
     }
     
     @Test
     public void verifyEmailMustHaveUrlVariable() {
         study.setVerifyEmailTemplate(new EmailTemplate("subject", "no url variable", MimeType.TEXT));
-        assertCorrectMessage(study, "verifyEmailTemplate.body", "verifyEmailTemplate.body must contain the ${url} template variable");
+        assertValidatorMessage(INSTANCE, study, "verifyEmailTemplate.body", "must contain the ${url} template variable");
     }
 
     @Test
     public void cannotCreateIdentifierWithUppercase() {
         study.setIdentifier("Test");
-        assertCorrectMessage(study, "identifier", "identifier must contain only lower-case letters and/or numbers with optional dashes");
+        assertValidatorMessage(INSTANCE, study, "identifier", "must contain only lower-case letters and/or numbers with optional dashes");
     }
 
     @Test
     public void cannotCreateInvalidIdentifierWithSpaces() {
         study.setIdentifier("test test");
-        assertCorrectMessage(study, "identifier", "identifier must contain only lower-case letters and/or numbers with optional dashes");
+        assertValidatorMessage(INSTANCE, study, "identifier", "must contain only lower-case letters and/or numbers with optional dashes");
     }
 
     @Test
@@ -107,15 +101,13 @@ public class StudyValidatorTest {
     @Test
     public void rejectEventKeysWithColons() {
         study.setActivityEventKeys(Sets.newHashSet("a-1", "b:2"));
-        assertCorrectMessage(study, "activityEventKeys",
-                "activityEventKeys must contain only lower-case letters and/or numbers with optional dashes");
+        assertValidatorMessage(INSTANCE, study, "activityEventKeys", "must contain only lower-case letters and/or numbers with optional dashes");
     }
 
     @Test
     public void cannotCreateIdentifierWithColons() {
         study.setActivityEventKeys(Sets.newHashSet("a-1", "b:2"));
-        assertCorrectMessage(study, "activityEventKeys",
-                "activityEventKeys must contain only lower-case letters and/or numbers with optional dashes");
+        assertValidatorMessage(INSTANCE, study, "activityEventKeys", "must contain only lower-case letters and/or numbers with optional dashes");
     }
 
     @Test
@@ -127,13 +119,13 @@ public class StudyValidatorTest {
     @Test
     public void rejectsInvalidSupportEmailAddresses() {
         study.setSupportEmail("test@test.com,asdf,test2@test.com");
-        assertCorrectMessage(study, "supportEmail", "supportEmail 'asdf' is not a valid email address");
+        assertValidatorMessage(INSTANCE, study, "supportEmail", "'asdf' is not a valid email address");
     }
     
     @Test
     public void requiresMissingSupportEmail() {
         study.setSupportEmail(null);
-        assertCorrectMessage(study, "supportEmail", "supportEmail is required");
+        assertValidatorMessage(INSTANCE, study, "supportEmail", "is required");
     }
     
     @Test
@@ -145,13 +137,13 @@ public class StudyValidatorTest {
     @Test
     public void rejectsInvalidTechnicalEmailAddresses() {
         study.setTechnicalEmail("test@test.com,asdf,test2@test.com");
-        assertCorrectMessage(study, "technicalEmail", "technicalEmail 'asdf' is not a valid email address");
-    }
+        assertValidatorMessage(INSTANCE, study, "technicalEmail", "'asdf' is not a valid email address");
+    }        
     
     @Test
     public void requiresMissingTechnicalEmail() {
         study.setTechnicalEmail(null);
-        assertCorrectMessage(study, "technicalEmail", "technicalEmail is required");
+        assertValidatorMessage(INSTANCE, study, "technicalEmail", "is required");
     }
 
     @Test
@@ -167,38 +159,37 @@ public class StudyValidatorTest {
         // error here.
         study.setUploadMetadataFieldDefinitions(ImmutableList.of(new UploadFieldDefinition.Builder().withName(null)
                 .withType(UploadFieldType.INT).build()));
-        assertValidatorMessage(StudyValidator.INSTANCE, study, "uploadMetadataFieldDefinitions[0].name",
-                "is required");
+        assertValidatorMessage(INSTANCE, study, "uploadMetadataFieldDefinitions[0].name", "is required");
     }
 
     @Test
     public void rejectsInvalidConsentEmailAddresses() {
         study.setConsentNotificationEmail("test@test.com,asdf,test2@test.com");
-        assertCorrectMessage(study, "consentNotificationEmail", "consentNotificationEmail 'asdf' is not a valid email address");
+        assertValidatorMessage(INSTANCE, study, "consentNotificationEmail", "'asdf' is not a valid email address");
     }
     
     @Test
     public void cannotAddConflictingEmailAttribute() {
         study.getUserProfileAttributes().add("email");
-        assertCorrectMessage(study, "userProfileAttributes", "userProfileAttributes 'email' conflicts with existing user profile property");
+        assertValidatorMessage(INSTANCE, study, "userProfileAttributes", "'email' conflicts with existing user profile property");
     }
     
     @Test
     public void cannotAddConflictingExternalIdAttribute() {
         study.getUserProfileAttributes().add("externalId");
-        assertCorrectMessage(study, "userProfileAttributes", "userProfileAttributes 'externalId' conflicts with existing user profile property");
+        assertValidatorMessage(INSTANCE, study, "userProfileAttributes", "'externalId' conflicts with existing user profile property");
     }
     
     @Test
     public void userProfileAttributesCannotStartWithDash() {
         study.getUserProfileAttributes().add("-illegal");
-        assertCorrectMessage(study, "userProfileAttributes", "userProfileAttributes '-illegal' must contain only digits, letters, underscores and dashes, and cannot start with a dash");
+        assertValidatorMessage(INSTANCE, study, "userProfileAttributes", "'-illegal' must contain only digits, letters, underscores and dashes, and cannot start with a dash");
     }
     
     @Test
     public void userProfileAttributesCannotContainSpaces() {
         study.getUserProfileAttributes().add("Game Points");
-        assertCorrectMessage(study, "userProfileAttributes", "userProfileAttributes 'Game Points' must contain only digits, letters, underscores and dashes, and cannot start with a dash");
+        assertValidatorMessage(INSTANCE, study, "userProfileAttributes", "'Game Points' must contain only digits, letters, underscores and dashes, and cannot start with a dash");
     }
     
     @Test
@@ -216,55 +207,55 @@ public class StudyValidatorTest {
     @Test
     public void userProfileAttributesCannotBeEmpty() {
         study.getUserProfileAttributes().add("");
-        assertCorrectMessage(study, "userProfileAttributes", "userProfileAttributes '' must contain only digits, letters, underscores and dashes, and cannot start with a dash");
+        assertValidatorMessage(INSTANCE, study, "userProfileAttributes", "'' must contain only digits, letters, underscores and dashes, and cannot start with a dash");
     }
     
     @Test
     public void requiresMissingConsentNotificationEmail() {
         study.setConsentNotificationEmail(null);
-        assertCorrectMessage(study, "consentNotificationEmail", "consentNotificationEmail is required");
+        assertValidatorMessage(INSTANCE, study, "consentNotificationEmail", "is required");
     }
     
     @Test
     public void requiresPasswordPolicy() {
         study.setPasswordPolicy(null);
-        assertCorrectMessage(study, "passwordPolicy", "passwordPolicy is required");
+        assertValidatorMessage(INSTANCE, study, "passwordPolicy", "is required");
     }
     
     @Test
     public void requiresVerifyEmailTemplate() {
         study.setVerifyEmailTemplate(null);
-        assertCorrectMessage(study, "verifyEmailTemplate", "verifyEmailTemplate is required");
+        assertValidatorMessage(INSTANCE, study, "verifyEmailTemplate", "is required");
     }
 
     @Test
     public void requiresVerifyEmailTemplateWithSubject() {
         study.setVerifyEmailTemplate(new EmailTemplate("  ", "body", MimeType.HTML));
-        assertCorrectMessage(study, "verifyEmailTemplate.subject", "verifyEmailTemplate.subject is required");
+        assertValidatorMessage(INSTANCE, study, "verifyEmailTemplate.subject", "is required");
     }
 
     @Test
     public void requiresVerifyEmailTemplateWithBody() {
         study.setVerifyEmailTemplate(new EmailTemplate("subject", null, MimeType.HTML));
-        assertCorrectMessage(study, "verifyEmailTemplate.body", "verifyEmailTemplate.body is required");
+        assertValidatorMessage(INSTANCE, study, "verifyEmailTemplate.body", "is required");
     }
 
     @Test
     public void requiresResetPasswordTemplate() {
         study.setResetPasswordTemplate(null);
-        assertCorrectMessage(study, "resetPasswordTemplate", "resetPasswordTemplate is required");
+        assertValidatorMessage(INSTANCE, study, "resetPasswordTemplate", "is required");
     }
 
     @Test
     public void requiresResetPasswordTemplateWithSubject() {
         study.setResetPasswordTemplate(new EmailTemplate("  ", "body", MimeType.TEXT));
-        assertCorrectMessage(study, "resetPasswordTemplate.subject", "resetPasswordTemplate.subject is required");
+        assertValidatorMessage(INSTANCE, study, "resetPasswordTemplate.subject", "is required");
     }
 
     @Test
     public void requiresResetPasswordTemplateWithBody() {
         study.setResetPasswordTemplate(new EmailTemplate("subject", null, MimeType.TEXT));
-        assertCorrectMessage(study, "resetPasswordTemplate.body", "resetPasswordTemplate.body is required");
+        assertValidatorMessage(INSTANCE, study, "resetPasswordTemplate.body", "is required");
     }
     
     @Test
@@ -276,19 +267,19 @@ public class StudyValidatorTest {
     @Test
     public void requiresEmailSignInTemplateWithSubject() {
         study.setEmailSignInTemplate(new EmailTemplate(null, "body", MimeType.HTML));
-        assertCorrectMessage(study, "emailSignInTemplate.subject", "emailSignInTemplate.subject is required");
+        assertValidatorMessage(INSTANCE, study, "emailSignInTemplate.subject", "is required");
     }
 
     @Test
     public void requiresEmailSignInTemplateWithBody() {
         study.setEmailSignInTemplate(new EmailTemplate("subject", null, MimeType.HTML));
-        assertCorrectMessage(study, "emailSignInTemplate.body", "emailSignInTemplate.body is required");
+        assertValidatorMessage(INSTANCE, study, "emailSignInTemplate.body", "is required");
     }
     
     @Test
     public void requiresEmailSignInTemplateRequiresToken() {
         study.setEmailSignInTemplate(new EmailTemplate("subject", "body with no token", MimeType.HTML));
-        assertCorrectMessage(study, "emailSignInTemplate.body", "emailSignInTemplate.body must contain the ${token} template variable");
+        assertValidatorMessage(INSTANCE, study, "emailSignInTemplate.body", "must contain the ${token} template variable");
     }
     
     @Test
@@ -300,31 +291,31 @@ public class StudyValidatorTest {
     @Test
     public void requiresAccountExistsTemplateWithSubject() {
         study.setAccountExistsTemplate(new EmailTemplate(null, "body", MimeType.HTML));
-        assertCorrectMessage(study, "accountExistsTemplate.subject", "accountExistsTemplate.subject is required");
+        assertValidatorMessage(INSTANCE, study, "accountExistsTemplate.subject", "is required");
     }
 
     @Test
     public void requiresAccountExistsTemplateWithBody() {
         study.setAccountExistsTemplate(new EmailTemplate("subject", null, MimeType.HTML));
-        assertCorrectMessage(study, "accountExistsTemplate.body", "accountExistsTemplate.body is required");
+        assertValidatorMessage(INSTANCE, study, "accountExistsTemplate.body", "is required");
     }
     
     @Test
     public void requiresAccountExistsTemplateRequiresURL() {
         study.setAccountExistsTemplate(new EmailTemplate("subject", "body with no url", MimeType.HTML));
-        assertCorrectMessage(study, "accountExistsTemplate.body", "accountExistsTemplate.body must contain the ${url} template variable");
+        assertValidatorMessage(INSTANCE, study, "accountExistsTemplate.body", "must contain the ${url} template variable");
     }
     
     @Test
     public void cannotSetMinAgeOfConsentLessThanZero() {
         study.setMinAgeOfConsent(-100);
-        assertCorrectMessage(study, "minAgeOfConsent", "minAgeOfConsent must be zero (no minimum age of consent) or higher");
+        assertValidatorMessage(INSTANCE, study, "minAgeOfConsent", "must be zero (no minimum age of consent) or higher");
     }
     
     @Test
     public void cannotSetAccountLimitLessThanZero() {
         study.setAccountLimit(-100);
-        assertCorrectMessage(study, "accountLimit", "accountLimit must be zero (no limit set) or higher");
+        assertValidatorMessage(INSTANCE, study, "accountLimit", "must be zero (no limit set) or higher");
     }
     
     @Test
@@ -336,13 +327,13 @@ public class StudyValidatorTest {
     @Test
     public void longListOfDataGroupsInvalid() {
         study.setDataGroups(Sets.newTreeSet(Lists.newArrayList("Antwerp", "Ghent", "Charleroi", "Liege", "Brussels-City", "Bruges", "Schaerbeek", "Anderlecht", "Namur", "Leuven", "Mons", "Molenbeek-Saint-Jean")));
-        assertCorrectMessage(study, "dataGroups", "dataGroups will not export to Synapse (string is over 100 characters: 'Anderlecht, Antwerp, Bruges, Brussels-City, Charleroi, Ghent, Leuven, Liege, Molenbeek-Saint-Jean, Mons, Namur, Schaerbeek')");
+        assertValidatorMessage(INSTANCE, study, "dataGroups", "will not export to Synapse (string is over 100 characters: 'Anderlecht, Antwerp, Bruges, Brussels-City, Charleroi, Ghent, Leuven, Liege, Molenbeek-Saint-Jean, Mons, Namur, Schaerbeek')");
     }
     
     @Test
     public void dataGroupCharactersRestricted() {
         study.setDataGroups(Sets.newHashSet("Liège"));
-        assertCorrectMessage(study, "dataGroups", "dataGroups contains invalid tag 'Liège' (only letters, numbers, underscore and dash allowed)");
+        assertValidatorMessage(INSTANCE, study, "dataGroups", "contains invalid tag 'Liège' (only letters, numbers, underscore and dash allowed)");
     }
 
     @Test
@@ -361,13 +352,13 @@ public class StudyValidatorTest {
     public void nonPublicStudiesMustEnableExternalIdValdation() {
         study.setEmailVerificationEnabled(false);
         study.setExternalIdValidationEnabled(false);
-        assertCorrectMessage(study, "externalIdValidationEnabled", "externalIdValidationEnabled cannot be disabled if email verification has been disabled");
+        assertValidatorMessage(INSTANCE, study, "externalIdValidationEnabled", "cannot be disabled if email verification has been disabled");
     }
     
     @Test
     public void nonPublicStudiesMustRequireExternalIdOnSignUp() {
         study.setEmailVerificationEnabled(false);
         study.setExternalIdRequiredOnSignup(false);
-        assertCorrectMessage(study, "externalIdRequiredOnSignup", "externalIdRequiredOnSignup cannot be disabled if email verification has been disabled");
+        assertValidatorMessage(INSTANCE, study, "externalIdRequiredOnSignup", "cannot be disabled if email verification has been disabled");
     }    
 }

--- a/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
@@ -39,12 +39,6 @@ public class StudyValidatorTest {
     }
     
     @Test
-    public void shortNameRequired() {
-        study.setShortName("");
-        assertValidatorMessage(INSTANCE, study, "shortName", "is required");
-    }
-    
-    @Test
     public void shortNameTooLong() {
         study.setShortName("ThisNameIsOverTenCharactersLong");
         assertValidatorMessage(INSTANCE, study, "shortName", "must be 10 characters or less");


### PR DESCRIPTION
BRIDGE-1955; BRIDGE-1970; 
NOTE: You will need to run the following command as email is no longer required with this check-in:

ALTER TABLE `BridgeDB`.`Accounts` CHANGE COLUMN `email` `email` VARCHAR(255) NULL;

- Either email or phone (or both) must be provided on sign up. Providing a password is now optional;
- added 10 character app "short name" for SMS messages;
- added phone sign in "channel" similar to email-based sign in (unlike email-based sign in, you cannot currently disable it for a study... we can add this if we feel we need it);
- added phone to the AccountSummary object. Absolutely need it for the BSM to display these Accounts;
- request reset password will send either an email or SMS message depending on what is available, preferring email; it silently fails if neither has been verified;
- User data download service returns 400 if the account in question does not have a verified email address;
- email verification silently fails if the user has no email address (should not be triggered during sign up, but there's an API call to resend the token... this does nothing and returns 200);
- Notify account exists now either sends an email message or an SMS text with the link to reset the password;
- Consenting, or requesting that a consent be emailed again to the user, now silently do nothing for accounts with no email addresses. We need an alternative pathway for this, which is filed as BRIDGE-1988.
