### PR TITLE
Switch to using new Bridge Exporter queue

### DIFF
--- a/conf/bridge-server.conf
+++ b/conf/bridge-server.conf
@@ -127,9 +127,9 @@ prod.consents.bucket = org-sagebridge-consents-prod
 
 # Bridge Exporter SQS queues
 local.exporter.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-EX-Request-local
-dev.exporter.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-EX-Request-dev
-uat.exporter.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-EX-Request-uat
-prod.exporter.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-EX-Request-prod
+dev.exporter.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/awseb-e-mi3sym9mrs-stack-AWSEBWorkerQueue-1W434RXLTTRO1
+uat.exporter.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/awseb-e-agmuuqbanv-stack-AWSEBWorkerQueue-QTOVH1V7SHS6
+prod.exporter.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/awseb-e-8fm2xp95rm-stack-AWSEBWorkerQueue-1ELXM125D5PL2
 
 # Bridge User Data Download Service SQS queues
 local.udd.sqs.queue.url = https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-WorkerPlatform-Request-local


### PR DESCRIPTION
The infra for Bridge-Exporter app is now automated with
Bridge-Exporter-infra[1] repo.  This project uses cloudformation
to setup the EB worker env and SQS queues. We should switch to using
this queue and deprecate the manually created SQS queues.

[1] https://github.com/Sage-Bionetworks/Bridge-Exporter-infra