### PR TITLE
Add expirationPeriod to all the emails that are sent out.

### DIFF
--- a/app/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/app/org/sagebionetworks/bridge/BridgeConstants.java
@@ -100,11 +100,6 @@ public class BridgeConstants {
      * SNS converts these to ASCII.
      */
     public static final int SMS_CHARACTER_LIMIT = 140;
-    
-    /**
-     * The key used to communicate the expiration period in an email or SMS template.
-     */
-    public static final String EXPIRATION_PERIOD_KEY = "expirationPeriod";
 
     /**
      * This whitelist adds a few additional tags and attributes that are used by the CKEDITOR options 

--- a/app/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/app/org/sagebionetworks/bridge/BridgeConstants.java
@@ -100,6 +100,11 @@ public class BridgeConstants {
      * SNS converts these to ASCII.
      */
     public static final int SMS_CHARACTER_LIMIT = 140;
+    
+    /**
+     * The key used to communicate the expiration period in an email or SMS template.
+     */
+    public static final String EXPIRATION_PERIOD_KEY = "expirationPeriod";
 
     /**
      * This whitelist adds a few additional tags and attributes that are used by the CKEDITOR options 

--- a/app/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/app/org/sagebionetworks/bridge/BridgeUtils.java
@@ -57,6 +57,32 @@ public class BridgeUtils {
     
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
+    private static final int ONE_HOUR = 60*60;
+    private static final int ONE_DAY = 60*60*24;
+    private static final int ONE_MINUTE = 60;
+    
+    /**
+     * Convert expiration measures in seconds to an English language explanation of
+     * the expiration time. This is not intended to cover odd cases, our expirations 
+     * are always in minutes or more commonly, hours 
+     */
+    public static String secondsToTimeString(int seconds) {
+        if (seconds >= (ONE_DAY*2) && seconds % ONE_DAY == 0) {
+            return Integer.toString(seconds/ONE_DAY) + " days";
+        } else if (seconds >= ONE_DAY && seconds % ONE_DAY == 0) {
+            return Integer.toString(seconds/ONE_DAY) + " day";
+        } else if (seconds >= (ONE_HOUR*2) && seconds % ONE_HOUR == 0) {
+            return Integer.toString(seconds/ONE_HOUR) + " hours";
+        } else if (seconds >= ONE_HOUR && seconds % ONE_HOUR == 0) {
+            return Integer.toString(seconds/ONE_HOUR) + " hour";
+        } else if (seconds >= (ONE_MINUTE*2) && seconds % ONE_MINUTE == 0) {
+            return Integer.toString(seconds/ONE_MINUTE) + " minutes";
+        } else if (seconds >= ONE_MINUTE && seconds % ONE_MINUTE == 0) {
+            return Integer.toString(seconds/ONE_MINUTE) + " minute";
+        }
+        return Integer.toString(seconds) + " seconds";
+    }
+    
     public static AccountId parseAccountId(String studyId, String identifier) {
         checkNotNull(studyId);
         checkNotNull(identifier);

--- a/app/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/app/org/sagebionetworks/bridge/BridgeUtils.java
@@ -54,19 +54,18 @@ public class BridgeUtils {
     public static final Joiner COMMA_JOINER = Joiner.on(",");
     public static final Joiner SEMICOLON_SPACE_JOINER = Joiner.on("; ");
     public static final Joiner SPACE_JOINER = Joiner.on(" ");
-    
-    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
-
     private static final int ONE_HOUR = 60*60;
     private static final int ONE_DAY = 60*60*24;
     private static final int ONE_MINUTE = 60;
     
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+    
     /**
      * Convert expiration measures in seconds to an English language explanation of
-     * the expiration time. This is not intended to cover odd cases, our expirations 
-     * are always in minutes or more commonly, hours 
+     * the expiration time. This is not intended to cover odd cases--our expirations 
+     * are in minutes, hours, or possibly days. 
      */
-    public static String secondsToTimeString(int seconds) {
+    public static String secondsToPeriodString(int seconds) {
         if (seconds >= (ONE_DAY*2) && seconds % ONE_DAY == 0) {
             return Integer.toString(seconds/ONE_DAY) + " days";
         } else if (seconds >= ONE_DAY && seconds % ONE_DAY == 0) {

--- a/app/org/sagebionetworks/bridge/services/AccountWorkflowService.java
+++ b/app/org/sagebionetworks/bridge/services/AccountWorkflowService.java
@@ -16,6 +16,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.SecureTokenGenerator;
 import org.sagebionetworks.bridge.cache.CacheProvider;
@@ -207,7 +208,10 @@ public class AccountWorkflowService {
                 .withRecipientEmail(recipientEmail)
                 .withToken(SPTOKEN_KEY, sptoken)
                 .withToken(URL_KEY, url)
-                .withToken(SHORT_URL_KEY, shortUrl).build();
+                .withToken(SHORT_URL_KEY, shortUrl)
+                .withToken(BridgeConstants.EXPIRATION_PERIOD_KEY, 
+                        BridgeUtils.secondsToTimeString(EXPIRE_IN_SECONDS))
+                .build();
         sendMailService.sendEmail(provider);
     }
     
@@ -310,6 +314,8 @@ public class AccountWorkflowService {
             .withToken(SPTOKEN_KEY, sptoken)
             .withToken(URL_KEY, url)
             .withToken(SHORT_URL_KEY, shortUrl)
+            .withToken(BridgeConstants.EXPIRATION_PERIOD_KEY, 
+                    BridgeUtils.secondsToTimeString(EXPIRE_IN_SECONDS))
             .withToken(EXP_WINDOW_TOKEN, Integer.toString(EXPIRE_IN_SECONDS/60/60));
             
         if (includeEmailSignIn && study.isEmailSignInEnabled()) {
@@ -416,7 +422,10 @@ public class AccountWorkflowService {
                 .withToken(EMAIL_KEY, BridgeUtils.encodeURIComponent(signIn.getEmail()))
                 .withToken(TOKEN_KEY, token)
                 .withToken(URL_KEY, url)
-                .withToken(SHORT_URL_KEY, shortUrl).build();
+                .withToken(SHORT_URL_KEY, shortUrl)
+                .withToken(BridgeConstants.EXPIRATION_PERIOD_KEY, 
+                        BridgeUtils.secondsToTimeString(SESSION_SIGNIN_EXPIRE_IN_SECONDS))
+                .build();
             sendMailService.sendEmail(provider);
         });
     }

--- a/app/org/sagebionetworks/bridge/services/AccountWorkflowService.java
+++ b/app/org/sagebionetworks/bridge/services/AccountWorkflowService.java
@@ -16,7 +16,6 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.SecureTokenGenerator;
 import org.sagebionetworks.bridge.cache.CacheProvider;
@@ -209,8 +208,7 @@ public class AccountWorkflowService {
                 .withToken(SPTOKEN_KEY, sptoken)
                 .withToken(URL_KEY, url)
                 .withToken(SHORT_URL_KEY, shortUrl)
-                .withToken(BridgeConstants.EXPIRATION_PERIOD_KEY, 
-                        BridgeUtils.secondsToTimeString(EXPIRE_IN_SECONDS))
+                .withExpirationPeriod(EXPIRE_IN_SECONDS)
                 .build();
         sendMailService.sendEmail(provider);
     }
@@ -314,8 +312,7 @@ public class AccountWorkflowService {
             .withToken(SPTOKEN_KEY, sptoken)
             .withToken(URL_KEY, url)
             .withToken(SHORT_URL_KEY, shortUrl)
-            .withToken(BridgeConstants.EXPIRATION_PERIOD_KEY, 
-                    BridgeUtils.secondsToTimeString(EXPIRE_IN_SECONDS))
+            .withExpirationPeriod(EXPIRE_IN_SECONDS)
             .withToken(EXP_WINDOW_TOKEN, Integer.toString(EXPIRE_IN_SECONDS/60/60));
             
         if (includeEmailSignIn && study.isEmailSignInEnabled()) {
@@ -423,8 +420,7 @@ public class AccountWorkflowService {
                 .withToken(TOKEN_KEY, token)
                 .withToken(URL_KEY, url)
                 .withToken(SHORT_URL_KEY, shortUrl)
-                .withToken(BridgeConstants.EXPIRATION_PERIOD_KEY, 
-                        BridgeUtils.secondsToTimeString(SESSION_SIGNIN_EXPIRE_IN_SECONDS))
+                .withExpirationPeriod(SESSION_SIGNIN_EXPIRE_IN_SECONDS)
                 .build();
             sendMailService.sendEmail(provider);
         });

--- a/app/org/sagebionetworks/bridge/services/StudyService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyService.java
@@ -4,6 +4,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.sagebionetworks.bridge.BridgeConstants.EXPIRATION_PERIOD_KEY;
+import static org.sagebionetworks.bridge.BridgeUtils.secondsToTimeString;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -770,7 +772,8 @@ public class StudyService {
 
         BasicEmailProvider provider = new BasicEmailProvider.Builder().withStudy(study).withEmailTemplate(template)
                 .withOverrideSenderEmail(bridgeSupportEmailPlain).withRecipientEmail(email).withToken(URL_TOKEN, url)
-                .withToken(SHORT_URL_TOKEN, shortUrl).build();
+                .withToken(SHORT_URL_TOKEN, shortUrl)
+                .withToken(EXPIRATION_PERIOD_KEY, secondsToTimeString(VERIFY_STUDY_EMAIL_EXPIRE_IN_SECONDS)).build();
         sendMailService.sendEmail(provider);
     }
 

--- a/app/org/sagebionetworks/bridge/services/StudyService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyService.java
@@ -4,8 +4,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static org.sagebionetworks.bridge.BridgeConstants.EXPIRATION_PERIOD_KEY;
-import static org.sagebionetworks.bridge.BridgeUtils.secondsToTimeString;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -773,7 +771,7 @@ public class StudyService {
         BasicEmailProvider provider = new BasicEmailProvider.Builder().withStudy(study).withEmailTemplate(template)
                 .withOverrideSenderEmail(bridgeSupportEmailPlain).withRecipientEmail(email).withToken(URL_TOKEN, url)
                 .withToken(SHORT_URL_TOKEN, shortUrl)
-                .withToken(EXPIRATION_PERIOD_KEY, secondsToTimeString(VERIFY_STUDY_EMAIL_EXPIRE_IN_SECONDS)).build();
+                .withExpirationPeriod(VERIFY_STUDY_EMAIL_EXPIRE_IN_SECONDS).build();
         sendMailService.sendEmail(provider);
     }
 

--- a/app/org/sagebionetworks/bridge/services/email/BasicEmailProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/BasicEmailProvider.java
@@ -19,6 +19,8 @@ import com.google.common.collect.Sets;
 import org.apache.commons.lang3.StringUtils;
 
 public class BasicEmailProvider extends MimeTypeEmailProvider {
+    private static final String EXPIRATION_PERIOD_KEY = "expirationPeriod";
+    
     private final String overrideSenderEmail;
     private final Set<String> recipientEmails;
     private final Map<String,String> tokenMap;
@@ -112,6 +114,10 @@ public class BasicEmailProvider extends MimeTypeEmailProvider {
         }
         public Builder withToken(String name, String value) {
             tokenMap.put(name, value);
+            return this;
+        }
+        public Builder withExpirationPeriod(int expireInSeconds) {
+            withToken(EXPIRATION_PERIOD_KEY, BridgeUtils.secondsToPeriodString(expireInSeconds));
             return this;
         }
         public BasicEmailProvider build() {

--- a/conf/study-defaults/account-exists.txt
+++ b/conf/study-defaults/account-exists.txt
@@ -1,6 +1,6 @@
 <p>You have signed up for ${studyName}, but our records indicate you already have an account for this study. </p>
 
-<p>You can sign in using your original password. If you have forgotten it, and you wish to reset it, please click on this link or cut and paste this URL into your browser (link expires in ${expirationWindow} hours):</p>
+<p>You can sign in using your original password. If you have forgotten it, and you wish to reset it, please click on this link or cut and paste this URL into your browser (link expires in ${expirationPeriod}):</p>
 
 <p>${shortUrl}</p>
 

--- a/conf/study-defaults/reset-password.txt
+++ b/conf/study-defaults/reset-password.txt
@@ -2,7 +2,7 @@
 
 <p>You have requested to reset your password. If you don't want to reset your password, please ignore this message. Your password will not be reset.</p>
 
-<p>To reset your password, please click on this link or cut and paste this URL into your browser (link expires in ${expirationWindow} hours):</p>
+<p>To reset your password, please click on this link or cut and paste this URL into your browser (link expires in ${expirationPeriod}):</p>
 
 <p>${shortUrl}</p>
 

--- a/conf/templates/study-email-verification.txt
+++ b/conf/templates/study-email-verification.txt
@@ -3,7 +3,7 @@
 <p>
     You have registered this email address to receive notifications for your study ${studyName}. In order to proceed,
     you must first confirm your email address by clicking the link below, or copying and pasting it into the address
-    bar of your browser:
+    bar of your browser (link expires in ${expirationPeriod}):
 </p>
 
 <p>${shortUrl}</p>

--- a/test/org/sagebionetworks/bridge/BridgeUtilsTest.java
+++ b/test/org/sagebionetworks/bridge/BridgeUtilsTest.java
@@ -35,6 +35,20 @@ public class BridgeUtilsTest {
     private static final LocalDateTime LOCAL_DATE_TIME = LocalDateTime.parse("2010-10-10T10:10:10.111");
     
     @Test
+    public void secondsToTimeString() {
+        assertEquals("30 seconds", BridgeUtils.secondsToTimeString(30));
+        assertEquals("1 minute", BridgeUtils.secondsToTimeString(60));
+        assertEquals("5 minutes", BridgeUtils.secondsToTimeString(60*5));
+        assertEquals("25 minutes", BridgeUtils.secondsToTimeString(60*25));
+        assertEquals("90 minutes", BridgeUtils.secondsToTimeString(60*90));
+        assertEquals("1 hour", BridgeUtils.secondsToTimeString(60*60));
+        assertEquals("2 hours", BridgeUtils.secondsToTimeString(60*60*2));
+        assertEquals("36 hours", BridgeUtils.secondsToTimeString(60*60*36));
+        assertEquals("1 day", BridgeUtils.secondsToTimeString(60*60*24));
+        assertEquals("2 days", BridgeUtils.secondsToTimeString(60*60*24*2));
+    }
+    
+    @Test
     public void parseAccountId() {
         // Identifier has upper-case letter to ensure we don't downcase or otherwise change it.
         AccountId accountId = BridgeUtils.parseAccountId("test", "IdentifierA9");

--- a/test/org/sagebionetworks/bridge/BridgeUtilsTest.java
+++ b/test/org/sagebionetworks/bridge/BridgeUtilsTest.java
@@ -35,17 +35,17 @@ public class BridgeUtilsTest {
     private static final LocalDateTime LOCAL_DATE_TIME = LocalDateTime.parse("2010-10-10T10:10:10.111");
     
     @Test
-    public void secondsToTimeString() {
-        assertEquals("30 seconds", BridgeUtils.secondsToTimeString(30));
-        assertEquals("1 minute", BridgeUtils.secondsToTimeString(60));
-        assertEquals("5 minutes", BridgeUtils.secondsToTimeString(60*5));
-        assertEquals("25 minutes", BridgeUtils.secondsToTimeString(60*25));
-        assertEquals("90 minutes", BridgeUtils.secondsToTimeString(60*90));
-        assertEquals("1 hour", BridgeUtils.secondsToTimeString(60*60));
-        assertEquals("2 hours", BridgeUtils.secondsToTimeString(60*60*2));
-        assertEquals("36 hours", BridgeUtils.secondsToTimeString(60*60*36));
-        assertEquals("1 day", BridgeUtils.secondsToTimeString(60*60*24));
-        assertEquals("2 days", BridgeUtils.secondsToTimeString(60*60*24*2));
+    public void secondsToPeriodString() {
+        assertEquals("30 seconds", BridgeUtils.secondsToPeriodString(30));
+        assertEquals("1 minute", BridgeUtils.secondsToPeriodString(60));
+        assertEquals("5 minutes", BridgeUtils.secondsToPeriodString(60*5));
+        assertEquals("25 minutes", BridgeUtils.secondsToPeriodString(60*25));
+        assertEquals("90 minutes", BridgeUtils.secondsToPeriodString(60*90));
+        assertEquals("1 hour", BridgeUtils.secondsToPeriodString(60*60));
+        assertEquals("2 hours", BridgeUtils.secondsToPeriodString(60*60*2));
+        assertEquals("36 hours", BridgeUtils.secondsToPeriodString(60*60*36));
+        assertEquals("1 day", BridgeUtils.secondsToPeriodString(60*60*24));
+        assertEquals("2 days", BridgeUtils.secondsToPeriodString(60*60*24*2));
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
@@ -166,6 +166,7 @@ public class AccountWorkflowServiceTest {
         BasicEmailProvider provider = emailProviderCaptor.getValue();
         Map<String,String> tokens = provider.getTokenMap();
         assertEquals(SPTOKEN, tokens.get("sptoken"));
+        assertEquals("2 hours", tokens.get("expirationPeriod"));
         
         MimeTypeEmail email = provider.getMimeTypeEmail();
         assertEquals("\"This study name\" <support@support.com>", email.getSenderAddress());
@@ -277,6 +278,7 @@ public class AccountWorkflowServiceTest {
         
         assertEquals(TOKEN, provider.getTokenMap().get("token"));
         assertEquals(SPTOKEN, provider.getTokenMap().get("sptoken"));
+        assertEquals("2 hours", provider.getTokenMap().get("expirationPeriod"));
         assertEquals(BridgeUtils.encodeURIComponent(EMAIL), provider.getTokenMap().get("email"));
         assertEquals("2", provider.getTokenMap().get("expirationWindow"));
         
@@ -325,6 +327,7 @@ public class AccountWorkflowServiceTest {
             assertEquals("2", oneEmailProvider.getTokenMap().get("expirationWindow"));
             assertEquals(SPTOKEN, oneEmailProvider.getTokenMap().get("sptoken"));
             assertEquals(TOKEN, oneEmailProvider.getTokenMap().get("token"));
+            assertEquals("2 hours", oneEmailProvider.getTokenMap().get("expirationPeriod"));
             assertEquals(BridgeUtils.encodeURIComponent(EMAIL), oneEmailProvider.getTokenMap().get("email"));
             
             // Email content is verified in test above. Just verify email sign-in URL.
@@ -355,6 +358,7 @@ public class AccountWorkflowServiceTest {
         BasicEmailProvider provider = emailProviderCaptor.getValue();
         assertEquals(SPTOKEN, provider.getTokenMap().get("sptoken"));
         assertEquals("2", provider.getTokenMap().get("expirationWindow"));
+        assertEquals("2 hours", provider.getTokenMap().get("expirationPeriod"));
 
         String bodyString = (String) provider.getMimeTypeEmail().getMessageParts().get(0).getContent();
         
@@ -398,6 +402,7 @@ public class AccountWorkflowServiceTest {
         
         assertEquals(SPTOKEN, provider.getTokenMap().get("sptoken"));
         assertEquals("2", provider.getTokenMap().get("expirationWindow"));
+        assertEquals("2 hours", provider.getTokenMap().get("expirationPeriod"));
         
         MimeTypeEmail email = provider.getMimeTypeEmail();
         assertEquals("\"This study name\" <support@support.com>", email.getSenderAddress());
@@ -502,7 +507,6 @@ public class AccountWorkflowServiceTest {
         when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(mockAccount);
 
         PasswordReset passwordReset = new PasswordReset("newPassword", SPTOKEN, TEST_STUDY_IDENTIFIER);
-        
         service.resetPassword(passwordReset);
         
         verify(mockCacheProvider).getObject(SPTOKEN+":api", String.class);
@@ -518,7 +522,6 @@ public class AccountWorkflowServiceTest {
         when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
 
         PasswordReset passwordReset = new PasswordReset("newPassword", SPTOKEN, TEST_STUDY_IDENTIFIER);
-        
         service.resetPassword(passwordReset);
         
         verify(mockCacheProvider).getObject(SPTOKEN+":phone:api", String.class);
@@ -583,6 +586,7 @@ public class AccountWorkflowServiceTest {
         BasicEmailProvider provider = emailProviderCaptor.getValue();
         assertEquals(BridgeUtils.encodeURIComponent(EMAIL), provider.getTokenMap().get("email"));
         assertEquals(TOKEN, provider.getTokenMap().get("token"));
+        assertEquals("5 minutes", provider.getTokenMap().get("expirationPeriod"));
         
         String token = provider.getTokenMap().get("token");
         
@@ -663,6 +667,7 @@ public class AccountWorkflowServiceTest {
         BasicEmailProvider provider = emailProviderCaptor.getValue();
         assertEquals(BridgeUtils.encodeURIComponent(EMAIL), provider.getTokenMap().get("email"));
         assertEquals(TOKEN, provider.getTokenMap().get("token"));
+        assertEquals("5 minutes", provider.getTokenMap().get("expirationPeriod"));
         
         assertEquals(EMAIL, provider.getMimeTypeEmail().getRecipientAddresses().get(0));
         assertEquals(SUPPORT_EMAIL, provider.getPlainSenderEmail());

--- a/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
@@ -77,6 +77,7 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
 import org.sagebionetworks.bridge.models.upload.UploadFieldType;
+import org.sagebionetworks.bridge.services.email.BasicEmailProvider;
 import org.sagebionetworks.bridge.services.email.MimeTypeEmail;
 import org.sagebionetworks.bridge.services.email.MimeTypeEmailProvider;
 import org.sagebionetworks.bridge.validators.StudyValidator;
@@ -269,8 +270,8 @@ public class StudyServiceMockTest {
         assertEquals(consentNotificationEmail, verificationData.get("email").textValue());
 
         // Verify sent email.
-        ArgumentCaptor<MimeTypeEmailProvider> emailProviderCaptor = ArgumentCaptor.forClass(
-                MimeTypeEmailProvider.class);
+        ArgumentCaptor<BasicEmailProvider> emailProviderCaptor = ArgumentCaptor.forClass(
+                BasicEmailProvider.class);
         verify(sendMailService).sendEmail(emailProviderCaptor.capture());
 
         MimeTypeEmail email = emailProviderCaptor.getValue().getMimeTypeEmail();
@@ -280,7 +281,8 @@ public class StudyServiceMockTest {
         assertTrue(body.contains("/vse?study="+ TEST_STUDY_ID + "&token=" +
                 VERIFICATION_TOKEN + "&type=consent_notification"));
         assertTrue(email.getSenderAddress().contains(SUPPORT_EMAIL));
-
+        assertEquals("1 day", emailProviderCaptor.getValue().getTokenMap().get("expirationPeriod"));
+        
         List<String> recipientList = email.getRecipientAddresses();
         assertEquals(1, recipientList.size());
         assertEquals(consentNotificationEmail, recipientList.get(0));


### PR DESCRIPTION
We're inconsistent in including this and we don't include the time period, so if we change it in the code we'd have to update all the templates everywhere.

I am going to go through, update all the templates at some point, and then delete the older expiration variable, ${expirationWindow}. But there's no rush on that.