### PR TITLE
No longer require external ID validation of some kind if email verification is disabled.

### DIFF
--- a/app/org/sagebionetworks/bridge/validators/StudyValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/StudyValidator.java
@@ -144,19 +144,6 @@ public class StudyValidator implements Validator {
         validateEmails(errors, study.getConsentNotificationEmail(), "consentNotificationEmail");
         validateDataGroupNamesAndFitForSynapseExport(errors, study.getDataGroups());
         
-        // emailVerificationEnabled=true (public study):
-        //     externalIdValidationEnabled and externalIdRequiredOnSignup can vary independently
-        // emailVerificationEnabled=false:
-        //     externalIdValidationEnabled and externalIdRequiredOnSignup must both be true
-        if (!study.isEmailVerificationEnabled()) {
-            if (!study.isExternalIdRequiredOnSignup()) {
-                errors.rejectValue("externalIdRequiredOnSignup", "cannot be disabled if email verification has been disabled");
-            }
-            if (!study.isExternalIdValidationEnabled()) {
-                errors.rejectValue("externalIdValidationEnabled", "cannot be disabled if email verification has been disabled");
-            }
-        }
-        
         for (Map.Entry<String, OAuthProvider> entry : study.getOAuthProviders().entrySet()) {
             String fieldName = "oauthProviders["+entry.getKey()+"]";
             OAuthProvider provider = entry.getValue();

--- a/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
@@ -364,21 +364,21 @@ public class StudyValidatorTest {
         study.setExternalIdRequiredOnSignup(false);
         Validate.entityThrowingException(INSTANCE, study);
     }
-    
+
     @Test
-    public void nonPublicStudiesMustEnableExternalIdValdation() {
+    public void nonPublicStudiesWithoutExternalIdValdationIsValid() {
         study.setEmailVerificationEnabled(false);
         study.setExternalIdValidationEnabled(false);
-        assertValidatorMessage(INSTANCE, study, "externalIdValidationEnabled", "cannot be disabled if email verification has been disabled");
+        Validate.entityThrowingException(INSTANCE, study);
     }
     
     @Test
-    public void nonPublicStudiesMustRequireExternalIdOnSignUp() {
+    public void nonPublicStudiesWithoutExternalIdOnSignUpIsValid() {
         study.setEmailVerificationEnabled(false);
         study.setExternalIdRequiredOnSignup(false);
-        assertValidatorMessage(INSTANCE, study, "externalIdRequiredOnSignup", "cannot be disabled if email verification has been disabled");
+        Validate.entityThrowingException(INSTANCE, study);
     } 
-    
+
     @Test
     public void oauthProviderRequiresClientId() {
         OAuthProvider provider = new OAuthProvider(null, "secret", "endpoint", CALLBACK_URL);


### PR DESCRIPTION
No longer want this behavior for studies where people register and sign in using only an email address, and we have studies being configured to behave this way now.