### PR TITLE
add elapsed milliseconds to MetricsInterceptor

### DIFF
--- a/app/org/sagebionetworks/bridge/json/JsonUtils.java
+++ b/app/org/sagebionetworks/bridge/json/JsonUtils.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
+import org.joda.time.DateTime;
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.models.surveys.Constraints;
@@ -32,6 +34,22 @@ public class JsonUtils {
     private static final String MULTIVALUE_PROPERTY = "multivalue";
     public static final TypeReference<Map<String, Object>> TYPE_REF_RAW_MAP =
             new TypeReference<Map<String, Object>>(){};
+
+    /**
+     * Parses a JSON String value in ISO8601 format as a Joda DateTime. Returns null if the value is not a valid
+     * ISO8601 date-time.
+     */
+    public static DateTime asDateTime(JsonNode parent, String property) {
+        String dateTimeStr = asText(parent, property);
+        if (StringUtils.isBlank(dateTimeStr)) {
+            return null;
+        }
+        try {
+            return DateTime.parse(dateTimeStr);
+        } catch (IllegalArgumentException ex) {
+            return null;
+        }
+    }
 
     public static String asText(JsonNode parent, String property) {
         if (parent != null && parent.hasNonNull(property)) {

--- a/app/org/sagebionetworks/bridge/models/Metrics.java
+++ b/app/org/sagebionetworks/bridge/models/Metrics.java
@@ -3,10 +3,12 @@ package org.sagebionetworks.bridge.models;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
+import org.joda.time.DateTime;
 import org.sagebionetworks.bridge.json.DateUtils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.sagebionetworks.bridge.json.JsonUtils;
 
 /**
  * Request-scoped metrics.
@@ -50,7 +52,18 @@ public class Metrics {
     }
 
     public void end() {
-        json.put("end", DateUtils.getCurrentISODateTime());
+        // Log endTime
+        DateTime endDateTime = DateUtils.getCurrentDateTime();
+        json.put("end", endDateTime.toString());
+
+        // Calculate elapsed time.
+        DateTime startDateTime = JsonUtils.asDateTime(json, "start");
+        if (startDateTime == null) {
+            // This should not be possible, but if it happens, don't throw an NPE.
+            return;
+        }
+        long elapsedMillis = endDateTime.getMillis() - startDateTime.getMillis();
+        json.put("elapsedMillis", elapsedMillis);
     }
 
     /** Record ID, used for synchronous health data submission API. */

--- a/test/org/sagebionetworks/bridge/json/JsonUtilsTest.java
+++ b/test/org/sagebionetworks/bridge/json/JsonUtilsTest.java
@@ -1,9 +1,6 @@
 package org.sagebionetworks.bridge.json;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.Roles.TEST_USERS;
@@ -34,7 +31,34 @@ public class JsonUtilsTest {
     private String esc(String string) {
         return string.replaceAll("'", "\"");
     }
-    
+
+    @Test
+    public void asDateTime() throws Exception {
+        String expectedDateTimeStr = "2018-02-16T17:14:05.520-08:00";
+
+        // Set up test cases
+        String jsonText = "{\n" +
+                "   \"json-null\":null,\n" +
+                "   \"empty-string\":\"\",\n" +
+                "   \"blank-string\":\"   \",\n" +
+                "   \"bad-format\":\"February 16, 2018 2 5:14pm\",\n" +
+                "   \"success-with-time-zone\":\"" + expectedDateTimeStr + "\"\n" +
+                "}";
+        JsonNode node = mapper.readTree(jsonText);
+
+        // Null cases
+        assertNull(JsonUtils.asDateTime(node, "no-value"));
+        assertNull(JsonUtils.asDateTime(node, "json-null"));
+        assertNull(JsonUtils.asDateTime(node, "empty-string"));
+        assertNull(JsonUtils.asDateTime(node, "blank-string"));
+        assertNull(JsonUtils.asDateTime(node, "bad-format"));
+
+        // Success case
+        DateTime dateTime = JsonUtils.asDateTime(node, "success-with-time-zone");
+        assertNotNull(dateTime);
+        assertEquals(expectedDateTimeStr, dateTime.toString());
+    }
+
     @Test
     public void asText() throws Exception {
         JsonNode node = mapper.readTree(esc("{'key':'value'}"));


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-2073

Adds elapsed milliseconds to MetricsInterceptor to make it easier to analyze timing on requests.

Testing done:
* unit tests
* manual tests - Simple sign-in, sign-out and verify timing in the logs.