### PR TITLE
fix UserDataDownload

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
@@ -381,9 +381,13 @@ public abstract class BaseController extends Controller {
      * Retrieves the metrics object from the cache. Can be null if the metrics is not in the cache.
      */
     Metrics getMetrics() {
-        final String requestId = RequestUtils.getRequestId(request());
-        final String cacheKey = Metrics.getCacheKey(requestId);
+        final String cacheKey = Metrics.getCacheKey(getRequestId());
         return (Metrics)Cache.get(cacheKey);
+    }
+
+    /** Helper method which abstracts away getting the request ID from the request. */
+    protected String getRequestId() {
+        return RequestUtils.getRequestId(request());
     }
 
     /** Writes the user's account ID, internal session ID, and study ID to the metrics. */

--- a/app/org/sagebionetworks/bridge/play/controllers/UserDataDownloadController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/UserDataDownloadController.java
@@ -5,10 +5,11 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import org.joda.time.LocalDate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 
-import play.mvc.BodyParser;
 import play.mvc.Result;
 
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
@@ -21,6 +22,8 @@ import org.sagebionetworks.bridge.services.UserDataDownloadService;
 /** Play controller for User Data Download requests. */
 @Controller
 public class UserDataDownloadController extends BaseController {
+    private static final Logger LOG = LoggerFactory.getLogger(UserDataDownloadController.class);
+
     private UserDataDownloadService userDataDownloadService;
 
     /** Service handler for User Data Download requests. */
@@ -33,7 +36,6 @@ public class UserDataDownloadController extends BaseController {
      * Play handler for requesting user data. User must be authenticated and consented. (Otherwise, they couldn't have
      * any data to download to begin with.)
      */
-    @BodyParser.Of(BodyParser.Empty.class)
     public Result requestUserData(String startDate, String endDate) throws JsonProcessingException {
         UserSession session = getAuthenticatedAndConsentedSession();
         StudyIdentifier studyIdentifier = session.getStudyIdentifier();
@@ -46,6 +48,7 @@ public class UserDataDownloadController extends BaseController {
         
         DateRange dateRange;
         if (isNotBlank(startDate) && isNotBlank(endDate)) {
+            LOG.warn("Deprecated UDD query param API called from request " + getRequestId());
             dateRange = new DateRange(LocalDate.parse(startDate), LocalDate.parse(endDate));
         } else {
             dateRange = parseJson(request(), DateRange.class);    

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -269,9 +269,16 @@ public class ParticipantService {
         updateAccountOptionsAndRoles(study, callerRoles, options, account, participant);
         
         boolean sendVerifyEmail = requestSendVerifyEmail && study.isEmailVerificationEnabled();
-        
-        account.setStatus(sendVerifyEmail ? AccountStatus.UNVERIFIED : AccountStatus.ENABLED);
-        
+
+        if (sendVerifyEmail) {
+            account.setStatus(AccountStatus.UNVERIFIED);
+        } else {
+            account.setStatus(AccountStatus.ENABLED);
+            if (participant.getEmail() != null) {
+                account.setEmailVerified(true);
+            }
+        }
+
         String accountId = accountDao.createAccount(study, account);
 
         externalIdService.assignExternalId(study, participant.getExternalId(), account.getHealthCode());

--- a/test/org/sagebionetworks/bridge/play/controllers/BaseControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/BaseControllerTest.java
@@ -21,6 +21,7 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.common.collect.ImmutableMap;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Test;
@@ -719,7 +720,14 @@ public class BaseControllerTest {
         assertEquals(UPLOADED_ON.withZone(MSK), info.getUploadedOn());
         assertEquals(SIGNED_IN_ON.withZone(MSK), info.getSignedInOn());
     }
-    
+
+    @Test
+    public void testGetRequestId() throws Exception {
+        mockHeader(BridgeConstants.X_REQUEST_ID_HEADER, "dummy-request-id");
+        BaseController controller = new SchedulePlanController();
+        assertEquals("dummy-request-id", controller.getRequestId());
+    }
+
     private BaseController setupForSessionTest(UserSession session) {
         BaseController controller = spy(new SchedulePlanController());
         doReturn(session).when(controller).getSessionIfItExists();
@@ -739,6 +747,7 @@ public class BaseControllerTest {
     private void mockHeader(String header, String value) throws Exception {
         Http.Request mockRequest = mock(Http.Request.class);
         when(mockRequest.getHeader(header)).thenReturn(value);
+        when(mockRequest.headers()).thenReturn(ImmutableMap.of(header, new String[] { value }));
         mockPlayContext(mockRequest);
     }
 


### PR DESCRIPTION
User Data Download was originally implemented using the HTTP request body to pass in start and end date. At some point, we added the ability to call using query parameters, then made a change that broke the HTTP request body.

Additionally, due to limitations in Swagger (can't make different APIs with the same method and URL) and Retrofit (can't send a null body), it's impossible to support both call patterns simultaneously. Since the iOS client already uses the HTTP request body, and since Android apps are only just starting development, we're going to deprecate the query params version. For now, I'm adding a log warning so we can verify that no one uses the query params before we shut it down.

Lastly, this includes a bug fix so that the admin createUser API can create users with emailVerified=true. This is necessary in order to create integ tests for User Data Download. Note that this overlaps somewhat with https://github.com/Sage-Bionetworks/BridgePF/pull/1626

Testing done:
* updated unit tests
* manually tested query param version and the log warning
* manually tested JSON body version
* integ tests for the JSON body version