### PR TITLE
Refactoring accountWorkflowService, pulling it up to the service layer to make adding email/phone easier.

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/AccountDao.java
+++ b/app/org/sagebionetworks/bridge/dao/AccountDao.java
@@ -8,8 +8,6 @@ import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.AccountSummary;
-import org.sagebionetworks.bridge.models.accounts.EmailVerification;
-import org.sagebionetworks.bridge.models.accounts.PasswordReset;
 import org.sagebionetworks.bridge.models.accounts.Phone;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
 import org.sagebionetworks.bridge.models.studies.Study;
@@ -26,30 +24,12 @@ public interface AccountDao {
     /**
      * Verify an email address using a supplied, one-time token for verification.
      */
-    void verifyEmail(EmailVerification verification);
+    void verifyEmail(Account account);
     
     /**
      * Set the verified flag for the channel (email or phone) to true, and enable the account (if needed).
      */
     void verifyChannel(AuthenticationService.ChannelType channelType, Account account);
-    
-    /**
-     * Sign up sends an email address with a link that includes a one-time token for verification. That email
-     * can be resent by calling this method.
-     */
-    void resendEmailVerificationToken(AccountId accountId);
-    
-    /**
-     * Request that an email be sent to the account holder with a link to reset a password, including a 
-     * one-time verification token. 
-     */
-    void requestResetPassword(Study study, AccountId accountId);
-    
-    /**
-     * Reset a password, supplying a new password and the one-time verification token that was sent via email 
-     * to the account holder.
-     */
-    void resetPassword(PasswordReset passwordReset);
     
     /**
      * Call to change a password without a password reset workflow.
@@ -95,7 +75,7 @@ public interface AccountDao {
      * Create an account. The account object should initially be retrieved from the 
      * constructAccount() factory method. Returns the created account's ID.
      */
-    String createAccount(Study study, Account account, boolean sendVerifyEmail);
+    String createAccount(Study study, Account account);
     
     /**
      * Save account changes. Account should have been retrieved from the getAccount() method 

--- a/app/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -293,7 +293,8 @@ public class AuthenticationService {
         checkNotNull(verification);
 
         Validate.entityThrowingException(EmailVerificationValidator.INSTANCE, verification);
-        accountDao.verifyEmail(verification);
+        Account account = accountWorkflowService.verifyEmail(verification);
+        accountDao.verifyEmail(account);
     }
     
     public void resendEmailVerification(StudyIdentifier studyIdentifier, Email email) {
@@ -303,7 +304,7 @@ public class AuthenticationService {
         Validate.entityThrowingException(EmailValidator.INSTANCE, email);
         try {
             AccountId accountId = AccountId.forEmail(studyIdentifier.getIdentifier(), email.getEmail());
-            accountDao.resendEmailVerificationToken(accountId);    
+            accountWorkflowService.resendEmailVerificationToken(accountId);    
         } catch(EntityNotFoundException e) {
             // Suppress this. Otherwise it reveals if the account does not exist
             LOG.info("Resend email verification for unregistered email in study '"+studyIdentifier.getIdentifier()+"'");
@@ -317,7 +318,7 @@ public class AuthenticationService {
         // validate the data in signIn, then convert it to an account ID which we know will be valid.
         Validate.entityThrowingException(SignInValidator.REQUEST_RESET_PASSWORD, signIn);
         try {
-            accountDao.requestResetPassword(study, signIn.getAccountId());    
+            accountWorkflowService.requestResetPassword(study, signIn.getAccountId());    
         } catch(EntityNotFoundException e) {
             // Suppress this. Otherwise it reveals if the account does not exist
             LOG.info("Request reset password request for unregistered email in study '"+signIn.getStudyId()+"'");
@@ -329,7 +330,7 @@ public class AuthenticationService {
 
         Validate.entityThrowingException(passwordResetValidator, passwordReset);
         
-        accountDao.resetPassword(passwordReset);
+        accountWorkflowService.resetPassword(passwordReset);
     }
     
     protected String getEmailToken() {

--- a/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
+++ b/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
@@ -693,19 +693,6 @@ public class HibernateAccountDaoTest {
     }
 
     @Test
-    public void createAccountVerifyEmail() {
-        dao.createAccount(STUDY, makeValidGenericAccount());
-        
-        // created account has account status unverified
-        ArgumentCaptor<HibernateAccount> createdHibernateAccountCaptor = ArgumentCaptor.forClass(
-                HibernateAccount.class);
-        verify(mockHibernateHelper).create(createdHibernateAccountCaptor.capture());
-
-        HibernateAccount createdHibernateAccount = createdHibernateAccountCaptor.getValue();
-        assertEquals(AccountStatus.UNVERIFIED, createdHibernateAccount.getStatus());
-    }
-
-    @Test
     public void createAccountForMigration() {
         // Most of this is tested in createAccountSuccess(). Just test that account ID is correctly propagated and that
         // email workflow is *not* called despite the flag.

--- a/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
+++ b/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
@@ -43,19 +43,16 @@ import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.AccountStatus;
 import org.sagebionetworks.bridge.models.accounts.AccountSummary;
-import org.sagebionetworks.bridge.models.accounts.EmailVerification;
 import org.sagebionetworks.bridge.models.accounts.GenericAccount;
 import org.sagebionetworks.bridge.models.accounts.HealthId;
 import org.sagebionetworks.bridge.models.accounts.HealthIdImpl;
 import org.sagebionetworks.bridge.models.accounts.PasswordAlgorithm;
-import org.sagebionetworks.bridge.models.accounts.PasswordReset;
 import org.sagebionetworks.bridge.models.accounts.Phone;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
-import org.sagebionetworks.bridge.services.AccountWorkflowService;
 import org.sagebionetworks.bridge.services.AuthenticationService;
 import org.sagebionetworks.bridge.services.HealthCodeService;
 
@@ -64,7 +61,6 @@ public class HibernateAccountDaoTest {
     private static final DateTime CREATED_ON = DateTime.parse("2017-05-19T11:03:50.224-0700");
     private static final String DUMMY_PASSWORD = "Aa!Aa!Aa!Aa!1";
     private static final String DUMMY_PASSWORD_HASH = "dummy-password-hash";
-    private static final String DUMMY_TOKEN = "dummy-token";
     private static final String EMAIL = "eggplant@example.com";
     private static final Phone PHONE = TestConstants.PHONE;
     private static final Phone OTHER_PHONE = new Phone("+12065881469", "US");
@@ -90,7 +86,6 @@ public class HibernateAccountDaoTest {
         STUDY.setIdentifier(TestConstants.TEST_STUDY_IDENTIFIER);
     }
 
-    private AccountWorkflowService mockAccountWorkflowService;
     private HealthCodeService mockHealthCodeService;
     private HibernateAccountDao dao;
     private HibernateHelper mockHibernateHelper;
@@ -107,11 +102,9 @@ public class HibernateAccountDaoTest {
 
     @Before
     public void before() {
-        mockAccountWorkflowService = mock(AccountWorkflowService.class);
         mockHealthCodeService = mock(HealthCodeService.class);
         mockHibernateHelper = mock(HibernateHelper.class);
         dao = new HibernateAccountDao();
-        dao.setAccountWorkflowService(mockAccountWorkflowService);
         dao.setHealthCodeService(mockHealthCodeService);
         dao.setHibernateHelper(mockHibernateHelper);
         
@@ -130,13 +123,10 @@ public class HibernateAccountDaoTest {
         account.setStatus(AccountStatus.UNVERIFIED);
         account.setEmailVerified(Boolean.FALSE);
         
-        when(mockAccountWorkflowService.verifyEmail(any())).thenReturn(account);
         when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(hibernateAccount);
         
-        EmailVerification verification = new EmailVerification(DUMMY_TOKEN);
-        dao.verifyEmail(verification);
+        dao.verifyEmail(account);
         
-        verify(mockAccountWorkflowService).verifyEmail(verification);
         assertEquals(AccountStatus.ENABLED, hibernateAccount.getStatus());
         assertEquals(Boolean.TRUE, hibernateAccount.getEmailVerified());
         assertTrue(hibernateAccount.getModifiedOn() > 0L);
@@ -156,7 +146,6 @@ public class HibernateAccountDaoTest {
         account.setStatus(AccountStatus.UNVERIFIED);
         account.setEmailVerified(Boolean.FALSE);
         
-        when(mockAccountWorkflowService.verifyEmail(any())).thenReturn(account);
         when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(hibernateAccount);
         
         dao.verifyChannel(AuthenticationService.ChannelType.EMAIL, account);
@@ -180,7 +169,6 @@ public class HibernateAccountDaoTest {
         account.setStatus(AccountStatus.ENABLED);
         account.setEmailVerified(Boolean.TRUE);
         
-        when(mockAccountWorkflowService.verifyEmail(any())).thenReturn(account);
         when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(hibernateAccount);
         
         dao.verifyChannel(AuthenticationService.ChannelType.EMAIL, account);
@@ -227,7 +215,6 @@ public class HibernateAccountDaoTest {
         account.setStatus(AccountStatus.UNVERIFIED);
         account.setPhoneVerified(Boolean.FALSE);
         
-        when(mockAccountWorkflowService.verifyEmail(any())).thenReturn(account);
         when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(hibernateAccount);
         
         dao.verifyChannel(AuthenticationService.ChannelType.PHONE, account);
@@ -251,7 +238,6 @@ public class HibernateAccountDaoTest {
         account.setStatus(AccountStatus.ENABLED);
         account.setPhoneVerified(Boolean.TRUE);
         
-        when(mockAccountWorkflowService.verifyEmail(any())).thenReturn(account);
         when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(hibernateAccount);
         
         dao.verifyChannel(AuthenticationService.ChannelType.PHONE, account);
@@ -287,26 +273,6 @@ public class HibernateAccountDaoTest {
         assertNull(account.getPhoneVerified());
     }    
     
-    @Test
-    public void resendEmailVerificationToken() {
-        dao.resendEmailVerificationToken(ACCOUNT_ID_WITH_EMAIL);
-        verify(mockAccountWorkflowService).resendEmailVerificationToken(ACCOUNT_ID_WITH_EMAIL);
-    }
-
-    @Test
-    public void requestResetPassword() {
-        dao.requestResetPassword(STUDY, ACCOUNT_ID_WITH_EMAIL);
-        verify(mockAccountWorkflowService).requestResetPassword(STUDY, ACCOUNT_ID_WITH_EMAIL);
-    }
-
-    @Test
-    public void resetPassword() {
-        PasswordReset passwordReset = new PasswordReset(DUMMY_PASSWORD, DUMMY_TOKEN,
-                TestConstants.TEST_STUDY_IDENTIFIER);
-        dao.resetPassword(passwordReset);
-        verify(mockAccountWorkflowService).resetPassword(passwordReset);
-    }
-
     @Test
     public void changePasswordSuccess() throws Exception {
         // mock hibernate
@@ -704,10 +670,11 @@ public class HibernateAccountDaoTest {
         // Study passed into createAccount() takes precedence over StudyId in the Account object. To test this, make
         // the account have a different study.
         GenericAccount account = makeValidGenericAccount();
+        account.setStatus(AccountStatus.ENABLED);
         account.setStudyId(new StudyIdentifierImpl("wrong-study"));
 
         // execute - We generate a new account ID.
-        String daoOutputAcountId = dao.createAccount(STUDY, account, false);
+        String daoOutputAcountId = dao.createAccount(STUDY, account);
         assertNotNull(daoOutputAcountId);
         assertNotEquals(ACCOUNT_ID, daoOutputAcountId);
 
@@ -723,17 +690,12 @@ public class HibernateAccountDaoTest {
         assertEquals(MOCK_NOW_MILLIS, createdHibernateAccount.getModifiedOn().longValue());
         assertEquals(MOCK_NOW_MILLIS, createdHibernateAccount.getPasswordModifiedOn().longValue());
         assertEquals(AccountStatus.ENABLED, createdHibernateAccount.getStatus());
-
-        // don't call sendEmailVerificationToken
-        verify(mockAccountWorkflowService, never()).sendEmailVerificationToken(any(), any(), any());
     }
 
     @Test
     public void createAccountVerifyEmail() {
-        // Most of this is tested in createAccountSuccess(). Just test email workflow.
-        String accountId = dao.createAccount(STUDY, makeValidGenericAccount(), true);
-        verify(mockAccountWorkflowService).sendEmailVerificationToken(STUDY, accountId, EMAIL);
-
+        dao.createAccount(STUDY, makeValidGenericAccount());
+        
         // created account has account status unverified
         ArgumentCaptor<HibernateAccount> createdHibernateAccountCaptor = ArgumentCaptor.forClass(
                 HibernateAccount.class);
@@ -747,8 +709,7 @@ public class HibernateAccountDaoTest {
     public void createAccountForMigration() {
         // Most of this is tested in createAccountSuccess(). Just test that account ID is correctly propagated and that
         // email workflow is *not* called despite the flag.
-        dao.createAccountForMigration(STUDY, makeValidGenericAccount(), ACCOUNT_ID, true);
-        verify(mockAccountWorkflowService, never()).sendEmailVerificationToken(any(), any(), any());
+        dao.createAccountForMigration(STUDY, makeValidGenericAccount(), ACCOUNT_ID);
 
         // created account has correct account ID account status unverified
         ArgumentCaptor<HibernateAccount> createdHibernateAccountCaptor = ArgumentCaptor.forClass(
@@ -774,7 +735,7 @@ public class HibernateAccountDaoTest {
 
         // execute
         try {
-            dao.createAccount(STUDY, makeValidGenericAccount(), false);
+            dao.createAccount(STUDY, makeValidGenericAccount());
             fail("expected exception");
         } catch (EntityAlreadyExistsException ex) {
             assertEquals(otherAccountId, ex.getEntity().get("userId"));
@@ -789,7 +750,7 @@ public class HibernateAccountDaoTest {
         doThrow(ConcurrentModificationException.class).when(mockHibernateHelper).create(any());
 
         // execute
-        dao.createAccount(STUDY, makeValidGenericAccount(), false);
+        dao.createAccount(STUDY, makeValidGenericAccount());
     }
 
     @Test
@@ -809,7 +770,7 @@ public class HibernateAccountDaoTest {
             GenericAccount account = makeValidGenericAccount();
             account.setEmail(null);
             account.setPhone(TestConstants.PHONE);
-            dao.createAccount(STUDY, account, false);
+            dao.createAccount(STUDY, account);
             fail("expected exception");
         } catch (EntityAlreadyExistsException ex) {
             assertEquals(otherAccountId, ex.getEntity().get("userId"));
@@ -1547,6 +1508,7 @@ public class HibernateAccountDaoTest {
         genericAccount.setId(ACCOUNT_ID);
         genericAccount.setStudyId(TestConstants.TEST_STUDY);
         genericAccount.setEmail(EMAIL);
+        genericAccount.setStatus(AccountStatus.UNVERIFIED);
         return genericAccount;
     }
 

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
@@ -39,6 +39,7 @@ import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.AccountStatus;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
+import org.sagebionetworks.bridge.models.accounts.EmailVerification;
 import org.sagebionetworks.bridge.models.accounts.GenericAccount;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
@@ -599,4 +600,22 @@ public class AuthenticationServiceMockTest {
     public void phoneSignInFails() {
         service.phoneSignIn(CONTEXT, SIGN_IN_WITH_PHONE);
     }
+    
+    @Test
+    public void verifyEmail() {
+        EmailVerification ev = new EmailVerification("sptoken");
+        when(accountWorkflowService.verifyEmail(ev)).thenReturn(account);
+        
+        service.verifyEmail(ev);
+        
+        verify(accountWorkflowService).verifyEmail(ev);
+        verify(accountDao).verifyEmail(account);
+    }
+    
+    @Test(expected = InvalidEntityException.class)
+    public void verifyEmailInvalid() {
+        EmailVerification ev = new EmailVerification(null);
+        service.verifyEmail(ev);
+    }
+
 }

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
@@ -493,7 +493,7 @@ public class AuthenticationServiceMockTest {
         
         service.requestResetPassword(study, signIn);
         
-        verify(accountDao).requestResetPassword(study, signIn.getAccountId());
+        verify(accountWorkflowService).requestResetPassword(study, signIn.getAccountId());
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -332,6 +332,50 @@ public class ParticipantServiceTest {
     }
     
     @Test
+    public void createParticipantEmailDisabledNoVerificationWanted() {
+        STUDY.setEmailVerificationEnabled(false);
+        mockHealthCodeAndAccountRetrieval();
+        
+        participantService.createParticipant(STUDY, CALLER_ROLES, PARTICIPANT, false);
+        
+        verify(accountWorkflowService, never()).sendEmailVerificationToken(any(), any(), any());
+        verify(account).setStatus(AccountStatus.ENABLED);
+    }
+    
+    @Test
+    public void createParticipantEmailDisabledVerificationWanted() {
+        STUDY.setEmailVerificationEnabled(false);
+        mockHealthCodeAndAccountRetrieval();
+        
+        participantService.createParticipant(STUDY, CALLER_ROLES, PARTICIPANT, true);
+        
+        verify(accountWorkflowService, never()).sendEmailVerificationToken(any(), any(), any());
+        verify(account).setStatus(AccountStatus.ENABLED);
+    }
+    
+    @Test
+    public void createParticipantEmailEnabledNoVerificationWanted() {
+        STUDY.setEmailVerificationEnabled(true);
+        mockHealthCodeAndAccountRetrieval();
+        
+        participantService.createParticipant(STUDY, CALLER_ROLES, PARTICIPANT, false);
+        
+        verify(accountWorkflowService, never()).sendEmailVerificationToken(any(), any(), any());
+        verify(account).setStatus(AccountStatus.ENABLED);
+    }
+    
+    @Test
+    public void createParticipantEmailEnabledVerificationWanted() {
+        STUDY.setEmailVerificationEnabled(true);
+        mockHealthCodeAndAccountRetrieval();
+        
+        participantService.createParticipant(STUDY, CALLER_ROLES, PARTICIPANT, true);
+        
+        verify(accountWorkflowService).sendEmailVerificationToken(any(), any(), any());
+        verify(account).setStatus(AccountStatus.UNVERIFIED);
+    }
+    
+    @Test
     public void getPagedAccountSummaries() {
         participantService.getPagedAccountSummaries(STUDY, 1100, 50, "foo", "bar", START_DATE, END_DATE);
         

--- a/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;


### PR DESCRIPTION
On an update it will be possible to add an email address (or phone number). When that happens we'll need to send the email verification email for studies that are configured to send it, and that in turn is easier if we refactor to call the AccountWorkflowService from other services, and not from the AccountDao. So this refactor does that in a first check in.