### PR TITLE
Suppress consent email

### DIFF
--- a/app/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/app/org/sagebionetworks/bridge/BridgeUtils.java
@@ -116,8 +116,10 @@ public class BridgeUtils {
                 Iterables.getFirst(commaListToOrderedSet(study.getSupportEmail()), ""));
         map.put("technicalEmail", 
                 Iterables.getFirst(commaListToOrderedSet(study.getTechnicalEmail()), ""));
-        map.put("consentEmail", 
-                Iterables.getFirst(commaListToOrderedSet(study.getConsentNotificationEmail()), ""));
+        if (study.getConsentNotificationEmail() != null) {
+            map.put("consentEmail", 
+                    Iterables.getFirst(commaListToOrderedSet(study.getConsentNotificationEmail()), ""));
+        }
         map.put("host", BridgeConfigFactory.getConfig().getHostnameWithPostfix("ws"));
         if (escaper != null) {
             for (Map.Entry<String,String> entry : map.entrySet()) {

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulation.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulation.java
@@ -38,6 +38,7 @@ public final class DynamoSubpopulation implements Subpopulation {
     private boolean required;
     private boolean deleted;
     private boolean defaultGroup;
+    private boolean autoSendConsentSuppressed;
     private Long version;
     private long publishedConsentCreatedOn;
     private Criteria criteria;
@@ -164,11 +165,20 @@ public final class DynamoSubpopulation implements Subpopulation {
     public Criteria getCriteria() {
         return criteria;
     }
+    @DynamoDBAttribute
+    @Override
+    public boolean isAutoSendConsentSuppressed() {
+        return autoSendConsentSuppressed;
+    }
+    @Override
+    public void setAutoSendConsentSuppressed(boolean autoSendConsentSuppressed) {
+        this.autoSendConsentSuppressed = autoSendConsentSuppressed;
+    }
     
     @Override
     public int hashCode() {
         return Objects.hash(name, description, required, deleted, defaultGroup, guid, studyIdentifier,
-                publishedConsentCreatedOn, version, criteria);
+                publishedConsentCreatedOn, version, criteria, autoSendConsentSuppressed);
     }
     @Override
     public boolean equals(Object obj) {
@@ -182,13 +192,15 @@ public final class DynamoSubpopulation implements Subpopulation {
                 && Objects.equals(deleted, other.deleted) && Objects.equals(studyIdentifier, other.studyIdentifier)
                 && Objects.equals(publishedConsentCreatedOn, other.publishedConsentCreatedOn)
                 && Objects.equals(version, other.version) && Objects.equals(defaultGroup, other.defaultGroup)
-                && Objects.equals(criteria, other.criteria);
+                && Objects.equals(criteria, other.criteria)
+                && Objects.equals(autoSendConsentSuppressed,  other.autoSendConsentSuppressed);
     }
     @Override
     public String toString() {
         return "DynamoSubpopulation [studyIdentifier=" + studyIdentifier + ", guid=" + guid + ", name=" + name
                 + ", description=" + description + ", required=" + required + ", deleted=" + deleted + ", criteria="
-                + criteria + ", publishedConsentCreatedOn=" + publishedConsentCreatedOn + ", version=" + version + "]";
+                + criteria + ", publishedConsentCreatedOn=" + publishedConsentCreatedOn + ", version=" + version 
+                + ", autoSendConsentSuppressed=" + autoSendConsentSuppressed + "]";
     }
 
 }

--- a/app/org/sagebionetworks/bridge/models/subpopulations/Subpopulation.java
+++ b/app/org/sagebionetworks/bridge/models/subpopulations/Subpopulation.java
@@ -34,6 +34,14 @@ public interface Subpopulation extends BridgeEntity {
      */
     void setRequired(boolean required);
     boolean isRequired();
+
+    /**
+     * When a consent is signed by a participant, we send the signed consent to them via email or 
+     * via an SMS link. If this is true, suppress this behavior.
+     */
+    boolean isAutoSendConsentSuppressed();
+
+    void setAutoSendConsentSuppressed(boolean autoSendConsentSuppressed);
     
     /**
      * Has this subpopulation been deleted? The record remains for reconstructing historical 

--- a/app/org/sagebionetworks/bridge/services/ConsentService.java
+++ b/app/org/sagebionetworks/bridge/services/ConsentService.java
@@ -299,9 +299,8 @@ public class ConsentService {
         
         String htmlTemplate = studyConsentService.getActiveConsent(subpop).getDocumentContent();
         
-        String participantEmail = subpop.isAutoSendConsentSuppressed() ? null : participant.getEmail();
         ConsentEmailProvider consentEmail = new ConsentEmailProvider(study, participant.getTimeZone(),
-                participantEmail, consentSignature, sharingScope, htmlTemplate, consentTemplate);
+                participant.getEmail(), consentSignature, sharingScope, htmlTemplate, consentTemplate);
         if (!consentEmail.getRecipients().isEmpty()) {
             sendMailService.sendEmail(consentEmail);    
         }

--- a/app/org/sagebionetworks/bridge/services/StudyService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyService.java
@@ -566,6 +566,12 @@ public class StudyService {
             // You can't use the updateStudy() API to set consentNotificationEmailVerified from false to true.
             study.setConsentNotificationEmailVerified(false);
         }
+        // This needs to happen before the study is updated.
+        boolean consentHasChanged = !Objects.equals(originalStudy.getConsentNotificationEmail(),
+                study.getConsentNotificationEmail());
+        if (consentHasChanged) {
+            study.setConsentNotificationEmailVerified(false);
+        }
 
         // Only admins can delete or modify upload metadata fields. Check this after validation, so we don't have to
         // deal with duplicates.
@@ -579,12 +585,9 @@ public class StudyService {
         if (!originalStudy.getSupportEmail().equals(study.getSupportEmail())) {
             emailVerificationService.verifyEmailAddress(study.getSupportEmail());
         }
-
-        if (!originalStudy.getConsentNotificationEmail().equals(study.getConsentNotificationEmail())) {
-            study.setConsentNotificationEmailVerified(false);
-            sendVerifyEmail(study, StudyEmailType.CONSENT_NOTIFICATION);
+        if (consentHasChanged && study.getConsentNotificationEmail() != null) {
+            sendVerifyEmail(study, StudyEmailType.CONSENT_NOTIFICATION);    
         }
-
         return updatedStudy;
     }
 

--- a/app/org/sagebionetworks/bridge/services/email/ConsentEmailProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/ConsentEmailProvider.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.bridge.services.email;
 
+import static org.sagebionetworks.bridge.BridgeUtils.commaListToOrderedSet;
+
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
@@ -50,6 +52,7 @@ public class ConsentEmailProvider extends MimeTypeEmailProvider {
     private String consentAgreementHTML;
     private String consentTemplate;
     private DateTimeZone userTimeZone;
+    private List<String> recipients;
 
     public ConsentEmailProvider(Study study, DateTimeZone userTimeZone, String userEmail,
             ConsentSignature consentSignature, SharingScope sharingScope, String consentAgreementHTML,
@@ -61,21 +64,20 @@ public class ConsentEmailProvider extends MimeTypeEmailProvider {
         this.sharingScope = sharingScope;
         this.consentAgreementHTML = consentAgreementHTML;
         this.consentTemplate = consentTemplate;
-    }
-
-    public List<String> getRecipients() {
-        List<String> recipients = Lists.newArrayList();
+        this.recipients = Lists.newArrayList();
         // Check if consent notification email is verified. For backwards-compatibility, a null 
         // value means the email is verified.
         Boolean consentNotificationEmailVerified = getStudy().isConsentNotificationEmailVerified();
         if (consentNotificationEmailVerified == null || consentNotificationEmailVerified) {
-            // Must wrap in new list because set from BridgeUtils.commaListToSet() is immutable
-            Set<String> studyRecipients = BridgeUtils.commaListToOrderedSet(getStudy().getConsentNotificationEmail());
+            Set<String> studyRecipients = commaListToOrderedSet(getStudy().getConsentNotificationEmail());
             recipients.addAll( studyRecipients );
         }
         if (userEmail != null) {
             recipients.add(userEmail);
         }
+    }
+
+    public List<String> getRecipients() {
         return recipients;
     }
     
@@ -89,7 +91,7 @@ public class ConsentEmailProvider extends MimeTypeEmailProvider {
         final String sendFromEmail = getFormattedSenderEmail();
         builder.withSender(sendFromEmail);
 
-        builder.withRecipients(getRecipients());
+        builder.withRecipients(recipients);
 
         final String consentDoc = createSignedDocument();
 

--- a/app/org/sagebionetworks/bridge/services/email/MimeTypeEmail.java
+++ b/app/org/sagebionetworks/bridge/services/email/MimeTypeEmail.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.services.email;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.util.List;
@@ -32,7 +33,7 @@ public final class MimeTypeEmail {
     
     MimeTypeEmail(String subject, String senderAddress, List<String> recipientAddresses, List<MimeBodyPart> messageParts) {
         checkArgument(isNotBlank(subject));
-        checkArgument(recipientAddresses != null && !recipientAddresses.isEmpty());
+        checkNotNull(recipientAddresses);
         checkArgument(messageParts != null && !messageParts.isEmpty());
         
         this.subject = subject;

--- a/app/org/sagebionetworks/bridge/services/email/WithdrawConsentEmailProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/WithdrawConsentEmailProvider.java
@@ -45,9 +45,11 @@ public class WithdrawConsentEmailProvider extends MimeTypeEmailProvider {
 
         final String sendFromEmail = getFormattedSenderEmail();
         builder.withSender(sendFromEmail);
-
-        Set<String> emailAddresses = BridgeUtils.commaListToOrderedSet(getStudy().getConsentNotificationEmail());
-        builder.withRecipients(emailAddresses);
+        
+        if (getStudy().getConsentNotificationEmail() != null) {
+            Set<String> emailAddresses = BridgeUtils.commaListToOrderedSet(getStudy().getConsentNotificationEmail());
+            builder.withRecipients(emailAddresses);
+        }
 
         String content = String.format("<p>User %s withdrew from the study on %s. </p>", 
                 getUserLabel(), FORMATTER.print(withdrewOn));

--- a/app/org/sagebionetworks/bridge/validators/StudyValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/StudyValidator.java
@@ -98,10 +98,6 @@ public class StudyValidator implements Validator {
             UploadFieldDefinitionListValidator.INSTANCE.validate(study.getUploadMetadataFieldDefinitions(), errors,
                     "uploadMetadataFieldDefinitions");
         }
-
-        if (StringUtils.isBlank(study.getConsentNotificationEmail())) {
-            errors.rejectValue("consentNotificationEmail", "is required");
-        }
         // These *should* be set if they are null, with defaults
         if (study.getPasswordPolicy() == null) {
             errors.rejectValue("passwordPolicy", "is required");

--- a/test/org/sagebionetworks/bridge/BridgeUtilsTest.java
+++ b/test/org/sagebionetworks/bridge/BridgeUtilsTest.java
@@ -108,6 +108,14 @@ public class BridgeUtilsTest {
         assertEquals(host, map.get("host"));
     }
     
+    @Test
+    public void templateResolverHandlesNullConsentEmail() {
+        Study study = TestUtils.getValidStudy(BridgeUtilsTest.class);
+        study.setConsentNotificationEmail(null);
+        
+        Map<String,String> map = BridgeUtils.studyTemplateVariables(study);
+        assertNull(map.get("consentEmail"));
+    }
     
     @Test
     public void templateResolverWorks() {

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationTest.java
@@ -48,6 +48,7 @@ public class DynamoSubpopulationTest {
         subpop.setDefaultGroup(true);
         subpop.setPublishedConsentCreatedOn(PUBLISHED_CONSENT_TIMESTAMP.getMillis());
         subpop.setDeleted(true);
+        subpop.setAutoSendConsentSuppressed(true);
         subpop.setVersion(3L);
         
         Criteria criteria = TestUtils.createCriteria(2, 10, ALL_OF_GROUPS, NONE_OF_GROUPS);
@@ -58,14 +59,15 @@ public class DynamoSubpopulationTest {
         // This does not need to be passed to the user; the user is never allowed to set it.
         // This should be standard across the API, BTW, but this is leaked out by some classes.
         assertNull(node.get("studyIdentifier"));
-        assertEquals("Name", node.get("name").asText());
-        assertEquals("Description", node.get("description").asText());
-        assertEquals("guid", node.get("guid").asText());
-        assertEquals(PUBLISHED_CONSENT_TIMESTAMP.toString(), node.get("publishedConsentCreatedOn").asText());
-        assertTrue(node.get("required").asBoolean());
-        assertTrue(node.get("defaultGroup").asBoolean());
+        assertEquals("Name", node.get("name").textValue());
+        assertEquals("Description", node.get("description").textValue());
+        assertEquals("guid", node.get("guid").textValue());
+        assertEquals(PUBLISHED_CONSENT_TIMESTAMP.toString(), node.get("publishedConsentCreatedOn").textValue());
+        assertTrue(node.get("required").booleanValue());
+        assertTrue(node.get("defaultGroup").booleanValue());
+        assertTrue(node.get("autoSendConsentSuppressed").booleanValue());
         assertNull(node.get("deleted")); // users do not see this flag, they never get deleted items
-        assertEquals(3L, node.get("version").asLong());
+        assertEquals(3L, node.get("version").longValue());
         
         JsonNode critNode = node.get("criteria");
         assertEquals(ALL_OF_GROUPS, JsonUtils.asStringSet(critNode, "allOfGroups"));

--- a/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
@@ -1468,14 +1468,15 @@ public class StudyServiceMockTest {
         String originalEmail = TestUtils.getValidStudy(StudyServiceMockTest.class).getConsentNotificationEmail();
         String newEmail = "changed@changed.com";
         
-        setupConsentEmailChangeTest(null, null);
-        setupConsentEmailChangeTest(originalEmail, originalEmail);
-        setupConsentEmailChangeTest(null, newEmail);
-        setupConsentEmailChangeTest(originalEmail, null);
-        setupConsentEmailChangeTest(originalEmail, newEmail);
+        setupConsentEmailChangeTest(null, null, false, false);
+        setupConsentEmailChangeTest(originalEmail, originalEmail, false, false);
+        setupConsentEmailChangeTest(null, newEmail, true, true);
+        setupConsentEmailChangeTest(originalEmail, null, true, false);
+        setupConsentEmailChangeTest(originalEmail, newEmail, true, true);
     }
     
-    private void setupConsentEmailChangeTest(String originalEmail, String newEmail) {
+    private void setupConsentEmailChangeTest(String originalEmail, String newEmail, boolean shouldBeChanged,
+            boolean expectedSendEmail) {
         reset(sendMailService);
         Study original = TestUtils.getValidStudy(StudyServiceMockTest.class);
         original.setConsentNotificationEmail(originalEmail);
@@ -1488,18 +1489,15 @@ public class StudyServiceMockTest {
         
         service.updateStudy(update, true);
         
-        boolean hasChanged = !Objects.equals(original.getConsentNotificationEmail(),
-                update.getConsentNotificationEmail());
-        
-        if (update.getConsentNotificationEmail() == null) {
-            verify(sendMailService, never()).sendEmail(any());
-            assertEquals(hasChanged, !update.isConsentNotificationEmailVerified());
-        } else if (hasChanged) {
+        if (shouldBeChanged && expectedSendEmail) {
             verify(sendMailService).sendEmail(any());
-            assertFalse(update.isConsentNotificationEmailVerified()); // this is always true
         } else {
             verify(sendMailService, never()).sendEmail(any());
-            assertEquals(hasChanged, !update.isConsentNotificationEmailVerified());
+        }
+        if (shouldBeChanged) {
+            assertFalse(update.isConsentNotificationEmailVerified());
+        } else {
+            assertTrue(update.isConsentNotificationEmailVerified());
         }
     }
 

--- a/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
@@ -1489,7 +1489,7 @@ public class StudyServiceMockTest {
         
         service.updateStudy(update, true);
         
-        if (shouldBeChanged && expectedSendEmail) {
+        if (expectedSendEmail) {
             verify(sendMailService).sendEmail(any());
         } else {
             verify(sendMailService, never()).sendEmail(any());

--- a/test/org/sagebionetworks/bridge/services/email/ConsentEmailProviderTest.java
+++ b/test/org/sagebionetworks/bridge/services/email/ConsentEmailProviderTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.services.email;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.FileInputStream;
@@ -242,6 +243,26 @@ public class ConsentEmailProviderTest {
         List<String> recipientList = email.getRecipientAddresses();
         assertEquals(1, recipientList.size());
         assertEquals("user@user.com", recipientList.get(0));
+    }
+    
+    @Test
+    public void providerWithoutRecipientsWorks() {
+        study.setConsentNotificationEmail(null);
+        ConsentSignature sig = makeSignatureWithoutImage();
+        
+        // The provider reports that there are no addresses to send to, which is correct
+        ConsentEmailProvider provider = new ConsentEmailProvider(study, PST, null, sig,
+                SharingScope.NO_SHARING, NEW_DOCUMENT_FRAGMENT, consentBodyTemplate);
+        assertTrue(provider.getRecipients().isEmpty());
+        
+        provider = new ConsentEmailProvider(study, PST, "email@email.com", sig, SharingScope.NO_SHARING,
+                NEW_DOCUMENT_FRAGMENT, consentBodyTemplate);
+        assertFalse(provider.getRecipients().isEmpty());
+        
+        study.setConsentNotificationEmail("email@email.com");
+        provider = new ConsentEmailProvider(study, PST, null, sig, SharingScope.NO_SHARING, NEW_DOCUMENT_FRAGMENT,
+                consentBodyTemplate);
+        assertFalse(provider.getRecipients().isEmpty());
     }
 
     private static ConsentSignature makeSignatureWithoutImage() {

--- a/test/org/sagebionetworks/bridge/services/email/ConsentEmailProviderTest.java
+++ b/test/org/sagebionetworks/bridge/services/email/ConsentEmailProviderTest.java
@@ -230,6 +230,19 @@ public class ConsentEmailProviderTest {
         assertEquals(1, recipientList.size());
         assertEquals("user@user.com", recipientList.get(0));
     }
+    
+    @Test
+    public void consentCanHandleNullConsentEmail() throws Exception {
+        study.setConsentNotificationEmail(null);
+        ConsentSignature sig = makeSignatureWithoutImage();
+        
+        ConsentEmailProvider provider = new ConsentEmailProvider(study, PST, participant.getEmail(), sig,
+                SharingScope.NO_SHARING, NEW_DOCUMENT_FRAGMENT, consentBodyTemplate);
+        MimeTypeEmail email = provider.getMimeTypeEmail();
+        List<String> recipientList = email.getRecipientAddresses();
+        assertEquals(1, recipientList.size());
+        assertEquals("user@user.com", recipientList.get(0));
+    }
 
     private static ConsentSignature makeSignatureWithoutImage() {
         return new ConsentSignature.Builder().withName("Test Person").withBirthdate("1980-06-06").build();

--- a/test/org/sagebionetworks/bridge/services/email/WithdrawConsentEmailProviderTest.java
+++ b/test/org/sagebionetworks/bridge/services/email/WithdrawConsentEmailProviderTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.services.email;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -85,4 +86,21 @@ public class WithdrawConsentEmailProviderTest {
         assertEquals("<p>User Jack Aubrey &lt;d@d.com&gt; (external ID: AAA)  withdrew from the study on October 28, 2015. </p><p>Reason:</p><p>Because, reasons.</p>", body.getContent());
     }
     
+    @Test
+    public void unverifiedStudyConsentEmailGeneratesNoRecipients() {
+        study.setConsentNotificationEmailVerified(false);
+        provider = new WithdrawConsentEmailProvider(study, EXTERNAL_ID, account, WITHDRAWAL, UNIX_TIMESTAMP);
+        
+        assertTrue(provider.getRecipients().isEmpty());
+    }
+    
+    @Test
+    public void nullStudyConsentEmailGeneratesNoRecipients() {
+        // email shouldn't be verified if it is null, but regardless, there should still be no recipients
+        study.setConsentNotificationEmailVerified(true); 
+        study.setConsentNotificationEmail(null);
+        provider = new WithdrawConsentEmailProvider(study, EXTERNAL_ID, account, WITHDRAWAL, UNIX_TIMESTAMP);
+        
+        assertTrue(provider.getRecipients().isEmpty());
+    }
 }

--- a/test/org/sagebionetworks/bridge/services/email/WithdrawConsentEmailProviderTest.java
+++ b/test/org/sagebionetworks/bridge/services/email/WithdrawConsentEmailProviderTest.java
@@ -39,6 +39,7 @@ public class WithdrawConsentEmailProviderTest {
     @Test
     public void canGenerateMinimalEmail() throws Exception {
         when(study.getConsentNotificationEmail()).thenReturn("a@a.com");
+        when(study.isConsentNotificationEmailVerified()).thenReturn(true);
         when(study.getName()).thenReturn("Study Name");
         when(study.getSupportEmail()).thenReturn("c@c.com");
 
@@ -61,6 +62,7 @@ public class WithdrawConsentEmailProviderTest {
     @Test
     public void canGenerateMaximalEmail() throws Exception {
         when(study.getConsentNotificationEmail()).thenReturn("a@a.com, b@b.com");
+        when(study.isConsentNotificationEmailVerified()).thenReturn(true);
         when(study.getName()).thenReturn("Study Name");
         when(study.getSupportEmail()).thenReturn("c@c.com");
         account.setFirstName("<b>Jack</b>");

--- a/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
@@ -231,6 +231,12 @@ public class StudyValidatorTest {
     }
     
     @Test
+    public void missingConsentNotificationEmailOK() {
+        study.setConsentNotificationEmail(null);
+        Validate.entityThrowingException(INSTANCE, study);
+    }    
+    
+    @Test
     public void requiresPasswordPolicy() {
         study.setPasswordPolicy(null);
         assertValidatorMessage(INSTANCE, study, "passwordPolicy", "is required");

--- a/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
@@ -231,12 +231,6 @@ public class StudyValidatorTest {
     }
     
     @Test
-    public void requiresMissingConsentNotificationEmail() {
-        study.setConsentNotificationEmail(null);
-        assertValidatorMessage(INSTANCE, study, "consentNotificationEmail", "is required");
-    }
-    
-    @Test
     public void requiresPasswordPolicy() {
         study.setPasswordPolicy(null);
         assertValidatorMessage(INSTANCE, study, "passwordPolicy", "is required");


### PR DESCRIPTION
- users don't have to receive an email copy of their consent when they consent or withdraw (can be disabled per subpopulation);
- study administrators don't have to provide an email to receive consents every time they are signed. That's why we have them all in a database.