### PR TITLE
Removing healthCode-index from the code base.

### DIFF
--- a/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
+++ b/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
@@ -396,14 +396,6 @@ public class BridgeSpringConfig {
             DynamoNamingHelper dynamoNamingHelper) {
         return DynamoIndexHelper.create(DynamoUpload2.class, "studyId-requestedOn-index", dynamoDBClient, dynamoNamingHelper, dynamoUtils);
     }
-    
-    @Bean(name = "healthDataHealthCodeIndex")
-    @Autowired
-    public DynamoIndexHelper healthDataHealthCodeIndex(AmazonDynamoDBClient dynamoDBClient,
-                                                       DynamoUtils dynamoUtils,
-                                                       DynamoNamingHelper dynamoNamingHelper) {
-        return DynamoIndexHelper.create(DynamoHealthDataRecord.class, "healthCode-index", dynamoDBClient, dynamoNamingHelper, dynamoUtils);
-    }
 
     @Bean(name = "healthDataHealthCodeCreatedOnIndex")
     @Autowired

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataDao.java
@@ -40,7 +40,7 @@ public class DynamoHealthDataDao implements HealthDataDao {
      * DynamoDB Index reference for the healthCode index. This is needed because the DynamoDB mapper does allow queries
      * using global secondary indices. This is configured by Spring
      */
-    @Resource(name = "healthDataHealthCodeIndex")
+    @Resource(name = "healthDataHealthCodeCreatedOnIndex")
     public void setHealthCodeIndex(DynamoIndexHelper healthCodeIndex) {
         this.healthCodeIndex = healthCodeIndex;
     }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataDao.java
@@ -8,9 +8,12 @@ import java.util.stream.Collectors;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
 import com.amazonaws.services.dynamodbv2.datamodeling.QueryResultPage;
+import com.amazonaws.services.dynamodbv2.document.Index;
+import com.amazonaws.services.dynamodbv2.document.Item;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
 import com.amazonaws.services.dynamodbv2.model.Condition;
+import com.google.common.collect.Lists;
 
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.BridgeUtils;
@@ -73,9 +76,17 @@ public class DynamoHealthDataDao implements HealthDataDao {
     /** {@inheritDoc} */
     @Override
     public int deleteRecordsForHealthCode(@Nonnull String healthCode) {
-        // query for the keys we need to delete
-        List<HealthDataRecord> keysToDelete = healthCodeIndex.queryKeys(HealthDataRecord.class, "healthCode",
-                healthCode, null);
+        // query for the keys we need to delete. The index returns all fields which are
+        // not correctly deserialized by IndexHelper, so do it manually.
+        Index index = healthCodeIndex.getIndex();
+        Iterable<Item> iter = index.query("healthCode", healthCode);
+        
+        List<DynamoHealthDataRecord> keysToDelete = Lists.newArrayList();
+        for (Item item : iter) {
+            DynamoHealthDataRecord oneRecord = new DynamoHealthDataRecord();
+            oneRecord.setId(item.getString("id"));
+            keysToDelete.add(oneRecord);
+        }
 
         // and then delete
         List<DynamoDBMapper.FailedBatch> failureList = mapper.batchDelete(keysToDelete);

--- a/test/org/sagebionetworks/bridge/cache/CacheProviderMockTest.java
+++ b/test/org/sagebionetworks/bridge/cache/CacheProviderMockTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 


### PR DESCRIPTION
As I understand it, this index is redundant with healthCode-createdOn-Index, and so the one reference in the code has been removed. As this is pushed out, healthCode-index can be deleted.

Tests: ran the BridgePF unit tests and the integration tests. Dwayne should review this as he knew more about why the healthCode-index is not created by our DDB table creation code.

Once this is deployed, we can delete healthCode-Index, and then table creation should be complete in fresh install.