### PR TITLE
Fix linking template vars

### DIFF
--- a/app/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/app/org/sagebionetworks/bridge/BridgeConstants.java
@@ -120,9 +120,10 @@ public class BridgeConstants {
      * we have displayed in the UI.
      */
     public static final Whitelist CKEDITOR_WHITELIST = Whitelist.relaxed()
+            .preserveRelativeLinks(true)
             .addTags("hr", "s", "caption")
-            .addAttributes(":all", "style", "scope")
-            .addAttributes("a", "target")
+            .addAttributes(":all", "style", "scope", "href")
+            .addAttributes("a", "target", "href")
             .addAttributes("table", "align", "border", "cellpadding", "cellspacing", "summary");
     
 }

--- a/app/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/app/org/sagebionetworks/bridge/BridgeConstants.java
@@ -122,7 +122,7 @@ public class BridgeConstants {
     public static final Whitelist CKEDITOR_WHITELIST = Whitelist.relaxed()
             .preserveRelativeLinks(true)
             .addTags("hr", "s", "caption")
-            .addAttributes(":all", "style", "scope", "href")
+            .addAttributes(":all", "style", "scope")
             .addAttributes("a", "target", "href")
             .addAttributes("table", "align", "border", "cellpadding", "cellspacing", "summary");
     

--- a/app/org/sagebionetworks/bridge/services/StudyService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyService.java
@@ -771,7 +771,10 @@ public class StudyService {
             if (template.getMimeType() == MimeType.TEXT) {
                 body = Jsoup.clean(body, Whitelist.none());
             } else {
-                body = Jsoup.clean(body, BridgeConstants.CKEDITOR_WHITELIST);
+                // Providing the baseUrl allows relative URLs to be preserved, which we're interested in 
+                // so users can link template variables, e.g. <a href="${url}">${url}</a>
+                String baseUrl = BridgeConfigFactory.getConfig().get("webservices.url");
+                body = Jsoup.clean(body, baseUrl, BridgeConstants.CKEDITOR_WHITELIST);
             }
         }
         return new EmailTemplate(subject, body, template.getMimeType());

--- a/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
@@ -1435,6 +1435,16 @@ public class StudyServiceMockTest {
     }
     
     @Test
+    public void htmlTemplatePreservesLinksWithTemplateVariables() {
+        EmailTemplate source = new EmailTemplate("", "<p><a href=\"http://www.google.com/\"></a><a href=\"/foo.html\">Foo</a><a href=\"${url}\">${url}</a></p>", MimeType.HTML); 
+        
+        EmailTemplate result = service.sanitizeEmailTemplate(source);
+        
+        // The absolute, relative, and template URLs are all preserved correctly. 
+        assertEquals("<p><a href=\"http://www.google.com/\"></a><a href=\"/foo.html\">Foo</a><a href=\"${url}\">${url}</a></p>", result.getBody());
+    }
+    
+    @Test
     public void emptyTemplateIsSanitized() {
         EmailTemplate source = new EmailTemplate("", "", MimeType.HTML); 
         EmailTemplate result = service.sanitizeEmailTemplate(source);


### PR DESCRIPTION
Minor, but linking ${url} doesn't work in our email templates, and people have wanted to link these. This change in the configuration prevents JSoup from removing this kind of link: `<a href="${url}">${url}</a>`