### PR TITLE
Show an error if the email sign in URL isn't captured by the phone.

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/ApplicationController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ApplicationController.java
@@ -51,7 +51,7 @@ public class ApplicationController extends BaseController {
     public Result verifyEmail(String studyId) {
         Study study = studyService.getStudy(studyId);
         return ok(views.html.verifyEmail.render(ASSETS_HOST, ASSETS_BUILD,
-                StringEscapeUtils.escapeHtml4(study.getName()), study.getSupportEmail()));
+                StringEscapeUtils.escapeHtml4(study.getName()), study.getSupportEmail(), study.getIdentifier()));
     }
 
     public Result resetPassword(String studyId) {
@@ -59,17 +59,18 @@ public class ApplicationController extends BaseController {
         String passwordDescription = BridgeUtils.passwordPolicyDescription(study.getPasswordPolicy());
         return ok(views.html.resetPassword.render(ASSETS_HOST, ASSETS_BUILD,
             StringEscapeUtils.escapeHtml4(study.getName()), study.getSupportEmail(), 
-            passwordDescription));
+            passwordDescription, study.getIdentifier()));
     }
     
+    /**
+     * If this page is loaded, it is because the mobile client did not intercept the 
+     * email sign in link. Change the behavior here so that instead of authenticating the user, 
+     * this simple shows an error message and keeps the link valid so the user can try again 
+     * on a phone.
+     */
     public Result startSession(String studyId, String email, String token) {
-        SignIn signIn = new SignIn.Builder().withStudy(studyId).withEmail(email).withToken(token).build();
-        
-        StudyIdentifier studyIdentifier = new StudyIdentifierImpl(studyId);
-        CriteriaContext context = getCriteriaContext(studyIdentifier);
-        UserSession session = authenticationService.emailSignIn(context, signIn);
-        
-        return okResult(UserSessionInfo.toJSON(session));
+        Study study = studyService.getStudy(studyId);
+        return ok(views.html.startSession.render(ASSETS_HOST, ASSETS_BUILD, study.getName(), study.getIdentifier()));
     }
     
     public Result androidAppLinks() throws Exception {

--- a/app/org/sagebionetworks/bridge/play/controllers/ApplicationController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ApplicationController.java
@@ -64,9 +64,8 @@ public class ApplicationController extends BaseController {
     
     /**
      * If this page is loaded, it is because the mobile client did not intercept the 
-     * email sign in link. Change the behavior here so that instead of authenticating the user, 
-     * this simple shows an error message and keeps the link valid so the user can try again 
-     * on a phone.
+     * email sign in link. Show an error message and keeps the link valid so the user 
+     * can try again on a phone.
      */
     public Result startSession(String studyId, String email, String token) {
         Study study = studyService.getStudy(studyId);

--- a/app/views/resetPassword.scala.html
+++ b/app/views/resetPassword.scala.html
@@ -1,4 +1,4 @@
-@(assetsHost: String, assetsBuild: String, studyName: String, studySupportEmail: String, passwordDescription: String)
+@(assetsHost: String, assetsBuild: String, studyName: String, studySupportEmail: String, passwordDescription: String, studyId: String)
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -13,7 +13,10 @@
     <link href="//@assetsHost/mobile/styles/mobile.css" type="text/css" rel="stylesheet"/>
 </head>
 <body>
-<div class="logo_box"><img id="logo" onerror="this.style.visibility='hidden'"/></div>
+<div class="logo_box">
+    <img id="logo" onerror="this.style.display='none'"
+    	    src="//@assetsHost/mobile/images/@{studyId}.svg">
+</div>
 <div class="form_box" id="resetPasswordSection">
 	<form method="post">
 		<div>

--- a/app/views/startSession.scala.html
+++ b/app/views/startSession.scala.html
@@ -1,0 +1,27 @@
+@(assetsHost: String, assetsBuild: String, studyName: String, studyId: String)
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>@studyName Sign In Error</title>
+    <script>
+        window.assetsHost = "@assetsHost";
+    </script>
+    <link href="//@assetsHost/mobile/styles/normalize.css" type="text/css" rel="stylesheet"/>
+    <link href="//@assetsHost/mobile/styles/skeleton.css" type="text/css" rel="stylesheet"/>
+    <link href="//@assetsHost/mobile/styles/mobile.css" type="text/css" rel="stylesheet"/>
+</head>
+<body>
+<div class="logo_box">
+    <img id="logo" onerror="this.style.display='none'"
+    	    src="//@assetsHost/mobile/images/@{studyId}.svg">
+</div>
+<div class="form_box">
+	<h3>Please try again on your phone</h3>
+	
+	<p>In order to sign in to @studyName, open the sign in email on your phone, 
+		and click the link again to sign in through the app. </p>
+</div>
+</body>
+</html>

--- a/app/views/verifyEmail.scala.html
+++ b/app/views/verifyEmail.scala.html
@@ -1,4 +1,4 @@
-@(assetsHost: String, assetsBuild: String, studyName: String, studySupportEmail: String)
+@(assetsHost: String, assetsBuild: String, studyName: String, studySupportEmail: String, studyId: String)
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -12,8 +12,10 @@
     <link href="//@assetsHost/mobile/styles/mobile.css" type="text/css" rel="stylesheet"/>
 </head>
 <body>
-
-<div class="logo_box"><img id="logo" onerror="this.style.visibility='hidden'"/></div>
+<div class="logo_box">
+    <img id="logo" onerror="this.style.display='none'"
+    	    src="//@assetsHost/mobile/images/@{studyId}.svg">
+</div>
 <div class="message" id="m1">Verifying...</div>
 <div class="message" id="m2"></div>
 
@@ -24,10 +26,6 @@ location.search.substr(1).split("&").forEach(function(item) {
 	var k = item.split("=")[0], v = decodeURIComponent(item.split("=")[1]); 
 	params[k] = v;
 });
-
-setTimeout(function() {
-    $("#logo").attr("src", "//" + window.assetsHost + "/mobile/images/"+params.study+".svg");
-}, 1);
 
 function success() {
     $("#m1").text("Your email address has now been verified.");

--- a/test/org/sagebionetworks/bridge/play/controllers/ApplicationControllerMockTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ApplicationControllerMockTest.java
@@ -120,19 +120,10 @@ public class ApplicationControllerMockTest {
         
         Result result = controller.startSession("test-study", "email", "token");
 
-        TestUtils.assertResult(result, 200);
-        verify(authenticationService).emailSignIn(contextCaptor.capture(), signInCaptor.capture());
+        assertEquals("text/html; charset=utf-8", result.header("Content-Type"));
+        assertEquals(200, result.status());
         
-        JsonNode node = BridgeObjectMapper.get().readTree(Helpers.contentAsString(result));
-        assertEquals("UserSessionInfo", node.get("type").asText());
-        assertEquals("ABC", node.get("sessionToken").asText());
-
-        CriteriaContext context = contextCaptor.getValue();
-        assertEquals("en", context.getLanguages().iterator().next());
-
-        SignIn signIn = signInCaptor.getValue();
-        assertEquals("email", signIn.getEmail());
-        assertEquals("token", signIn.getToken());
+        assertTrue(Helpers.contentAsString(result).contains("Please try again on your phone"));
     }
     
     @Test


### PR DESCRIPTION
Instead of consuming the token and returning JSON, this now shows an error page if the URL is not captured by the phone, explaining that the user should try again on their phone.