### PR TITLE
participant signOut API can delete the session without deleting the reauth token

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/AccountDao.java
+++ b/app/org/sagebionetworks/bridge/dao/AccountDao.java
@@ -23,7 +23,7 @@ import org.sagebionetworks.bridge.services.AuthenticationService;
  */
 public interface AccountDao {
     
-    static final int MIGRATION_VERSION = 1;
+    int MIGRATION_VERSION = 1;
     
     /**
      * Verify an email address using a supplied, one-time token for verification.
@@ -54,9 +54,9 @@ public interface AccountDao {
     Account reauthenticate(Study study, SignIn signIn);
     
     /**
-     * Sign the user out of Bridge. This clears the user's reauthentication token.
+     * This clears the user's reauthentication token.
      */
-    void signOut(AccountId accountId);
+    void deleteReauthToken(AccountId accountId);
     
     /**
      * Retrieve an account where authentication is handled outside of the DAO (If we

--- a/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
@@ -220,9 +220,9 @@ public class HibernateAccountDao implements AccountDao {
     }
 
     @Override
-    public void signOut(AccountId accountId) {
+    public void deleteReauthToken(AccountId accountId) {
         HibernateAccount hibernateAccount = getHibernateAccount(accountId);
-        if (hibernateAccount != null) {
+        if (hibernateAccount != null && hibernateAccount.getReauthTokenHash() != null) {
             hibernateAccount.setReauthTokenHash(null);
             hibernateAccount.setReauthTokenAlgorithm(null);
             hibernateAccount.setReauthTokenModifiedOn(null);

--- a/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
@@ -161,7 +161,7 @@ public class ParticipantController extends BaseController {
         
         // Similarly, we will return startTime/endTime in the top-level request parameter properties as 
         // startDate/endDate while transitioning, to maintain backwards compatibility.
-        ObjectNode node = (ObjectNode)MAPPER.valueToTree(page);
+        ObjectNode node = MAPPER.valueToTree(page);
         Map<String,Object> rp = page.getRequestParams();
         if (rp.get(START_TIME) != null) {
             node.put(START_DATE, (String)rp.get(START_TIME));    
@@ -239,11 +239,11 @@ public class ParticipantController extends BaseController {
     }
     
     @BodyParser.Of(BodyParser.Empty.class)
-    public Result signOut(String userId) throws Exception {
+    public Result signOut(String userId, boolean deleteReauthToken) throws Exception {
         UserSession session = getAuthenticatedSession(RESEARCHER);
         Study study = studyService.getStudy(session.getStudyIdentifier());
 
-        participantService.signUserOut(study, userId);
+        participantService.signUserOut(study, userId, deleteReauthToken);
 
         return okResult("User signed out.");
     }

--- a/app/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -187,7 +187,7 @@ public class AuthenticationService {
     public void signOut(final UserSession session) {
         if (session != null) {
             AccountId accountId = AccountId.forId(session.getStudyIdentifier().getIdentifier(), session.getId());
-            accountDao.signOut(accountId);
+            accountDao.deleteReauthToken(accountId);
             cacheProvider.removeSession(session);
         }
     }

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -223,14 +223,17 @@ public class ParticipantService {
         return accountDao.getPagedAccountSummaries(study, offsetBy, pageSize, emailFilter, phoneFilter, startTime, endTime);
     }
 
-    public void signUserOut(Study study, String email) {
+    public void signUserOut(Study study, String email, boolean deleteReauthToken) {
         checkNotNull(study);
         checkArgument(isNotBlank(email));
 
         Account account = getAccountThrowingException(study, email);
         
         AccountId accountId = AccountId.forId(study.getIdentifier(), account.getId());
-        accountDao.signOut(accountId);
+
+        if (deleteReauthToken) {
+            accountDao.deleteReauthToken(accountId);
+        }
         
         cacheProvider.removeSessionByUserId(account.getId());
     }

--- a/conf/routes
+++ b/conf/routes
@@ -89,7 +89,7 @@ GET    /v3/participants/:userId/activities/:activityType/:referentGuid @org.sage
 GET    /v3/participants/:userId/activities/:activityGuid               @org.sagebionetworks.bridge.play.controllers.ParticipantController.getActivityHistoryV2(userId: String, activityGuid: String, scheduledOnStart: String ?= null, scheduledOnEnd: String ?= null, offsetBy: String ?= null, offsetKey: String ?= null, pageSize: String ?= null)
 GET    /v3/participants/:userId/notifications                          @org.sagebionetworks.bridge.play.controllers.ParticipantController.getNotificationRegistrations(userId: String)
 POST   /v3/participants/:userId/sendNotification                       @org.sagebionetworks.bridge.play.controllers.ParticipantController.sendNotification(userId: String)
-POST   /v3/participants/:userId/signOut                                @org.sagebionetworks.bridge.play.controllers.ParticipantController.signOut(userId: String)
+POST   /v3/participants/:userId/signOut                                @org.sagebionetworks.bridge.play.controllers.ParticipantController.signOut(userId: String, deleteReauthToken: Boolean ?= true)
 POST   /v3/participants/:userId/requestResetPassword                   @org.sagebionetworks.bridge.play.controllers.ParticipantController.requestResetPassword(userId: String)
 POST   /v3/participants/:userId/resendEmailVerification                @org.sagebionetworks.bridge.play.controllers.ParticipantController.resendEmailVerification(userId: String)
 POST   /v3/participants/:userId/consents/withdraw                      @org.sagebionetworks.bridge.play.controllers.ParticipantController.withdrawFromAllConsents(userId: String)

--- a/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
@@ -172,9 +172,7 @@ public class ParticipantControllerTest {
     private Study study;
     
     private StudyParticipant participant;
-    
-    private SessionUpdateService sessionUpdateService;
-    
+
     @Before
     public void before() throws Exception {
         study = new DynamoStudy();
@@ -212,8 +210,8 @@ public class ParticipantControllerTest {
         controller.setStudyService(mockStudyService);
         controller.setAuthenticationService(authService);
         controller.setCacheProvider(mockCacheProvider);
-        
-        sessionUpdateService = new SessionUpdateService();
+
+        SessionUpdateService sessionUpdateService = new SessionUpdateService();
         sessionUpdateService.setCacheProvider(mockCacheProvider);
         sessionUpdateService.setConsentService(mockConsentService);
         
@@ -299,10 +297,10 @@ public class ParticipantControllerTest {
     
     @Test
     public void signUserOut() throws Exception {
-        Result result = controller.signOut(ID);
+        Result result = controller.signOut(ID, false);
         TestUtils.assertResult(result, 200, "User signed out.");
 
-        verify(mockParticipantService).signUserOut(study, ID);
+        verify(mockParticipantService).signUserOut(study, ID, false);
     }
 
     @Test

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
@@ -234,7 +234,7 @@ public class AuthenticationServiceMockTest {
         session.setParticipant(new StudyParticipant.Builder().withEmail("email@email.com").withId(USER_ID).build());
         service.signOut(session);
         
-        verify(accountDao).signOut(ACCOUNT_ID);
+        verify(accountDao).deleteReauthToken(ACCOUNT_ID);
         verify(cacheProvider).removeSession(session);
     }
     
@@ -242,7 +242,7 @@ public class AuthenticationServiceMockTest {
     public void signOutNoSessionToken() {
         service.signOut(null);
         
-        verify(accountDao, never()).signOut(any());
+        verify(accountDao, never()).deleteReauthToken(any());
         verify(cacheProvider, never()).removeSession(any());
     }
     


### PR DESCRIPTION
Currently, it's very difficult to test reauth, because we have to wait 12 hours for the session to expire before we can trigger the reauth code. This change changes that by adding a deleteReauthToken flag to the participant signOut API.

This is added to the researcher participant signOut API, and not to the standard signOut API, because we don't want to open this up to end users.

deleteReauthToken defaults to true for backwards compatibility.

Testing done:
* unit tests
* integ tests
* manual tests