### PR TITLE
Schedule on multiple event IDs

### DIFF
--- a/app/org/sagebionetworks/bridge/models/schedules/ActivityScheduler.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/ActivityScheduler.java
@@ -40,7 +40,11 @@ public abstract class ActivityScheduler {
         if (eventIdString == null) {
             eventIdString = "enrollment";
         }
-        List<DateTime> eventTimeList = getEventDateTimes(context, eventIdString, true);
+
+        // For one-time and persistent schedules, schedule off the first event specified in the list. For recurring
+        // schedules, schedule off _all_ events specified.
+        boolean getAll = schedule.getScheduleType() == ScheduleType.RECURRING;
+        List<DateTime> eventTimeList = getEventDateTimes(context, eventIdString, getAll);
 
         List<RangeTuple<DateTime>> scheduleWindowList = new ArrayList<>();
         for (DateTime oneEventTime : eventTimeList) {

--- a/app/org/sagebionetworks/bridge/models/schedules/IntervalActivityScheduler.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/IntervalActivityScheduler.java
@@ -6,6 +6,8 @@ import org.joda.time.DateTime;
 
 import com.google.common.collect.Lists;
 
+import org.sagebionetworks.bridge.models.RangeTuple;
+
 /**
  * This scheduler handles schedules that include an interval, times of day, and/or a delay 
  * in order to schedule (rather than a cron expression). In addition, it also handles one-time, 
@@ -20,10 +22,11 @@ class IntervalActivityScheduler extends ActivityScheduler {
     @Override
     public List<ScheduledActivity> getScheduledActivities(SchedulePlan plan, ScheduleContext context) {
         List<ScheduledActivity> scheduledActivities = Lists.newArrayList();
-        DateTime datetime = getScheduledTimeBasedOnEvent(context);
+        List<RangeTuple<DateTime>> scheduleWindowList = getScheduleWindowsBasedOnEvents(context);
 
-        if (datetime != null) {
-            while(shouldContinueScheduling(context, datetime, scheduledActivities)) {
+        for (RangeTuple<DateTime> oneScheduleWindow : scheduleWindowList) {
+            DateTime datetime = oneScheduleWindow.getStart();
+            while(shouldContinueScheduling(context, datetime, oneScheduleWindow, scheduledActivities)) {
                 addScheduledActivityForAllTimes(scheduledActivities, plan, context, datetime);
                 // A one-time activity with no interval (for example); don't loop
                 if (schedule.getInterval() == null) {

--- a/app/org/sagebionetworks/bridge/models/schedules/PersistentActivityScheduler.java
+++ b/app/org/sagebionetworks/bridge/models/schedules/PersistentActivityScheduler.java
@@ -14,7 +14,7 @@ public class PersistentActivityScheduler extends ActivityScheduler {
     
     @Override
     public List<ScheduledActivity> getScheduledActivities(SchedulePlan plan, ScheduleContext context) {
-        // similar to a safety check in ActivityScheduler.getScheduledTimeBasedOnEvent
+        // similar to a safety check in ActivityScheduler.getScheduleWindowsBasedOnEvents
         if (schedule.getEventId() == null) {
             schedule.setEventId("enrollment");
         }
@@ -26,9 +26,11 @@ public class PersistentActivityScheduler extends ActivityScheduler {
             // when creating a schedule. It's clearer if you don't include this "finished" event, though it 
             // won't break anything if a user does include it in the eventId.
             String finishedId = "activity:"+activity.getGuid()+":finished";
-            DateTime scheduledTime = getFirstEventDateTime(context, finishedId+"," + schedule.getEventId());
+            List<DateTime> scheduledTimeList = getEventDateTimes(context,
+                    finishedId+"," + schedule.getEventId(), false);
 
-            if (scheduledTime != null) {
+            if (!scheduledTimeList.isEmpty()) {
+                DateTime scheduledTime = scheduledTimeList.get(0);
                 DateTime localDateTime = scheduledTime.withZone(context.getInitialTimeZone());
                 
                 addScheduledActivityAtTimeForOneActivity(scheduledActivities, plan, context,

--- a/test/org/sagebionetworks/bridge/models/schedules/ActivitySchedulerTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/ActivitySchedulerTest.java
@@ -248,10 +248,12 @@ public class ActivitySchedulerTest {
         schedule.setScheduleType(ONCE);
         
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(NOW.plusDays(1)));
+        assertEquals(1, scheduledActivities.size());
         assertEquals(ENROLLMENT.plusDays(2).withZone(PST), scheduledActivities.get(0).getScheduledOn());
-        
+
         events.remove("survey:event");
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(NOW.plusDays(1)));
+        assertEquals(1, scheduledActivities.size());
         assertEquals(ENROLLMENT.withZone(PST), scheduledActivities.get(0).getScheduledOn());
         
         // BUT this produces nothing because the system doesn't fallback to enrollment if an event has been set
@@ -271,10 +273,12 @@ public class ActivitySchedulerTest {
         schedule.addTimes(localTime);
         
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(NOW.plusDays(1)));
+        assertEquals(1, scheduledActivities.size());
         assertEquals(ENROLLMENT.withTime(localTime).plusDays(2).withZoneRetainFields(PST), scheduledActivities.get(0).getScheduledOn());
-        
+
         events.remove("survey:event");
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(NOW.plusDays(1)));
+        assertEquals(1, scheduledActivities.size());
         assertEquals(ENROLLMENT.withZone(PST).withTime(localTime), scheduledActivities.get(0).getScheduledOn());
         
         // BUT this produces nothing because the system doesn't fallback to enrollment if an event has been set

--- a/test/org/sagebionetworks/bridge/models/schedules/ActivitySchedulerTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/ActivitySchedulerTest.java
@@ -282,7 +282,20 @@ public class ActivitySchedulerTest {
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(NOW.plusDays(1)));
         assertEquals(0, scheduledActivities.size());
     }
-    
+
+    // branch coverage
+    @Test
+    public void contextWithEmptyEventMap() {
+        Schedule schedule = new Schedule();
+        schedule.addActivity(TestUtils.getActivity3());
+        schedule.setScheduleType(ONCE);
+
+        events.clear();
+
+        scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(NOW.plusDays(14)));
+        assertTrue(scheduledActivities.isEmpty());
+    }
+
     @Test
     public void activitiesMarkedPersistentUnderCorrectCircumstances() throws Exception {
         Schedule schedule = new Schedule();

--- a/test/org/sagebionetworks/bridge/models/schedules/CronActivitySchedulerTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/CronActivitySchedulerTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.models.schedules;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.sagebionetworks.bridge.models.schedules.ScheduleTestUtils.asDT;
 import static org.sagebionetworks.bridge.models.schedules.ScheduleTestUtils.assertDates;
 import static org.sagebionetworks.bridge.models.schedules.ScheduleType.ONCE;
@@ -32,7 +33,7 @@ public class CronActivitySchedulerTest {
     
     private static final DateTime NOW = DateTime.parse("2015-03-26T14:40:00-07:00");
     private static final DateTimeZone PST = DateTimeZone.forOffsetHours(-7);
-    private static DateTime ENROLLMENT = DateTime.parse("2015-03-23T10:00:00Z");
+    private static final DateTime ENROLLMENT = DateTime.parse("2015-03-23T10:00:00Z");
     
     private Map<String, DateTime> events;
     private List<ScheduledActivity> scheduledActivities;
@@ -228,7 +229,7 @@ public class CronActivitySchedulerTest {
         // We'd expect, based on that schedule, to have a task:
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(now.plusDays(4)));
         assertDates(scheduledActivities, "2016-03-14 00:00");
-        
+
         DateTimeUtils.setCurrentMillisSystem();
     }
     
@@ -257,7 +258,30 @@ public class CronActivitySchedulerTest {
         
         DateTimeUtils.setCurrentMillisSystem();
     }
-    
+
+    @Test
+    public void recurringCronScheduleWithNoEvents() {
+        Schedule schedule = createScheduleWith(RECURRING);
+        schedule.setCronTrigger("0 0 6 * * ?"); // daily at 6am
+        schedule.setEventId("non-existent-event");
+
+        scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusDays(4)));
+        assertTrue(scheduledActivities.isEmpty());
+    }
+
+    @Test
+    public void recurringCronScheduleWithMultipleEvents() {
+        Schedule schedule = createScheduleWith(RECURRING);
+        schedule.setCronTrigger("0 0 6 * * ?"); // daily at 6am
+        schedule.setSequencePeriod("P3D");
+        schedule.setEventId("two_weeks_before_enrollment,enrollment");
+
+        scheduledActivities = schedule.getScheduler().getScheduledActivities(plan,
+                getContext(ENROLLMENT.plusDays(14)));
+        assertDates(scheduledActivities, "2015-03-10 06:00", "2015-03-11 06:00", "2015-03-12 06:00",
+                "2015-03-24 06:00", "2015-03-25 06:00", "2015-03-26 06:00");
+    }
+
     @Test
     public void verifyTimesAreConvertedCorrectly() {
         DateTimeZone initialTimeZone = DateTimeZone.forOffsetHours(4);

--- a/test/org/sagebionetworks/bridge/models/schedules/CronActivitySchedulerTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/CronActivitySchedulerTest.java
@@ -161,6 +161,18 @@ public class CronActivitySchedulerTest {
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusWeeks(2)));
         assertDates(scheduledActivities, "2015-03-28 09:15");
     }
+
+    @Test
+    public void onceCronScheduleWithMultipleEventsOnlyReturnsOneActivity() {
+        Schedule schedule = createScheduleWith(ONCE);
+        schedule.setCronTrigger("0 0 6 * * ?"); // at 6am
+        schedule.setEventId("two_weeks_before_enrollment,enrollment");
+
+        scheduledActivities = schedule.getScheduler().getScheduledActivities(plan,
+                getContext(ENROLLMENT.plusDays(14)));
+        assertDates(scheduledActivities, "2015-03-10 06:00");
+    }
+
     @Test
     public void recurringCronScheduleWorks() {
         Schedule schedule = createScheduleWith(RECURRING);

--- a/test/org/sagebionetworks/bridge/models/schedules/IntervalActivitySchedulerTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/IntervalActivitySchedulerTest.java
@@ -397,6 +397,21 @@ public class IntervalActivitySchedulerTest {
         // Pulled back to yesterday midnight to avoid TZ changes causing activity to be unavailable
         assertDates(scheduledActivities, "2015-04-02 12:22");
     }
+
+    @Test
+    public void onceScheduleWithMultipleEventsOnlyReturnsOneActivity() {
+        Schedule schedule = createScheduleWith(ONCE);
+        schedule.setTimes(ImmutableList.of(LocalTime.parse("06:00")));
+        schedule.setInterval("P1D");
+        schedule.setEventId("two_weeks_before_enrollment,enrollment");
+
+        events.put("two_weeks_before_enrollment", ENROLLMENT.minusWeeks(2));
+
+        scheduledActivities = schedule.getScheduler().getScheduledActivities(plan,
+                getContext(ENROLLMENT.plusDays(14)));
+        assertDates(scheduledActivities, "2015-03-09 06:00");
+    }
+
     @Test
     public void onceEventDelayExpiresStartEndsOnScheduleWorks() {
         Schedule schedule = createScheduleWith(ONCE);

--- a/test/org/sagebionetworks/bridge/models/schedules/IntervalActivitySchedulerTest.java
+++ b/test/org/sagebionetworks/bridge/models/schedules/IntervalActivitySchedulerTest.java
@@ -12,9 +12,11 @@ import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.collect.ImmutableList;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.joda.time.DateTimeZone;
+import org.joda.time.LocalTime;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,7 +29,7 @@ public class IntervalActivitySchedulerTest {
 
     private static final DateTime NOW = DateTime.parse("2015-03-26T14:40:00-07:00");
     private static final DateTimeZone PST = DateTimeZone.forOffsetHours(-7);
-    private static DateTime ENROLLMENT = DateTime.parse("2015-03-23T10:00:00Z");
+    private static final DateTime ENROLLMENT = DateTime.parse("2015-03-23T10:00:00Z");
     
     private Map<String, DateTime> events;
     private List<ScheduledActivity> scheduledActivities;
@@ -598,6 +600,32 @@ public class IntervalActivitySchedulerTest {
         
         assertDates(scheduledActivities, 
                 "2015-04-07 09:40", "2015-04-07 13:40", "2015-04-09 09:40", "2015-04-09 13:40");
+    }
+
+    @Test
+    public void recurringScheduleWithNoEvents() {
+        Schedule schedule = createScheduleWith(RECURRING);
+        schedule.setInterval("P1D");
+        schedule.setEventId("non-existent-event");
+
+        scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusDays(4)));
+        assertTrue(scheduledActivities.isEmpty());
+    }
+
+    @Test
+    public void recurringScheduleWithMultipleEvents() {
+        Schedule schedule = createScheduleWith(RECURRING);
+        schedule.setTimes(ImmutableList.of(LocalTime.parse("06:00")));
+        schedule.setInterval("P1D");
+        schedule.setSequencePeriod("P3D");
+        schedule.setEventId("two_weeks_before_enrollment,enrollment");
+
+        events.put("two_weeks_before_enrollment", ENROLLMENT.minusWeeks(2));
+
+        scheduledActivities = schedule.getScheduler().getScheduledActivities(plan,
+                getContext(ENROLLMENT.plusDays(14)));
+        assertDates(scheduledActivities, "2015-03-09 06:00", "2015-03-10 06:00", "2015-03-11 06:00",
+                "2015-03-23 06:00", "2015-03-24 06:00", "2015-03-25 06:00");
     }
 
     // This is a specific scenario in one of our studies and I wanted to have a test specifically to verify this works.


### PR DESCRIPTION
This is needed to model study bursts. Each study burst looks the same, so instead of creating 9 identical schedules, it would be better to create 1 schedule that can be scheduled off of 9 different event IDs. See https://sagebionetworks.jira.com/wiki/spaces/BRIDGE/pages/438665217/Activity+Burst+Notifications

Testing done: unit tests and integ tests