### PR TITLE
Adding templates to send signed consents via email or SMS.

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
@@ -84,11 +84,13 @@ public final class DynamoStudy implements Study {
     private EmailTemplate resetPasswordTemplate;
     private EmailTemplate emailSignInTemplate;
     private EmailTemplate accountExistsTemplate;
+    private EmailTemplate signedConsentTemplate;
     private SmsTemplate resetPasswordSmsTemplate;
     private SmsTemplate phoneSignInSmsTemplate;
     private SmsTemplate appInstallLinkSmsTemplate;
     private SmsTemplate verifyPhoneSmsTemplate;
     private SmsTemplate accountExistsSmsTemplate;
+    private SmsTemplate signedConsentSmsTemplate;
     private boolean strictUploadValidationEnabled;
     private boolean healthCodeExportEnabled;
     private boolean emailVerificationEnabled;
@@ -457,6 +459,19 @@ public final class DynamoStudy implements Study {
     }
     
     @Override
+    public void setSignedConsentTemplate(EmailTemplate template) {
+        this.signedConsentTemplate = template;
+    }
+    
+    /** {@inheritDoc} */
+    @DynamoDBTypeConvertedJson
+    @Override
+    public EmailTemplate getSignedConsentTemplate() {
+        return signedConsentTemplate;
+    }
+    
+    
+    @Override
     public void setAccountExistsTemplate(EmailTemplate template) {
         this.accountExistsTemplate = template;
     }
@@ -693,6 +708,17 @@ public final class DynamoStudy implements Study {
     public void setAccountExistsSmsTemplate(SmsTemplate accountExistsSmsTemplate) {
         this.accountExistsSmsTemplate = accountExistsSmsTemplate;
     }
+    
+    @DynamoDBTypeConvertedJson
+    @Override
+    public SmsTemplate getSignedConsentSmsTemplate() {
+        return signedConsentSmsTemplate;
+    }
+    
+    @Override
+    public void setSignedConsentSmsTemplate(SmsTemplate template) {
+        this.signedConsentSmsTemplate = template;
+    }
 
     @Override
     public boolean isAutoVerificationPhoneSuppressed() {
@@ -717,7 +743,7 @@ public final class DynamoStudy implements Study {
                 minSupportedAppVersions, pushNotificationARNs, installLinks, disableExport, oauthProviders,
                 appleAppLinks, androidAppLinks, reauthenticationEnabled, resetPasswordSmsTemplate,
                 phoneSignInSmsTemplate, appInstallLinkSmsTemplate, verifyPhoneSmsTemplate, accountExistsSmsTemplate,
-                autoVerificationPhoneSuppressed);
+                autoVerificationPhoneSuppressed, signedConsentTemplate, signedConsentSmsTemplate);
     }
 
     @Override
@@ -777,7 +803,9 @@ public final class DynamoStudy implements Study {
                 && Objects.equals(appInstallLinkSmsTemplate, other.appInstallLinkSmsTemplate)
                 && Objects.equals(verifyPhoneSmsTemplate, other.verifyPhoneSmsTemplate)
                 && Objects.equals(accountExistsSmsTemplate, other.accountExistsSmsTemplate)
-                && Objects.equals(autoVerificationPhoneSuppressed, other.autoVerificationPhoneSuppressed);
+                && Objects.equals(autoVerificationPhoneSuppressed, other.autoVerificationPhoneSuppressed)
+                && Objects.equals(signedConsentTemplate, other.signedConsentTemplate)
+                && Objects.equals(signedConsentSmsTemplate, other.signedConsentSmsTemplate);
     }
 
     @Override
@@ -795,8 +823,9 @@ public final class DynamoStudy implements Study {
                         + "emailSignInTemplate=%s, emailSignInEnabled=%s, phoneSignInEnabled=%s, accountLimit=%s, "
                         + "oauthProviders=%s, appleAppLinks=%s, androidAppLinks=%s, reauthenticationEnabled=%s, "
                         + "resetPasswordSmsTemplate=%s, phoneSignInSmsTemplate=%s, appInstallLinkSmsTemplate=%s, "
-                        + "verifyPhoneSmsTemplate=%s, accountExistsSmsTemplate=%s, autoVerificationPhoneSuppressed=%s]",
-                name, shortName, active, sponsorName, identifier, automaticCustomEvents, autoVerificationEmailSuppressed, minAgeOfConsent,
+                        + "verifyPhoneSmsTemplate=%s, accountExistsSmsTemplate=%s, autoVerificationPhoneSuppressed=%s, "
+                        + "signedConsentTemplate=%s, signedConsentSmsTemplate=%s",
+                name, shortName, active, sponsorName, identifier, autoVerificationEmailSuppressed, minAgeOfConsent,
                 studyIdExcludedInExport, supportEmail, synapseDataAccessTeamId, synapseProjectId, technicalEmail,
                 uploadValidationStrictness, consentNotificationEmail, consentNotificationEmailVerified, version,
                 profileAttributes, taskIdentifiers, activityEventKeys, dataGroups, passwordPolicy, verifyEmailTemplate,
@@ -805,6 +834,7 @@ public final class DynamoStudy implements Study {
                 usesCustomExportSchedule, pushNotificationARNs, installLinks, disableExport, emailSignInTemplate,
                 emailSignInEnabled, phoneSignInEnabled, accountLimit, oauthProviders, appleAppLinks, androidAppLinks,
                 reauthenticationEnabled, resetPasswordSmsTemplate, phoneSignInSmsTemplate, appInstallLinkSmsTemplate,
-                verifyPhoneSmsTemplate, accountExistsSmsTemplate, autoVerificationPhoneSuppressed);
+                verifyPhoneSmsTemplate, accountExistsSmsTemplate, autoVerificationPhoneSuppressed,
+                signedConsentTemplate, signedConsentSmsTemplate);
     }
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoStudy.java
@@ -825,11 +825,12 @@ public final class DynamoStudy implements Study {
                         + "resetPasswordSmsTemplate=%s, phoneSignInSmsTemplate=%s, appInstallLinkSmsTemplate=%s, "
                         + "verifyPhoneSmsTemplate=%s, accountExistsSmsTemplate=%s, autoVerificationPhoneSuppressed=%s, "
                         + "signedConsentTemplate=%s, signedConsentSmsTemplate=%s",
-                name, shortName, active, sponsorName, identifier, autoVerificationEmailSuppressed, minAgeOfConsent,
-                studyIdExcludedInExport, supportEmail, synapseDataAccessTeamId, synapseProjectId, technicalEmail,
-                uploadValidationStrictness, consentNotificationEmail, consentNotificationEmailVerified, version,
-                profileAttributes, taskIdentifiers, activityEventKeys, dataGroups, passwordPolicy, verifyEmailTemplate,
-                resetPasswordTemplate, strictUploadValidationEnabled, healthCodeExportEnabled, emailVerificationEnabled,
+                name, shortName, active, sponsorName, identifier, automaticCustomEvents,
+                autoVerificationEmailSuppressed, minAgeOfConsent, studyIdExcludedInExport, supportEmail,
+                synapseDataAccessTeamId, synapseProjectId, technicalEmail, uploadValidationStrictness,
+                consentNotificationEmail, consentNotificationEmailVerified, version, profileAttributes, taskIdentifiers,
+                activityEventKeys, dataGroups, passwordPolicy, verifyEmailTemplate, resetPasswordTemplate,
+                strictUploadValidationEnabled, healthCodeExportEnabled, emailVerificationEnabled,
                 externalIdValidationEnabled, externalIdRequiredOnSignup, minSupportedAppVersions,
                 usesCustomExportSchedule, pushNotificationARNs, installLinks, disableExport, emailSignInTemplate,
                 emailSignInEnabled, phoneSignInEnabled, accountLimit, oauthProviders, appleAppLinks, androidAppLinks,

--- a/app/org/sagebionetworks/bridge/models/studies/Study.java
+++ b/app/org/sagebionetworks/bridge/models/studies/Study.java
@@ -278,7 +278,14 @@ public interface Study extends BridgeEntity, StudyIdentifier {
      */
     EmailTemplate getAccountExistsTemplate();
     void setAccountExistsTemplate(EmailTemplate template);
-        
+    
+    /**
+     * The template for an email that is sent to a user when they sign a consent agreement to 
+     * participate in a study. 
+     */
+    EmailTemplate getSignedConsentTemplate();
+    void setSignedConsentTemplate(EmailTemplate template);
+    
     /**
      * The template for an SMS message sent to a user that triggers the reset password workflow, 
      * on an account that only has a phone number.
@@ -311,6 +318,13 @@ public interface Study extends BridgeEntity, StudyIdentifier {
      */
     SmsTemplate getAccountExistsSmsTemplate();
     void setAccountExistsSmsTemplate(SmsTemplate template);
+    
+    /**
+     * The template for an SMS message that is sent to a user when they sign a consent agreement to 
+     * participate in a study. 
+     */
+    SmsTemplate getSignedConsentSmsTemplate();
+    void setSignedConsentSmsTemplate(SmsTemplate template);
     
     /**
      * Is this study active? Currently not in use, a de-activated study will be hidden from the 

--- a/app/org/sagebionetworks/bridge/services/StudyService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyService.java
@@ -123,14 +123,19 @@ public class StudyService {
     private String defaultEmailSignInTemplateSubject;
     private String defaultAccountExistsTemplate;
     private String defaultAccountExistsTemplateSubject;
-    private String studyEmailVerificationTemplate;
-    private String studyEmailVerificationTemplateSubject;
+    private String defaultSignedConsentTemplate;
+    private String defaultSignedConsentTemplateSubject;
     private String defaultResetPasswordSmsTemplate;
     private String defaultPhoneSignInSmsTemplate;
     private String defaultAppInstallLinkSmsTemplate;
     private String defaultVerifyPhoneSmsTemplate;
     private String defaultAccountExistsSmsTemplate;
+    private String defaultSignedConsentSmsTemplate;
 
+    // Not defaults, if you wish to change these, change in source. Not configurable per study
+    private String studyEmailVerificationTemplate;
+    private String studyEmailVerificationTemplateSubject;
+    
     @Value("classpath:study-defaults/email-verification.txt")
     final void setDefaultEmailVerificationTemplate(org.springframework.core.io.Resource resource) throws IOException {
         this.defaultEmailVerificationTemplate = IOUtils.toString(resource.getInputStream(), StandardCharsets.UTF_8);
@@ -163,6 +168,16 @@ public class StudyService {
     final void setDefaultAccountExistsTemplateSubject(org.springframework.core.io.Resource resource) throws IOException {
         this.defaultAccountExistsTemplateSubject = IOUtils.toString(resource.getInputStream(), StandardCharsets.UTF_8);
     }
+    
+    @Value("classpath:study-defaults/signed-consent.txt")
+    final void setSignedConsentTemplate(org.springframework.core.io.Resource resource) throws IOException {
+        this.defaultSignedConsentTemplate = IOUtils.toString(resource.getInputStream(), StandardCharsets.UTF_8);
+    }
+    @Value("classpath:study-defaults/signed-consent-subject.txt")
+    final void setSignedConsentTemplateSubject(org.springframework.core.io.Resource resource) throws IOException {
+        this.defaultSignedConsentTemplateSubject = IOUtils.toString(resource.getInputStream(), StandardCharsets.UTF_8);
+    }
+    
     @Value("classpath:templates/study-email-verification.txt")
     final void setStudyEmailVerificationTemplate(org.springframework.core.io.Resource resource)
             throws IOException {
@@ -194,6 +209,11 @@ public class StudyService {
     final void setAccountExistsSmsTemplate(String template) {
         this.defaultAccountExistsSmsTemplate = template;
     }
+    @Value("${sms.signed.consent}")
+    final void setSignedConsentSmsTemplate(String template) {
+        this.defaultSignedConsentSmsTemplate = template;
+    }
+    
     /** Bridge config. */
     @Autowired
     public final void setBridgeConfig(BridgeConfig bridgeConfig) {
@@ -270,6 +290,10 @@ public class StudyService {
     
     private EmailTemplate getAccountExistsTemplate() {
         return getTemplate(defaultAccountExistsTemplateSubject, defaultAccountExistsTemplate);
+    }
+    
+    private EmailTemplate getSignedConsentTemplate() {
+        return getTemplate(defaultSignedConsentTemplateSubject, defaultSignedConsentTemplate);
     }
     
     private EmailTemplate getTemplate(String subject, String body) {
@@ -391,7 +415,7 @@ public class StudyService {
         checkNotNull(study, Validate.CANNOT_BE_NULL, "study");
         if (study.getVersion() != null){
             throw new EntityAlreadyExistsException(Study.class, "Study has a version value; it may already exist",
-                new ImmutableMap.Builder<String,Object>().put(IDENTIFIER_PROPERTY, study.getIdentifier()).build());
+                new ImmutableMap.Builder<String,Object>().put(IDENTIFIER_PROPERTY, study.getIdentifier()).build()); 
         }
 
         study.setActive(true);
@@ -721,8 +745,8 @@ public class StudyService {
         if (study.getEmailSignInTemplate() == null) {
             study.setEmailSignInTemplate( getEmailSignInTemplate() );
         }
-        if (study.getAccountExistsTemplate() == null) {
-            study.setAccountExistsTemplate( getAccountExistsTemplate() );
+        if (study.getSignedConsentTemplate() == null) {
+            study.setSignedConsentTemplate( getSignedConsentTemplate() );
         }
         if (study.getResetPasswordSmsTemplate() == null) {
             study.setResetPasswordSmsTemplate(new SmsTemplate(defaultResetPasswordSmsTemplate));
@@ -738,6 +762,9 @@ public class StudyService {
         }
         if (study.getAccountExistsSmsTemplate() == null) {
             study.setAccountExistsSmsTemplate(new SmsTemplate(defaultAccountExistsSmsTemplate));
+        }
+        if (study.getSignedConsentSmsTemplate() == null) {
+            study.setSignedConsentSmsTemplate(new SmsTemplate(defaultSignedConsentSmsTemplate));
         }
     }
 
@@ -758,6 +785,9 @@ public class StudyService {
 
         template = study.getAccountExistsTemplate();
         study.setAccountExistsTemplate(sanitizeEmailTemplate(template));
+        
+        template = study.getSignedConsentTemplate();
+        study.setSignedConsentTemplate(sanitizeEmailTemplate(template));
     }
     
     protected EmailTemplate sanitizeEmailTemplate(EmailTemplate template) {

--- a/app/org/sagebionetworks/bridge/validators/StudyValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/StudyValidator.java
@@ -118,6 +118,9 @@ public class StudyValidator implements Validator {
         validateEmailTemplate(errors, study.getVerifyEmailTemplate(), "verifyEmailTemplate", "${url}", "${emailVerificationUrl}");
         validateEmailTemplate(errors, study.getResetPasswordTemplate(), "resetPasswordTemplate", "${url}", "${resetPasswordUrl}");
         // Existing studies don't have the template, we use a default template. Okay to be missing.
+        if (study.getSignedConsentTemplate() != null) {
+            validateEmailTemplate(errors, study.getSignedConsentTemplate(), "signedConsentTemplate");    
+        }
         if (study.getEmailSignInTemplate() != null) {
             validateEmailTemplate(errors, study.getEmailSignInTemplate(), "emailSignInTemplate", "${url}", "${emailSignInUrl}",
                     "${token}");
@@ -132,6 +135,7 @@ public class StudyValidator implements Validator {
         validateSmsTemplate(errors, study.getVerifyPhoneSmsTemplate(), "verifyPhoneSmsTemplate", "${token}");
         validateSmsTemplate(errors, study.getAccountExistsSmsTemplate(), "accountExistsSmsTemplate", "${token}",
                 "${resetPasswordUrl}");
+        validateSmsTemplate(errors, study.getSignedConsentSmsTemplate(), "signedConsentSmsTemplate", "${consentUrl}");
         
         for (String userProfileAttribute : study.getUserProfileAttributes()) {
             if (RESERVED_ATTR_NAMES.contains(userProfileAttribute)) {
@@ -283,7 +287,7 @@ public class StudyValidator implements Validator {
             }
             if (StringUtils.isBlank(template.getBody())) {
                 errors.rejectValue("body", "cannot be blank");
-            } else {
+            } else if (templateVariables.length > 0){
                 boolean missingTemplateVariable = true;
                 for (int i=0; i < templateVariables.length; i++) {
                     if (template.getBody().contains(templateVariables[i])) {
@@ -309,7 +313,7 @@ public class StudyValidator implements Validator {
                 errors.rejectValue("message", "cannot be blank");
             } else if (template.getMessage().length() > 160) {
                 errors.rejectValue("message", "cannot be more than 160 characters");
-            } else {
+            } else if (templateVariables.length > 0) {
                 boolean missingTemplateVariable = true;
                 for (int i=0; i < templateVariables.length; i++) {
                     if (template.getMessage().contains(templateVariables[i])) {

--- a/app/org/sagebionetworks/bridge/validators/StudyValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/StudyValidator.java
@@ -135,7 +135,10 @@ public class StudyValidator implements Validator {
         validateSmsTemplate(errors, study.getVerifyPhoneSmsTemplate(), "verifyPhoneSmsTemplate", "${token}");
         validateSmsTemplate(errors, study.getAccountExistsSmsTemplate(), "accountExistsSmsTemplate", "${token}",
                 "${resetPasswordUrl}");
-        validateSmsTemplate(errors, study.getSignedConsentSmsTemplate(), "signedConsentSmsTemplate", "${consentUrl}");
+        // Existing studies don't have the template, we use a default template. Okay to be missing.
+        if (study.getSignedConsentSmsTemplate() != null) {
+            validateSmsTemplate(errors, study.getSignedConsentSmsTemplate(), "signedConsentSmsTemplate", "${consentUrl}");    
+        }
         
         for (String userProfileAttribute : study.getUserProfileAttributes()) {
             if (RESERVED_ATTR_NAMES.contains(userProfileAttribute)) {
@@ -287,7 +290,7 @@ public class StudyValidator implements Validator {
             }
             if (StringUtils.isBlank(template.getBody())) {
                 errors.rejectValue("body", "cannot be blank");
-            } else if (templateVariables.length > 0){
+            } else if (templateVariables.length > 0) {
                 boolean missingTemplateVariable = true;
                 for (int i=0; i < templateVariables.length; i++) {
                     if (template.getBody().contains(templateVariables[i])) {
@@ -313,7 +316,7 @@ public class StudyValidator implements Validator {
                 errors.rejectValue("message", "cannot be blank");
             } else if (template.getMessage().length() > 160) {
                 errors.rejectValue("message", "cannot be more than 160 characters");
-            } else if (templateVariables.length > 0) {
+            } else {
                 boolean missingTemplateVariable = true;
                 for (int i=0; i < templateVariables.length; i++) {
                     if (template.getMessage().contains(templateVariables[i])) {

--- a/conf/study-defaults/signed-consent-subject.txt
+++ b/conf/study-defaults/signed-consent-subject.txt
@@ -1,0 +1,1 @@
+Your consent agreement for participating in ${studyName}

--- a/conf/study-defaults/signed-consent.txt
+++ b/conf/study-defaults/signed-consent.txt
@@ -1,0 +1,11 @@
+<p>Hi,</p>
+
+<p>For your reference, here’s a copy of the consent agreement you just signed to participate in ${studyName}.</p>
+
+<p>Regards,</p>
+
+<p>${sponsorName}</p>
+
+<hr/>
+
+<p>For general inquiries or to request support with your account, please email ${supportEmail}</p>

--- a/conf/study-defaults/sms-messages.properties
+++ b/conf/study-defaults/sms-messages.properties
@@ -3,3 +3,4 @@ sms.phone.signin = Enter ${token} to sign in to ${studyShortName}
 sms.app.install.link = Install ${appInstallUrl}
 sms.verify.phone = Enter ${token} to verify your phone number
 sms.account.exists = Account for ${studyShortName} already exists. Reset password: ${resetPasswordUrl}
+sms.signed.consent = Here\u2019s the consent agreement you signed to join the ${studyShortName}: ${consentUrl}

--- a/conf/study-defaults/sms-messages.properties
+++ b/conf/study-defaults/sms-messages.properties
@@ -3,4 +3,4 @@ sms.phone.signin = Enter ${token} to sign in to ${studyShortName}
 sms.app.install.link = Install ${appInstallUrl}
 sms.verify.phone = Enter ${token} to verify your phone number
 sms.account.exists = Account for ${studyShortName} already exists. Reset password: ${resetPasswordUrl}
-sms.signed.consent = Here\u2019s the consent agreement you signed to join the ${studyShortName}: ${consentUrl}
+sms.signed.consent = Here\u2019s the consent for ${studyShortName}: ${consentUrl}

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -443,11 +443,13 @@ public class TestUtils {
         study.setResetPasswordTemplate(new EmailTemplate("resetPassword subject", "body with ${url}", MimeType.TEXT));
         study.setEmailSignInTemplate(new EmailTemplate("${studyName} link", "Follow link ${url}", MimeType.TEXT));
         study.setAccountExistsTemplate(new EmailTemplate("accountExists subject", "body with ${resetPasswordUrl}", MimeType.TEXT));
+        study.setSignedConsentTemplate(new EmailTemplate("signedConsent subject", "body", MimeType.TEXT));
         study.setResetPasswordSmsTemplate(new SmsTemplate("resetPasswordSmsTemplate ${resetPasswordUrl}"));
         study.setPhoneSignInSmsTemplate(new SmsTemplate("phoneSignInSmsTemplate ${token}"));
         study.setAppInstallLinkSmsTemplate(new SmsTemplate("appInstallLinkSmsTemplate ${appInstallUrl}"));
         study.setVerifyPhoneSmsTemplate(new SmsTemplate("verifyPhoneSmsTemplate ${token}"));
         study.setAccountExistsSmsTemplate(new SmsTemplate("accountExistsSmsTemplate ${token}"));
+        study.setSignedConsentSmsTemplate(new SmsTemplate("signedConsent ${consentUrl}"));
         study.setIdentifier(id);
         study.setMinAgeOfConsent(18);
         study.setSponsorName("The Council on Test Studies");

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
@@ -133,6 +133,8 @@ public class DynamoStudyTest {
                 JsonUtils.asEntity(node, "emailSignInTemplate", EmailTemplate.class));
         assertEqualsAndNotNull(study.getAccountExistsTemplate(),
                 JsonUtils.asEntity(node, "accountExistsTemplate", EmailTemplate.class));
+        assertEqualsAndNotNull(study.getSignedConsentTemplate(),
+                JsonUtils.asEntity(node, "signedConsentTemplate", EmailTemplate.class));
         assertEquals(study.getResetPasswordSmsTemplate(),
                 JsonUtils.asEntity(node, "resetPasswordSmsTemplate", SmsTemplate.class));
         assertEquals(study.getPhoneSignInSmsTemplate(),
@@ -143,6 +145,8 @@ public class DynamoStudyTest {
                 JsonUtils.asEntity(node, "verifyPhoneSmsTemplate", SmsTemplate.class));
         assertEquals(study.getAccountExistsSmsTemplate(),
                 JsonUtils.asEntity(node, "accountExistsSmsTemplate", SmsTemplate.class));
+        assertEquals(study.getSignedConsentSmsTemplate(),
+                JsonUtils.asEntity(node, "signedConsentSmsTemplate", SmsTemplate.class));
         assertEqualsAndNotNull(study.getUserProfileAttributes(), JsonUtils.asStringSet(node, "userProfileAttributes"));
         assertEqualsAndNotNull(study.getTaskIdentifiers(), JsonUtils.asStringSet(node, "taskIdentifiers"));
         assertEqualsAndNotNull(study.getActivityEventKeys(), JsonUtils.asStringSet(node, "activityEventKeys"));

--- a/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
@@ -632,6 +632,16 @@ public class StudyServiceMockTest {
     }
     
     @Test
+    public void loadingStudyWithoutSignedConsentSmsTemplateAddsADefault() {
+        Study study = TestUtils.getValidStudy(StudyServiceMockTest.class);
+        study.setSignedConsentSmsTemplate(null);
+        when(studyDao.getStudy("foo")).thenReturn(study);
+        
+        Study retStudy = service.getStudy("foo");
+        assertNotNull(retStudy.getAccountExistsSmsTemplate());
+    }
+    
+    @Test
     public void updateStudyWithoutResetPasswordSmsTemplateAddsADefault() {
         Study study = TestUtils.getValidStudy(StudyServiceMockTest.class);
         study.setResetPasswordSmsTemplate(null);
@@ -675,6 +685,16 @@ public class StudyServiceMockTest {
     public void updateStudyWithoutAccountExistsSmsTemplateAddsADefault() {
         Study study = TestUtils.getValidStudy(StudyServiceMockTest.class);
         study.setAccountExistsSmsTemplate(null);
+        when(studyDao.getStudy(study.getIdentifier())).thenReturn(study);
+        
+        Study retStudy = service.updateStudy(study, false);
+        assertNotNull(retStudy.getAccountExistsSmsTemplate());
+    }
+    
+    @Test
+    public void updateStudyWithoutSignedConsentSmsTemplateAddsADefault() {
+        Study study = TestUtils.getValidStudy(StudyServiceMockTest.class);
+        study.setSignedConsentSmsTemplate(null);
         when(studyDao.getStudy(study.getIdentifier())).thenReturn(study);
         
         Study retStudy = service.updateStudy(study, false);
@@ -729,7 +749,18 @@ public class StudyServiceMockTest {
         
         Study retStudy = service.createStudy(study);
         assertNotNull(retStudy.getAccountExistsSmsTemplate());
-    }    
+    }
+    
+    @Test
+    public void createStudyWithoutSignedConsentSmsTemplateAddsADefault() {
+        Study study = TestUtils.getValidStudy(StudyServiceMockTest.class);
+        study.setSignedConsentSmsTemplate(null);
+        when(studyDao.getStudy(study.getIdentifier())).thenReturn(study);
+        
+        Study retStudy = service.createStudy(study);
+        assertNotNull(retStudy.getAccountExistsSmsTemplate());
+    }
+    
     @Test
     public void physicallyDeleteStudy() {
         // execute
@@ -1458,19 +1489,21 @@ public class StudyServiceMockTest {
     }
     
     @Test
-    public void testAllFourTemplatesAreSanitized() {
+    public void testAllFiveTemplatesAreSanitized() {
         EmailTemplate source = new EmailTemplate("<p>${studyName} test</p>", "<p>This should remove: <iframe src=''></iframe></p>", MimeType.HTML);
         Study study = new DynamoStudy();
         study.setEmailSignInTemplate(source);
         study.setResetPasswordTemplate(source);
         study.setVerifyEmailTemplate(source);
         study.setAccountExistsTemplate(source);
+        study.setSignedConsentTemplate(source);
         
         service.sanitizeHTML(study);
         assertHtmlTemplateSanitized( study.getEmailSignInTemplate() );
         assertHtmlTemplateSanitized( study.getResetPasswordTemplate() );
         assertHtmlTemplateSanitized( study.getVerifyEmailTemplate() );
         assertHtmlTemplateSanitized( study.getAccountExistsTemplate() );
+        assertHtmlTemplateSanitized( study.getSignedConsentTemplate() );
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
@@ -175,6 +175,8 @@ public class StudyServiceMockTest {
                 "Verify your study email"));
         service.setStudyEmailVerificationTemplate(mockTemplateAsSpringResource(
                 "Click here ${studyEmailVerificationUrl} ${studyEmailVerificationExpirationPeriod}"));
+        service.setSignedConsentTemplateSubject(mockTemplateAsSpringResource("subject"));
+        service.setSignedConsentTemplate(mockTemplateAsSpringResource("Test this"));
 
         when(service.getNameScopingToken()).thenReturn(TEST_NAME_SCOPING_TOKEN);
         
@@ -202,6 +204,7 @@ public class StudyServiceMockTest {
         service.setAppInstallLinkSmsTemplate(study.getAppInstallLinkSmsTemplate().getMessage());
         service.setVerifyPhoneSmsTemplate(study.getVerifyPhoneSmsTemplate().getMessage());
         service.setAccountExistsSmsTemplate(study.getAccountExistsSmsTemplate().getMessage());
+        service.setSignedConsentSmsTemplate(study.getSignedConsentSmsTemplate().getMessage());
 
         // Spy StudyService.createTimeLimitedToken() to create a known token instead of a random one. This makes our
         // tests easier.
@@ -580,7 +583,37 @@ public class StudyServiceMockTest {
         assertNotNull(retStudy.getEmailSignInTemplate());
         assertNotNull(retStudy.getAccountExistsTemplate());
     }
+
+    @Test
+    public void loadingStudyWithoutSignedConsentTemplateAddsADefault() {
+        Study study = TestUtils.getValidStudy(StudyServiceMockTest.class);
+        study.setSignedConsentTemplate(null);
+        when(studyDao.getStudy("foo")).thenReturn(study);
+        
+        Study retStudy = service.getStudy("foo");
+        assertNotNull(retStudy.getSignedConsentTemplate());
+    }
+
+    @Test
+    public void createStudyWithoutSignedConsentTemplateAddsADefault() {
+        Study study = TestUtils.getValidStudy(StudyServiceMockTest.class);
+        study.setSignedConsentTemplate(null);
+        when(studyDao.getStudy(study.getIdentifier())).thenReturn(study);
+        
+        Study retStudy = service.createStudy(study);
+        assertNotNull(retStudy.getSignedConsentTemplate());
+    }
     
+    @Test
+    public void updateStudyWithoutSignedConsentTemplateAddsADefault() {
+        Study study = TestUtils.getValidStudy(StudyServiceMockTest.class);
+        study.setSignedConsentTemplate(null);
+        when(studyDao.getStudy(study.getIdentifier())).thenReturn(study);
+        
+        Study retStudy = service.updateStudy(study, false);
+        assertNotNull(retStudy.getSignedConsentTemplate());
+    }
+
     @Test
     public void loadingStudyWithoutResetPasswordSmsTemplateAddsADefault() {
         Study study = TestUtils.getValidStudy(StudyServiceMockTest.class);
@@ -638,7 +671,7 @@ public class StudyServiceMockTest {
         when(studyDao.getStudy("foo")).thenReturn(study);
         
         Study retStudy = service.getStudy("foo");
-        assertNotNull(retStudy.getAccountExistsSmsTemplate());
+        assertNotNull(retStudy.getSignedConsentSmsTemplate());
     }
     
     @Test
@@ -698,7 +731,7 @@ public class StudyServiceMockTest {
         when(studyDao.getStudy(study.getIdentifier())).thenReturn(study);
         
         Study retStudy = service.updateStudy(study, false);
-        assertNotNull(retStudy.getAccountExistsSmsTemplate());
+        assertNotNull(retStudy.getSignedConsentSmsTemplate());
     }
     
     @Test
@@ -758,7 +791,7 @@ public class StudyServiceMockTest {
         when(studyDao.getStudy(study.getIdentifier())).thenReturn(study);
         
         Study retStudy = service.createStudy(study);
-        assertNotNull(retStudy.getAccountExistsSmsTemplate());
+        assertNotNull(retStudy.getSignedConsentSmsTemplate());
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
@@ -722,4 +722,10 @@ public class StudyValidatorTest {
         study.setAccountExistsSmsTemplate(new SmsTemplate("content"));
         assertValidatorMessage(INSTANCE, study, "accountExistsSmsTemplate.message", "must contain one of these template variables: ${token}, ${resetPasswordUrl}");
     }
+    
+    @Test
+    public void signedConsentTemplateRequiresNoTemplateVars() {
+        study.setSignedConsentTemplate(new EmailTemplate("subject", "no template var", MimeType.TEXT));
+        Validate.entityThrowingException(INSTANCE, study);
+    }
 }

--- a/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
@@ -255,11 +255,23 @@ public class StudyValidatorTest {
     }
 
     @Test
+    public void requiresSignedConsentTemplateWithSubject() {
+        study.setSignedConsentTemplate(new EmailTemplate("  ", "body", MimeType.HTML));
+        assertValidatorMessage(INSTANCE, study, "signedConsentTemplate.subject", "cannot be blank");
+    }
+    
+    @Test
     public void requiresVerifyEmailTemplateWithBody() {
         study.setVerifyEmailTemplate(new EmailTemplate("subject", null, MimeType.HTML));
         assertValidatorMessage(INSTANCE, study, "verifyEmailTemplate.body", "cannot be blank");
     }
 
+    @Test
+    public void requiresSignedConsentTemplateWithBody() {
+        study.setSignedConsentTemplate(new EmailTemplate("subject", null, MimeType.HTML));
+        assertValidatorMessage(INSTANCE, study, "signedConsentTemplate.body", "cannot be blank");
+    }
+    
     @Test
     public void requiresResetPasswordTemplate() {
         study.setResetPasswordTemplate(null);
@@ -592,6 +604,12 @@ public class StudyValidatorTest {
     }
     
     @Test
+    public void signedConsentSmsTemplateCanBeNull() {
+        study.setSignedConsentSmsTemplate(null);
+        Validate.entityThrowingException(INSTANCE, study);
+    }
+    
+    @Test
     public void accountExistsSmsTemplateCanBeNull() {
         study.setAccountExistsSmsTemplate(null);
         Validate.entityThrowingException(INSTANCE, study);
@@ -619,6 +637,12 @@ public class StudyValidatorTest {
     public void verifyPhoneSmsTemplateMessageRequired() {
         study.setVerifyPhoneSmsTemplate(new SmsTemplate(null));
         assertValidatorMessage(INSTANCE, study, "verifyPhoneSmsTemplate.message", "cannot be blank");
+    }
+    
+    @Test
+    public void signedConsentSmsTemplateMessageRequired() {
+        study.setSignedConsentSmsTemplate(new SmsTemplate(null));
+        assertValidatorMessage(INSTANCE, study, "signedConsentSmsTemplate.message", "cannot be blank");
     }
     
     @Test
@@ -652,6 +676,12 @@ public class StudyValidatorTest {
     }
     
     @Test
+    public void signedConsentSmsTemplateHasMaxLength() {
+        study.setSignedConsentSmsTemplate(new SmsTemplate(TOO_LONG_STRING));
+        assertValidatorMessage(INSTANCE, study, "signedConsentSmsTemplate.message", "cannot be more than 160 characters");
+    }
+    
+    @Test
     public void accountExistsSmsTemplateHasMaxLength() {
         study.setAccountExistsSmsTemplate(new SmsTemplate(TOO_LONG_STRING));
         assertValidatorMessage(INSTANCE, study, "accountExistsSmsTemplate.message", "cannot be more than 160 characters");
@@ -679,6 +709,12 @@ public class StudyValidatorTest {
     public void verifyPhoneSmsTemplateRequiresTemplateVar() {
         study.setVerifyPhoneSmsTemplate(new SmsTemplate("content"));
         assertValidatorMessage(INSTANCE, study, "verifyPhoneSmsTemplate.message", "must contain one of these template variables: ${token}");
+    }
+    
+    @Test
+    public void signedConsentSmsTemplateRequiresTemplateVar() {
+        study.setSignedConsentSmsTemplate(new SmsTemplate("content"));
+        assertValidatorMessage(INSTANCE, study, "signedConsentSmsTemplate.message", "must contain one of these template variables: ${consentUrl}");
     }
     
     @Test


### PR DESCRIPTION
A first step toward sending signed consents via SMS, we're adding a template for email as well so we can explain what we're sending, rather than just sending it directly to people (it'll be attached to the email, as it currently is). This gives us a place to explain *what* the consent is, so people are less likely to delete it or report it as spam. We need a template in the SMS case because all we can send is a link to download the consent.