### PR TITLE
Joda thinks there are 18 years between Feb 29 2000 and Feb 28 2018

### DIFF
--- a/test/org/sagebionetworks/bridge/services/ConsentServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ConsentServiceTest.java
@@ -205,8 +205,8 @@ public class ConsentServiceTest {
     public void cannotConsentIfTooYoung() {
         LocalDate now = LocalDate.now();
         LocalDate today18YearsAgo = now.minusYears(18);
-        LocalDate yesterday18YearsAgo = today18YearsAgo.minusDays(1);
-        LocalDate tomorrow18YearsAgo = today18YearsAgo.plusDays(1);
+        LocalDate yesterday18YearsAgo = today18YearsAgo.minusDays(2);
+        LocalDate tomorrow18YearsAgo = today18YearsAgo.plusDays(2);
         SharingScope sharingScope = SharingScope.NO_SHARING;
 
         // This will work
@@ -308,7 +308,7 @@ public class ConsentServiceTest {
         assertEquals(consent.getSignedOn(), historicalSignature.getSignedOn());
         
         assertNull(account.getActiveConsentSignature(defaultSubpopulation.getGuid()));
-        
+
         long newSignedOn = DateTime.now().getMillis();
         consent = new ConsentSignature.Builder().withConsentSignature(consent).withSignedOn(newSignedOn).build();
         consentService.consentToResearch(testUser.getStudy(), defaultSubpopulation.getGuid(), testUser.getStudyParticipant(), consent,


### PR DESCRIPTION
An unusual leap year bug on a non-leap year day. Debugging suggests that Joda thinks there are 18 years between Feb 29 2000 and Feb 28 2018. (Also, there are 18 years between Feb 28 2000 and Feb 28 2018, and 18 years 1 day between Feb 27 2000 and Feb 28 2018.) This causes one of our unit tests to fail.

Just to unblock builds that will be happening tomorrow, I'm temporarily setting the test to use a 2-day difference instead of a 1-day difference. Filing JIRA https://sagebionetworks.jira.com/browse/BRIDGE-2136 for long-term tracking, if we decide we want to fix it before 2020.

Testing done:
* Mock unit tests so that "now" is on Feb 28. Verified that original tests fail.
* Update tests to use a 2-day difference. Unit tests now succeed.
* Verified that the test works for all days between Feb 26 and Mar 3.