### PR TITLE
Update synapse client

### DIFF
--- a/app/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/app/org/sagebionetworks/bridge/BridgeUtils.java
@@ -4,7 +4,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.Integer.parseInt;
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.springframework.util.StringUtils.commaDelimitedListToSet;
 
 import java.io.UnsupportedEncodingException;
@@ -41,7 +40,6 @@ import org.springframework.core.annotation.AnnotationUtils;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper.FailedBatch;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;

--- a/app/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/app/org/sagebionetworks/bridge/BridgeUtils.java
@@ -1,8 +1,10 @@
 package org.sagebionetworks.bridge;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.Integer.parseInt;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.springframework.util.StringUtils.commaDelimitedListToSet;
 
 import java.io.UnsupportedEncodingException;
@@ -39,6 +41,7 @@ import org.springframework.core.annotation.AnnotationUtils;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper.FailedBatch;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -399,9 +402,11 @@ public class BridgeUtils {
     }
     
     public static String toSynapseFriendlyName(String input) {
-        if (input == null) {
-            return "";
-        }
-        return input.replaceAll("[^a-zA-Z0-9\\.\\-_\\s]", " ").replaceAll("\\s+", " ").trim();
+        checkNotNull(input);
+        
+        String value = input.replaceAll("[^a-zA-Z0-9\\.\\-_\\s]", " ").replaceAll("\\s+", " ").trim();
+        checkArgument(StringUtils.isNotBlank(value));
+        
+        return value; 
     }
 }

