### PR TITLE
Increase the allowed size of client data on scheduled activities.

### DIFF
--- a/app/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/app/org/sagebionetworks/bridge/BridgeConstants.java
@@ -50,7 +50,7 @@ public class BridgeConstants {
     public static final String X_FORWARDED_FOR_HEADER = "X-Forwarded-For";
 
     /** Limit the total length of JSON string that is submitted as client data for a scheduled activity. */
-    public static final int CLIENT_DATA_MAX_BYTES = 2048;
+    public static final int CLIENT_DATA_MAX_BYTES = 8192;
 
     /** Used to cap the number of dupe records we fetch from DDB and the number of log messages we write. */
     public static final int DUPE_RECORDS_MAX_COUNT = 10;

--- a/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceMockTest.java
@@ -336,7 +336,7 @@ public class ScheduledActivityServiceMockTest {
     public void activityListsWithTooLargeClientDataRejected() throws Exception {
         JsonNode node = TestUtils.getClientData();
         ArrayNode array = JsonNodeFactory.instance.arrayNode();
-        for (int i=0; i < 35; i++) {
+        for (int i=0; i < 140; i++) {
             array.add(node);
         }
         


### PR DESCRIPTION
Not 50k, more like 8k. Do we need to store/load this data via S3? Or can we continue along with this if it's only a study or two, and a higher DDB throughput?