### PR TITLE
require email validation; flag to suppress email verification email on sign-up

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
@@ -58,6 +58,7 @@ public final class DynamoStudy implements Study {
     private String shortName;
     private String sponsorName;
     private String identifier;
+    private boolean autoVerificationEmailSuppressed;
     private boolean studyIdExcludedInExport;
     private String supportEmail;
     private Long synapseDataAccessTeamId;
@@ -170,6 +171,18 @@ public final class DynamoStudy implements Study {
 
     public void setVersion(Long version) {
         this.version = version;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean isAutoVerificationEmailSuppressed() {
+        return autoVerificationEmailSuppressed;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setAutoVerificationEmailSuppressed(boolean autoVerificationEmailSuppressed) {
+        this.autoVerificationEmailSuppressed = autoVerificationEmailSuppressed;
     }
 
     /** {@inheritDoc} */
@@ -569,7 +582,8 @@ public final class DynamoStudy implements Study {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, shortName, sponsorName, identifier, studyIdExcludedInExport, supportEmail,
+        return Objects.hash(name, shortName, sponsorName, identifier, autoVerificationEmailSuppressed,
+                studyIdExcludedInExport, supportEmail,
                 synapseDataAccessTeamId, synapseProjectId, technicalEmail, usesCustomExportSchedule,
                 uploadMetadataFieldDefinitions, uploadValidationStrictness, consentNotificationEmail, minAgeOfConsent,
                 accountLimit, version, active, profileAttributes, taskIdentifiers, activityEventKeys, dataGroups,
@@ -588,6 +602,7 @@ public final class DynamoStudy implements Study {
         DynamoStudy other = (DynamoStudy) obj;
 
         return (Objects.equals(identifier, other.identifier)
+                && Objects.equals(autoVerificationEmailSuppressed, other.autoVerificationEmailSuppressed)
                 && Objects.equals(studyIdExcludedInExport, other.studyIdExcludedInExport)
                 && Objects.equals(supportEmail, other.supportEmail)
                 && Objects.equals(uploadMetadataFieldDefinitions, other.uploadMetadataFieldDefinitions)
@@ -631,7 +646,8 @@ public final class DynamoStudy implements Study {
     @Override
     public String toString() {
         return String.format(
-            "DynamoStudy [name=%s, shortName=%s, active=%s, sponsorName=%s, identifier=%s, minAgeOfConsent=%s, studyIdExcludedInExport=%b, "
+            "DynamoStudy [name=%s, shortName=%s, active=%s, sponsorName=%s, identifier=%s, "
+                        + "autoVerificationEmailSuppressed=%b, minAgeOfConsent=%s, studyIdExcludedInExport=%b, "
                         + "supportEmail=%s, synapseDataAccessTeamId=%s, synapseProjectId=%s, technicalEmail=%s, "
                         + "uploadValidationStrictness=%s, consentNotificationEmail=%s, version=%s, userProfileAttributes=%s, taskIdentifiers=%s, "
                         + "activityEventKeys=%s, dataGroups=%s, passwordPolicy=%s, verifyEmailTemplate=%s, "
@@ -640,7 +656,8 @@ public final class DynamoStudy implements Study {
                         + "minSupportedAppVersions=%s, usesCustomExportSchedule=%s, pushNotificationARNs=%s, installLinks=%s"
                         + "disableExport=%s, emailSignInTemplate=%s, emailSignInEnabled=%s, accountLimit=%s, oauthProviders=%s, "
                         + "appleAppLinks=%s, androidAppLinks=%s]",
-                name, shortName, active, sponsorName, identifier, minAgeOfConsent, studyIdExcludedInExport, supportEmail,
+                name, shortName, active, sponsorName, identifier, autoVerificationEmailSuppressed, minAgeOfConsent,
+                studyIdExcludedInExport, supportEmail,
                 synapseDataAccessTeamId, synapseProjectId, technicalEmail, uploadValidationStrictness, consentNotificationEmail, version,
                 profileAttributes, taskIdentifiers, activityEventKeys, dataGroups, passwordPolicy, verifyEmailTemplate,
                 resetPasswordTemplate, strictUploadValidationEnabled, healthCodeExportEnabled, emailVerificationEnabled,

--- a/app/org/sagebionetworks/bridge/models/studies/Study.java
+++ b/app/org/sagebionetworks/bridge/models/studies/Study.java
@@ -72,6 +72,16 @@ public interface Study extends BridgeEntity, StudyIdentifier {
     void setVersion(Long version);
 
     /**
+     * True if the automatic email verification email on sign-up should be suppressed. False if the email should be
+     * sent on sign-up. This is generally used in conjunction with email sign-in, where sending a separate email
+     * verification email would be redundant.
+     */
+    boolean isAutoVerificationEmailSuppressed();
+
+    /** @see #isAutoVerificationEmailSuppressed */
+    void setAutoVerificationEmailSuppressed(boolean autoVerificationEmailSuppressed);
+
+    /**
      * User must confirm that they are at least this many years old in order to
      * participate in the study. 
      */

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -284,7 +284,7 @@ public class ParticipantService {
         externalIdService.assignExternalId(study, participant.getExternalId(), account.getHealthCode());
         optionsService.setAllOptions(study.getStudyIdentifier(), account.getHealthCode(), options);
         // send verify email
-        if (sendVerifyEmail) {
+        if (sendVerifyEmail && !study.isAutoVerificationEmailSuppressed()) {
             accountWorkflowService.sendEmailVerificationToken(study, accountId, account.getEmail());
         }
         return new IdentifierHolder(accountId);

--- a/app/org/sagebionetworks/bridge/validators/StudyValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/StudyValidator.java
@@ -143,7 +143,20 @@ public class StudyValidator implements Validator {
         validateEmails(errors, study.getTechnicalEmail(), "technicalEmail");
         validateEmails(errors, study.getConsentNotificationEmail(), "consentNotificationEmail");
         validateDataGroupNamesAndFitForSynapseExport(errors, study.getDataGroups());
-        
+
+        // emailVerificationEnabled=true (public study):
+        //     externalIdValidationEnabled and externalIdRequiredOnSignup can vary independently
+        // emailVerificationEnabled=false:
+        //     externalIdValidationEnabled and externalIdRequiredOnSignup must both be true
+        if (!study.isEmailVerificationEnabled()) {
+            if (!study.isExternalIdRequiredOnSignup()) {
+                errors.rejectValue("externalIdRequiredOnSignup", "cannot be disabled if email verification has been disabled");
+            }
+            if (!study.isExternalIdValidationEnabled()) {
+                errors.rejectValue("externalIdValidationEnabled", "cannot be disabled if email verification has been disabled");
+            }
+        }
+
         // Links in installedLinks are length-constrained by SMS.
         if (!study.getInstallLinks().isEmpty()) {
             for (Map.Entry<String,String> entry : study.getInstallLinks().entrySet()) {

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -405,6 +405,7 @@ public class TestUtils {
         DynamoStudy study = new DynamoStudy();
         study.setName("Test Study ["+clazz.getSimpleName()+"]");
         study.setShortName("ShortName");
+        study.setAutoVerificationEmailSuppressed(true);
         study.setPasswordPolicy(PasswordPolicy.DEFAULT_PASSWORD_POLICY);
         study.setStudyIdExcludedInExport(true);
         study.setVerifyEmailTemplate(new EmailTemplate("verifyEmail subject", "body with ${url}", MimeType.TEXT));

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
@@ -88,7 +88,8 @@ public class DynamoStudyTest {
         study.setAppleAppLinks(APPLE_APP_LINKS);
 
         final JsonNode node = BridgeObjectMapper.get().valueToTree(study);
-        
+
+        assertTrue(node.get("autoVerificationEmailSuppressed").booleanValue());
         assertEqualsAndNotNull(study.getConsentNotificationEmail(), node.get("consentNotificationEmail").asText());
         assertTrue(node.get("studyIdExcludedInExport").booleanValue());
         assertEqualsAndNotNull(study.getSupportEmail(), node.get("supportEmail").asText());

--- a/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
@@ -367,17 +367,19 @@ public class StudyValidatorTest {
     }
 
     @Test
-    public void nonPublicStudiesWithoutExternalIdValdationIsValid() {
+    public void nonPublicStudiesMustEnableExternalIdValdation() {
         study.setEmailVerificationEnabled(false);
         study.setExternalIdValidationEnabled(false);
-        Validate.entityThrowingException(INSTANCE, study);
+        assertValidatorMessage(INSTANCE, study, "externalIdValidationEnabled",
+                "cannot be disabled if email verification has been disabled");
     }
     
     @Test
-    public void nonPublicStudiesWithoutExternalIdOnSignUpIsValid() {
+    public void nonPublicStudiesMustRequireExternalIdOnSignUp() {
         study.setEmailVerificationEnabled(false);
         study.setExternalIdRequiredOnSignup(false);
-        Validate.entityThrowingException(INSTANCE, study);
+        assertValidatorMessage(INSTANCE, study, "externalIdRequiredOnSignup",
+                "cannot be disabled if email verification has been disabled");
     } 
 
     @Test


### PR DESCRIPTION
Studies using email sign-in shouldn't disable email verification, as this removes the server-side check to prevent email bounces. Instead,we introduce a flag to separately suppress the email verification email.

This also reverts https://github.com/Sage-Bionetworks/BridgePF/pull/1624

Testing done:
* unit tests
* manually tested the email sign-in scenario both with and without the flag and verified that (a) email sign-in works and (b) email sign-in automatically verifies the email on first sign-in