### PR TITLE
Adding support for shorter URLs to be included in emails and more importantly, SMS messages.

### DIFF
--- a/app/org/sagebionetworks/bridge/services/StudyService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyService.java
@@ -85,12 +85,14 @@ public class StudyService {
     private static final String BASE_URL = BridgeConfigFactory.getConfig().get("webservices.url");
     static final String CONFIG_KEY_SUPPORT_EMAIL_PLAIN = "support.email.plain";
     private static final String VERIFY_STUDY_EMAIL_URL = "%s/mobile/verifyStudyEmail.html?study=%s&token=%s&type=%s";
+    private static final String SHORT_VERIFY_STUDY_EMAIL_URL = "%s/vse?study=%s&token=%s&type=%s";
     static final int VERIFY_STUDY_EMAIL_EXPIRE_IN_SECONDS = 60*60*24;
     static final String EXPORTER_SYNAPSE_USER_ID = BridgeConfigFactory.getConfig().getExporterSynapseId(); // copy-paste from website
     static final String SYNAPSE_REGISTER_END_POINT = "https://www.synapse.org/#!NewAccount:";
     private static final String STUDY_PROPERTY = "Study";
     private static final String TYPE_PROPERTY = "type";
     private static final String URL_TOKEN = "url";
+    private static final String SHORT_URL_TOKEN = "shortUrl";
     private static final String IDENTIFIER_PROPERTY = "identifier";
     private final Set<String> studyWhitelist = Collections.unmodifiableSet(new HashSet<>(
             BridgeConfigFactory.getConfig().getPropertyAsList("study.whitelist")));
@@ -761,13 +763,14 @@ public class StudyService {
         // Create and send verification email.
         String studyId = BridgeUtils.encodeURIComponent(study.getIdentifier());
         String url = String.format(VERIFY_STUDY_EMAIL_URL, BASE_URL, studyId, token, type.toString().toLowerCase());
-
+        String shortUrl = String.format(SHORT_VERIFY_STUDY_EMAIL_URL, BASE_URL, studyId, token, type.toString().toLowerCase());
+        
         EmailTemplate template = new EmailTemplate(studyEmailVerificationTemplateSubject,
                 studyEmailVerificationTemplate, MimeType.HTML);
 
         BasicEmailProvider provider = new BasicEmailProvider.Builder().withStudy(study).withEmailTemplate(template)
                 .withOverrideSenderEmail(bridgeSupportEmailPlain).withRecipientEmail(email).withToken(URL_TOKEN, url)
-                .build();
+                .withToken(SHORT_URL_TOKEN, shortUrl).build();
         sendMailService.sendEmail(provider);
     }
 

--- a/app/org/sagebionetworks/bridge/services/email/BasicEmailProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/BasicEmailProvider.java
@@ -59,7 +59,7 @@ public class BasicEmailProvider extends MimeTypeEmailProvider {
     @Override
     public MimeTypeEmail getMimeTypeEmail() throws MessagingException {
         tokenMap.putAll(BridgeUtils.studyTemplateVariables(getStudy()));
-        tokenMap.put("host", BridgeConfigFactory.getConfig().getHostnameWithPostfix("webservices"));
+        tokenMap.put("host", BridgeConfigFactory.getConfig().getHostnameWithPostfix("ws"));
         
         final MimeTypeEmailBuilder emailBuilder = new MimeTypeEmailBuilder();
 

--- a/app/org/sagebionetworks/bridge/validators/StudyValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/StudyValidator.java
@@ -118,15 +118,16 @@ public class StudyValidator implements Validator {
         if (study.getAccountLimit() < 0) {
             errors.rejectValue("accountLimit", "must be zero (no limit set) or higher");
         }
-        validateTemplate(errors, study.getVerifyEmailTemplate(), "verifyEmailTemplate", "${url}");
-        validateTemplate(errors, study.getResetPasswordTemplate(), "resetPasswordTemplate", "${url}");
+        validateTemplate(errors, study.getVerifyEmailTemplate(), "verifyEmailTemplate", "${url}", "${shortUrl}");
+        validateTemplate(errors, study.getResetPasswordTemplate(), "resetPasswordTemplate", "${url}", "${shortUrl}");
         // Existing studies don't have the template, we use a default template. Okay to be missing.
         if (study.getEmailSignInTemplate() != null) {
-            validateTemplate(errors, study.getEmailSignInTemplate(), "emailSignInTemplate", "${url}", "${token}");
+            validateTemplate(errors, study.getEmailSignInTemplate(), "emailSignInTemplate", "${url}", "${shortUrl}",
+                    "${token}");
         }
         if (study.getAccountExistsTemplate() != null) {
             validateTemplate(errors, study.getAccountExistsTemplate(), "accountExistsTemplate", "${url}",
-                    "${emailSignInUrl}", "${resetPasswordUrl}");
+                    "${shortUrl}", "${emailSignInUrl}", "${resetPasswordUrl}");
         }
         
         for (String userProfileAttribute : study.getUserProfileAttributes()) {

--- a/conf/bridge-server.conf
+++ b/conf/bridge-server.conf
@@ -65,9 +65,9 @@ uat.host.postfix = -staging.sagebridge.org
 prod.host.postfix = .sagebridge.org
 
 local.webservices.url = http://localhost:9000
-dev.webservices.url = https://webservices-develop.sagebridge.org
-uat.webservices.url = https://webservices-staging.sagebridge.org
-prod.webservices.url = https://webservices.sagebridge.org
+dev.webservices.url = https://ws-develop.sagebridge.org
+uat.webservices.url = https://ws-staging.sagebridge.org
+prod.webservices.url = https://ws.sagebridge.org
 
 route53.zone = ZP0HNVK1V670D
 

--- a/conf/routes
+++ b/conf/routes
@@ -6,6 +6,10 @@ GET    /mobile/verifyEmail.html                @org.sagebionetworks.bridge.play.
 GET    /mobile/resetPassword.html              @org.sagebionetworks.bridge.play.controllers.ApplicationController.resetPassword(study: String ?= "api")
 GET    /mobile/startSession.html               @org.sagebionetworks.bridge.play.controllers.ApplicationController.startSession(study: String ?= null, email: String ?= null, token: String ?= null)
 GET    /mobile/:study/startSession.html        @org.sagebionetworks.bridge.play.controllers.ApplicationController.startSession(study: String, email: String ?= null, token: String ?= null)
+GET    /vse                                    @org.sagebionetworks.bridge.play.controllers.ApplicationController.verifyStudyEmail(study: String ?= "api")
+GET    /ve                                     @org.sagebionetworks.bridge.play.controllers.ApplicationController.verifyEmail(study: String ?= "api")
+GET    /rp                                     @org.sagebionetworks.bridge.play.controllers.ApplicationController.resetPassword(study: String ?= "api")
+GET    /s/:study                               @org.sagebionetworks.bridge.play.controllers.ApplicationController.startSession(study: String, email: String ?= null, token: String ?= null)
 GET    /.well-known/assetlinks.json            @org.sagebionetworks.bridge.play.controllers.ApplicationController.androidAppLinks
 GET    /.well-known/apple-app-site-association @org.sagebionetworks.bridge.play.controllers.ApplicationController.appleAppLinks
 

--- a/conf/study-defaults/account-exists.txt
+++ b/conf/study-defaults/account-exists.txt
@@ -2,7 +2,7 @@
 
 <p>You can sign in using your original password. If you have forgotten it, and you wish to reset it, please click on this link or cut and paste this URL into your browser (link expires in ${expirationWindow} hours):</p>
 
-<p>${url}</p>
+<p>${shortUrl}</p>
 
 <p>This link takes you to a secure page where you can change your password.</p>
 

--- a/conf/study-defaults/email-sign-in.txt
+++ b/conf/study-defaults/email-sign-in.txt
@@ -1,1 +1,1 @@
-Click here to sign in: ${url}
+Click here to sign in: ${shortUrl}

--- a/conf/study-defaults/email-verification.txt
+++ b/conf/study-defaults/email-verification.txt
@@ -4,7 +4,7 @@
 
 <p>This research study is powered by Bridge, a secure data storage service operated by Sage Bionetworks. In order to proceed, you must first confirm your email address by clicking the link below, or copying and pasting it into the address bar of your browser:</p>
 
-<p>${url}</p>
+<p>${shortUrl}</p>
 
 <p>Once you confirm your email, you will be able to finish setting up your profile for the study.</p> 
 

--- a/conf/study-defaults/reset-password.txt
+++ b/conf/study-defaults/reset-password.txt
@@ -4,7 +4,7 @@
 
 <p>To reset your password, please click on this link or cut and paste this URL into your browser (link expires in ${expirationWindow} hours):</p>
 
-<p>${url}</p>
+<p>${shortUrl}</p>
 
 <p>This link takes you to a secure page where you can change your password.</p>
 

--- a/conf/templates/study-email-verification.txt
+++ b/conf/templates/study-email-verification.txt
@@ -6,7 +6,7 @@
     bar of your browser:
 </p>
 
-<p>${url}</p>
+<p>${shortUrl}</p>
 
 <p>
     Once you confirm your email, you will be able to receive email notifications for your study.

--- a/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
@@ -170,7 +170,7 @@ public class StudyServiceMockTest {
         // Mock templates
         service.setStudyEmailVerificationTemplateSubject(mockTemplateAsSpringResource(
                 "Verify your study email"));
-        service.setStudyEmailVerificationTemplate(mockTemplateAsSpringResource("Click here ${url}"));
+        service.setStudyEmailVerificationTemplate(mockTemplateAsSpringResource("Click here ${url} ${shortUrl}"));
 
         when(service.getNameScopingToken()).thenReturn(TEST_NAME_SCOPING_TOKEN);
         
@@ -276,6 +276,8 @@ public class StudyServiceMockTest {
         MimeTypeEmail email = emailProviderCaptor.getValue().getMimeTypeEmail();
         String body = (String) email.getMessageParts().get(0).getContent();
         assertTrue(body.contains("/mobile/verifyStudyEmail.html?study="+ TEST_STUDY_ID + "&token=" +
+                VERIFICATION_TOKEN + "&type=consent_notification"));
+        assertTrue(body.contains("/vse?study="+ TEST_STUDY_ID + "&token=" +
                 VERIFICATION_TOKEN + "&type=consent_notification"));
         assertTrue(email.getSenderAddress().contains(SUPPORT_EMAIL));
 

--- a/test/org/sagebionetworks/bridge/services/email/EmailSignInEmailProviderTest.java
+++ b/test/org/sagebionetworks/bridge/services/email/EmailSignInEmailProviderTest.java
@@ -39,7 +39,7 @@ public class EmailSignInEmailProviderTest {
                 .withToken("token", "ABC").build();
         
         String url = String.format("https://%s/mobile/startSession.html?email=%s&study=foo&token=ABC", 
-                BridgeConfigFactory.getConfig().getHostnameWithPostfix("webservices"),
+                BridgeConfigFactory.getConfig().getHostnameWithPostfix("ws"),
                 URLEncoder.encode(RECIPIENT_EMAIL, "UTF-8"));
         
         String finalBody = String.format("Click here to sign in: <a href=\"%s\">%s</a>", url, url);

--- a/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
@@ -83,13 +83,13 @@ public class StudyValidatorTest {
     @Test
     public void resetPasswordMustHaveUrlVariable() {
         study.setResetPasswordTemplate(new EmailTemplate("subject", "no url variable", MimeType.TEXT));
-        assertValidatorMessage(INSTANCE, study, "resetPasswordTemplate.body", "must contain one of these template variables: ${url}");
+        assertValidatorMessage(INSTANCE, study, "resetPasswordTemplate.body", "must contain one of these template variables: ${url}, ${shortUrl}");
     }
     
     @Test
     public void verifyEmailMustHaveUrlVariable() {
         study.setVerifyEmailTemplate(new EmailTemplate("subject", "no url variable", MimeType.TEXT));
-        assertValidatorMessage(INSTANCE, study, "verifyEmailTemplate.body", "must contain one of these template variables: ${url}");
+        assertValidatorMessage(INSTANCE, study, "verifyEmailTemplate.body", "must contain one of these template variables: ${url}, ${shortUrl}");
     }
 
     @Test
@@ -300,7 +300,7 @@ public class StudyValidatorTest {
     @Test
     public void requiresEmailSignInTemplateRequiresToken() {
         study.setEmailSignInTemplate(new EmailTemplate("subject", "body with no token", MimeType.HTML));
-        assertValidatorMessage(INSTANCE, study, "emailSignInTemplate.body", "must contain one of these template variables: ${url}, ${token}");
+        assertValidatorMessage(INSTANCE, study, "emailSignInTemplate.body", "must contain one of these template variables: ${url}, ${shortUrl}, ${token}");
     }    
 
     @Test
@@ -331,7 +331,7 @@ public class StudyValidatorTest {
     public void requiresAccountExistsTemplateRequiresURL() {
         study.setAccountExistsTemplate(new EmailTemplate("subject", "body with no url", MimeType.HTML));
         assertValidatorMessage(INSTANCE, study, "accountExistsTemplate.body",
-                "must contain one of these template variables: ${url}, ${emailSignInUrl}, ${resetPasswordUrl}");
+                "must contain one of these template variables: ${url}, ${shortUrl}, ${emailSignInUrl}, ${resetPasswordUrl}");
     }
     
     @Test


### PR DESCRIPTION
It would be nice to have these in place before creating SMS templates (SMS is limited to 160 characters). Ultimately the URLs will change about this much:

https://webservices.sagebridge.org/mobile/verifyEmail.html?study=api&email=email@email.com&token=12342341234

to

https://ws.sagebridge.org/ve?study=api&email=email@email.com&token=12342341234