### PR TITLE
remove query params from User Data Download

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/UserDataDownloadController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/UserDataDownloadController.java
@@ -1,12 +1,7 @@
 package org.sagebionetworks.bridge.play.controllers;
 
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 
-import org.joda.time.LocalDate;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 
@@ -22,8 +17,6 @@ import org.sagebionetworks.bridge.services.UserDataDownloadService;
 /** Play controller for User Data Download requests. */
 @Controller
 public class UserDataDownloadController extends BaseController {
-    private static final Logger LOG = LoggerFactory.getLogger(UserDataDownloadController.class);
-
     private UserDataDownloadService userDataDownloadService;
 
     /** Service handler for User Data Download requests. */
@@ -36,7 +29,7 @@ public class UserDataDownloadController extends BaseController {
      * Play handler for requesting user data. User must be authenticated and consented. (Otherwise, they couldn't have
      * any data to download to begin with.)
      */
-    public Result requestUserData(String startDate, String endDate) throws JsonProcessingException {
+    public Result requestUserData() throws JsonProcessingException {
         UserSession session = getAuthenticatedAndConsentedSession();
         StudyIdentifier studyIdentifier = session.getStudyIdentifier();
         
@@ -45,14 +38,8 @@ public class UserDataDownloadController extends BaseController {
         if (participant.getEmail() == null || participant.getEmailVerified() != Boolean.TRUE) {
             throw new BadRequestException("Cannot request user data, account has no verified email address.");
         }
-        
-        DateRange dateRange;
-        if (isNotBlank(startDate) && isNotBlank(endDate)) {
-            LOG.warn("Deprecated UDD query param API called from request " + getRequestId());
-            dateRange = new DateRange(LocalDate.parse(startDate), LocalDate.parse(endDate));
-        } else {
-            dateRange = parseJson(request(), DateRange.class);    
-        }
+
+        DateRange dateRange = parseJson(request(), DateRange.class);
         userDataDownloadService.requestUserData(studyIdentifier, session.getParticipant().getId(), dateRange);
         return acceptedResult("Request submitted.");
     }

--- a/conf/routes
+++ b/conf/routes
@@ -46,7 +46,7 @@ DELETE /v3/users/:userId                  @org.sagebionetworks.bridge.play.contr
 GET    /v3/users/self                     @org.sagebionetworks.bridge.play.controllers.UserProfileController.getUserProfile
 POST   /v3/users/self                     @org.sagebionetworks.bridge.play.controllers.UserProfileController.updateUserProfile
 POST   /v3/users/self/externalId          @org.sagebionetworks.bridge.play.controllers.UserProfileController.createExternalIdentifier
-POST   /v3/users/self/emailData           @org.sagebionetworks.bridge.play.controllers.UserDataDownloadController.requestUserData(startDate: String ?= null, endDate: String ?= null)
+POST   /v3/users/self/emailData           @org.sagebionetworks.bridge.play.controllers.UserDataDownloadController.requestUserData
 GET    /v3/users/self/unsubscribeEmail    @org.sagebionetworks.bridge.play.controllers.EmailController.unsubscribeFromEmail
 POST   /v3/users/self/unsubscribeEmail    @org.sagebionetworks.bridge.play.controllers.EmailController.unsubscribeFromEmail
 POST   /v3/users/self/dataSharing         @org.sagebionetworks.bridge.play.controllers.ConsentController.changeSharingScope

--- a/test/org/sagebionetworks/bridge/play/controllers/UserDataDownloadControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/UserDataDownloadControllerTest.java
@@ -61,7 +61,7 @@ public class UserDataDownloadControllerTest {
         mockWithJson();
 
         // execute and validate
-        Result result = controller.requestUserData(null, null);
+        Result result = controller.requestUserData();
         TestUtils.assertResult(result, 202);
 
         verify(mockService).requestUserData(eq(STUDY_ID), eq(USER_ID), dateRangeCaptor.capture());
@@ -71,31 +71,14 @@ public class UserDataDownloadControllerTest {
         assertEquals("2015-08-15", dateRange.getStartDate().toString());
         assertEquals("2015-08-19", dateRange.getEndDate().toString());
     }
-    
-    @Test
-    public void testQueryParameters() throws Exception {
-        StudyParticipant participant = new StudyParticipant.Builder().withId(USER_ID).withEmail(EMAIL)
-                .withEmailVerified(Boolean.TRUE).build();
-        doReturn(participant).when(mockSession).getParticipant();
-        
-        Result result = controller.requestUserData("2015-08-15", "2015-08-19");
-        TestUtils.assertResult(result, 202);
 
-        verify(mockService).requestUserData(eq(STUDY_ID), eq(USER_ID), dateRangeCaptor.capture());
-        
-        // validate args sent to mock service
-        DateRange dateRange = dateRangeCaptor.getValue();
-        assertEquals("2015-08-15", dateRange.getStartDate().toString());
-        assertEquals("2015-08-19", dateRange.getEndDate().toString());
-    }
-    
     @Test(expected = BadRequestException.class)
     public void throwExceptionIfAccountHasNoEmail() throws Exception {
         StudyParticipant participant = new StudyParticipant.Builder().withId(USER_ID).build();
         doReturn(participant).when(mockSession).getParticipant();
         mockWithJson();
 
-        controller.requestUserData(null, null);
+        controller.requestUserData();
     }
     
     @Test(expected = BadRequestException.class)
@@ -105,7 +88,7 @@ public class UserDataDownloadControllerTest {
         doReturn(participant).when(mockSession).getParticipant();
         mockWithJson();
 
-        controller.requestUserData(null, null);
+        controller.requestUserData();
     }
 
     private void mockWithJson() throws Exception {


### PR DESCRIPTION
UDD API currently accepts both JSON body and query params. However, this is not testable. See https://github.com/Sage-Bionetworks/BridgePF/pull/1632 for details.

I've confirmed that in the last 2 weeks, we've only had 1 caller using query params, and this was a test request through the browser. As such, I believe it's safe to delete the query params from this API.

Testing done:
* updated unit tests
* ran UserDataDownloadTest in Integ Tests (which only tests that the API succeeds
* manually tested UDD to test the feature end-to-end