### PR TITLE
automatic custom events

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
@@ -59,6 +59,7 @@ public final class DynamoStudy implements Study {
     private String shortName;
     private String sponsorName;
     private String identifier;
+    private Map<String, String> automaticCustomEvents;
     private boolean autoVerificationEmailSuppressed;
     private boolean studyIdExcludedInExport;
     private String supportEmail;
@@ -106,6 +107,7 @@ public final class DynamoStudy implements Study {
     private List<AndroidAppLink> androidAppLinks;
 
     public DynamoStudy() {
+        automaticCustomEvents = new HashMap<>();
         uploadMetadataFieldDefinitions = new ArrayList<>();
         profileAttributes = new HashSet<>();
         taskIdentifiers = new HashSet<>();
@@ -181,6 +183,18 @@ public final class DynamoStudy implements Study {
 
     public void setVersion(Long version) {
         this.version = version;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Map<String, String> getAutomaticCustomEvents() {
+        return automaticCustomEvents;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setAutomaticCustomEvents(Map<String, String> automaticCustomEvents) {
+        this.automaticCustomEvents = automaticCustomEvents == null ? new HashMap<>() : automaticCustomEvents;
     }
 
     /** {@inheritDoc} */
@@ -692,7 +706,7 @@ public final class DynamoStudy implements Study {
     
     @Override
     public int hashCode() {
-        return Objects.hash(name, shortName, sponsorName, identifier, autoVerificationEmailSuppressed,
+        return Objects.hash(name, shortName, sponsorName, identifier, automaticCustomEvents, autoVerificationEmailSuppressed,
                 studyIdExcludedInExport, supportEmail, synapseDataAccessTeamId, synapseProjectId, technicalEmail,
                 usesCustomExportSchedule, uploadMetadataFieldDefinitions, uploadValidationStrictness,
                 consentNotificationEmail, consentNotificationEmailVerified, minAgeOfConsent, accountLimit, version,
@@ -715,6 +729,7 @@ public final class DynamoStudy implements Study {
         DynamoStudy other = (DynamoStudy) obj;
 
         return (Objects.equals(identifier, other.identifier)
+                && Objects.equals(automaticCustomEvents, other.automaticCustomEvents)
                 && Objects.equals(autoVerificationEmailSuppressed, other.autoVerificationEmailSuppressed)
                 && Objects.equals(studyIdExcludedInExport, other.studyIdExcludedInExport)
                 && Objects.equals(supportEmail, other.supportEmail)
@@ -768,7 +783,7 @@ public final class DynamoStudy implements Study {
     @Override
     public String toString() {
         return String.format(
-                "DynamoStudy [name=%s, shortName=%s, active=%s, sponsorName=%s, identifier=%s, "
+                "DynamoStudy [name=%s, shortName=%s, active=%s, sponsorName=%s, identifier=%s, automaticCustomEvents=%s"
                         + "autoVerificationEmailSuppressed=%b, minAgeOfConsent=%s, studyIdExcludedInExport=%b, "
                         + "supportEmail=%s, synapseDataAccessTeamId=%s, synapseProjectId=%s, technicalEmail=%s, "
                         + "uploadValidationStrictness=%s, consentNotificationEmail=%s, consentNotificationEmailVerified=%s, "
@@ -781,7 +796,7 @@ public final class DynamoStudy implements Study {
                         + "oauthProviders=%s, appleAppLinks=%s, androidAppLinks=%s, reauthenticationEnabled=%s, "
                         + "resetPasswordSmsTemplate=%s, phoneSignInSmsTemplate=%s, appInstallLinkSmsTemplate=%s, "
                         + "verifyPhoneSmsTemplate=%s, accountExistsSmsTemplate=%s, autoVerificationPhoneSuppressed=%s]",
-                name, shortName, active, sponsorName, identifier, autoVerificationEmailSuppressed, minAgeOfConsent,
+                name, shortName, active, sponsorName, identifier, automaticCustomEvents, autoVerificationEmailSuppressed, minAgeOfConsent,
                 studyIdExcludedInExport, supportEmail, synapseDataAccessTeamId, synapseProjectId, technicalEmail,
                 uploadValidationStrictness, consentNotificationEmail, consentNotificationEmailVerified, version,
                 profileAttributes, taskIdentifiers, activityEventKeys, dataGroups, passwordPolicy, verifyEmailTemplate,

--- a/app/org/sagebionetworks/bridge/models/activities/CustomActivityEventRequest.java
+++ b/app/org/sagebionetworks/bridge/models/activities/CustomActivityEventRequest.java
@@ -1,27 +1,59 @@
 package org.sagebionetworks.bridge.models.activities;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.joda.time.DateTime;
 
-/**
- * Created by jyliu on 6/12/2017.
- */
+import org.sagebionetworks.bridge.json.DateTimeDeserializer;
+import org.sagebionetworks.bridge.json.DateTimeSerializer;
+
+/** An API request to add a custom activity event. */
+@JsonDeserialize(builder = CustomActivityEventRequest.Builder.class)
 public class CustomActivityEventRequest {
     private final String eventKey;
     private final DateTime timestamp;
 
-    @JsonCreator
-    public CustomActivityEventRequest(@JsonProperty("eventKey") String eventKey,
-            @JsonProperty("timestamp") DateTime timestamp) {
+    // Private constructor. Use builder.
+    private CustomActivityEventRequest(String eventKey, DateTime timestamp) {
         this.eventKey = eventKey;
         this.timestamp = timestamp;
     }
+
+    /**
+     * Activity event key. Bridge will automatically pre-pend "custom:" when forming the event ID (eg, event key
+     * "studyBurstStart" becomes event ID "custom:studyBurstStart").
+     */
     public String getEventKey() {
         return eventKey;
     }
 
+    /** When the activity occurred. */
+    @JsonSerialize(using = DateTimeSerializer.class)
     public DateTime getTimestamp() {
         return timestamp;
+    }
+
+    /** Custom activity event request builder. */
+    public static class Builder {
+        private String eventKey;
+        private DateTime timestamp;
+
+        /** @see CustomActivityEventRequest#getEventKey */
+        public Builder withEventKey(String eventKey) {
+            this.eventKey = eventKey;
+            return this;
+        }
+
+        /** @see CustomActivityEventRequest#getTimestamp */
+        @JsonDeserialize(using = DateTimeDeserializer.class)
+        public Builder withTimestamp(DateTime timestamp) {
+            this.timestamp = timestamp;
+            return this;
+        }
+
+        /** Builds a custom activity event request. */
+        public CustomActivityEventRequest build() {
+            return new CustomActivityEventRequest(eventKey, timestamp);
+        }
     }
 }

--- a/app/org/sagebionetworks/bridge/models/studies/Study.java
+++ b/app/org/sagebionetworks/bridge/models/studies/Study.java
@@ -72,6 +72,17 @@ public interface Study extends BridgeEntity, StudyIdentifier {
     void setVersion(Long version);
 
     /**
+     * Custom events that should be generated for participant upon enrollment. The key in this map is the eventKey, and
+     * the value is the offset after the enrollment event (eg, "P1D" for one day after enrollment, "P2W" for 2 weeks
+     * after enrollment). Note that this API will automatically pre-pend "custom:" in front of the event key when
+     * generating the eventId (eg, eventKey "studyBurstStart" becomes event ID "custom:studyBurstStart").
+     */
+    Map<String, String> getAutomaticCustomEvents();
+
+    /** @see #getAutomaticCustomEvents */
+    void setAutomaticCustomEvents(Map<String, String> automaticCustomEvents);
+
+    /**
      * True if the automatic email verification email on sign-up should be suppressed. False if the email should be
      * sent on sign-up. This is generally used in conjunction with email sign-in, where sending a separate email
      * verification email would be redundant.

--- a/app/org/sagebionetworks/bridge/play/controllers/ActivityEventController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ActivityEventController.java
@@ -12,6 +12,7 @@ import org.sagebionetworks.bridge.models.ResourceList;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.activities.ActivityEvent;
 import org.sagebionetworks.bridge.models.activities.CustomActivityEventRequest;
+import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.services.ActivityEventService;
 
 @Controller
@@ -27,7 +28,8 @@ public class ActivityEventController extends BaseController {
         UserSession session = getAuthenticatedAndConsentedSession();
         CustomActivityEventRequest activityEvent = parseJson(request(), CustomActivityEventRequest.class);
 
-        activityEventService.publishCustomEvent(session.getStudyIdentifier(), session.getHealthCode(),
+        Study study = studyService.getStudy(session.getStudyIdentifier());
+        activityEventService.publishCustomEvent(study, session.getHealthCode(),
                 activityEvent.getEventKey(), activityEvent.getTimestamp());
 
         return createdResult("Event recorded");

--- a/app/org/sagebionetworks/bridge/services/ConsentService.java
+++ b/app/org/sagebionetworks/bridge/services/ConsentService.java
@@ -157,7 +157,7 @@ public class ConsentService {
         accountDao.updateAccount(account, false);
         
         // Publish an enrollment event, set sharing scope 
-        activityEventService.publishEnrollmentEvent(participant.getHealthCode(), withConsentCreatedOnSignature);
+        activityEventService.publishEnrollmentEvent(study, participant.getHealthCode(), withConsentCreatedOnSignature);
         
         // Send email, if required.
         if (sendEmail && participant.getEmail() != null) {

--- a/test/org/sagebionetworks/bridge/models/activities/CustomActivityEventRequestTest.java
+++ b/test/org/sagebionetworks/bridge/models/activities/CustomActivityEventRequestTest.java
@@ -1,0 +1,45 @@
+package org.sagebionetworks.bridge.models.activities;
+
+import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.TestUtils;
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+public class CustomActivityEventRequestTest {
+    private static final String EVENT_KEY = "my-event";
+    private static final String EVENT_TIMESTAMP_STRING = "2018-04-04T16:43:11.357-07:00";
+    private static final DateTime EVENT_TIMESTAMP = DateTime.parse(EVENT_TIMESTAMP_STRING);
+
+    @Test
+    public void builder() {
+        CustomActivityEventRequest req = new CustomActivityEventRequest.Builder().withEventKey(EVENT_KEY)
+                .withTimestamp(EVENT_TIMESTAMP).build();
+        assertEquals(EVENT_KEY, req.getEventKey());
+        TestUtils.assertDatesWithTimeZoneEqual(EVENT_TIMESTAMP, req.getTimestamp());
+    }
+
+    @Test
+    public void serialize() throws Exception {
+        // Start with JSON
+        String jsonText = "{\n" +
+                "   \"eventKey\":\"" + EVENT_KEY + "\",\n" +
+                "   \"timestamp\":\"" + EVENT_TIMESTAMP_STRING + "\"\n" +
+                "}";
+
+        // Convert to POJO
+        CustomActivityEventRequest req = BridgeObjectMapper.get().readValue(jsonText,
+                CustomActivityEventRequest.class);
+        assertEquals(EVENT_KEY, req.getEventKey());
+        TestUtils.assertDatesWithTimeZoneEqual(EVENT_TIMESTAMP, req.getTimestamp());
+
+        // Convert back to JSON
+        JsonNode node = BridgeObjectMapper.get().convertValue(req, JsonNode.class);
+        assertEquals(3, node.size());
+        assertEquals(EVENT_KEY, node.get("eventKey").textValue());
+        TestUtils.assertDatesWithTimeZoneEqual(EVENT_TIMESTAMP, DateTime.parse(node.get("timestamp").textValue()));
+    }
+}

--- a/test/org/sagebionetworks/bridge/play/controllers/ActivityEventControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ActivityEventControllerTest.java
@@ -1,0 +1,74 @@
+package org.sagebionetworks.bridge.play.controllers;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import play.mvc.Result;
+
+import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.TestUtils;
+import org.sagebionetworks.bridge.models.accounts.UserSession;
+import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.services.ActivityEventService;
+import org.sagebionetworks.bridge.services.StudyService;
+
+public class ActivityEventControllerTest {
+    private static final Study DUMMY_STUDY = Study.create();
+    private static final String HEALTH_CODE = "my-health-code";
+    private static final String EVENT_KEY = "my-event";
+    private static final String EVENT_TIMESTAMP_STRING = "2018-04-04T16:43:11.357-0700";
+    private static final DateTime EVENT_TIMESTAMP = DateTime.parse(EVENT_TIMESTAMP_STRING);
+
+    private ActivityEventController controller;
+    private ActivityEventService mockActivityEventService;
+
+    @Before
+    public void setup() {
+        // Mock services
+        mockActivityEventService = mock(ActivityEventService.class);
+
+        StudyService mockStudyService = mock(StudyService.class);
+        when(mockStudyService.getStudy(TestConstants.TEST_STUDY)).thenReturn(DUMMY_STUDY);
+
+        controller = spy(new ActivityEventController(mockActivityEventService));
+        controller.setStudyService(mockStudyService);
+
+        // Mock session
+        UserSession mockSession = mock(UserSession.class);
+        when(mockSession.getStudyIdentifier()).thenReturn(TestConstants.TEST_STUDY);
+        when(mockSession.getHealthCode()).thenReturn(HEALTH_CODE);
+        doReturn(mockSession).when(controller).getAuthenticatedAndConsentedSession();
+    }
+
+    @Test
+    public void createCustomActivityEvent() throws Exception {
+        // Mock request JSON
+        String jsonText = "{\n" +
+                "   \"eventKey\":\"" + EVENT_KEY + "\",\n" +
+                "   \"timestamp\":\"" + EVENT_TIMESTAMP_STRING + "\"\n" +
+                "}";
+        TestUtils.mockPlayContextWithJson(jsonText);
+
+        // Execute
+        Result result = controller.createCustomActivityEvent();
+        TestUtils.assertResult(result, 201, "Event recorded");
+
+        // Validate back-end call
+        ArgumentCaptor<DateTime> eventTimeCaptor = ArgumentCaptor.forClass(DateTime.class);
+        verify(mockActivityEventService).publishCustomEvent(same(DUMMY_STUDY), eq(HEALTH_CODE), eq(EVENT_KEY),
+                eventTimeCaptor.capture());
+
+        DateTime eventTime = eventTimeCaptor.getValue();
+        System.out.println("eventTime=" + eventTime);
+        TestUtils.assertDatesWithTimeZoneEqual(EVENT_TIMESTAMP, eventTime);
+    }
+}

--- a/test/org/sagebionetworks/bridge/services/ConsentServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/ConsentServiceMockTest.java
@@ -183,7 +183,7 @@ public class ConsentServiceMockTest {
         assertNull(updatedConsentList.get(1).getWithdrewOn());
 
         // Consent we send to activityEventService is same as the second consent.
-        verify(activityEventService).publishEnrollmentEvent(participant.getHealthCode(), updatedConsentList.get(1));
+        verify(activityEventService).publishEnrollmentEvent(study, participant.getHealthCode(), updatedConsentList.get(1));
     }
 
     @Test


### PR DESCRIPTION
This is for Study Burst modeling https://sagebionetworks.jira.com/wiki/spaces/BRIDGE/pages/438665217/Activity+Burst+Notifications

The idea is that the study can be configured with a map of custom event IDs and periods, and when a user enrolls, we automatically generate these custom events for them. These events can be used to mark the starts of each study burst.

Testing done: unit tests and integ tests