### PR TITLE
Minor addition: add study short name so it's available to templates (SMS will use it).

### DIFF
--- a/app/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/app/org/sagebionetworks/bridge/BridgeUtils.java
@@ -43,9 +43,9 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.newrelic.agent.deps.com.google.common.collect.Iterables;
 
 public class BridgeUtils {
     

--- a/app/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/app/org/sagebionetworks/bridge/BridgeUtils.java
@@ -45,6 +45,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.newrelic.agent.deps.com.google.common.collect.Iterables;
 
 public class BridgeUtils {
     
@@ -74,9 +75,12 @@ public class BridgeUtils {
         map.put("studyShortName", study.getShortName());
         map.put("studyId", study.getIdentifier());
         map.put("sponsorName", study.getSponsorName());
-        map.put("supportEmail", study.getSupportEmail());
-        map.put("technicalEmail", study.getTechnicalEmail());
-        map.put("consentEmail", study.getConsentNotificationEmail());
+        map.put("supportEmail", 
+                Iterables.getFirst(commaListToOrderedSet(study.getSupportEmail()), ""));
+        map.put("technicalEmail", 
+                Iterables.getFirst(commaListToOrderedSet(study.getTechnicalEmail()), ""));
+        map.put("consentEmail", 
+                Iterables.getFirst(commaListToOrderedSet(study.getConsentNotificationEmail()), ""));
         if (escaper != null) {
             for (Map.Entry<String,String> entry : map.entrySet()) {
                 map.put(entry.getKey(), escaper.apply(entry.getValue()));

--- a/app/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/app/org/sagebionetworks/bridge/BridgeUtils.java
@@ -60,6 +60,7 @@ public class BridgeUtils {
      * a study that used in most of our templates. The map is mutable. Variables include:
      * <ul>
      *  <li>studyName = study.getName()</li>
+     *  <li>studyShortName = study.getShortName()</li>
      *  <li>studyId = study.getIdentifier()</li>
      *  <li>sponsorName = study.getSponsorName()</li>
      *  <li>supportEmail = study.getSupportEmail()</li>
@@ -70,6 +71,7 @@ public class BridgeUtils {
     public static Map<String,String> studyTemplateVariables(Study study, Function<String,String> escaper) {
         Map<String,String> map = Maps.newHashMap();
         map.put("studyName", study.getName());
+        map.put("studyShortName", study.getShortName());
         map.put("studyId", study.getIdentifier());
         map.put("sponsorName", study.getSponsorName());
         map.put("supportEmail", study.getSupportEmail());

--- a/test/org/sagebionetworks/bridge/BridgeUtilsTest.java
+++ b/test/org/sagebionetworks/bridge/BridgeUtilsTest.java
@@ -37,6 +37,7 @@ public class BridgeUtilsTest {
     public void studyTemplateVariblesWorks() {
         Study study = Study.create();
         study.setName("name1");
+        study.setShortName("shortName");
         study.setIdentifier("identifier1");
         study.setSponsorName("sponsorName1");
         study.setSupportEmail("supportEmail1");
@@ -49,6 +50,7 @@ public class BridgeUtilsTest {
         map.put("thisMap", "isMutable");
         
         assertEquals("name2", map.get("studyName"));
+        assertEquals("shortName", map.get("studyShortName"));
         assertEquals("identifier2", map.get("studyId"));
         assertEquals("sponsorName2", map.get("sponsorName"));
         assertEquals("supportEmail2", map.get("supportEmail"));

--- a/test/org/sagebionetworks/bridge/services/email/BasicEmailProviderTest.java
+++ b/test/org/sagebionetworks/bridge/services/email/BasicEmailProviderTest.java
@@ -18,9 +18,10 @@ public class BasicEmailProviderTest {
     public void test() throws Exception {
         Study study = Study.create();
         study.setName("Study Name");
+        study.setShortName("ShortName");
         study.setSupportEmail("email@email.com,email2@email.com");
         
-        EmailTemplate template = new EmailTemplate("Subject ${url}", "Body ${url}", MimeType.HTML); 
+        EmailTemplate template = new EmailTemplate("Subject ${url}", "Body ${studyShortName} ${url}", MimeType.HTML);
         
         BasicEmailProvider provider = new BasicEmailProvider.Builder()
             .withStudy(study)
@@ -37,6 +38,6 @@ public class BasicEmailProviderTest {
         MimeBodyPart body = email.getMessageParts().get(0);
         
         String bodyString = (String)body.getContent();
-        assertEquals("Body some-url", bodyString);
+        assertEquals("Body ShortName some-url", bodyString);
     }
 }

--- a/test/org/sagebionetworks/bridge/services/email/BasicEmailProviderTest.java
+++ b/test/org/sagebionetworks/bridge/services/email/BasicEmailProviderTest.java
@@ -17,11 +17,18 @@ public class BasicEmailProviderTest {
     @Test
     public void test() throws Exception {
         Study study = Study.create();
-        study.setName("Study Name");
-        study.setShortName("ShortName");
-        study.setSupportEmail("email@email.com,email2@email.com");
         
-        EmailTemplate template = new EmailTemplate("Subject ${url}", "Body ${studyShortName} ${url}", MimeType.HTML);
+        study.setName("Name");
+        study.setShortName("ShortName");
+        study.setIdentifier("id");
+        study.setSponsorName("SponsorName");
+        study.setSupportEmail("support@email.com");
+        study.setTechnicalEmail("tech@email.com");
+        study.setConsentNotificationEmail("consent@email.com,consent2@email.com");
+        
+        EmailTemplate template = new EmailTemplate("Subject ${url}", 
+            "${studyName} ${studyShortName} ${studyId} ${sponsorName} ${supportEmail} "+
+            "${technicalEmail} ${consentEmail} ${url}", MimeType.HTML);
         
         BasicEmailProvider provider = new BasicEmailProvider.Builder()
             .withStudy(study)
@@ -32,12 +39,13 @@ public class BasicEmailProviderTest {
         
         MimeTypeEmail email = provider.getMimeTypeEmail();
         assertEquals("Subject some-url", email.getSubject());
-        assertEquals("\"Study Name\" <email@email.com>", email.getSenderAddress());
+        assertEquals("\"Name\" <support@email.com>", email.getSenderAddress());
         assertEquals(Sets.newHashSet("recipient@recipient.com", "recipient2@recipient.com"),
                 Sets.newHashSet(email.getRecipientAddresses()));
         MimeBodyPart body = email.getMessageParts().get(0);
         
         String bodyString = (String)body.getContent();
-        assertEquals("Body ShortName some-url", bodyString);
+        assertEquals("Name ShortName id SponsorName support@email.com tech@email.com consent@email.com some-url", 
+                bodyString);
     }
 }


### PR DESCRIPTION
Also, study email fields can contain comma-separated lists of emails. Parse those so they are substituted into templates nicely.