### PR TITLE
Generalizing CacheProvider in preparation to cache subpopulations.

### DIFF
--- a/app/org/sagebionetworks/bridge/cache/CacheProvider.java
+++ b/app/org/sagebionetworks/bridge/cache/CacheProvider.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import javax.annotation.Resource;
 
+import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
@@ -189,13 +190,13 @@ public class CacheProvider {
     public void setStudy(Study study) {
         checkNotNull(study);
         String redisKey = RedisKey.STUDY.getRedisKey(study.getIdentifier());
-        setObject(redisKey, study);
+        setObject(redisKey, study, BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS);
     }
 
     public Study getStudy(String identifier) {
         checkNotNull(identifier);
         String redisKey = RedisKey.STUDY.getRedisKey(identifier);
-        return getObject(redisKey, Study.class);
+        return getObject(redisKey, Study.class, BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS);
     }
 
     public void removeStudy(String identifier) {

--- a/app/org/sagebionetworks/bridge/cache/CacheProvider.java
+++ b/app/org/sagebionetworks/bridge/cache/CacheProvider.java
@@ -2,12 +2,10 @@ package org.sagebionetworks.bridge.cache;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.io.IOException;
 import java.util.List;
 
 import javax.annotation.Resource;
 
-import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
@@ -71,38 +69,20 @@ public class CacheProvider {
     
     public void removeRequestInfo(String userId) {
         checkNotNull(userId);
-        try {
-            final String requestInfoKey = RedisKey.REQUEST_INFO.getRedisKey(userId);
-            jedisOps.del(requestInfoKey);
-        } catch(Throwable e) {
-            promptToStartRedisIfLocal(e);
-            throw new BridgeServiceException(e);
-        }
+        final String requestInfoKey = RedisKey.REQUEST_INFO.getRedisKey(userId);
+        removeObject(requestInfoKey);
     }
     
     private void setRequestInfo(RequestInfo requestInfo) {
-        try {
-            String ser = bridgeObjectMapper.writeValueAsString(requestInfo);
-            String redisKey = RedisKey.REQUEST_INFO.getRedisKey(requestInfo.getUserId());
-            jedisOps.set(redisKey, ser);
-        } catch (Throwable e) {
-            promptToStartRedisIfLocal(e);
-            throw new BridgeServiceException(e);
-        }
+        checkNotNull(requestInfo);
+        String redisKey = RedisKey.REQUEST_INFO.getRedisKey(requestInfo.getUserId());
+        setObject(redisKey, requestInfo);
     }
     
     public RequestInfo getRequestInfo(String userId) {
-        try {
-            String redisKey = RedisKey.REQUEST_INFO.getRedisKey(userId);
-            String ser = jedisOps.get(redisKey);
-            if (ser != null) {
-                return bridgeObjectMapper.readValue(ser, RequestInfo.class);
-            }
-        } catch (Throwable e) {
-            promptToStartRedisIfLocal(e);
-            throw new BridgeServiceException(e);
-        }
-        return null;
+        checkNotNull(userId);
+        String redisKey = RedisKey.REQUEST_INFO.getRedisKey(userId);
+        return getObject(redisKey, RequestInfo.class);
     }
 
     public void setUserSession(final UserSession session) {
@@ -153,14 +133,7 @@ public class CacheProvider {
             if (ser == null) {
                 return null;
             }
-            try {
-                return bridgeObjectMapper.readValue(ser, UserSession.class);
-            } catch (IOException ex) {
-                // Because StudyParticipant.Builder.withEncryptedHealthCode() can throw, and because of the way
-                // Jackson's BuilderBasedDeserializer, the error message actually contains the JSON. To prevent leaking
-                // personal identifying info, we should squelch the error message and replace it with our own.
-                throw new BridgeServiceException("Error parsing JSON for session " + sessionToken);
-            }
+            return bridgeObjectMapper.readValue(ser, UserSession.class);
         } catch (Throwable e) {
             promptToStartRedisIfLocal(e);
             throw new BridgeServiceException(e);
@@ -169,18 +142,16 @@ public class CacheProvider {
 
     public UserSession getUserSessionByUserId(final String userId) {
         checkNotNull(userId);
-        String sessionToken;
+        
         try {
             final String userKey = RedisKey.USER_SESSION.getRedisKey(userId);
-            sessionToken = jedisOps.get(userKey);
+            // This key isn't stored as a JSON string, retrieve it directly
+            String sessionToken = jedisOps.get(userKey);
+            return (sessionToken == null) ? null : getUserSession(sessionToken);
         } catch(Throwable e) {
             promptToStartRedisIfLocal(e);
             throw new BridgeServiceException(e);
         }
-        if (sessionToken == null) {
-            return null;
-        }
-        return getUserSession(sessionToken);
     }
 
     public void removeSession(final UserSession session) {
@@ -199,6 +170,7 @@ public class CacheProvider {
     }
 
     public void removeSessionByUserId(final String userId) {
+        checkNotNull(userId);
         try {
             final String userKey = RedisKey.USER_SESSION.getRedisKey(userId);
             String sessionToken = jedisOps.get(userKey);
@@ -215,26 +187,30 @@ public class CacheProvider {
     }
 
     public void setStudy(Study study) {
-        try {
-            String ser = bridgeObjectMapper.writeValueAsString(study);
-            String redisKey = RedisKey.STUDY.getRedisKey(study.getIdentifier());
-            String result = jedisOps.setex(redisKey, BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS, ser);
-            if (!"OK".equals(result)) {
-                throw new BridgeServiceException("Study storage error");
-            }
-        } catch (Throwable e) {
-            promptToStartRedisIfLocal(e);
-            throw new BridgeServiceException(e);
-        }
+        checkNotNull(study);
+        String redisKey = RedisKey.STUDY.getRedisKey(study.getIdentifier());
+        setObject(redisKey, study);
     }
 
     public Study getStudy(String identifier) {
+        checkNotNull(identifier);
+        String redisKey = RedisKey.STUDY.getRedisKey(identifier);
+        return getObject(redisKey, Study.class);
+    }
+
+    public void removeStudy(String identifier) {
+        checkNotNull(identifier);
+        String redisKey = RedisKey.STUDY.getRedisKey(identifier);
+        removeObject(redisKey);
+    }
+
+    public <T> T getObject(String cacheKey, Class<T> clazz) {
+        checkNotNull(cacheKey);
+        checkNotNull(clazz);
         try {
-            String redisKey = RedisKey.STUDY.getRedisKey(identifier);
-            String ser = jedisOps.get(redisKey);
+            String ser = jedisOps.get(cacheKey);
             if (ser != null) {
-                jedisOps.expire(redisKey, BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS);
-                return bridgeObjectMapper.readValue(ser, Study.class);
+                return bridgeObjectMapper.readValue(ser, clazz);
             }
         } catch (Throwable e) {
             promptToStartRedisIfLocal(e);
@@ -242,31 +218,37 @@ public class CacheProvider {
         }
         return null;
     }
-
-    public void removeStudy(String identifier) {
+    
+    /**
+     * Get the object, resetting its expiration period.
+     */
+    public <T> T getObject(String cacheKey, Class<T> clazz, int expireInSeconds) {
+        checkNotNull(cacheKey);
+        checkNotNull(clazz);
         try {
-            String redisKey = RedisKey.STUDY.getRedisKey(identifier);
-            jedisOps.del(redisKey);
-        } catch(Throwable e) {
-            promptToStartRedisIfLocal(e);
-            throw new BridgeServiceException(e);
-        }
-    }
-
-    public String getString(String cacheKey) {
-        try {
-            return jedisOps.get(cacheKey);
+            String ser = jedisOps.get(cacheKey);
+            if (ser != null) {
+                jedisOps.expire(cacheKey, expireInSeconds);
+                return bridgeObjectMapper.readValue(ser, clazz);
+            }
         } catch (Throwable e) {
             promptToStartRedisIfLocal(e);
             throw new BridgeServiceException(e);
         }
+        return null;
     }
-
-    public void setString(String cacheKey, String value, int expireInSeconds) {
+    
+    /**
+     * Set an object in the cache with no expiration.
+     */
+    public void setObject(String cacheKey, Object object) {
+        checkNotNull(cacheKey);
+        checkNotNull(object);
         try {
-            String result = jedisOps.setex(cacheKey, expireInSeconds, value);
+            String ser = bridgeObjectMapper.writeValueAsString(object);
+            String result = jedisOps.set(cacheKey, ser);
             if (!"OK".equals(result)) {
-                throw new BridgeServiceException("View storage error");
+                throw new BridgeServiceException(object.getClass().getSimpleName() + " storage error");
             }
         } catch (Throwable e) {
             promptToStartRedisIfLocal(e);
@@ -274,13 +256,35 @@ public class CacheProvider {
         }
     }
     
-    public void removeString(String cacheKey) {
+    /**
+     * Set an object in the cache with an expiration in seconds
+     */
+    public void setObject(String cacheKey, Object object, int expireInSeconds) {
+        checkNotNull(cacheKey);
+        checkNotNull(object);
+        try {
+            String ser = bridgeObjectMapper.writeValueAsString(object);
+            String result = jedisOps.setex(cacheKey, expireInSeconds, ser);
+            if (!"OK".equals(result)) {
+                throw new BridgeServiceException(object.getClass().getSimpleName() + " storage error");
+            }
+        } catch (Throwable e) {
+            promptToStartRedisIfLocal(e);
+            throw new BridgeServiceException(e);
+        }
+    }
+    
+    /**
+     * Remove object from cache, if it exists.
+     */
+    public void removeObject(String cacheKey) {
+        checkNotNull(cacheKey);
         try {
             jedisOps.del(cacheKey);
         } catch(Throwable e) {
             promptToStartRedisIfLocal(e);
             throw new BridgeServiceException(e);
-        }
+        }        
     }
     
     private void promptToStartRedisIfLocal(Throwable e) {

--- a/app/org/sagebionetworks/bridge/cache/ViewCache.java
+++ b/app/org/sagebionetworks/bridge/cache/ViewCache.java
@@ -51,7 +51,7 @@ public class ViewCache {
      */
     public <T> String getView(ViewCacheKey<T> key, Supplier<T> supplier) {
         try {
-            String value = cache.getString(key.getKey());
+            String value = cache.getObject(key.getKey(), String.class);
             if (value == null) {
                 value = cacheView(key, supplier);
             } else {
@@ -69,7 +69,7 @@ public class ViewCache {
      */
     public <T> void removeView(ViewCacheKey<T> key) {
         logger.debug("Deleting JSON for '" +key.getKey() +"'");
-        cache.removeString(key.getKey());
+        cache.removeObject(key.getKey());
     }
     
     /**
@@ -88,7 +88,7 @@ public class ViewCache {
         logger.debug("Caching JSON for " +key.getKey()+"'");
         T object = supplier.get();
         String value = objectMapper.writeValueAsString(object);
-        cache.setString(key.getKey(), value, cachePeriod);
+        cache.setObject(key.getKey(), value, cachePeriod);
         return value;
     }
     

--- a/app/org/sagebionetworks/bridge/services/AccountWorkflowService.java
+++ b/app/org/sagebionetworks/bridge/services/AccountWorkflowService.java
@@ -205,7 +205,7 @@ public class AccountWorkflowService {
         String sptoken = createTimeLimitedToken();
         
         String cacheKey = sptoken + ":" + study.getIdentifier();
-        cacheProvider.setString(cacheKey, email, EXPIRE_IN_SECONDS);
+        cacheProvider.setObject(cacheKey, email, EXPIRE_IN_SECONDS);
         
         String studyId = BridgeUtils.encodeURIComponent(study.getIdentifier());
         String url = String.format(RESET_PASSWORD_URL, BASE_URL, studyId, sptoken);
@@ -222,7 +222,7 @@ public class AccountWorkflowService {
     private void sendPasswordResetRelatedSMS(Study study, Phone phone, String message) {
         String sptoken = createTimeLimitedToken();        
         String cacheKey = sptoken + ":phone:" + study.getIdentifier();
-        cacheProvider.setString(cacheKey, getPhoneString(phone), EXPIRE_IN_SECONDS);
+        cacheProvider.setObject(cacheKey, getPhoneString(phone), EXPIRE_IN_SECONDS);
         
         String studyId = BridgeUtils.encodeURIComponent(study.getIdentifier());
         String url = String.format(RESET_PASSWORD_URL, BASE_URL, studyId, sptoken);
@@ -242,13 +242,13 @@ public class AccountWorkflowService {
         String emailCacheKey = passwordReset.getSptoken() + ":" + passwordReset.getStudyIdentifier();
         String phoneCacheKey = passwordReset.getSptoken() + ":phone:" + passwordReset.getStudyIdentifier();
         
-        String email = cacheProvider.getString(emailCacheKey);
-        String phoneJson = cacheProvider.getString(phoneCacheKey);
+        String email = cacheProvider.getObject(emailCacheKey, String.class);
+        String phoneJson = cacheProvider.getObject(phoneCacheKey, String.class);
         if (email == null && phoneJson == null) {
             throw new BadRequestException(PASSWORD_RESET_TOKEN_EXPIRED);
         }
-        cacheProvider.removeString(emailCacheKey);
-        cacheProvider.removeString(phoneCacheKey);
+        cacheProvider.removeObject(emailCacheKey);
+        cacheProvider.removeObject(phoneCacheKey);
         
         Study study = studyService.getStudy(passwordReset.getStudyIdentifier());
         AccountId accountId = null;
@@ -271,7 +271,7 @@ public class AccountWorkflowService {
         checkNotNull(data);
                  
         try {
-            cacheProvider.setString(sptoken, BridgeObjectMapper.get().writeValueAsString(data), EXPIRE_IN_SECONDS);
+            cacheProvider.setObject(sptoken, BridgeObjectMapper.get().writeValueAsString(data), EXPIRE_IN_SECONDS);
         } catch (IOException e) {
             throw new BridgeServiceException(e);
         }
@@ -280,10 +280,10 @@ public class AccountWorkflowService {
     private VerificationData restoreVerification(String sptoken) {
         checkArgument(isNotBlank(sptoken));
                  
-        String json = cacheProvider.getString(sptoken);
+        String json = cacheProvider.getObject(sptoken, String.class);
         if (json != null) {
             try {
-                cacheProvider.removeString(sptoken);
+                cacheProvider.removeObject(sptoken);
                 return BridgeObjectMapper.get().readValue(json, VerificationData.class);
             } catch (IOException e) {
                 throw new BridgeServiceException(e);

--- a/app/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -365,10 +365,10 @@ public class AuthenticationService {
             }
             return;
         }
-        String token = cacheProvider.getString(cacheKey);
+        String token = cacheProvider.getObject(cacheKey, String.class);
         if (token == null) {
             token = tokenSupplier.get();
-            cacheProvider.setString(cacheKey, token, SESSION_SIGNIN_TIMEOUT);
+            cacheProvider.setObject(cacheKey, token, SESSION_SIGNIN_TIMEOUT);
         }
 
         messageSender.accept(study, token);
@@ -382,12 +382,12 @@ public class AuthenticationService {
         Study study = studyService.getStudy(signIn.getStudyId());
         String cacheKey = cacheKeySupplier.get();
         
-        String storedToken = cacheProvider.getString(cacheKey);
+        String storedToken = cacheProvider.getObject(cacheKey, String.class);
         if (storedToken == null || !storedToken.equals(signIn.getToken())) {
             throw new AuthenticationFailedException();
         }
         // Consume the key regardless of what happens
-        cacheProvider.removeString(cacheKey);
+        cacheProvider.removeObject(cacheKey);
         
         Account account = accountDao.getAccountAfterAuthentication(signIn.getAccountId());
         if (account.getStatus() == AccountStatus.DISABLED) {

--- a/app/org/sagebionetworks/bridge/services/EmailVerificationService.java
+++ b/app/org/sagebionetworks/bridge/services/EmailVerificationService.java
@@ -53,13 +53,13 @@ public class EmailVerificationService {
     
     private EmailVerificationStatus cacheAndReturn(String emailAddress, EmailVerificationStatus status) {
         String key = getVerifiedAddressKey(emailAddress);
-        cacheProvider.setString(key, status.name(), VERIFIED_EMAIL_CACHE_IN_SECONDS);
+        cacheProvider.setObject(key, status.name(), VERIFIED_EMAIL_CACHE_IN_SECONDS);
         return status;
     }
     
     public boolean isVerified(String emailAddress) {
         String key = getVerifiedAddressKey(emailAddress);
-        String value = cacheProvider.getString(key);
+        String value = cacheProvider.getObject(key, String.class);
         if (value == null) {
             EmailVerificationStatus status = getEmailStatus(emailAddress);
             value = cacheAndReturn(emailAddress, status).name();

--- a/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
@@ -109,7 +109,7 @@ public class SurveyControllerTest {
         viewCache.setCachePeriod(BridgeConstants.BRIDGE_VIEW_EXPIRE_IN_SECONDS);
         
         CacheProvider provider = mock(CacheProvider.class);
-        when(provider.getString(anyString())).thenAnswer(new Answer<String>() {
+        when(provider.getObject(anyString(), eq(String.class))).thenAnswer(new Answer<String>() {
             @Override
             public String answer(InvocationOnMock invocation) throws Throwable {
                 String key = invocation.getArgumentAt(0, String.class);
@@ -124,7 +124,7 @@ public class SurveyControllerTest {
                 cacheMap.put(key, value);
                 return null;
             }
-        }).when(provider).setString(anyString(), anyString(), anyInt());
+        }).when(provider).setObject(anyString(), anyString(), anyInt());
         doAnswer(new Answer<Void>() {
             @Override
             public Void answer(InvocationOnMock invocation) throws Throwable {
@@ -132,7 +132,7 @@ public class SurveyControllerTest {
                 cacheMap.remove(key);
                 return null;
             }
-        }).when(provider).removeString(anyString());
+        }).when(provider).removeObject(anyString());
         viewCache.setCacheProvider(provider);
         
         studyService = mock(StudyService.class);

--- a/test/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
@@ -173,7 +173,7 @@ public class AccountWorkflowServiceTest {
     
     @Test
     public void verifyEmail() {
-        when(mockCacheProvider.getString(SPTOKEN)).thenReturn(
+        when(mockCacheProvider.getObject(SPTOKEN, String.class)).thenReturn(
             TestUtils.createJson("{'studyId':'api','userId':'userId'}"));
         when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
         when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_ID)).thenReturn(mockAccount);
@@ -187,7 +187,7 @@ public class AccountWorkflowServiceTest {
     
     @Test(expected = BadRequestException.class)
     public void verifyEmailBadSptokenThrowsException() {
-        when(mockCacheProvider.getString(SPTOKEN)).thenReturn(null);
+        when(mockCacheProvider.getObject(SPTOKEN, String.class)).thenReturn(null);
         
         EmailVerification verification = new EmailVerification(SPTOKEN);
         
@@ -204,7 +204,7 @@ public class AccountWorkflowServiceTest {
         
         service.notifyAccountExists(study, accountId);
         
-        verify(mockCacheProvider).setString("ABC:api", EMAIL, 60*60*2);
+        verify(mockCacheProvider).setObject("ABC:api", EMAIL, 60*60*2);
         verify(mockSendMailService).sendEmail(emailProviderCaptor.capture());
         MimeTypeEmailProvider provider = emailProviderCaptor.getValue();
         MimeTypeEmail email = provider.getMimeTypeEmail();
@@ -227,7 +227,7 @@ public class AccountWorkflowServiceTest {
         
         service.notifyAccountExists(study, accountId);
         
-        verify(mockCacheProvider).setString("ABC:phone:api", 
+        verify(mockCacheProvider).setObject("ABC:phone:api", 
                 BridgeObjectMapper.get().writeValueAsString(TestConstants.PHONE), 
                 AccountWorkflowService.EXPIRE_IN_SECONDS);
         verify(mockNotificationsService).sendSMSMessage(eq(study.getStudyIdentifier()), 
@@ -248,7 +248,7 @@ public class AccountWorkflowServiceTest {
         
         service.requestResetPassword(study, ACCOUNT_ID_WITH_EMAIL);
         
-        verify(mockCacheProvider).setString("ABC:api", EMAIL, 60*60*2);
+        verify(mockCacheProvider).setObject("ABC:api", EMAIL, 60*60*2);
         verify(mockSendMailService).sendEmail(emailProviderCaptor.capture());
         MimeTypeEmailProvider provider = emailProviderCaptor.getValue();
         MimeTypeEmail email = provider.getMimeTypeEmail();
@@ -272,7 +272,7 @@ public class AccountWorkflowServiceTest {
         
         service.requestResetPassword(study, ACCOUNT_ID_WITH_PHONE);
         
-        verify(mockCacheProvider).setString(eq("ABC:phone:api"), stringCaptor.capture(), eq(60*60*2));
+        verify(mockCacheProvider).setObject(eq("ABC:phone:api"), stringCaptor.capture(), eq(60*60*2));
         verify(mockNotificationsService).sendSMSMessage(eq(TEST_STUDY), eq(TestConstants.PHONE), secondStringCaptor.capture());
         
         Phone captured = BridgeObjectMapper.get().readValue(stringCaptor.getValue(), Phone.class);
@@ -293,7 +293,7 @@ public class AccountWorkflowServiceTest {
 
         service.requestResetPassword(study, ACCOUNT_ID_WITH_PHONE);
         
-        verify(mockCacheProvider, never()).setString("ABC:api", TestConstants.PHONE.getNumber(), 60*60*2);
+        verify(mockCacheProvider, never()).setObject("ABC:api", TestConstants.PHONE.getNumber(), 60*60*2);
         verify(mockNotificationsService, never()).sendSMSMessage(eq(TEST_STUDY), eq(TestConstants.PHONE), any());
     }
 
@@ -307,7 +307,7 @@ public class AccountWorkflowServiceTest {
         
         service.requestResetPassword(study, ACCOUNT_ID_WITH_PHONE);
         
-        verify(mockCacheProvider, never()).setString("ABC:api", TestConstants.PHONE.getNumber(), 60*60*2);
+        verify(mockCacheProvider, never()).setObject("ABC:api", TestConstants.PHONE.getNumber(), 60*60*2);
         verify(mockNotificationsService, never()).sendSMSMessage(eq(TEST_STUDY), eq(TestConstants.PHONE), any());
     }
     
@@ -318,7 +318,7 @@ public class AccountWorkflowServiceTest {
         
         service.requestResetPassword(study, ACCOUNT_ID_WITH_EMAIL);
         
-        verify(mockCacheProvider, never()).setString("ABC:api", EMAIL, 60*5);
+        verify(mockCacheProvider, never()).setObject("ABC:api", EMAIL, 60*5);
         verify(mockSendMailService, never()).sendEmail(emailProviderCaptor.capture());
     }
 
@@ -348,7 +348,7 @@ public class AccountWorkflowServiceTest {
     
     @Test
     public void resetPasswordWithEmail() {
-        when(mockCacheProvider.getString("sptoken:api")).thenReturn(EMAIL);
+        when(mockCacheProvider.getObject("sptoken:api", String.class)).thenReturn(EMAIL);
         when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
         when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(mockAccount);
 
@@ -356,15 +356,15 @@ public class AccountWorkflowServiceTest {
         
         service.resetPassword(passwordReset);
         
-        verify(mockCacheProvider).getString("sptoken:api");
-        verify(mockCacheProvider).removeString("sptoken:api");
+        verify(mockCacheProvider).getObject("sptoken:api", String.class);
+        verify(mockCacheProvider).removeObject("sptoken:api");
         verify(mockAccountDao).changePassword(mockAccount, "newPassword");
     }
     
     @Test
     public void resetPasswordWithPhone() throws Exception {
         String phoneJson = BridgeObjectMapper.get().writeValueAsString(TestConstants.PHONE);
-        when(mockCacheProvider.getString("sptoken:phone:api")).thenReturn(phoneJson);
+        when(mockCacheProvider.getObject("sptoken:phone:api", String.class)).thenReturn(phoneJson);
         when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
         when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
 
@@ -372,14 +372,14 @@ public class AccountWorkflowServiceTest {
         
         service.resetPassword(passwordReset);
         
-        verify(mockCacheProvider).getString("sptoken:phone:api");
-        verify(mockCacheProvider).removeString("sptoken:phone:api");
+        verify(mockCacheProvider).getObject("sptoken:phone:api", String.class);
+        verify(mockCacheProvider).removeObject("sptoken:phone:api");
         verify(mockAccountDao).changePassword(mockAccount, "newPassword");
     }
     
     @Test
     public void resetPasswordInvalidSptokenThrowsException() {
-        when(mockCacheProvider.getString("sptoken:api")).thenReturn(null);
+        when(mockCacheProvider.getObject("sptoken:api", String.class)).thenReturn(null);
 
         PasswordReset passwordReset = new PasswordReset("newPassword", "sptoken", TEST_STUDY_IDENTIFIER);
         try {
@@ -388,14 +388,14 @@ public class AccountWorkflowServiceTest {
         } catch(BadRequestException e) {
             assertEquals("Password reset token has expired (or already been used).", e.getMessage());
         }
-        verify(mockCacheProvider).getString("sptoken:api");
-        verify(mockCacheProvider, never()).removeString("sptoken:api");
+        verify(mockCacheProvider).getObject("sptoken:api", String.class);
+        verify(mockCacheProvider, never()).removeObject("sptoken:api");
         verify(mockAccountDao, never()).changePassword(mockAccount, "newPassword");
     }
     
     @Test
     public void resetPasswordInvalidAccount() {
-        when(mockCacheProvider.getString("sptoken:api")).thenReturn(EMAIL);
+        when(mockCacheProvider.getObject("sptoken:api", String.class)).thenReturn(EMAIL);
         when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
         when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(null);
 
@@ -406,8 +406,8 @@ public class AccountWorkflowServiceTest {
             fail("Should have thrown an exception");
         } catch(EntityNotFoundException e) {
         }
-        verify(mockCacheProvider).getString("sptoken:api");
-        verify(mockCacheProvider).removeString("sptoken:api");
+        verify(mockCacheProvider).getObject("sptoken:api", String.class);
+        verify(mockCacheProvider).removeObject("sptoken:api");
         verify(mockAccountDao, never()).changePassword(mockAccount, "newPassword");
     }
 }

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
@@ -189,12 +189,12 @@ public class AuthenticationServiceMockTest {
         
         service.requestEmailSignIn(SIGN_IN_REQUEST_WITH_EMAIL);
         
-        verify(cacheProvider).getString(stringCaptor.capture());
+        verify(cacheProvider).getObject(stringCaptor.capture(), eq(String.class));
         assertEquals(CACHE_KEY, stringCaptor.getValue());
         
         verify(accountDao).getAccount(SIGN_IN_REQUEST_WITH_EMAIL.getAccountId());
         
-        verify(cacheProvider).setString(eq(CACHE_KEY), stringCaptor.capture(), eq(300));
+        verify(cacheProvider).setObject(eq(CACHE_KEY), stringCaptor.capture(), eq(300));
         assertNotNull(stringCaptor.getValue());
 
         verify(sendMailService).sendEmail(providerCaptor.capture());
@@ -216,12 +216,12 @@ public class AuthenticationServiceMockTest {
     public void requestEmailSignInTwiceReturnsSameToken() throws Exception {
         // In this case, where there is a value and an account, we do't generate a new one,
         // we just send the message again.
-        doReturn("something").when(cacheProvider).getString(CACHE_KEY);
+        doReturn("something").when(cacheProvider).getObject(CACHE_KEY, String.class);
         doReturn(account).when(accountDao).getAccount(any());
         
         service.requestEmailSignIn(SIGN_IN_REQUEST_WITH_EMAIL);
         
-        verify(cacheProvider, never()).setString(any(), any(), anyInt());
+        verify(cacheProvider, never()).setObject(any(), any(), anyInt());
         verify(sendMailService).sendEmail(providerCaptor.capture());
         
         MimeTypeEmailProvider provider = providerCaptor.getValue();
@@ -258,7 +258,7 @@ public class AuthenticationServiceMockTest {
         
         service.requestEmailSignIn(SIGN_IN_REQUEST_WITH_EMAIL);
 
-        verify(cacheProvider, never()).setString(eq(CACHE_KEY), any(), eq(60));
+        verify(cacheProvider, never()).setObject(eq(CACHE_KEY), any(), eq(60));
         verify(sendMailService, never()).sendEmail(any());
     }
 
@@ -266,7 +266,7 @@ public class AuthenticationServiceMockTest {
     public void emailSignIn() {
         account.setReauthToken(REAUTH_TOKEN);
         account.setStatus(AccountStatus.UNVERIFIED);
-        doReturn(TOKEN).when(cacheProvider).getString(CACHE_KEY);
+        doReturn(TOKEN).when(cacheProvider).getObject(CACHE_KEY, String.class);
         doReturn(account).when(accountDao).getAccountAfterAuthentication(SIGN_IN_WITH_EMAIL.getAccountId());
         doReturn(PARTICIPANT).when(participantService).getParticipant(study, account, false);
         doReturn(CONSENTED_STATUS_MAP).when(consentService).getConsentStatuses(any());
@@ -278,12 +278,12 @@ public class AuthenticationServiceMockTest {
         verify(accountDao, never()).changePassword(eq(account), any());
         verify(accountDao).getAccountAfterAuthentication(SIGN_IN_WITH_EMAIL.getAccountId());
         verify(accountDao).verifyChannel(AuthenticationService.ChannelType.EMAIL, account);
-        verify(cacheProvider).removeString(CACHE_KEY);
+        verify(cacheProvider).removeObject(CACHE_KEY);
     }
     
     @Test(expected = AuthenticationFailedException.class)
     public void emailSignInTokenWrong() {
-        doReturn(TOKEN).when(cacheProvider).getString(CACHE_KEY);
+        doReturn(TOKEN).when(cacheProvider).getObject(CACHE_KEY, String.class);
         doReturn(account).when(accountDao).getAccount(ACCOUNT_ID);
         doReturn(PARTICIPANT).when(participantService).getParticipant(study, account, false);
         
@@ -295,7 +295,7 @@ public class AuthenticationServiceMockTest {
     
     @Test(expected = AuthenticationFailedException.class)
     public void emailSignInTokenNotSet() {
-        doReturn(null).when(cacheProvider).getString(CACHE_KEY);
+        doReturn(null).when(cacheProvider).getObject(CACHE_KEY, String.class);
         doReturn(account).when(accountDao).getAccount(ACCOUNT_ID);
         doReturn(PARTICIPANT).when(participantService).getParticipant(study, account, false);
         
@@ -357,7 +357,7 @@ public class AuthenticationServiceMockTest {
         
         doReturn(participant).when(participantService).getParticipant(study, account, false);
         study.setIdentifier(STUDY_ID);
-        doReturn(TOKEN).when(cacheProvider).getString(CACHE_KEY);
+        doReturn(TOKEN).when(cacheProvider).getObject(CACHE_KEY, String.class);
         doReturn(study).when(studyService).getStudy(STUDY_ID);
         doReturn(account).when(accountDao).getAccountAfterAuthentication(SIGN_IN_WITH_EMAIL.getAccountId());
         account.setStatus(AccountStatus.DISABLED);
@@ -372,7 +372,7 @@ public class AuthenticationServiceMockTest {
         doReturn(UNCONSENTED_STATUS_MAP).when(consentService).getConsentStatuses(any());
         doReturn(participant).when(participantService).getParticipant(study, account, false);
         study.setIdentifier(STUDY_ID);
-        doReturn(TOKEN).when(cacheProvider).getString(CACHE_KEY);
+        doReturn(TOKEN).when(cacheProvider).getObject(CACHE_KEY, String.class);
         doReturn(study).when(studyService).getStudy(STUDY_ID);
         doReturn(account).when(accountDao).getAccountAfterAuthentication(SIGN_IN_WITH_EMAIL.getAccountId());
         
@@ -491,8 +491,8 @@ public class AuthenticationServiceMockTest {
         
         service.requestPhoneSignIn(SIGN_IN_REQUEST_WITH_PHONE);
         
-        verify(cacheProvider).getString(cacheKey);
-        verify(cacheProvider).setString(cacheKey, "123456", 300);
+        verify(cacheProvider).getObject(cacheKey, String.class);
+        verify(cacheProvider).setObject(cacheKey, "123456", 300);
         verify(notificationsService).sendSMSMessage(study.getStudyIdentifier(), TestConstants.PHONE,
                 "Enter 123-456 to sign in to AppName");
     }
@@ -502,7 +502,7 @@ public class AuthenticationServiceMockTest {
         // This should fail silently, or we risk giving away information about accounts in the system.
         service.requestPhoneSignIn(SIGN_IN_REQUEST_WITH_PHONE);
         
-        verify(cacheProvider, never()).setString(any(), any(), anyInt());
+        verify(cacheProvider, never()).setObject(any(), any(), anyInt());
         verify(notificationsService, never()).sendSMSMessage(any(), any(), any());
     }    
     
@@ -513,7 +513,7 @@ public class AuthenticationServiceMockTest {
                 .withEmail(RECIPIENT_EMAIL).withFirstName("Test").withLastName("Tester").build();
         
         String cacheKey = TestConstants.PHONE.getNumber() + ":api:phoneSignInRequest";
-        when(cacheProvider.getString(cacheKey)).thenReturn(TOKEN);
+        when(cacheProvider.getObject(cacheKey, String.class)).thenReturn(TOKEN);
         when(accountDao.getAccountAfterAuthentication(ACCOUNT_ID_WITH_PHONE)).thenReturn(account);
         when(participantService.getParticipant(study, account, false)).thenReturn(participant);
         when(consentService.getConsentStatuses(any())).thenReturn(CONSENTED_STATUS_MAP);
@@ -525,7 +525,7 @@ public class AuthenticationServiceMockTest {
         assertEquals("Tester", session.getParticipant().getLastName());
         
         // this doesn't pass if our mock calls above aren't executed, but verify these:
-        verify(cacheProvider).removeString(cacheKey);
+        verify(cacheProvider).removeObject(cacheKey);
         verify(accountDao).verifyChannel(ChannelType.PHONE, account);
     }
 

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
@@ -63,7 +63,7 @@ import com.google.common.collect.Sets;
 @RunWith(SpringJUnit4ClassRunner.class)
 public class AuthenticationServiceTest {
     
-    private static final Set<Roles> CALLER_ROLES = Sets.newHashSet();
+    private static   final Set<Roles> CALLER_ROLES = Sets.newHashSet();
     private static final Set<String> ORIGINAL_DATA_GROUPS = Sets.newHashSet("group1");
     private static final Set<String> UPDATED_DATA_GROUPS = Sets.newHashSet("sdk-int-1","sdk-int-2","group1");
     

--- a/test/org/sagebionetworks/bridge/services/EmailVerificationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/EmailVerificationServiceTest.java
@@ -77,7 +77,7 @@ public class EmailVerificationServiceTest {
         verify(sesClient).getIdentityVerificationAttributes(getCaptor.capture());
         assertEquals(EMAIL_ADDRESS, getCaptor.getValue().getIdentities().get(0));
 
-        verify(cacheProvider).setString(eq(EMAIL_ADDRESS_KEY), eq("VERIFIED"), anyInt());
+        verify(cacheProvider).setObject(eq(EMAIL_ADDRESS_KEY), eq("VERIFIED"), anyInt());
     }
     
     @Test
@@ -91,7 +91,7 @@ public class EmailVerificationServiceTest {
         verify(sesClient).getIdentityVerificationAttributes(getCaptor.capture());
         assertEquals(EMAIL_ADDRESS, getCaptor.getValue().getIdentities().get(0));
 
-        verify(cacheProvider).setString(eq(EMAIL_ADDRESS_KEY), eq("UNVERIFIED"), anyInt());
+        verify(cacheProvider).setObject(eq(EMAIL_ADDRESS_KEY), eq("UNVERIFIED"), anyInt());
     }
     
     @Test
@@ -108,7 +108,7 @@ public class EmailVerificationServiceTest {
         assertEquals(EMAIL_ADDRESS, verifyCaptor.getValue().getEmailAddress());
         assertEquals(EMAIL_ADDRESS, getCaptor.getValue().getIdentities().get(0));
         
-        verify(cacheProvider).setString(eq(EMAIL_ADDRESS_KEY), eq("PENDING"), anyInt());
+        verify(cacheProvider).setObject(eq(EMAIL_ADDRESS_KEY), eq("PENDING"), anyInt());
     }
     
     @Test
@@ -123,7 +123,7 @@ public class EmailVerificationServiceTest {
         verify(sesClient).verifyEmailIdentity(verifyCaptor.capture());
         assertEquals(EMAIL_ADDRESS, verifyCaptor.getValue().getEmailAddress());
         
-        verify(cacheProvider).setString(eq(EMAIL_ADDRESS_KEY), eq("PENDING"), anyInt());
+        verify(cacheProvider).setObject(eq(EMAIL_ADDRESS_KEY), eq("PENDING"), anyInt());
     }
     
     @Test
@@ -134,7 +134,7 @@ public class EmailVerificationServiceTest {
 
         verify(sesClient).getIdentityVerificationAttributes(any());
         assertEquals(EmailVerificationStatus.VERIFIED, status);
-        verify(cacheProvider).setString(eq(EMAIL_ADDRESS_KEY), eq("VERIFIED"), anyInt());
+        verify(cacheProvider).setObject(eq(EMAIL_ADDRESS_KEY), eq("VERIFIED"), anyInt());
     }
     
     @Test
@@ -151,7 +151,7 @@ public class EmailVerificationServiceTest {
         verify(sesClient).getIdentityVerificationAttributes(any());
         assertEquals(EmailVerificationStatus.UNVERIFIED, status);
         
-        verify(cacheProvider).setString(eq(EMAIL_ADDRESS_KEY), eq("UNVERIFIED"), anyInt());        
+        verify(cacheProvider).setObject(eq(EMAIL_ADDRESS_KEY), eq("UNVERIFIED"), anyInt());        
     }
     
     @Test
@@ -169,7 +169,7 @@ public class EmailVerificationServiceTest {
         verify(sesClient).getIdentityVerificationAttributes(any());
         assertEquals(EmailVerificationStatus.UNVERIFIED, status);
         
-        verify(cacheProvider).setString(eq(EMAIL_ADDRESS_KEY), eq("UNVERIFIED"), anyInt());        
+        verify(cacheProvider).setObject(eq(EMAIL_ADDRESS_KEY), eq("UNVERIFIED"), anyInt());        
     }
     
     @Test
@@ -179,24 +179,24 @@ public class EmailVerificationServiceTest {
 
         verify(sesClient).verifyEmailIdentity(any());
         
-        verify(cacheProvider).setString(eq(EMAIL_ADDRESS_KEY), eq("PENDING"), anyInt()); 
+        verify(cacheProvider).setObject(eq(EMAIL_ADDRESS_KEY), eq("PENDING"), anyInt()); 
     }
     
     @Test
     public void isVerifiedAndCached() throws Exception {
-        when(cacheProvider.getString(EMAIL_ADDRESS_KEY)).thenReturn("VERIFIED");
+        when(cacheProvider.getObject(EMAIL_ADDRESS_KEY, String.class)).thenReturn("VERIFIED");
         assertTrue(service.isVerified(EMAIL_ADDRESS));
     }
     
     @Test
     public void isPendingAndCached() throws Exception {
-        when(cacheProvider.getString(EMAIL_ADDRESS_KEY)).thenReturn("PENDING");
+        when(cacheProvider.getObject(EMAIL_ADDRESS_KEY, String.class)).thenReturn("PENDING");
         assertFalse(service.isVerified(EMAIL_ADDRESS));
     }
     
     @Test
     public void isUnverifiedAndCached() throws Exception {
-        when(cacheProvider.getString(EMAIL_ADDRESS_KEY)).thenReturn("UNVERIFIED");
+        when(cacheProvider.getObject(EMAIL_ADDRESS_KEY, String.class)).thenReturn("UNVERIFIED");
         assertFalse(service.isVerified(EMAIL_ADDRESS));
     }
     
@@ -206,8 +206,7 @@ public class EmailVerificationServiceTest {
         
         assertTrue(service.isVerified(EMAIL_ADDRESS));
         
-        verify(cacheProvider).setString(eq(EMAIL_ADDRESS_KEY),
-                eq("VERIFIED"), anyInt());
+        verify(cacheProvider).setObject(eq(EMAIL_ADDRESS_KEY), eq("VERIFIED"), anyInt());
     }
     
     @Test
@@ -216,8 +215,7 @@ public class EmailVerificationServiceTest {
         
         assertFalse(service.isVerified(EMAIL_ADDRESS));
         
-        verify(cacheProvider).setString(eq(EMAIL_ADDRESS_KEY),
-                eq("PENDING"), anyInt());
+        verify(cacheProvider).setObject(eq(EMAIL_ADDRESS_KEY), eq("PENDING"), anyInt());
     }
     
     @Test
@@ -226,8 +224,7 @@ public class EmailVerificationServiceTest {
         
         assertFalse(service.isVerified(EMAIL_ADDRESS));
         
-        verify(cacheProvider).setString(eq(EMAIL_ADDRESS_KEY),
-                eq("UNVERIFIED"), anyInt());
+        verify(cacheProvider).setObject(eq(EMAIL_ADDRESS_KEY), eq("UNVERIFIED"), anyInt());
     }
 
 }


### PR DESCRIPTION
Creating a generic set of methods to cache objects, and refactoring to use them. Because otherwise I would have to add subpopulation-specific methods, which is unnecessary.

And also the intent to participate API, where I'd like to use the same object-based methods to cache the Intent to Participate.