### PR TITLE
Remove non needed script

### DIFF
--- a/dist/.ebextensions/00_awslogs.config
+++ b/dist/.ebextensions/00_awslogs.config
@@ -1,5 +1,0 @@
-container_commands:
-  autostart_logs:
-    command: chkconfig awslogs on
-  start_logs:
-    command: service awslogs start


### PR DESCRIPTION
EB uses AWS AMI which contains a logging agent and by default it starts
the logging service on bootup so we don't need an extra script for this
purpose.