### PR TITLE
Changing order and kind of exceptions that are thrown for disabled/unverified accounts.

### DIFF
--- a/app/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -227,7 +227,7 @@ public class AuthenticationService {
         checkNotNull(signIn);
 
         Validate.entityThrowingException(SignInValidator.PASSWORD_SIGNIN, signIn);
-
+        
         Account account = accountDao.authenticate(study, signIn);
 
         UserSession session = getSessionFromAccount(study, context, account);
@@ -237,7 +237,8 @@ public class AuthenticationService {
         return session;
     }
     
-    public UserSession reauthenticate(Study study, CriteriaContext context, SignIn signIn) throws EntityNotFoundException {
+    public UserSession reauthenticate(Study study, CriteriaContext context, SignIn signIn)
+            throws EntityNotFoundException {
         checkNotNull(study);
         checkNotNull(context);
         checkNotNull(signIn);

--- a/conf/routes
+++ b/conf/routes
@@ -8,9 +8,9 @@ GET    /.well-known/assetlinks.json            @org.sagebionetworks.bridge.play.
 GET    /.well-known/apple-app-site-association @org.sagebionetworks.bridge.play.controllers.ApplicationController.appleAppLinks
 
 # Authentication
-POST   /v3/auth/signIn                  @org.sagebionetworks.bridge.play.controllers.AuthenticationController.signIn
+POST   /v3/auth/signIn                  @org.sagebionetworks.bridge.play.controllers.AuthenticationController.signInV3
 POST   /v3/auth/signOut                 @org.sagebionetworks.bridge.play.controllers.AuthenticationController.signOut
-POST   /v3/auth/reauth                  @org.sagebionetworks.bridge.play.controllers.AuthenticationController.reauthenticate
+POST   /v3/auth/reauth                  @org.sagebionetworks.bridge.play.controllers.AuthenticationController.reauthenticateV3
 POST   /v3/auth/requestResetPassword    @org.sagebionetworks.bridge.play.controllers.AuthenticationController.requestResetPassword
 POST   /v3/auth/resetPassword           @org.sagebionetworks.bridge.play.controllers.AuthenticationController.resetPassword
 POST   /v3/auth/signUp                  @org.sagebionetworks.bridge.play.controllers.AuthenticationController.signUp
@@ -20,7 +20,8 @@ POST   /v3/auth/email                   @org.sagebionetworks.bridge.play.control
 POST   /v3/auth/email/signIn            @org.sagebionetworks.bridge.play.controllers.AuthenticationController.emailSignIn
 POST   /v3/auth/phone                   @org.sagebionetworks.bridge.play.controllers.AuthenticationController.requestPhoneSignIn
 POST   /v3/auth/phone/signIn            @org.sagebionetworks.bridge.play.controllers.AuthenticationController.phoneSignIn
-
+POST   /v4/auth/signIn                  @org.sagebionetworks.bridge.play.controllers.AuthenticationController.signInV4
+POST   /v4/auth/reauth                  @org.sagebionetworks.bridge.play.controllers.AuthenticationController.reauthenticateV4
 
 # Compound Activity Definitions
 GET    /v3/compoundactivitydefinitions @org.sagebionetworks.bridge.play.controllers.CompoundActivityDefinitionController.getAllCompoundActivityDefinitionsInStudy
@@ -277,7 +278,7 @@ POST   /fphs/externalIds  @org.sagebionetworks.bridge.play.controllers.FPHSContr
 # OLD API ----------------------------------------------------------------------------------------------------
 
 # API - Authentication
-POST   /api/v1/auth/signIn                  @org.sagebionetworks.bridge.play.controllers.AuthenticationController.signIn
+POST   /api/v1/auth/signIn                  @org.sagebionetworks.bridge.play.controllers.AuthenticationController.signInV3
 GET    /api/v1/auth/signOut                 @org.sagebionetworks.bridge.play.controllers.AuthenticationController.signOut
 POST   /api/v1/auth/requestResetPassword    @org.sagebionetworks.bridge.play.controllers.AuthenticationController.requestResetPassword
 POST   /api/v1/auth/resetPassword           @org.sagebionetworks.bridge.play.controllers.AuthenticationController.resetPassword


### PR DESCRIPTION
Creates a v4 of signIn and reauthenticate with a couple of changes:

- failures to sign in always thrown "not found exceptions" now, and not exceptions indicating the account is unverified or disabled
- v4 versions of the APIs throw UnauthorizedException if the account is not verified (neither email or phone has been verified). v3 still returns a 404, but the 403 allows the client to know that the account exists, but the user has yet to verify it.