### PR TITLE
Do not lose fields when caching a subpopulation

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulation.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulation.java
@@ -16,7 +16,7 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIgnore;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBVersionAttribute;
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
  */
 @DynamoDBTable(tableName = "Subpopulation")
 @BridgeTypeName("Subpopulation")
+@JsonFilter("filter")
 public final class DynamoSubpopulation implements Subpopulation {
 
     private static final String DOCS_HOST = BridgeConfigFactory.getConfig().getHostnameWithPostfix("docs");
@@ -47,7 +48,6 @@ public final class DynamoSubpopulation implements Subpopulation {
         criteria = Criteria.create();
     }
     
-    @JsonIgnore
     @Override
     @DynamoDBHashKey
     public String getStudyIdentifier() {
@@ -69,7 +69,6 @@ public final class DynamoSubpopulation implements Subpopulation {
     }
     @Override
     @DynamoDBIgnore
-    @JsonIgnore
     public SubpopulationGuid getGuid() {
         return (guid == null) ? null : SubpopulationGuid.create(guid);
     }    
@@ -105,7 +104,6 @@ public final class DynamoSubpopulation implements Subpopulation {
         this.required = required;
     }
     @DynamoDBAttribute
-    @JsonIgnore
     @Override
     public boolean isDeleted() {
         return deleted;

--- a/app/org/sagebionetworks/bridge/models/subpopulations/Subpopulation.java
+++ b/app/org/sagebionetworks/bridge/models/subpopulations/Subpopulation.java
@@ -1,13 +1,20 @@
 package org.sagebionetworks.bridge.models.subpopulations;
 
 import org.sagebionetworks.bridge.dynamodb.DynamoSubpopulation;
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.BridgeEntity;
 import org.sagebionetworks.bridge.models.Criteria;
 
+import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
+import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
 @JsonDeserialize(as=DynamoSubpopulation.class)
 public interface Subpopulation extends BridgeEntity {
+    ObjectWriter SUBPOP_WRITER = new BridgeObjectMapper().writer(
+            new SimpleFilterProvider().addFilter("filter",
+            SimpleBeanPropertyFilter.serializeAllExcept("studyIdentifier", "deleted")));
 
     static Subpopulation create() {
         return new DynamoSubpopulation();

--- a/app/org/sagebionetworks/bridge/play/controllers/SubpopulationController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/SubpopulationController.java
@@ -8,9 +8,10 @@ import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
-
+import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.models.GuidVersionHolder;
+import org.sagebionetworks.bridge.models.ResourceList;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
@@ -29,11 +30,13 @@ public class SubpopulationController extends BaseController {
         this.subpopService = subpopService;
     }
 
-    public Result getAllSubpopulations() {
+    public Result getAllSubpopulations() throws Exception {
         UserSession session = getAuthenticatedSession(DEVELOPER);
         
         List<Subpopulation> subpopulations = subpopService.getSubpopulations(session.getStudyIdentifier());
-        return okResult(subpopulations);
+        
+        String ser = Subpopulation.SUBPOP_WRITER.writeValueAsString(new ResourceList<Subpopulation>(subpopulations));
+        return ok(ser).as(BridgeConstants.JSON_MIME_TYPE);
     }
     public Result createSubpopulation() throws Exception {
         UserSession session = getAuthenticatedSession(DEVELOPER);
@@ -55,12 +58,14 @@ public class SubpopulationController extends BaseController {
         
         return okResult(new GuidVersionHolder(subpop.getGuidString(), subpop.getVersion()));
     }
-    public Result getSubpopulation(String guid) {
+    public Result getSubpopulation(String guid) throws Exception {
         UserSession session = getAuthenticatedSession(DEVELOPER, RESEARCHER);
         SubpopulationGuid subpopGuid = SubpopulationGuid.create(guid);
 
         Subpopulation subpop = subpopService.getSubpopulation(session.getStudyIdentifier(), subpopGuid);
-        return okResult(subpop);
+        
+        String ser = Subpopulation.SUBPOP_WRITER.writeValueAsString(subpop);
+        return ok(ser).as(BridgeConstants.JSON_MIME_TYPE);
     }
     public Result deleteSubpopulation(String guid, String physicalDeleteString) {
         UserSession session = getAuthenticatedSession(ADMIN, DEVELOPER);

--- a/test/org/sagebionetworks/bridge/play/controllers/SubpopulationControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SubpopulationControllerTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.play.controllers;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
@@ -99,6 +100,11 @@ public class SubpopulationControllerTest {
 
         String json = Helpers.contentAsString(result);
         
+        JsonNode node = BridgeObjectMapper.get().readTree(json);
+        JsonNode oneSubpop = node.get("items").get(0);
+        assertNull(oneSubpop.get("studyIdentifier"));
+        assertNull(oneSubpop.get("deleted"));
+        
         ResourceList<Subpopulation> rList = BridgeObjectMapper.get().readValue(json, subpopType);
         assertEquals(list, rList.getItems());
         assertEquals(2, rList.getItems().size());
@@ -184,6 +190,8 @@ public class SubpopulationControllerTest {
         JsonNode node = BridgeObjectMapper.get().readTree(json);
         assertEquals("Subpopulation", node.get("type").asText());
         assertEquals("AAA", node.get("guid").asText());
+        assertNull(node.get("studyIdentifier"));
+        assertNull(node.get("deleted"));
         
         verify(subpopService).getSubpopulation(STUDY_IDENTIFIER, SUBPOP_GUID);
     }


### PR DESCRIPTION
I am not using it in the final code for sending consents via SMS, but at one point I was trying to retrieve the studyId from the subpopulation and in manual testing, realized the subpopulation caching was wiping out the value. This and the loss of the deleted flag could cause bugs in our runtime code. Changed this so the whole subpopulation is serialized in cache, and used a writer on the subpopulation controller to remove the two fields I wanted to hide via the API.