### PR TITLE
Do not store healthCode in the SNS registration, it can generate an unlikely error where a phone is used between two users.

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoNotificationRegistrationDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoNotificationRegistrationDao.java
@@ -33,7 +33,6 @@ import com.google.common.collect.Maps;
 @Component
 public class DynamoNotificationRegistrationDao implements NotificationRegistrationDao {
 
-    private static final String CUSTOM_USER_DATA = "CustomUserData";
     private static final String ENABLED = "Enabled";
     private static final String TOKEN = "Token";
 
@@ -94,7 +93,6 @@ public class DynamoNotificationRegistrationDao implements NotificationRegistrati
         // (If the client is submitting same data a second time, SNS quietly ignores it, returns same endpointARN.) 
         CreatePlatformEndpointRequest request = new CreatePlatformEndpointRequest()
                 .withToken(registration.getDeviceId())
-                .withCustomUserData(registration.getHealthCode())
                 .withPlatformApplicationArn(platformARN);
         CreatePlatformEndpointResult result = snsClient.createPlatformEndpoint(request);
         
@@ -186,7 +184,6 @@ public class DynamoNotificationRegistrationDao implements NotificationRegistrati
         SetEndpointAttributesRequest attrRequest = new SetEndpointAttributesRequest();
         attrRequest.addAttributesEntry(TOKEN, deviceToken);
         attrRequest.addAttributesEntry(ENABLED, Boolean.TRUE.toString());
-        attrRequest.addAttributesEntry(CUSTOM_USER_DATA, healthCode);
         snsClient.setEndpointAttributes(attrRequest);
     }
 }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoNotificationRegistrationDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoNotificationRegistrationDaoTest.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge.dynamodb;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -150,7 +151,7 @@ public class DynamoNotificationRegistrationDaoTest {
         CreatePlatformEndpointRequest snsRequest = createPlatformEndpointRequestCaptor.getValue();
         assertEquals(PLATFORM_ARN, snsRequest.getPlatformApplicationArn());
         assertEquals(DEVICE_ID, snsRequest.getToken());
-        assertEquals(HEALTH_CODE, snsRequest.getCustomUserData());
+        assertNull(snsRequest.getCustomUserData());
         
         assertNotNull(result.getGuid());
         assertNotEquals(GUID, result.getGuid());
@@ -257,7 +258,7 @@ public class DynamoNotificationRegistrationDaoTest {
         Map<String,String> attributes = request.getAttributes();
         assertEquals(DEVICE_ID, attributes.get("Token"));
         assertEquals("true", attributes.get("Enabled"));
-        assertEquals(HEALTH_CODE, attributes.get("CustomUserData"));
+        assertNull(attributes.get("CustomUserData"));
         
         verify(mockMapper).save(notificationRegistrationCaptor.capture());
         NotificationRegistration persisted = notificationRegistrationCaptor.getValue();


### PR DESCRIPTION
Addresses BRIDGE-2084

Invalid parameter: Token Reason: Endpoint arn:aws:sns:us-east-1:649232250620:endpoint/APNS_SANDBOX/ios-sdk-int-tests/fec2fffa-93cd-34de-81b5-43ac908f445c already exists with the same Token, but different attributes."

The different attribute is the healthCode of the prior user when someone creates a new account on the same phone. We don't actually need the healthCode in the registration, it was just to aid troubleshooting, so we can remove it to avoid this error.