### PR TITLE
upload file size limits

### DIFF
--- a/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2.java
+++ b/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2.java
@@ -339,12 +339,12 @@ public class IosSchemaValidationHandler2 implements UploadValidationHandler {
             }
 
             // Parse file into JSON nodes. Survey answer files should be very small. If they exceed the size, log a
-            // warning. In future releases, once we've verified that no one is sending large survey answer files (and
-            // there's no reason to), we'll simply skip parsing large files.
+            // warning and skip.
             long fileSize = fileHelper.fileSize(file);
             if (fileSize > UploadUtil.FILE_SIZE_LIMIT_SURVEY_ANSWER) {
                 logger.warn("Survey file exceeds max size, uploadId=" + uploadId + ", filename=" + filename +
                         ", fileSize=" + fileSize + " bytes");
+                continue;
             }
             JsonNode oneAnswerNode;
             try (InputStream fileInputStream = fileHelper.getInputStream(file)) {

--- a/app/org/sagebionetworks/bridge/upload/UploadUtil.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadUtil.java
@@ -52,7 +52,9 @@ public class UploadUtil {
     public static final String FIELD_SURVEY_CREATED_ON = "surveyCreatedOn";
     public static final int FILE_SIZE_LIMIT_SURVEY_ANSWER = 1024;
     public static final int FILE_SIZE_LIMIT_INLINE_FIELD = 10 * 1024;
-    public static final int FILE_SIZE_LIMIT_PARSED_JSON = 2 * 1024 * 1024;
+    public static final int FILE_SIZE_LIMIT_DATA_FILE = 2 * 1024 * 1024;
+    public static final int WARNING_LIMIT_PARSED_JSON = 5 * 1024 * 1024;
+    public static final int FILE_SIZE_LIMIT_PARSED_JSON = 20 * 1024 * 1024;
 
     // Regex patterns and strings for validation.
     private static final Pattern FIELD_NAME_MULTIPLE_SPECIAL_CHARS_PATTERN = Pattern.compile("[\\-\\._ ]{2,}");


### PR DESCRIPTION
Impose file size limits for parsing uploads in memory, so that we can raise general file size limits.