### PR TITLE
Fix command to restart healthd

### DIFF
--- a/dist/.ebextensions/ignore_4xx.config
+++ b/dist/.ebextensions/ignore_4xx.config
@@ -2,5 +2,4 @@ container_commands:
   01-patch-healthd:
     command: "sudo /bin/sed -i 's/\\# normalize units to seconds with millisecond resolution/if status \\&\\& status.index(\"4\") == 0 then next end/g' /opt/elasticbeanstalk/lib/ruby/lib/ruby/gems/2.2.0/gems/healthd-appstat-1.0.1/lib/healthd-appstat/plugin.rb"
   02-restart-healthd:
-    command: "sudo /usr/bin/kill $(/bin/ps aux | /bin/grep -e '/bin/bash -c healthd' | /usr/bin/awk '{ print $2 }')"
-    ignoreErrors: true
+    command: "sudo /bin/kill $(sudo /bin/ps aux | /bin/grep -e '/bin/bash -c healthd' | /bin/grep -v 'grep' | /usr/bin/awk '{ print $2 }')"


### PR DESCRIPTION
The command returned the two processes, healthd and grep:

$ /bin/ps aux | /bin/grep -e '/bin/bash -c healthd'
root      7979  0.0  0.1  56668  2704 ?        Ss   Dec28   0:00 su -s /bin/bash -c healthd healthd
ec2-user  8800  0.0  0.1 110456  2136 pts/0    S+   00:03   0:00 /bin/grep -e /bin/bash -c healthd

killing the ephemeral grep process caused the following error:

2017-12-28 23:18:26,263 [ERROR] Command 02-restart-healthd (sudo /usr/bin/kill $(/bin/ps aux | /bin/grep -e '/bin/bash -c healthd' | /usr/bin/awk '{ print $2 }')) failed

We only need to restart the healthd process.