### PR TITLE
An URL shortener service.

### DIFF
--- a/app/org/sagebionetworks/bridge/cache/CacheKey.java
+++ b/app/org/sagebionetworks/bridge/cache/CacheKey.java
@@ -30,6 +30,10 @@ public final class CacheKey {
         return false;
     }
     
+    public static final CacheKey shortenUrl(String token) {
+        return new CacheKey(token, "ShortenedUrl");
+    }
+    
     public static final CacheKey appConfigList(StudyIdentifier studyId) {
         return new CacheKey(studyId.getIdentifier(), "AppConfigList");
     }

--- a/app/org/sagebionetworks/bridge/play/controllers/ApplicationController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ApplicationController.java
@@ -119,7 +119,7 @@ public class ApplicationController extends BaseController {
         }
         String url = urlShortenerService.retrieveUrl(token);
         if (url != null) {
-            return temporaryRedirect(url);
+            return found(url);
         }
         return notFound(views.html.redirect.render());
     }

--- a/app/org/sagebionetworks/bridge/play/controllers/ApplicationController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ApplicationController.java
@@ -9,14 +9,18 @@ import java.util.List;
 import javax.annotation.Resource;
 
 import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.cache.ViewCache;
+import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.cache.CacheKey;
 import org.sagebionetworks.bridge.models.AndroidAppSiteAssociation;
 import org.sagebionetworks.bridge.models.AppleAppSiteAssociation;
 import org.sagebionetworks.bridge.models.studies.AndroidAppLink;
 import org.sagebionetworks.bridge.models.studies.AppleAppLink;
 import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.services.UrlShortenerService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 
 import com.google.common.collect.Lists;
@@ -32,10 +36,17 @@ public class ApplicationController extends BaseController {
     private static final String ASSETS_BUILD = "201501291830";
 
     private ViewCache viewCache;
+    
+    private UrlShortenerService urlShortenerService;
 
     @Resource(name = "appLinkViewCache")
     final void setViewCache(ViewCache viewCache) {
         this.viewCache = viewCache;
+    }
+    
+    @Autowired
+    final void setUrlShortenerService(UrlShortenerService urlShortenerService) {
+        this.urlShortenerService = urlShortenerService;
     }
     
     public Result loadApp() throws Exception {
@@ -100,5 +111,16 @@ public class ApplicationController extends BaseController {
             return new AppleAppSiteAssociation(links);
         });
         return ok(json).as(JSON_MIME_TYPE);
+    }
+    
+    public Result redirectToURL(String token) throws Exception {
+        if (StringUtils.isBlank(token)) {
+            throw new BadRequestException("URL is malformed.");
+        }
+        String url = urlShortenerService.retrieveUrl(token);
+        if (url != null) {
+            return temporaryRedirect(url);
+        }
+        return notFound(views.html.redirect.render());
     }
 }

--- a/app/org/sagebionetworks/bridge/services/UrlShortenerService.java
+++ b/app/org/sagebionetworks/bridge/services/UrlShortenerService.java
@@ -1,0 +1,53 @@
+package org.sagebionetworks.bridge.services;
+
+import org.sagebionetworks.bridge.SecureTokenGenerator;
+import org.sagebionetworks.bridge.cache.CacheKey;
+import org.sagebionetworks.bridge.cache.CacheProvider;
+import org.sagebionetworks.bridge.config.BridgeConfigFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.google.common.base.Preconditions;
+
+@Component
+public class UrlShortenerService {
+
+    private static final String WEBSERVICES_URL = BridgeConfigFactory.getConfig().get("webservices.url");
+    private CacheProvider cacheProvider;
+    
+    @Autowired
+    final void setCacheProvider(CacheProvider cacheProvider) {
+        this.cacheProvider = cacheProvider;
+    }
+    
+    public String shortenUrl(String url, int expireInSeconds) {
+        Preconditions.checkNotNull(url);
+        
+        // We are using a relatively short, randomized URL, so verify it isn't being
+        // used by another URL. If it's being used by the same URL, don't reset the 
+        // expiration
+        String token = getToken();
+        CacheKey cacheKey = CacheKey.shortenUrl(token);
+        String foundValue = cacheProvider.getObject(cacheKey, String.class);
+        while(foundValue != null && !foundValue.equals(url)) {
+            token = getToken();
+            cacheKey = CacheKey.shortenUrl(token);
+            foundValue = cacheProvider.getObject(cacheKey, String.class);
+        }
+        if (foundValue == null) {
+            cacheProvider.setObject(cacheKey, url, expireInSeconds);    
+        }
+        return WEBSERVICES_URL + "/r/" + token;
+    }
+    
+    public String retrieveUrl(String token) {
+        Preconditions.checkNotNull(token);
+        
+        CacheKey cacheKey = CacheKey.shortenUrl(token);
+        return cacheProvider.getObject(cacheKey, String.class);
+    }
+    
+    protected String getToken() {
+        return SecureTokenGenerator.NAME_SCOPE_INSTANCE.nextToken();
+    }
+}

