### PR TITLE
Add a method for researchers to delete test accounts.

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
@@ -122,7 +122,7 @@ public class ParticipantController extends BaseController {
         AccountId accountId = AccountId.forId(study.getIdentifier(), userId);
         
         StudyParticipant participant = participantService.getParticipant(study, accountId, false);
-        if (!participant.getDataGroups().contains("test_user")) {
+        if (!participant.getDataGroups().contains(BridgeConstants.TEST_USER_GROUP)) {
             throw new UnauthorizedException("Account is not a test account.");
         }
         userAdminService.deleteUser(study, userId);

--- a/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
@@ -31,6 +31,7 @@ import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
+import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.ForwardCursorPagedResourceList;
 import org.sagebionetworks.bridge.models.PagedResourceList;
@@ -53,15 +54,23 @@ import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 import org.sagebionetworks.bridge.models.upload.UploadView;
 import org.sagebionetworks.bridge.services.AuthenticationService.ChannelType;
 import org.sagebionetworks.bridge.services.ParticipantService;
+import org.sagebionetworks.bridge.services.UserAdminService;
 
 @Controller
 public class ParticipantController extends BaseController {
     
     private ParticipantService participantService;
     
+    private UserAdminService userAdminService;
+    
     @Autowired
     final void setParticipantService(ParticipantService participantService) {
         this.participantService = participantService;
+    }
+    
+    @Autowired
+    final void setUserAdminService(UserAdminService userAdminService) {
+        this.userAdminService = userAdminService;
     }
     
     public Result getSelfParticipant() throws Exception {
@@ -105,6 +114,20 @@ public class ParticipantController extends BaseController {
         sessionUpdateService.updateParticipant(session, context, updated);
         
         return okResult(UserSessionInfo.toJSON(session));
+    }
+    
+    public Result deleteTestParticipant(String userId) {
+        UserSession session = getAuthenticatedSession(Roles.RESEARCHER);
+        Study study = studyService.getStudy(session.getStudyIdentifier());
+        AccountId accountId = AccountId.forId(study.getIdentifier(), userId);
+        
+        StudyParticipant participant = participantService.getParticipant(study, accountId, false);
+        if (!participant.getDataGroups().contains("test_user")) {
+            throw new UnauthorizedException("Account is not a test account.");
+        }
+        userAdminService.deleteUser(study, userId);
+        
+        return okResult("User deleted.");
     }
     
     public Result getActivityEventsForWorker(String studyId, String userId) {

--- a/conf/routes
+++ b/conf/routes
@@ -86,6 +86,7 @@ POST   /v3/participants/self/identifiers @org.sagebionetworks.bridge.play.contro
 
 GET    /v3/participants/:userId                                        @org.sagebionetworks.bridge.play.controllers.ParticipantController.getParticipant(userId: String, consents: Boolean ?= true)
 POST   /v3/participants/:userId                                        @org.sagebionetworks.bridge.play.controllers.ParticipantController.updateParticipant(userId: String)
+DELETE /v3/participants/:userId                                        @org.sagebionetworks.bridge.play.controllers.ParticipantController.deleteTestParticipant(userId: String)
 GET    /v3/participants/:userId/uploads                                @org.sagebionetworks.bridge.play.controllers.ParticipantController.getUploads(userId: String, startTime: String ?= null, endTime: String ?= null, pageSize: Integer ?= null, offsetKey: String ?= null)
 GET    /v3/participants/:userId/requestInfo                            @org.sagebionetworks.bridge.play.controllers.ParticipantController.getRequestInfo(userId: String)
 DELETE /v3/participants/:userId/activities                             @org.sagebionetworks.bridge.play.controllers.ParticipantController.deleteActivities(userId: String)

--- a/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
@@ -86,6 +86,7 @@ import org.sagebionetworks.bridge.services.ConsentService;
 import org.sagebionetworks.bridge.services.ParticipantService;
 import org.sagebionetworks.bridge.services.SessionUpdateService;
 import org.sagebionetworks.bridge.services.StudyService;
+import org.sagebionetworks.bridge.services.UserAdminService;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ParticipantControllerTest {
@@ -146,6 +147,9 @@ public class ParticipantControllerTest {
     
     @Mock
     private CacheProvider mockCacheProvider;
+    
+    @Mock
+    private UserAdminService userAdminService;
     
     @Captor
     private ArgumentCaptor<StudyParticipant> participantCaptor;
@@ -221,6 +225,7 @@ public class ParticipantControllerTest {
         controller.setStudyService(mockStudyService);
         controller.setAuthenticationService(authService);
         controller.setCacheProvider(mockCacheProvider);
+        controller.setUserAdminService(userAdminService);
 
         SessionUpdateService sessionUpdateService = new SessionUpdateService();
         sessionUpdateService.setCacheProvider(mockCacheProvider);
@@ -1178,6 +1183,37 @@ public class ParticipantControllerTest {
         ForwardCursorPagedResourceList<ScheduledActivity> retrieved = TestUtils.getResponsePayload(result,
             new TypeReference<ForwardCursorPagedResourceList<ScheduledActivity>>() {});
         assertFalse(retrieved.getItems().isEmpty());
+    }
+    
+    @Test
+    public void deleteTestUserWorks() {
+        participant = new StudyParticipant.Builder().copyOf(participant).withDataGroups(Sets.newHashSet("test_user"))
+                .build();
+        
+        AccountId accountId = AccountId.forId(study.getIdentifier(), ID);
+        when(mockParticipantService.getParticipant(study, accountId, false)).thenReturn(participant);
+        controller.deleteTestParticipant(ID);
+        
+        verify(userAdminService).deleteUser(study, ID);
+    }
+    
+    @Test(expected = UnauthorizedException.class)
+    public void deleteTestUserNotAResearcher() {
+        participant = new StudyParticipant.Builder().copyOf(participant)
+                .withRoles(Sets.newHashSet(Roles.ADMIN)).build();
+        session.setParticipant(participant);
+        
+        controller.deleteTestParticipant(ID);
+    }
+    
+    @Test(expected = UnauthorizedException.class)
+    public void deleteTestUserNotATestAccount() {
+        participant = new StudyParticipant.Builder().copyOf(participant)
+                .withDataGroups(Sets.newHashSet()).build();
+        
+        AccountId accountId = AccountId.forId(study.getIdentifier(), ID);
+        when(mockParticipantService.getParticipant(study, accountId, false)).thenReturn(participant);
+        controller.deleteTestParticipant(ID);
     }
     
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
It's the researcher role as developers are marked as researchers during development so they can see their test accounts. In the Bridge UI, it'll hide the option to delete a test user unless the user is both a Developer and a Researcher (if we want, I can enforce that on the server as well).