### PR TITLE
Configuring the SMS delivery type

### DIFF
--- a/app/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/app/org/sagebionetworks/bridge/BridgeConstants.java
@@ -109,11 +109,11 @@ public class BridgeConstants {
      * 11 character label as to who sent the SMS message. Only in some supported countries (not US):
      * https://support.twilio.com/hc/en-us/articles/223133767-International-support-for-Alphanumeric-Sender-ID
      */
-    public static final String SENDER_ID = "AWS.SNS.SMS.SenderID";
-    /** SMS type (Promotional or Transactional). */
-    public static final String SMS_TYPE = "AWS.SNS.SMS.SMSType";
-    /** SMS message type. */
-    public static final String SMS_TYPE_TRANSACTIONAL = "Transactional";
+    public static final String AWS_SMS_SENDER_ID = "AWS.SNS.SMS.SenderID";
+    /** 
+     * SMS type ("Promotional" or "Transactional"). 
+     */
+    public static final String AWS_SMS_TYPE = "AWS.SNS.SMS.SMSType";
     
     /**
      * This whitelist adds a few additional tags and attributes that are used by the CKEDITOR options 

--- a/app/org/sagebionetworks/bridge/services/AccountWorkflowService.java
+++ b/app/org/sagebionetworks/bridge/services/AccountWorkflowService.java
@@ -252,6 +252,7 @@ public class AccountWorkflowService {
                 .withStudy(study)
                 .withToken("token", formattedSpToken)
                 .withSmsTemplate(study.getVerifyPhoneSmsTemplate())
+                .withTransactionType()
                 .withExpirationPeriod(PHONE_VERIFICATION_EXPIRATION_PERIOD, VERIFY_OR_RESET_EXPIRE_IN_SECONDS)
                 .withPhone(phone).build();
         notificationsService.sendSmsMessage(provider);
@@ -388,6 +389,7 @@ public class AccountWorkflowService {
 
         SmsMessageProvider.Builder builder = new SmsMessageProvider.Builder();
         builder.withSmsTemplate(template);
+        builder.withTransactionType();
         builder.withStudy(study);
         builder.withPhone(phone);
         builder.withToken(SPTOKEN_KEY, sptoken);
@@ -456,6 +458,7 @@ public class AccountWorkflowService {
             SmsMessageProvider provider = new SmsMessageProvider.Builder()
                     .withStudy(study)
                     .withSmsTemplate(study.getPhoneSignInSmsTemplate())
+                    .withTransactionType()
                     .withPhone(signIn.getPhone())
                     .withExpirationPeriod(PHONE_SIGNIN_EXPIRATION_PERIOD, SIGNIN_EXPIRE_IN_SECONDS)
                     .withToken(TOKEN_KEY, formattedToken).build();

--- a/app/org/sagebionetworks/bridge/services/IntentService.java
+++ b/app/org/sagebionetworks/bridge/services/IntentService.java
@@ -100,10 +100,13 @@ public class IntentService {
             if (!study.getInstallLinks().isEmpty()) {
                 String url = getInstallLink(intent.getOsName(), study.getInstallLinks());
                 
-                // The URL being sent does not expire.
+                // The URL being sent does not expire. We send with a transaction delivery type because
+                // this is a critical step in onboarding through this workflow and message needs to be 
+                // sent immediately after consenting.
                 SmsMessageProvider provider = new SmsMessageProvider.Builder()
                         .withStudy(study)
                         .withSmsTemplate(study.getAppInstallLinkSmsTemplate())
+                        .withTransactionType()
                         .withPhone(intent.getPhone())
                         .withToken(APP_INSTALL_URL_KEY, url).build();
                 notificationsService.sendSmsMessage(provider);

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -510,6 +510,10 @@ public class ParticipantService {
         notificationsService.sendNotificationToUser(study.getStudyIdentifier(), account.getHealthCode(), message);
     }
 
+    /**
+     * Send an SMS message to this user if they have a verified phone number. This message will be 
+     * sent with AWS' non-critical, "Promotional" level of delivery that optimizes for cost.
+     */
     public void sendSmsMessage(Study study, String userId, SmsTemplate template) {
         checkNotNull(study);
         checkNotNull(userId);
@@ -527,6 +531,7 @@ public class ParticipantService {
         SmsMessageProvider.Builder builder = new SmsMessageProvider.Builder()
                 .withPhone(account.getPhone())
                 .withSmsTemplate(template)
+                .withPromotionType()
                 .withStudy(study);
         for (Map.Entry<String, String> entry : variables.entrySet()) {
             builder.withToken(entry.getKey(), entry.getValue());

--- a/app/org/sagebionetworks/bridge/sms/SmsMessageProvider.java
+++ b/app/org/sagebionetworks/bridge/sms/SmsMessageProvider.java
@@ -18,13 +18,17 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 
 public class SmsMessageProvider {
+    
     private final Study study;
     private final Map<String,String> tokenMap;
     private final Phone phone;
+    private final String smsType;
     private final SmsTemplate template;
     
-    private SmsMessageProvider(Study study, SmsTemplate template, Phone phone, Map<String, String> tokenMap) {
+    private SmsMessageProvider(Study study, SmsTemplate template, String smsType, Phone phone,
+            Map<String, String> tokenMap) {
         this.study = study;
+        this.smsType = smsType;
         this.template = template;
         this.phone = phone;
         this.tokenMap = tokenMap;
@@ -39,14 +43,17 @@ public class SmsMessageProvider {
     public Phone getPhone() {
         return phone;
     }
+    public String getSmsType() {
+        return smsType;
+    }
     public Map<String,String> getTokenMap() {
         return tokenMap;
     }
 
     public PublishRequest getSmsRequest() {
         Map<String, MessageAttributeValue> smsAttributes = Maps.newHashMap();
-        smsAttributes.put(BridgeConstants.SMS_TYPE, attribute(BridgeConstants.SMS_TYPE_TRANSACTIONAL));
-        smsAttributes.put(BridgeConstants.SENDER_ID, attribute(tokenMap.get("studyShortName")));
+        smsAttributes.put(BridgeConstants.AWS_SMS_TYPE, attribute(getSmsType()));
+        smsAttributes.put(BridgeConstants.AWS_SMS_SENDER_ID, attribute(tokenMap.get("studyShortName")));
         // Costs seem too low to worry about this, but if need be, this is how we'd cap it.
         // smsAttributes.put("AWS.SNS.SMS.MaxPrice", attribute("0.50")); max price set to $.50
 
@@ -65,6 +72,7 @@ public class SmsMessageProvider {
         private Study study;
         private Map<String,String> tokenMap = Maps.newHashMap();
         private Phone phone;
+        private String smsType;
         private SmsTemplate template;
 
         public Builder withStudy(Study study) {
@@ -83,6 +91,14 @@ public class SmsMessageProvider {
             this.phone = phone;
             return this;
         }
+        public Builder withTransactionType() {
+            this.smsType = "Transactional";
+            return this;
+        }
+        public Builder withPromotionType() {
+            this.smsType = "Promotional";
+            return this;
+        }
         public Builder withExpirationPeriod(String name, int expireInSeconds) {
             withToken(name, BridgeUtils.secondsToPeriodString(expireInSeconds));
             return this;
@@ -91,6 +107,7 @@ public class SmsMessageProvider {
             checkNotNull(study);
             checkNotNull(template);
             checkNotNull(phone);
+            checkNotNull(smsType);
             tokenMap.putAll(BridgeUtils.studyTemplateVariables(study));
             
             // overwriting the study's short name field with a default value, if needed
@@ -99,7 +116,7 @@ public class SmsMessageProvider {
             // remove nulls, these will cause ImmutableMap.of to fail
             tokenMap.values().removeIf(Objects::isNull);
 
-            return new SmsMessageProvider(study, template, phone, ImmutableMap.copyOf(tokenMap));
+            return new SmsMessageProvider(study, template, smsType, phone, ImmutableMap.copyOf(tokenMap));
         }
     }
 }

--- a/test/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
@@ -250,6 +250,7 @@ public class AccountWorkflowServiceTest {
         Map<String,String> tokens = provider.getTokenMap();
         assertEquals("012-345", tokens.get("token"));
         assertEquals("2 hours", tokens.get("phoneVerificationExpirationPeriod"));
+        assertEquals("Transactional", provider.getSmsType());
         
         String message = provider.getSmsRequest().getMessage();
         assertTrue(message.contains("012-345"));
@@ -593,6 +594,7 @@ public class AccountWorkflowServiceTest {
         assertTrue(message.contains("Account for ShortName already exists. Reset password: "));
         assertTrue(message.contains("/rp?study=api&sptoken="+SPTOKEN));
         assertTrue(message.contains(" or "+TOKEN.substring(0,3) + "-" + TOKEN.substring(3,6)));
+        assertEquals("Transactional", smsMessageProviderCaptor.getValue().getSmsType());
     }
     
     @Test
@@ -641,6 +643,7 @@ public class AccountWorkflowServiceTest {
         
         assertEquals(study, smsMessageProviderCaptor.getValue().getStudy());
         assertEquals(TestConstants.PHONE, smsMessageProviderCaptor.getValue().getPhone());
+        assertEquals("Transactional", smsMessageProviderCaptor.getValue().getSmsType());
         String message = smsMessageProviderCaptor.getValue().getSmsRequest().getMessage();
         assertTrue(message.contains("Reset ShortName password: "));
         assertTrue(message.contains("/rp?study=api&sptoken="+SPTOKEN));
@@ -937,6 +940,7 @@ public class AccountWorkflowServiceTest {
         
         assertEquals(study, smsMessageProviderCaptor.getValue().getStudy());
         assertEquals(TestConstants.PHONE, smsMessageProviderCaptor.getValue().getPhone());
+        assertEquals("Transactional", smsMessageProviderCaptor.getValue().getSmsType());
         String message = smsMessageProviderCaptor.getValue().getSmsRequest().getMessage();
         assertEquals("Enter 123-456 to sign in to AppName", message);
         verifyNoMoreInteractions(mockCacheProvider);

--- a/test/org/sagebionetworks/bridge/services/IntentServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/IntentServiceTest.java
@@ -120,6 +120,7 @@ public class IntentServiceTest {
         assertEquals(mockStudy, provider.getStudy());
         assertEquals(intent.getPhone(), provider.getPhone());
         assertEquals("this-is-a-link", provider.getSmsRequest().getMessage());
+        assertEquals("Transactional", provider.getSmsType());
     }
     
     @Test(expected = InvalidEntityException.class)

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -1497,6 +1497,7 @@ public class ParticipantServiceTest {
         SmsMessageProvider provider = providerCaptor.getValue();
         assertEquals(TestConstants.PHONE, provider.getPhone());
         assertEquals("This is a test Bridge", provider.getSmsRequest().getMessage());
+        assertEquals("Promotional", provider.getSmsType());
     }
     
     @Test(expected = BadRequestException.class)

--- a/test/org/sagebionetworks/bridge/sms/SmsMessageProviderTest.java
+++ b/test/org/sagebionetworks/bridge/sms/SmsMessageProviderTest.java
@@ -33,6 +33,7 @@ public class SmsMessageProviderTest {
             .withStudy(study)
             .withPhone(TestConstants.PHONE)
             .withSmsTemplate(template)
+            .withTransactionType()
             .withExpirationPeriod("expirationPeriod", 60*60*4) // 4 hours
             .withToken("url", "some-url").build();
         
@@ -40,9 +41,9 @@ public class SmsMessageProviderTest {
         PublishRequest request = provider.getSmsRequest();
         assertEquals("ShortName some-url support@email.com 4 hours", request.getMessage());
         assertEquals(study.getShortName(),
-                request.getMessageAttributes().get(BridgeConstants.SENDER_ID).getStringValue());
-        assertEquals(BridgeConstants.SMS_TYPE_TRANSACTIONAL,
-                request.getMessageAttributes().get(BridgeConstants.SMS_TYPE).getStringValue());
+                request.getMessageAttributes().get(BridgeConstants.AWS_SMS_SENDER_ID).getStringValue());
+        assertEquals("Transactional",
+                request.getMessageAttributes().get(BridgeConstants.AWS_SMS_TYPE).getStringValue());
         
         assertEquals("some-url", provider.getTokenMap().get("url"));
         assertEquals("4 hours", provider.getTokenMap().get("expirationPeriod"));
@@ -67,6 +68,7 @@ public class SmsMessageProviderTest {
             .withStudy(study)
             .withPhone(TestConstants.PHONE)
             .withSmsTemplate(template)
+            .withPromotionType()
             .withToken("url", "some-url").build();
         PublishRequest request = provider.getSmsRequest();
         assertEquals("Bridge some-url", request.getMessage());
@@ -78,10 +80,21 @@ public class SmsMessageProviderTest {
                 .withStudy(Study.create())
                 .withPhone(TestConstants.PHONE)
                 .withSmsTemplate(new SmsTemplate(""))
+                .withPromotionType()
                 .withToken("url", null).build();
         
         Map<String,String> tokenMap = provider.getTokenMap();
         assertNull(tokenMap.get("supportName"));
+    }
+    
+    @Test
+    public void canConstructPromotionalMessage() {
+        SmsMessageProvider provider = new SmsMessageProvider.Builder()
+                .withStudy(Study.create())
+                .withPhone(TestConstants.PHONE)
+                .withSmsTemplate(new SmsTemplate(""))
+                .withPromotionType().build();
+        assertEquals("Promotional", provider.getSmsType());
     }
 
 }


### PR DESCRIPTION
SMS sent through the API is now marked as promotional, not transactional (which is cheaper). SMS messages sent for any aspect of authentication is still marked as transactional.