--- a/app/org/sagebionetworks/bridge/services/UrlShortenerService.java
+++ b/app/org/sagebionetworks/bridge/services/UrlShortenerService.java
@@ -26,14 +26,15 @@ public class UrlShortenerService {
         // We are using a relatively short, randomized URL, so verify it isn't being
         // used by another URL. If it's being used by the same URL, don't reset the 
         // expiration
-        String token = getToken();
-        CacheKey cacheKey = CacheKey.shortenUrl(token);
-        String foundValue = cacheProvider.getObject(cacheKey, String.class);
-        while(foundValue != null && !foundValue.equals(url)) {
+        String token = null;
+        CacheKey cacheKey = null;
+        String foundValue = null;
+        do {
             token = getToken();
             cacheKey = CacheKey.shortenUrl(token);
             foundValue = cacheProvider.getObject(cacheKey, String.class);
-        }
+        } while(foundValue != null && !foundValue.equals(url));
+        
         if (foundValue == null) {
             cacheProvider.setObject(cacheKey, url, expireInSeconds);    
         }

--- a/app/views/redirect.scala.html
+++ b/app/views/redirect.scala.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Not Found</title>
+    <link href="//assets.sagebridge.org/mobile/styles/normalize.css" type="text/css" rel="stylesheet"/>
+    <link href="//assets.sagebridge.org/mobile/styles/skeleton.css" type="text/css" rel="stylesheet"/>
+    <link href="//assets.sagebridge.org/mobile/styles/mobile.css" type="text/css" rel="stylesheet"/>
+</head>
+<body>
+<div class="logo_box">
+</div>
+<div class="form_box">
+	<p>That link has expired.</p>
+</div>
+</script>
+</body>
+</html>

--- a/conf/routes
+++ b/conf/routes
@@ -12,6 +12,7 @@ GET    /rp                                     @org.sagebionetworks.bridge.play.
 GET    /s/:study                               @org.sagebionetworks.bridge.play.controllers.ApplicationController.startSession(study: String, email: String ?= null, token: String ?= null)
 GET    /.well-known/assetlinks.json            @org.sagebionetworks.bridge.play.controllers.ApplicationController.androidAppLinks
 GET    /.well-known/apple-app-site-association @org.sagebionetworks.bridge.play.controllers.ApplicationController.appleAppLinks
+GET    /r/:token                               @org.sagebionetworks.bridge.play.controllers.ApplicationController.redirectToURL(token: String)
 
 # Authentication
 POST   /v3/auth/signIn                  @org.sagebionetworks.bridge.play.controllers.AuthenticationController.signInV3

--- a/test/org/sagebionetworks/bridge/cache/CacheKeyTest.java
+++ b/test/org/sagebionetworks/bridge/cache/CacheKeyTest.java
@@ -26,6 +26,11 @@ public class CacheKeyTest {
     }
     
     @Test
+    public void shortenUrl() {
+        assertEquals("ABC:ShortenedUrl", CacheKey.shortenUrl("ABC").toString());
+    }
+    
+    @Test
     public void appConfigList() {
         assertEquals("api:AppConfigList", CacheKey.appConfigList(TestConstants.TEST_STUDY).toString());
     }

--- a/test/org/sagebionetworks/bridge/play/controllers/ApplicationControllerMockTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ApplicationControllerMockTest.java
@@ -208,7 +208,7 @@ public class ApplicationControllerMockTest {
         when(urlShortenerService.retrieveUrl("ABC")).thenReturn("https://long.url.com/");
         
         Result result = controller.redirectToURL("ABC");
-        assertEquals(307, result.status()); // temporary redirect
+        assertEquals(302, result.status()); // Found
         assertEquals("https://long.url.com/", result.header("Location"));
     }
     

--- a/test/org/sagebionetworks/bridge/play/controllers/ApplicationControllerMockTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ApplicationControllerMockTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -22,6 +23,7 @@ import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.cache.ViewCache;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
+import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
@@ -32,6 +34,7 @@ import org.sagebionetworks.bridge.models.studies.PasswordPolicy;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.services.AuthenticationService;
 import org.sagebionetworks.bridge.services.StudyService;
+import org.sagebionetworks.bridge.services.UrlShortenerService;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -53,6 +56,9 @@ public class ApplicationControllerMockTest {
     
     @Mock
     CacheProvider cacheProvider;
+    
+    @Mock
+    UrlShortenerService urlShortenerService;
     
     @Captor
     ArgumentCaptor<CriteriaContext> contextCaptor;
@@ -76,6 +82,7 @@ public class ApplicationControllerMockTest {
         controller.setStudyService(studyService);
         controller.setAuthenticationService(authenticationService);
         controller.setViewCache(viewCache);
+        controller.setUrlShortenerService(urlShortenerService);
         
         study = new DynamoStudy();
         study.setIdentifier("test-study");
@@ -194,5 +201,27 @@ public class ApplicationControllerMockTest {
         assertEquals(TestConstants.APPLE_APP_LINK_2, link1);
         assertEquals(TestConstants.APPLE_APP_LINK_3, link2);
         assertEquals(TestConstants.APPLE_APP_LINK_4, link3);        
+    }
+    
+    @Test
+    public void redirectOk() throws Exception {
+        when(urlShortenerService.retrieveUrl("ABC")).thenReturn("https://long.url.com/");
+        
+        Result result = controller.redirectToURL("ABC");
+        assertEquals(307, result.status()); // temporary redirect
+        assertEquals("https://long.url.com/", result.header("Location"));
+    }
+    
+    @Test(expected = BadRequestException.class)
+    public void redirectBad() throws Exception {
+        controller.redirectToURL(" ");
+    }
+    
+    @Test
+    public void redirectFails() throws Exception {
+        when(urlShortenerService.retrieveUrl("ABC")).thenReturn(null);
+        
+        Result result = controller.redirectToURL("ABC");
+        assertEquals(404, result.status()); // temporary redirect
     }
 }

--- a/test/org/sagebionetworks/bridge/services/ConsentPdfTest.java
+++ b/test/org/sagebionetworks/bridge/services/ConsentPdfTest.java
@@ -2,7 +2,6 @@ package org.sagebionetworks.bridge.services;
 
 import static org.junit.Assert.assertTrue;
 
-import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 
 import org.apache.commons.io.IOUtils;
@@ -15,8 +14,6 @@ import org.sagebionetworks.bridge.models.accounts.SharingScope;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
-
-import com.sun.xml.internal.messaging.saaj.util.ByteInputStream;
 
 public class ConsentPdfTest {
     private static final String LEGACY_DOCUMENT = "<html><head></head><body>Passed through as is." +

--- a/test/org/sagebionetworks/bridge/services/UrlShortenerServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/UrlShortenerServiceTest.java
@@ -1,0 +1,87 @@
+package org.sagebionetworks.bridge.services;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.sagebionetworks.bridge.cache.CacheKey;
+import org.sagebionetworks.bridge.cache.CacheProvider;
+import org.sagebionetworks.bridge.config.BridgeConfigFactory;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UrlShortenerServiceTest {
+
+    private static final String WEBSERVICES_URL = BridgeConfigFactory.getConfig().get("webservices.url");
+    private static final String LONG_URL = "https://org-sagebridge-usersigned-consents-bridgepf-alxdark.s3.amazonaws.com/copy-test%3A1481654941786%3Abf3bbf23-050c-421d-9859-df0e37009474?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20180501T232536Z&X-Amz-SignedHeaders=host&X-Amz-Expires=7199&X-Amz-Credential=AKIAJLKGQW6FMKXQYUAA%2F20180501%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=1577975258dd8b0b23496f0ce3c30f4d214ad127e2705d3c2e4006ad9288f080";
+    private static final String ANOTHER_LONG_URL = "https://org-sagebridge-usersigned-consents-bridgepf-alxdark.s3.amazonaws.com/d8b0b23496f0ce3c30f4d214ad127e2705d3c2e4006ad9288f080";
+    private static final int EXPIRES_IN = 30*60; // 30 min
+    private static final String TOKEN = "ABC";
+    private static final String NEXT_TOKEN = "DEF";
+    
+    @Mock
+    private CacheProvider cacheProvider;
+    
+    @Spy
+    private UrlShortenerService service;
+    
+    @Before
+    public void before() {
+        service.setCacheProvider(cacheProvider);
+        when(service.getToken()).thenReturn(TOKEN, NEXT_TOKEN);
+    }
+    
+    @Test
+    public void newUrl() {
+        // nothing in the cache
+        String shortenedUrl = service.shortenUrl(LONG_URL, EXPIRES_IN);
+        assertEquals(WEBSERVICES_URL+"/r/"+TOKEN, shortenedUrl);
+
+        verify(cacheProvider).setObject(CacheKey.shortenUrl(TOKEN), LONG_URL, EXPIRES_IN);
+    }
+    
+    @Test
+    public void conflictingToken() {
+        CacheKey key = CacheKey.shortenUrl(TOKEN);
+        when(cacheProvider.getObject(key, String.class)).thenReturn(ANOTHER_LONG_URL);
+        
+        String shortenedUrl = service.shortenUrl(LONG_URL, EXPIRES_IN);
+        assertEquals(WEBSERVICES_URL+"/r/"+NEXT_TOKEN, shortenedUrl);
+        
+        verify(cacheProvider).setObject(CacheKey.shortenUrl(NEXT_TOKEN), LONG_URL, EXPIRES_IN);
+    }
+    
+    @Test
+    public void duplicateURL() {
+        CacheKey key = CacheKey.shortenUrl(TOKEN);
+        when(cacheProvider.getObject(key, String.class)).thenReturn(LONG_URL);
+        
+        String shortenedUrl = service.shortenUrl(LONG_URL, EXPIRES_IN);
+        assertEquals(WEBSERVICES_URL+"/r/"+TOKEN, shortenedUrl);
+        
+        verify(cacheProvider, never()).setObject(any(), any(), anyInt());
+    }
+    
+    @Test
+    public void retrieveLongUrl() { 
+        CacheKey key = CacheKey.shortenUrl(TOKEN);
+        when(cacheProvider.getObject(key, String.class)).thenReturn(LONG_URL);
+        
+        String longUrl = service.retrieveUrl(TOKEN);
+        assertEquals(LONG_URL, longUrl);
+    }
+    
+    @Test
+    public void retrieveLongUrlNoMatch() {
+        assertNull(service.retrieveUrl(TOKEN));
+    }
+}


### PR DESCRIPTION
Pretty simple, the service will generate an URL you can substitute for your original (probably very long) URL. The URL provided points back to BridgePF to resolve and redirect to the original URL. Service will not issue conflicting short URLs, and it will not generate a different URL for the same long URL if it hasn't expired. URLs do expire, and are not intended to be permanent (e.g. like bit.ly). The use case right now is to shorten Amazon presigned URLs, and these expire.