### PR TITLE
BRIDGE-1984: remove rediscloud.url parameter

### DIFF
--- a/conf/bridge-server.conf
+++ b/conf/bridge-server.conf
@@ -22,7 +22,6 @@ redis.min.idle = 3
 redis.max.idle = 50
 redis.timeout = 2000
 
-rediscloud.url = redis://localhost:6379
 elasticache.url = redis://localhost:6379
 
 async.worker.thread.count = 20


### PR DESCRIPTION
Change d0736f963 removed rediscloud migration code so we no longer
need the configuration parameter.