### PR TITLE
Switch to using new Bridge Platform worker queue

### DIFF
--- a/conf/bridge-server.conf
+++ b/conf/bridge-server.conf
@@ -132,10 +132,10 @@ uat.exporter.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250
 prod.exporter.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-EX-Request-prod
 
 # Bridge User Data Download Service SQS queues
-local.udd.sqs.queue.url = 	https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-WorkerPlatform-Request-local
-dev.udd.sqs.queue.url = https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-WorkerPlatform-Request-dev
-uat.udd.sqs.queue.url = https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-WorkerPlatform-Request-uat
-prod.udd.sqs.queue.url = https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-WorkerPlatform-Request-prod
+local.udd.sqs.queue.url = https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-WorkerPlatform-Request-local
+dev.udd.sqs.queue.url = https://sqs.us-east-1.amazonaws.com/649232250620/awseb-e-k27gydakh8-stack-AWSEBWorkerQueue-10LFYQ4O9F8D6
+uat.udd.sqs.queue.url = https://sqs.us-east-1.amazonaws.com/649232250620/awseb-e-4tmrkvfypx-stack-AWSEBWorkerQueue-4PPUVDIUC5N9
+prod.udd.sqs.queue.url = https://sqs.us-east-1.amazonaws.com/649232250620/awseb-e-7p7a3qcye3-stack-AWSEBWorkerQueue-1TRGQFVV1SU17
 
 # List of studies that should never be deleted
 local.study.whitelist = api


### PR DESCRIPTION
The infra for BridgeWorkerPlatform app is now automated with
BridgeWorkerPlatform-infra[1] repo.  This project uses cloudformation
to setup the EB worker env and SQS queues. We should switch to using
this queue and deprecate the manually created SQS queues.

[1] https://github.com/Sage-Bionetworks/BridgeWorkerPlatform-infra