### PR TITLE
Ensuring Android can specify a study-specific path so apps don't clash on the device.

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -4,6 +4,7 @@ GET    /index.html                             @org.sagebionetworks.bridge.play.
 GET    /mobile/verifyEmail.html                @org.sagebionetworks.bridge.play.controllers.ApplicationController.verifyEmail(study: String ?= "api")
 GET    /mobile/resetPassword.html              @org.sagebionetworks.bridge.play.controllers.ApplicationController.resetPassword(study: String ?= "api")
 GET    /mobile/startSession.html               @org.sagebionetworks.bridge.play.controllers.ApplicationController.startSession(study: String ?= null, email: String ?= null, token: String ?= null)
+GET    /mobile/:study/startSession.html        @org.sagebionetworks.bridge.play.controllers.ApplicationController.startSession(study: String, email: String ?= null, token: String ?= null)
 GET    /.well-known/assetlinks.json            @org.sagebionetworks.bridge.play.controllers.ApplicationController.androidAppLinks
 GET    /.well-known/apple-app-site-association @org.sagebionetworks.bridge.play.controllers.ApplicationController.appleAppLinks
 


### PR DESCRIPTION
PLEASE UPDATE CODE TO USE THIS PATH. Otherwise down the road, apps will conflict trying to intercept an email sign in link on the phone. Best case scenario, the user gets a dialog to choose the application, but that would be confusing.