--- a/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
+++ b/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
@@ -550,7 +550,7 @@ public class BridgeSpringConfig {
     @Bean(name="bridgePFSynapseClient")
     public SynapseClient synapseClient() throws IOException {
         SynapseClient synapseClient = new SynapseAdminClientImpl();
-        synapseClient.setUserName(bridgeConfig().get("synapse.user"));
+        synapseClient.setUsername(bridgeConfig().get("synapse.user"));
         synapseClient.setApiKey(bridgeConfig().get("synapse.api.key"));
         return synapseClient;
     }

--- a/app/org/sagebionetworks/bridge/services/StudyService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyService.java
@@ -31,7 +31,7 @@ import org.sagebionetworks.client.SynapseClient;
 import org.sagebionetworks.client.exceptions.SynapseException;
 import org.sagebionetworks.client.exceptions.SynapseNotFoundException;
 import org.sagebionetworks.client.exceptions.SynapseServerException;
-import org.sagebionetworks.repo.model.MembershipInvtnSubmission;
+import org.sagebionetworks.repo.model.MembershipInvitation;
 import org.sagebionetworks.repo.model.Project;
 import org.sagebionetworks.repo.model.ResourceAccess;
 import org.sagebionetworks.repo.model.Team;
@@ -302,7 +302,7 @@ public class StudyService {
             try {
                 synapseClient.newAccountEmailValidation(synapseUser, SYNAPSE_REGISTER_END_POINT);
             } catch (SynapseServerException e) {
-                if (!"The email address provided is already used.".equals(e.getMessage())) {
+                if (!e.getMessage().contains("The email address provided is already used.")) {
                     throw e;
                 } else {
                     LOG.info("Email: " + user.getEmail() + " already exists in Synapse", e);
@@ -417,7 +417,7 @@ public class StudyService {
 
         for (String synapseUserId : synapseUserIds) {
             // send invitation to target user for joining new team and grant admin permission to that user
-            MembershipInvtnSubmission teamMemberInvitation = new MembershipInvtnSubmission();
+            MembershipInvitation teamMemberInvitation = new MembershipInvitation();
             teamMemberInvitation.setInviteeId(synapseUserId);
             teamMemberInvitation.setTeamId(newTeam.getId());
             synapseClient.createMembershipInvitation(teamMemberInvitation, null, null);

--- a/app/org/sagebionetworks/bridge/services/StudyService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyService.java
@@ -387,7 +387,7 @@ public class StudyService {
             }
         }
 
-        // Name in Synapse are globally unique, so we add a rando token into the name to ensure it 
+        // Name in Synapse are globally unique, so we add a random token to the name to ensure it 
         // doesn't conflict with an existing name. Also, Synapse names can only contain a certain 
         // subset of characters.
         String nameScopingToken = SecureTokenGenerator.NAME_SCOPE_INSTANCE.nextToken();

--- a/app/org/sagebionetworks/bridge/services/StudyService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyService.java
@@ -391,8 +391,12 @@ public class StudyService {
         // doesn't conflict with an existing name. Also, Synapse names can only contain a certain 
         // subset of characters.
         String nameScopingToken = SecureTokenGenerator.NAME_SCOPE_INSTANCE.nextToken();
-        String synapseName = BridgeUtils.toSynapseFriendlyName(study.getName());
-        
+        String synapseName = null;
+        try {
+            synapseName = BridgeUtils.toSynapseFriendlyName(study.getName());    
+        } catch(NullPointerException | IllegalArgumentException e) {
+            throw new BadRequestException("Study name is invalid Synapse name: " + study.getName());
+        }
         // create synapse project and team
         Team team = new Team();
         team.setName(synapseName + " Access Team "+nameScopingToken);

--- a/app/org/sagebionetworks/bridge/services/StudyService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyService.java
@@ -390,7 +390,7 @@ public class StudyService {
         // Name in Synapse are globally unique, so we add a random token to the name to ensure it 
         // doesn't conflict with an existing name. Also, Synapse names can only contain a certain 
         // subset of characters.
-        String nameScopingToken = SecureTokenGenerator.NAME_SCOPE_INSTANCE.nextToken();
+        String nameScopingToken = getNameScopingToken();
         String synapseName = null;
         try {
             synapseName = BridgeUtils.toSynapseFriendlyName(study.getName());    
@@ -435,6 +435,10 @@ public class StudyService {
         updateStudy(study, false);
 
         return study;
+    }
+    
+    protected String getNameScopingToken() {
+        return SecureTokenGenerator.NAME_SCOPE_INSTANCE.nextToken();
     }
     
     private void addAdminToACL(AccessControlList acl, String principalId) {

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ libraryDependencies ++= Seq(
   filters,
   // Sage packages
   "org.sagebionetworks" % "bridge-base" % "2.7.6",
-  "org.sagebionetworks" % "synapseJavaClient" % "161.0-4-g843de2c",
+  "org.sagebionetworks" % "synapseJavaClient" % "206.0-9-gb27c77a5f7",
   // AWS
   "com.amazonaws" % "aws-java-sdk-s3" % "1.11.198",
   "com.amazonaws" % "aws-java-sdk-sqs" % "1.11.198",

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ libraryDependencies ++= Seq(
   filters,
   // Sage packages
   "org.sagebionetworks" % "bridge-base" % "2.7.7",
-  "org.sagebionetworks" % "synapseJavaClient" % "206.0-9-gb27c77a5f7",
+  "org.sagebionetworks" % "synapseJavaClient" % "206.0",
   // AWS
   "com.amazonaws" % "aws-java-sdk-s3" % "1.11.198",
   "com.amazonaws" % "aws-java-sdk-sqs" % "1.11.198",

--- a/test/org/sagebionetworks/bridge/BridgeUtilsTest.java
+++ b/test/org/sagebionetworks/bridge/BridgeUtilsTest.java
@@ -389,8 +389,8 @@ public class BridgeUtilsTest {
     
     @Test
     public void toSynapseFriendlyName() {
-        assertEquals("This is a .-_ synapse Friendly Name",
-                BridgeUtils.toSynapseFriendlyName("This (is a).-_ synapse Friendly Name "));
+        assertEquals("This is a .-_ synapse Friendly Name3",
+                BridgeUtils.toSynapseFriendlyName("This (is a).-_ synapse Friendly Name3 "));
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/BridgeUtilsTest.java
+++ b/test/org/sagebionetworks/bridge/BridgeUtilsTest.java
@@ -395,12 +395,12 @@ public class BridgeUtilsTest {
     
     @Test(expected = NullPointerException.class)
     public void nullToSynapseFriendlyNameThrowsException() {
-        assertEquals("", BridgeUtils.toSynapseFriendlyName(null));
+        BridgeUtils.toSynapseFriendlyName(null);
     }
     
     @Test(expected = IllegalArgumentException.class)
     public void emptyStringToSynapseFriendlyName() {
-        assertEquals("", BridgeUtils.toSynapseFriendlyName("  #"));
+        BridgeUtils.toSynapseFriendlyName("  #");
     }
     
     // assertEquals with two sets doesn't verify the order is the same... hence this test method.

--- a/test/org/sagebionetworks/bridge/BridgeUtilsTest.java
+++ b/test/org/sagebionetworks/bridge/BridgeUtilsTest.java
@@ -393,12 +393,12 @@ public class BridgeUtilsTest {
                 BridgeUtils.toSynapseFriendlyName("This (is a).-_ synapse Friendly Name3 "));
     }
     
-    @Test
-    public void nullToSynapseFriendlyName() {
+    @Test(expected = NullPointerException.class)
+    public void nullToSynapseFriendlyNameThrowsException() {
         assertEquals("", BridgeUtils.toSynapseFriendlyName(null));
     }
     
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void emptyStringToSynapseFriendlyName() {
         assertEquals("", BridgeUtils.toSynapseFriendlyName("  #"));
     }

--- a/test/org/sagebionetworks/bridge/services/ConsentServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/ConsentServiceMockTest.java
@@ -52,7 +52,6 @@ import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 import org.sagebionetworks.bridge.services.email.MimeTypeEmail;
 import org.sagebionetworks.bridge.services.email.MimeTypeEmailProvider;
-import org.sagebionetworks.bridge.services.email.WithdrawConsentEmailProvider;
 
 import com.google.common.collect.Maps;
 

--- a/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
@@ -35,6 +35,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.sagebionetworks.client.SynapseClient;
 import org.sagebionetworks.client.exceptions.SynapseClientException;
@@ -73,8 +74,9 @@ import org.sagebionetworks.bridge.validators.StudyValidator;
 @RunWith(MockitoJUnitRunner.class)
 public class StudyServiceMockTest {
     private static final Long TEST_USER_ID = Long.parseLong("3348228"); // test user exists in synapse
-    private static final String TEST_PROJECT_NAME = "Test Study StudyServiceMockTest Project";
-    private static final String TEST_TEAM_NAME = "Test Study StudyServiceMockTest Access Team";
+    private static final String TEST_NAME_SCOPING_TOKEN = "qwerty";
+    private static final String TEST_PROJECT_NAME = "Test Study StudyServiceMockTest Project " + TEST_NAME_SCOPING_TOKEN;
+    private static final String TEST_TEAM_NAME = "Test Study StudyServiceMockTest Access Team " + TEST_NAME_SCOPING_TOKEN;
     private static final String TEST_TEAM_ID = "1234";
     private static final String TEST_PROJECT_ID = "synapseProjectId";
 
@@ -119,7 +121,9 @@ public class StudyServiceMockTest {
     @Captor
     private ArgumentCaptor<Team> teamCaptor;
 
+    @Spy
     private StudyService service;
+    
     private Study study;
     private Team mockTeam;
     private Project mockProject;
@@ -127,7 +131,6 @@ public class StudyServiceMockTest {
 
     @Before
     public void before() {
-        service = spy(new StudyService());
         service.setCompoundActivityDefinitionService(compoundActivityDefinitionService);
         service.setNotificationTopicService(topicService);
         service.setUploadCertificateService(uploadCertService);
@@ -138,6 +141,8 @@ public class StudyServiceMockTest {
         service.setEmailVerificationService(emailVerificationService);
         service.setSynapseClient(mockSynapseClient);
         service.setParticipantService(participantService);
+        
+        when(service.getNameScopingToken()).thenReturn(TEST_NAME_SCOPING_TOKEN);
         
         study = getTestStudy();
         when(studyDao.getStudy(TEST_STUDY_ID)).thenReturn(study);
@@ -499,8 +504,8 @@ public class StudyServiceMockTest {
         verify(service).createStudy(study);
         verify(service).createSynapseProjectTeam(TEST_ADMIN_IDS, study);
         
-        assertTrue(projectCaptor.getValue().getName().startsWith(TEST_PROJECT_NAME));
-        assertTrue(teamCaptor.getValue().getName().startsWith(TEST_TEAM_NAME));
+        assertEquals(TEST_PROJECT_NAME, projectCaptor.getValue().getName());
+        assertEquals(TEST_TEAM_NAME, teamCaptor.getValue().getName());
     }
 
     @Test (expected = BadRequestException.class)

--- a/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
@@ -41,7 +41,7 @@ import org.sagebionetworks.client.exceptions.SynapseException;
 import org.sagebionetworks.client.exceptions.SynapseNotFoundException;
 import org.sagebionetworks.client.exceptions.SynapseServerException;
 import org.sagebionetworks.repo.model.AccessControlList;
-import org.sagebionetworks.repo.model.MembershipInvtnSubmission;
+import org.sagebionetworks.repo.model.MembershipInvitation;
 import org.sagebionetworks.repo.model.Project;
 import org.sagebionetworks.repo.model.ResourceAccess;
 import org.sagebionetworks.repo.model.Team;
@@ -117,7 +117,7 @@ public class StudyServiceMockTest {
     private Study study;
     private Team mockTeam;
     private Project mockProject;
-    private MembershipInvtnSubmission mockTeamMemberInvitation;
+    private MembershipInvitation mockTeamMemberInvitation;
 
     @Before
     public void before() {
@@ -145,7 +145,7 @@ public class StudyServiceMockTest {
         mockTeam.setName(TEST_TEAM_NAME);
         mockTeam.setId(TEST_TEAM_ID);
 
-        mockTeamMemberInvitation = new MembershipInvtnSubmission();
+        mockTeamMemberInvitation = new MembershipInvitation();
         mockTeamMemberInvitation.setInviteeId(TEST_USER_ID.toString());
         mockTeamMemberInvitation.setTeamId(TEST_TEAM_ID);
     }

--- a/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
@@ -499,8 +499,8 @@ public class StudyServiceMockTest {
         verify(service).createStudy(study);
         verify(service).createSynapseProjectTeam(TEST_ADMIN_IDS, study);
         
-        assertTrue(projectCaptor.getValue().getName().contains(TEST_PROJECT_NAME));
-        assertTrue(teamCaptor.getValue().getName().contains(TEST_TEAM_NAME));
+        assertTrue(projectCaptor.getValue().getName().startsWith(TEST_PROJECT_NAME));
+        assertTrue(teamCaptor.getValue().getName().startsWith(TEST_TEAM_NAME));
     }
 
     @Test (expected = BadRequestException.class)
@@ -705,6 +705,32 @@ public class StudyServiceMockTest {
         service.createStudyAndUsers(mockStudyAndUsers);
     }
 
+    @Test(expected = BadRequestException.class)
+    public void createStudyAndUserNullStudyName() throws Exception {
+        // mock
+        Study study = getTestStudy();
+        study.setExternalIdRequiredOnSignup(false);
+        study.setSynapseProjectId(null);
+        study.setSynapseDataAccessTeamId(null);
+        study.setExternalIdValidationEnabled(false);
+        study.setName(null); // This is not a good name...
+
+        service.createSynapseProjectTeam(ImmutableList.of(TEST_IDENTIFIER), study);
+    }
+    
+    @Test(expected = BadRequestException.class)
+    public void createStudyAndUserBadStudyName() throws Exception {
+        // mock
+        Study study = getTestStudy();
+        study.setExternalIdRequiredOnSignup(false);
+        study.setSynapseProjectId(null);
+        study.setSynapseDataAccessTeamId(null);
+        study.setExternalIdValidationEnabled(false);
+        study.setName("# # "); // This is not a good name...
+
+        service.createSynapseProjectTeam(ImmutableList.of(TEST_IDENTIFIER), study);
+    }
+    
     @Test
     public void createStudyAndUserThrowExceptionLogged() throws SynapseException {
         // mock

--- a/test/org/sagebionetworks/bridge/services/UserAdminServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/UserAdminServiceMockTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.dao.ParticipantOption.EXTERNAL_IDENTIFIER;


### PR DESCRIPTION
Fix for BRIDGE-1985, and some other observed issues with the project/team as they are created:

- Update synapse client version to eliminate problem where users show up in Synapse UI with "custom" permissions;
- Reduce permissions of the access team so new team members get read/download permissions (only);
- Do not send email verification emails while creating Bridge participants, because the email you add to the study will almost always be unverified by SES, and this throws an error while creating study. Instead, we're going to create these initial users verified, and instruct them in a follow-up email to go reset the password.
- Fixed the names, which were ugly, and added a random string at the end, to ensure they never conflict with any other GLOBALLY (!?) unique team or project name in Synapse. If there's any failure, the systems are left in an inconsistent state which is highly undesirable.