### PR TITLE
Consent fixes

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/AccountDao.java
+++ b/app/org/sagebionetworks/bridge/dao/AccountDao.java
@@ -27,7 +27,6 @@ public interface AccountDao {
     
     /**
      * Set the verified flag for the channel (email or phone) to true, and enable the account (if needed).
-     * Returns true if the account is updated, false if not.
      */
     void verifyChannel(AuthenticationService.ChannelType channelType, Account account);
     

--- a/app/org/sagebionetworks/bridge/dao/AccountDao.java
+++ b/app/org/sagebionetworks/bridge/dao/AccountDao.java
@@ -27,6 +27,7 @@ public interface AccountDao {
     
     /**
      * Set the verified flag for the channel (email or phone) to true, and enable the account (if needed).
+     * Returns true if the account is updated, false if not.
      */
     void verifyChannel(AuthenticationService.ChannelType channelType, Account account);
     

--- a/app/org/sagebionetworks/bridge/exceptions/ConsentRequiredException.java
+++ b/app/org/sagebionetworks/bridge/exceptions/ConsentRequiredException.java
@@ -10,7 +10,6 @@ public class ConsentRequiredException extends BridgeServiceException {
     private final UserSession userSession;
     
     public ConsentRequiredException(UserSession userSession) {
-        // TODO: This is not correct. You sign in, and find out the next thing you need to do is consent.
         super("Consent is required before signing in.", HttpStatus.SC_PRECONDITION_FAILED);
         this.userSession = userSession;
     }

--- a/app/org/sagebionetworks/bridge/exceptions/ConsentRequiredException.java
+++ b/app/org/sagebionetworks/bridge/exceptions/ConsentRequiredException.java
@@ -10,6 +10,7 @@ public class ConsentRequiredException extends BridgeServiceException {
     private final UserSession userSession;
     
     public ConsentRequiredException(UserSession userSession) {
+        // TODO: This is not correct. You sign in, and find out the next thing you need to do is consent.
         super("Consent is required before signing in.", HttpStatus.SC_PRECONDITION_FAILED);
         this.userSession = userSession;
     }

--- a/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
@@ -130,7 +130,6 @@ public class HibernateAccountDao implements AccountDao {
         }
     }
 
-
     /** {@inheritDoc} */
     @Override
     public void changePassword(Account account, String newPassword) {

--- a/app/org/sagebionetworks/bridge/models/accounts/Account.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/Account.java
@@ -21,6 +21,10 @@ import com.fasterxml.jackson.databind.JsonNode;
  */
 public interface Account extends BridgeEntity {
 
+    static Account create() {
+        return new GenericAccount();
+    }
+    
     default ConsentSignature getActiveConsentSignature(SubpopulationGuid subpopGuid) {
         List<ConsentSignature> history = getConsentSignatureHistory(subpopGuid);
         if (!history.isEmpty()) {
@@ -71,6 +75,7 @@ public interface Account extends BridgeEntity {
     Map<SubpopulationGuid,List<ConsentSignature>> getAllConsentSignatureHistories();
     
     String getHealthCode();
+    void setHealthCode(String healthCode);
 
     void setHealthId(HealthId healthId);
 

--- a/app/org/sagebionetworks/bridge/models/accounts/Account.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/Account.java
@@ -78,6 +78,7 @@ public interface Account extends BridgeEntity {
     void setStatus(AccountStatus status);
 
     StudyIdentifier getStudyIdentifier();
+    void setStudyId(StudyIdentifier studyId);
 
     /** Gets an immutable copy of the set of roles attached to this account. */
     Set<Roles> getRoles();
@@ -93,7 +94,8 @@ public interface Account extends BridgeEntity {
      * address or a user-chosen (possibly identifying) username.
      */
     String getId();
-    
+    void setId(String id);
+
     DateTime getCreatedOn();
     
     /**

--- a/app/org/sagebionetworks/bridge/models/accounts/GenericAccount.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/GenericAccount.java
@@ -308,6 +308,7 @@ public class GenericAccount implements Account {
     }
 
     /** @see #getStudyIdentifier */
+    @Override
     public void setStudyId(StudyIdentifier studyId) {
         this.studyId = studyId;
     }
@@ -331,6 +332,7 @@ public class GenericAccount implements Account {
     }
 
     /** @see #getId */
+    @Override
     public void setId(String id) {
         this.id = id;
     }

--- a/app/org/sagebionetworks/bridge/models/accounts/GenericAccount.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/GenericAccount.java
@@ -268,6 +268,7 @@ public class GenericAccount implements Account {
     }
 
     /** @see #getHealthCode */
+    @Override
     public void setHealthCode(String healthCode) {
         this.healthCode = healthCode;
     }

--- a/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
@@ -180,11 +180,9 @@ public class AuthenticationController extends BaseController {
         JsonNode node = requestToJSON(request());
         StudyParticipant participant = MAPPER.treeToValue(node, StudyParticipant.class);
         
-        boolean checkForConsent = JsonUtils.asBoolean(node, "checkForConsent");
-        
         String studyId = JsonUtils.asText(node, BridgeConstants.STUDY_PROPERTY);
         Study study = getStudyOrThrowException(studyId);
-        authenticationService.signUp(study, participant, checkForConsent);
+        authenticationService.signUp(study, participant);
         return createdResult("Signed up.");
     }
 

--- a/app/org/sagebionetworks/bridge/services/ConsentPdf.java
+++ b/app/org/sagebionetworks/bridge/services/ConsentPdf.java
@@ -114,6 +114,9 @@ public final class ConsentPdf {
             html = html.replace("@@sharing@@", sharingLabel);
             return html;
         } else {
+            // We have to be pretty lenient about this, because some of our tests cannot verify 
+            // a credential, and will allow a sign in by enabling the account. We have no way
+            // currently to verify an email address or phone number via the API.
             String contactInfo = "";
             String contactLabel = "";
             if (signer.getEmail() != null && Boolean.TRUE.equals(signer.getEmailVerified())) {
@@ -125,9 +128,11 @@ public final class ConsentPdf {
             } else if (signer.getExternalId() != null) {
                 contactInfo = signer.getExternalId();
                 contactLabel = "ID";
-            } else {
-                throw new BridgeServiceException("Attempting to send a consent to a user with no verified communication channel.");
             }
+            // Some integration tests enable the account without verifying either phone or email. Just
+            // silently fill out the consent without contact information (don't throw an error or these 
+            // integration tests will fail).
+            
             // This is now a fragment, assemble accordingly
             Map<String,String> map = BridgeUtils.studyTemplateVariables(study);
             String resolvedStudyConsentAgreement = BridgeUtils.resolveTemplate(studyConsentAgreement, map);

--- a/app/org/sagebionetworks/bridge/services/ConsentPdf.java
+++ b/app/org/sagebionetworks/bridge/services/ConsentPdf.java
@@ -129,10 +129,6 @@ public final class ConsentPdf {
                 contactInfo = signer.getExternalId();
                 contactLabel = "ID";
             }
-            // Some integration tests enable the account without verifying either phone or email. Just
-            // silently fill out the consent without contact information (don't throw an error or these 
-            // integration tests will fail).
-            
             // This is now a fragment, assemble accordingly
             Map<String,String> map = BridgeUtils.studyTemplateVariables(study);
             String resolvedStudyConsentAgreement = BridgeUtils.resolveTemplate(studyConsentAgreement, map);

--- a/app/org/sagebionetworks/bridge/services/ConsentService.java
+++ b/app/org/sagebionetworks/bridge/services/ConsentService.java
@@ -161,9 +161,8 @@ public class ConsentService {
         activityEventService.publishEnrollmentEvent(study, participant.getHealthCode(), withConsentCreatedOnSignature);
 
         if (sendSignedConsentToUser) {
-            ConsentPdf consentPdf = new ConsentPdf(study, participant.getTimeZone(), participant.getEmail(),
-                    withConsentCreatedOnSignature, sharingScope, studyConsent.getDocumentContent(),
-                    xmlTemplateWithSignatureBlock);
+            ConsentPdf consentPdf = new ConsentPdf(study, participant, withConsentCreatedOnSignature, sharingScope,
+                    studyConsent.getDocumentContent(), xmlTemplateWithSignatureBlock);
             
             // If the user's email exists and email notification is not suppressed, add the user to the provider
             String participantEmail = subpop.isAutoSendConsentSuppressed() ? null : participant.getEmail();
@@ -310,8 +309,8 @@ public class ConsentService {
         
         String studyConsentDocument = studyConsentService.getActiveConsent(subpop).getDocumentContent();
 
-        ConsentPdf consentPdf = new ConsentPdf(study, participant.getTimeZone(), participant.getEmail(),
-                consentSignature, sharingScope, studyConsentDocument, xmlTemplateWithSignatureBlock);            
+        ConsentPdf consentPdf = new ConsentPdf(study, participant, consentSignature, sharingScope, studyConsentDocument,
+                xmlTemplateWithSignatureBlock);
         
         BasicEmailProvider.Builder builder = new BasicEmailProvider.Builder()
                 .withStudy(study)

--- a/app/org/sagebionetworks/bridge/services/IntentService.java
+++ b/app/org/sagebionetworks/bridge/services/IntentService.java
@@ -43,6 +43,8 @@ public class IntentService {
     
     private AccountDao accountDao;
     
+    private ParticipantService participantService;
+    
     @Autowired
     final void setStudyService(StudyService studyService) {
         this.studyService = studyService;
@@ -71,6 +73,11 @@ public class IntentService {
     @Autowired
     final void setAccountDao(AccountDao accountDao) {
         this.accountDao = accountDao;
+    }
+    
+    @Autowired
+    final void setParticipantService(ParticipantService participantService) {
+        this.participantService = participantService;
     }
     
     public void submitIntentToParticipate(IntentToParticipate intent) {
@@ -131,6 +138,27 @@ public class IntentService {
                 cacheProvider.removeObject(cacheKey);
             }
         }
+    }
+    
+    public boolean registerIntentToParticipate(Study study, Account account) {
+        Phone phone = account.getPhone();
+        // Somehow, this is being called but the user has no phone number.
+        if (phone == null) {
+            return false;
+        }
+        List<Subpopulation> subpops = subpopService.getSubpopulations(study.getStudyIdentifier());
+        for (Subpopulation subpop : subpops) {
+            CacheKey cacheKey = CacheKey.itp(subpop.getGuid(), study.getStudyIdentifier(), phone);
+            IntentToParticipate intent = cacheProvider.getObject(cacheKey, IntentToParticipate.class);
+            if (intent != null) {
+                StudyParticipant participant = participantService.getParticipant(study, account.getId(), true);
+                consentService.consentToResearch(study, subpop.getGuid(), participant, 
+                        intent.getConsentSignature(), intent.getScope(), true);
+                cacheProvider.removeObject(cacheKey);
+                return true;
+            }
+        }
+        return false;
     }
     
     protected String getInstallLink(String osName, Map<String,String> installLinks) {

--- a/app/org/sagebionetworks/bridge/services/IntentService.java
+++ b/app/org/sagebionetworks/bridge/services/IntentService.java
@@ -127,7 +127,7 @@ public class IntentService {
         if (phone == null) {
             return false;
         }
-        boolean intentWasRegistered = false;
+        boolean consentsUpdated = false;
         StudyParticipant participant = null;
         List<Subpopulation> subpops = subpopService.getSubpopulations(study.getStudyIdentifier());
         for (Subpopulation subpop : subpops) {
@@ -140,10 +140,10 @@ public class IntentService {
                 consentService.consentToResearch(study, subpop.getGuid(), participant, 
                         intent.getConsentSignature(), intent.getScope(), true);
                 cacheProvider.removeObject(cacheKey);
-                intentWasRegistered = true;
+                consentsUpdated = true;
             }
         }
-        return intentWasRegistered;
+        return consentsUpdated;
     }
     
     protected String getInstallLink(String osName, Map<String,String> installLinks) {

--- a/conf/study-defaults/consent-page.xhtml
+++ b/conf/study-defaults/consent-page.xhtml
@@ -24,14 +24,14 @@ ${consent.body}
         <td colspan="5"><br /></td>
     </tr>
     <tr>
-        <td width="32%" nowrap="nowrap">${participant.email}</td>
+        <td width="32%" nowrap="nowrap">${participant.contactInfo}</td>
         <td width="2%"></td>
         <td width="32%" nowrap="nowrap">${participant.sharing}</td>
         <td width="2%"></td>
         <td width="32%" nowrap="nowrap"></td>
     </tr>
     <tr>
-        <td width="32%" style="border-top: 2px solid black">Email</td>
+        <td width="32%" style="border-top: 2px solid black">${participant.contactLabel}</td>
         <td width="2%"></td>
         <td width="32%" style="border-top: 2px solid black">Sharing Option</td>
         <td width="2%"></td>

--- a/test/org/sagebionetworks/bridge/play/controllers/AuthenticationControllerMockTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/AuthenticationControllerMockTest.java
@@ -365,7 +365,7 @@ public class AuthenticationControllerMockTest {
         Result result = controller.signUp();
         assertResult(result, 201, "Signed up.");
         
-        verify(authenticationService).signUp(eq(study), participantCaptor.capture(), eq(false));
+        verify(authenticationService).signUp(eq(study), participantCaptor.capture());
         
         StudyParticipant persistedParticipant = participantCaptor.getValue();
         assertEquals(originalParticipant.getFirstName(), persistedParticipant.getFirstName());
@@ -808,7 +808,7 @@ public class AuthenticationControllerMockTest {
         Result result = controller.signUp();
         TestUtils.assertResult(result, 201, "Signed up.");
         
-        verify(authenticationService).signUp(eq(study), participantCaptor.capture(), eq(false));
+        verify(authenticationService).signUp(eq(study), participantCaptor.capture());
         StudyParticipant captured = participantCaptor.getValue();
         assertEquals(TEST_EMAIL, captured.getEmail());
         assertEquals(TEST_PASSWORD, captured.getPassword());
@@ -827,7 +827,7 @@ public class AuthenticationControllerMockTest {
         Result result = controller.signUp();
         TestUtils.assertResult(result, 201, "Signed up.");
         
-        verify(authenticationService).signUp(eq(study), participantCaptor.capture(), eq(false));
+        verify(authenticationService).signUp(eq(study), participantCaptor.capture());
         StudyParticipant captured = participantCaptor.getValue();
         assertEquals(TEST_EMAIL, captured.getEmail());
         assertEquals(TEST_PASSWORD, captured.getPassword());
@@ -846,7 +846,7 @@ public class AuthenticationControllerMockTest {
         Result result = controller.signUp();
         TestUtils.assertResult(result, 201, "Signed up.");
         
-        verify(authenticationService).signUp(eq(study), participantCaptor.capture(), eq(true));
+        verify(authenticationService).signUp(eq(study), participantCaptor.capture());
         StudyParticipant captured = participantCaptor.getValue();
         assertEquals(TEST_EMAIL, captured.getEmail());
         assertEquals(TEST_PASSWORD, captured.getPassword());

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
@@ -163,7 +163,7 @@ public class AuthenticationServiceMockTest {
         study.setName("Sender");
         study.setPasswordPolicy(PasswordPolicy.DEFAULT_PASSWORD_POLICY);
         
-        account = new GenericAccount();
+        account = Account.create();
         
         service.setCacheProvider(cacheProvider);
         service.setBridgeConfig(config);
@@ -746,7 +746,7 @@ public class AuthenticationServiceMockTest {
     @Test
     public void signInWithIntentToParticipate() throws Exception {
         account.setId(USER_ID);
-        Account consentedAccount = new GenericAccount();
+        Account consentedAccount = Account.create();
         StudyParticipant consentedParticipant = new StudyParticipant.Builder().build();
         
         doReturn(account).when(accountDao).authenticate(study, EMAIL_PASSWORD_SIGN_IN);
@@ -765,7 +765,7 @@ public class AuthenticationServiceMockTest {
     
     @Test
     public void emailSignInWithIntentToParticipate() throws Exception {
-        Account consentedAccount = new GenericAccount();
+        Account consentedAccount = Account.create();
         StudyParticipant consentedParticipant = new StudyParticipant.Builder().build();
         
         when(accountWorkflowService.channelSignIn(ChannelType.EMAIL, CONTEXT, SIGN_IN_WITH_EMAIL,
@@ -786,7 +786,7 @@ public class AuthenticationServiceMockTest {
 
     @Test
     public void phoneSignInWithIntentToParticipate() throws Exception {
-        Account consentedAccount = new GenericAccount();
+        Account consentedAccount = Account.create();
         StudyParticipant consentedParticipant = new StudyParticipant.Builder().build();
         
         when(accountWorkflowService.channelSignIn(ChannelType.PHONE, CONTEXT, SIGN_IN_WITH_PHONE,

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
@@ -161,7 +161,7 @@ public class AuthenticationServiceTest {
             
             study.setAutoVerificationEmailSuppressed(true);
             study.setAutoVerificationPhoneSuppressed(true);
-            holder = authService.signUp(study, participant, true);
+            holder = authService.signUp(study, participant);
             
             Account account = accountDao.getAccount(
                     AccountId.forId(TestConstants.TEST_STUDY_IDENTIFIER, holder.getIdentifier()));
@@ -296,7 +296,7 @@ public class AuthenticationServiceTest {
         StudyParticipant participant = TestUtils.getStudyParticipant(AuthenticationServiceTest.class);
         IdentifierHolder holder = null;
         try {
-            holder = authService.signUp(study, participant, false);
+            holder = authService.signUp(study, participant);
             
             StudyParticipant persisted = participantService.getParticipant(study, holder.getIdentifier(), false);
             assertEquals(participant.getFirstName(), persisted.getFirstName());
@@ -324,7 +324,7 @@ public class AuthenticationServiceTest {
                 .withEmail(email).withPassword("P@ssword1").withDataGroups(groups).build();
         IdentifierHolder holder = null;
         try {
-            holder = authService.signUp(study, participant, false);
+            holder = authService.signUp(study, participant);
             
             Account account = accountDao.getAccount(AccountId.forId(study.getIdentifier(), holder.getIdentifier()));
             assertEquals(groups, account.getDataGroups());
@@ -367,7 +367,7 @@ public class AuthenticationServiceTest {
         authService.setAccountWorkflowService(accountWorkflowServiceSpy);
 
         // Second sign up
-        authService.signUp(testUser.getStudy(), testUser.getStudyParticipant(), false);
+        authService.signUp(testUser.getStudy(), testUser.getStudyParticipant());
         
         ArgumentCaptor<AccountId> accountIdCaptor = ArgumentCaptor.forClass(AccountId.class);
         verify(accountWorkflowServiceSpy).notifyAccountExists(eq(testUser.getStudy()), accountIdCaptor.capture());
@@ -472,7 +472,7 @@ public class AuthenticationServiceTest {
                 .withEmail(email).withPassword(PASSWORD).withRoles(roles).build();
         IdentifierHolder holder = null;
         try {
-            holder = authService.signUp(study, participant, false);    
+            holder = authService.signUp(study, participant);    
             participant = participantService.getParticipant(study, holder.getIdentifier(), false);
             assertTrue(participant.getRoles().isEmpty());
         } finally {

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
@@ -43,7 +43,6 @@ import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.OperatingSystem;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
-import org.sagebionetworks.bridge.models.accounts.AccountStatus;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.accounts.IdentifierHolder;
 import org.sagebionetworks.bridge.models.accounts.PasswordReset;
@@ -163,15 +162,12 @@ public class AuthenticationServiceTest {
             study.setAutoVerificationPhoneSuppressed(true);
             holder = authService.signUp(study, participant);
             
-            Account account = accountDao.getAccount(
-                    AccountId.forId(TestConstants.TEST_STUDY_IDENTIFIER, holder.getIdentifier()));
-            account.setPhoneVerified(true);
-            account.setEmailVerified(true);
-            account.setStatus(AccountStatus.ENABLED);
-            accountDao.updateAccount(account, true);
+            AccountId accountId = AccountId.forId(TestConstants.TEST_STUDY_IDENTIFIER, holder.getIdentifier());
+            Account account = accountDao.getAccount(accountId);
+            authService.updateChannelAfterVerification(ChannelType.EMAIL, account);
             
-            CriteriaContext context = new CriteriaContext.Builder()
-                    .withStudyIdentifier(TestConstants.TEST_STUDY).build();
+            CriteriaContext context = new CriteriaContext.Builder().withStudyIdentifier(TestConstants.TEST_STUDY)
+                    .build();
             
             // You should be able to sign in, and be consented. No exception.
             SignIn signIn = new SignIn.Builder().withStudy(TestConstants.TEST_STUDY_IDENTIFIER)

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
@@ -43,6 +43,7 @@ import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.OperatingSystem;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
+import org.sagebionetworks.bridge.models.accounts.AccountStatus;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.accounts.IdentifierHolder;
 import org.sagebionetworks.bridge.models.accounts.PasswordReset;
@@ -162,9 +163,12 @@ public class AuthenticationServiceTest {
             study.setAutoVerificationPhoneSuppressed(true);
             holder = authService.signUp(study, participant);
             
-            AccountId accountId = AccountId.forId(TestConstants.TEST_STUDY_IDENTIFIER, holder.getIdentifier());
-            Account account = accountDao.getAccount(accountId);
-            authService.updateChannelAfterVerification(ChannelType.EMAIL, account);
+            Account account = accountDao.getAccount(
+                    AccountId.forId(TestConstants.TEST_STUDY_IDENTIFIER, holder.getIdentifier()));
+            account.setPhoneVerified(true);
+            account.setEmailVerified(true);
+            account.setStatus(AccountStatus.ENABLED);
+            accountDao.updateAccount(account, true);
             
             CriteriaContext context = new CriteriaContext.Builder().withStudyIdentifier(TestConstants.TEST_STUDY)
                     .build();

--- a/test/org/sagebionetworks/bridge/services/ConsentPdfTest.java
+++ b/test/org/sagebionetworks/bridge/services/ConsentPdfTest.java
@@ -164,17 +164,6 @@ public class ConsentPdfTest {
         assertTrue(output.contains(">anId<"));
         assertTrue(output.contains(">ID<"));
     }
-
-    @Test(expected = BridgeServiceException.class)
-    public void noVerifiedCommunicationChannelThrows() throws Exception {
-        ConsentSignature sig = makeSignatureWithoutImage();
-        
-        StudyParticipant noChannelParticipant = new StudyParticipant.Builder().build();
-        
-        ConsentPdf consentPdf = new ConsentPdf(study, noChannelParticipant, sig, SharingScope.NO_SHARING,
-                NEW_DOCUMENT_FRAGMENT, consentBodyTemplate);
-        consentPdf.getFormattedConsentDocument();
-    }
     
     @Test 
     public void dateFormattedCorrectly() throws Exception {

--- a/test/org/sagebionetworks/bridge/services/ConsentServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/ConsentServiceMockTest.java
@@ -119,7 +119,8 @@ public class ConsentServiceMockTest {
         study.setSignedConsentTemplate(new EmailTemplate("Subject", "Body", MimeType.HTML));
 
         participant = new StudyParticipant.Builder().withHealthCode(HEALTH_CODE).withId(ID).withEmail(EMAIL)
-                .withSharingScope(SharingScope.ALL_QUALIFIED_RESEARCHERS).withExternalId(EXTERNAL_ID).build();
+                .withEmailVerified(true).withSharingScope(SharingScope.ALL_QUALIFIED_RESEARCHERS)
+                .withExternalId(EXTERNAL_ID).build();
         
         consentSignature = new ConsentSignature.Builder().withName("Test User").withBirthdate("1990-01-01")
                 .withSignedOn(SIGNED_ON).build();

--- a/test/org/sagebionetworks/bridge/services/ConsentServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/ConsentServiceMockTest.java
@@ -125,8 +125,8 @@ public class ConsentServiceMockTest {
         consentSignature = new ConsentSignature.Builder().withName("Test User").withBirthdate("1990-01-01")
                 .withSignedOn(SIGNED_ON).build();
         
-        account = spy(new GenericAccount()); // mock(Account.class);
-        ((GenericAccount)account).setId(ID);
+        account = Account.create(); // mock(Account.class);
+        account.setId(ID);
         when(accountDao.getAccount(any(AccountId.class))).thenReturn(account);
         
         StudyConsentView studyConsentView = mock(StudyConsentView.class);
@@ -273,8 +273,8 @@ public class ConsentServiceMockTest {
     @Test
     public void withdrawConsentWithParticipant() throws Exception {
         account.setEmail(EMAIL);
+        account.setHealthCode(participant.getHealthCode());
 
-        doReturn(participant.getHealthCode()).when(account).getHealthCode();
         doReturn(account).when(accountDao).getAccount(AccountId.forId(study.getIdentifier(), participant.getId()));
 
         // Add two consents to the account, one withdrawn, one active. This tests to make sure we're not accidentally
@@ -346,7 +346,7 @@ public class ConsentServiceMockTest {
         ArgumentCaptor<Account> accountCaptor = ArgumentCaptor.forClass(Account.class);
         
         verify(accountDao).updateAccount(accountCaptor.capture(), eq(false));
-        verify(account).setSharingScope(SharingScope.NO_SHARING);
+        assertEquals(SharingScope.NO_SHARING, account.getSharingScope());
 
         ArgumentCaptor<MimeTypeEmailProvider> emailCaptor = ArgumentCaptor.forClass(MimeTypeEmailProvider.class);
         verify(sendMailService).sendEmail(emailCaptor.capture());
@@ -373,8 +373,8 @@ public class ConsentServiceMockTest {
     public void withdrawAllConsentsWithPhone() {
         TestUtils.mockEditAccount(accountDao, account);
         account.setPhone(TestConstants.PHONE);
+        account.setHealthCode(participant.getHealthCode());
 
-        doReturn(participant.getHealthCode()).when(account).getHealthCode();
         doReturn(account).when(accountDao).getAccount(AccountId.forId(study.getIdentifier(), participant.getId()));
 
         account.setConsentSignatureHistory(SUBPOP_GUID, ImmutableList.of(consentSignature));
@@ -385,7 +385,7 @@ public class ConsentServiceMockTest {
         ArgumentCaptor<Account> accountCaptor = ArgumentCaptor.forClass(Account.class);
         
         verify(accountDao).updateAccount(accountCaptor.capture(), eq(false));
-        verify(account).setSharingScope(SharingScope.NO_SHARING);
+        assertEquals(SharingScope.NO_SHARING, account.getSharingScope());
         verify(sendMailService, never()).sendEmail(any(MimeTypeEmailProvider.class));
         
         Account updatedAccount = accountCaptor.getValue();
@@ -833,6 +833,7 @@ public class ConsentServiceMockTest {
         // two consents, withdrawing one does not turn sharing entirely off.
         account.setEmail(EMAIL);
         account.setSharingScope(SharingScope.ALL_QUALIFIED_RESEARCHERS);
+        account.setHealthCode(participant.getHealthCode());
         
         Subpopulation subpop1 = Subpopulation.create();
         subpop1.setName(SUBPOP_GUID.getGuid());
@@ -844,7 +845,6 @@ public class ConsentServiceMockTest {
         subpop2.setGuid(SECOND_SUBPOP);
         subpop2.setRequired(subpop2Required);
         
-        doReturn(participant.getHealthCode()).when(account).getHealthCode();
         doReturn(account).when(accountDao).getAccount(AccountId.forId(study.getIdentifier(), participant.getId()));
         doReturn(ImmutableList.of(subpop1, subpop2)).when(subpopService).getSubpopulationsForUser(any());
         
@@ -862,8 +862,8 @@ public class ConsentServiceMockTest {
     
     private void setupWithdrawTest() {
         account.setEmail(EMAIL);
+        account.setHealthCode(participant.getHealthCode());
 
-        doReturn(participant.getHealthCode()).when(account).getHealthCode();
         doReturn(account).when(accountDao).getAccount(AccountId.forId(study.getIdentifier(), participant.getId()));
 
         account.setConsentSignatureHistory(SUBPOP_GUID, ImmutableList.of(consentSignature));

--- a/test/org/sagebionetworks/bridge/services/IntentServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/IntentServiceTest.java
@@ -191,7 +191,7 @@ public class IntentServiceTest {
         
         AccountId accountId = AccountId.forPhone(intent.getStudyId(), intent.getPhone()); 
         
-        Account account = new GenericAccount();
+        Account account = Account.create();
         when(accountDao.getAccount(accountId)).thenReturn(account);
         
         service.submitIntentToParticipate(intent);
@@ -222,7 +222,7 @@ public class IntentServiceTest {
                         .build())
                 .build();
         
-        Account account = new GenericAccount();
+        Account account = Account.create();
         account.setPhone(TestConstants.PHONE);
         
         CacheKey key = CacheKey.itp(SubpopulationGuid.create("BBB"), TestConstants.TEST_STUDY, TestConstants.PHONE);
@@ -272,7 +272,7 @@ public class IntentServiceTest {
                         .build())
                 .build();
         
-        Account account = new GenericAccount();
+        Account account = Account.create();
         account.setId("id");
         account.setPhone(TestConstants.PHONE);
         
@@ -304,7 +304,7 @@ public class IntentServiceTest {
     
     @Test
     public void noPhoneDoesNothing() {
-        Account account = new GenericAccount();
+        Account account = Account.create();
         
         service.registerIntentToParticipate(mockStudy, account);
         
@@ -320,7 +320,7 @@ public class IntentServiceTest {
         Subpopulation subpopB = Subpopulation.create();
         subpopB.setGuidString("BBB");
         
-        Account account = new GenericAccount();
+        Account account = Account.create();
         account.setPhone(TestConstants.PHONE);
         
         StudyParticipant participant = new StudyParticipant.Builder().build();

--- a/test/org/sagebionetworks/bridge/services/IntentServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/IntentServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -63,6 +64,9 @@ public class IntentServiceTest {
     NotificationsService mockNotificationsService;
     
     @Mock
+    ParticipantService mockParticipantService;
+    
+    @Mock
     Study mockStudy;
     
     @Mock
@@ -89,6 +93,7 @@ public class IntentServiceTest {
         service.setCacheProvider(mockCacheProvider);
         service.setNotificationsService(mockNotificationsService);
         service.setAccountDao(accountDao);
+        service.setParticipantService(mockParticipantService);
     }
     
     @Test
@@ -217,8 +222,8 @@ public class IntentServiceTest {
                         .build())
                 .build();
         
-        StudyParticipant participant = new StudyParticipant.Builder()
-                .withPhone(TestConstants.PHONE).build();
+        Account account = new GenericAccount();
+        account.setPhone(TestConstants.PHONE);
         
         CacheKey key = CacheKey.itp(SubpopulationGuid.create("BBB"), TestConstants.TEST_STUDY, TestConstants.PHONE);
         
@@ -228,19 +233,80 @@ public class IntentServiceTest {
                 .thenReturn(Lists.newArrayList(subpopA, subpopB));
         when(mockCacheProvider.getObject(key, IntentToParticipate.class)).thenReturn(intent);
         
-        service.registerIntentToParticipate(mockStudy, participant);
+        service.registerIntentToParticipate(mockStudy, account);
         
         verify(mockSubpopService).getSubpopulations(TestConstants.TEST_STUDY);
         verify(mockCacheProvider).removeObject(key);
-        verify(mockConsentService).consentToResearch(mockStudy, SubpopulationGuid.create("BBB"), 
-                participant, intent.getConsentSignature(), intent.getScope(), true);
+        verify(mockConsentService).consentToResearch(eq(mockStudy), eq(SubpopulationGuid.create("BBB")), 
+                any(), eq(intent.getConsentSignature()), eq(intent.getScope()), eq(true));
+    }
+    
+    @Test
+    public void registerIntentToParticipateWithMultipleConsents() throws Exception {
+        Subpopulation subpopA = Subpopulation.create();
+        subpopA.setGuidString("AAA");
+        Subpopulation subpopB = Subpopulation.create();
+        subpopB.setGuidString("BBB");
+        
+        IntentToParticipate intentAAA = new IntentToParticipate.Builder()
+                .withOsName("Android")
+                .withPhone(TestConstants.PHONE)
+                .withScope(SharingScope.NO_SHARING)
+                .withStudyId(TestConstants.TEST_STUDY_IDENTIFIER)
+                .withSubpopGuid("AAA")
+                .withConsentSignature(new ConsentSignature.Builder()
+                        .withName("Test Name")
+                        .withBirthdate("1975-01-01")
+                        .build())
+                .build();
+        
+        IntentToParticipate intentBBB = new IntentToParticipate.Builder()
+                .withOsName("Android")
+                .withPhone(TestConstants.PHONE)
+                .withScope(SharingScope.NO_SHARING)
+                .withStudyId(TestConstants.TEST_STUDY_IDENTIFIER)
+                .withSubpopGuid("BBB")
+                .withConsentSignature(new ConsentSignature.Builder()
+                        .withName("Test Name")
+                        .withBirthdate("1975-01-01")
+                        .build())
+                .build();
+        
+        Account account = new GenericAccount();
+        account.setId("id");
+        account.setPhone(TestConstants.PHONE);
+        
+        StudyParticipant participant = new StudyParticipant.Builder().build(); 
+        
+        CacheKey keyAAA = CacheKey.itp(SubpopulationGuid.create("AAA"), TestConstants.TEST_STUDY, TestConstants.PHONE);
+        CacheKey keyBBB = CacheKey.itp(SubpopulationGuid.create("BBB"), TestConstants.TEST_STUDY, TestConstants.PHONE);
+        
+        when(mockStudy.getStudyIdentifier()).thenReturn(TestConstants.TEST_STUDY);
+        when(mockStudy.getIdentifier()).thenReturn(TestConstants.TEST_STUDY_IDENTIFIER);
+        when(mockSubpopService.getSubpopulations(TestConstants.TEST_STUDY))
+                .thenReturn(Lists.newArrayList(subpopA, subpopB));
+        when(mockCacheProvider.getObject(keyAAA, IntentToParticipate.class)).thenReturn(intentAAA);
+        when(mockCacheProvider.getObject(keyBBB, IntentToParticipate.class)).thenReturn(intentBBB);
+        when(mockParticipantService.getParticipant(mockStudy, "id", true)).thenReturn(participant);
+        
+        service.registerIntentToParticipate(mockStudy, account);
+        
+        verify(mockSubpopService).getSubpopulations(TestConstants.TEST_STUDY);
+        verify(mockCacheProvider).removeObject(keyAAA);
+        verify(mockCacheProvider).removeObject(keyBBB);
+        verify(mockConsentService).consentToResearch(eq(mockStudy), eq(SubpopulationGuid.create("AAA")), 
+                any(), eq(intentAAA.getConsentSignature()), eq(intentAAA.getScope()), eq(true));
+        verify(mockConsentService).consentToResearch(eq(mockStudy), eq(SubpopulationGuid.create("BBB")), 
+                any(), eq(intentBBB.getConsentSignature()), eq(intentBBB.getScope()), eq(true));
+        // Only loaded the participant once...
+        verify(mockParticipantService, times(1)).getParticipant(mockStudy, "id", true);
     }
     
     @Test
     public void noPhoneDoesNothing() {
-        StudyParticipant participant = new StudyParticipant.Builder().build();
+        Account account = new GenericAccount();
         
-        service.registerIntentToParticipate(mockStudy, participant);
+        service.registerIntentToParticipate(mockStudy, account);
         
         verifyNoMoreInteractions(mockSubpopService);
         verifyNoMoreInteractions(mockCacheProvider);
@@ -254,8 +320,10 @@ public class IntentServiceTest {
         Subpopulation subpopB = Subpopulation.create();
         subpopB.setGuidString("BBB");
         
-        StudyParticipant participant = new StudyParticipant.Builder()
-                .withPhone(TestConstants.PHONE).build();
+        Account account = new GenericAccount();
+        account.setPhone(TestConstants.PHONE);
+        
+        StudyParticipant participant = new StudyParticipant.Builder().build();
         
         CacheKey key = CacheKey.itp(SubpopulationGuid.create("BBB"), TestConstants.TEST_STUDY, TestConstants.PHONE);
         
@@ -263,8 +331,9 @@ public class IntentServiceTest {
         when(mockStudy.getIdentifier()).thenReturn(TestConstants.TEST_STUDY_IDENTIFIER);
         when(mockSubpopService.getSubpopulations(TestConstants.TEST_STUDY))
                 .thenReturn(Lists.newArrayList(subpopA, subpopB));
+        when(mockParticipantService.getParticipant(any(Study.class), any(String.class), eq(false))).thenReturn(participant);
         
-        service.registerIntentToParticipate(mockStudy, participant);
+        service.registerIntentToParticipate(mockStudy, account);
         
         verify(mockSubpopService).getSubpopulations(TestConstants.TEST_STUDY);
         verify(mockCacheProvider, never()).removeObject(key);
@@ -283,4 +352,5 @@ public class IntentServiceTest {
         assertEquals("iphone-os-link", service.getInstallLink("iPhone OS", installLinks));
         assertEquals("universal-link", service.getInstallLink("Android", installLinks));
     }
+
 }

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -229,7 +229,7 @@ public class ParticipantServiceTest {
         participantService.setScheduledActivityService(scheduledActivityService);
         participantService.setAccountWorkflowService(accountWorkflowService);
         
-        account = new GenericAccount();
+        account = Account.create();
     }
     
     private void mockHealthCodeAndAccountRetrieval() {

--- a/test/org/sagebionetworks/bridge/services/SendEmailIntegTest.java
+++ b/test/org/sagebionetworks/bridge/services/SendEmailIntegTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.sagebionetworks.bridge.time.DateUtils;
 import org.sagebionetworks.bridge.models.accounts.SharingScope;
+import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.studies.MimeType;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
@@ -66,10 +67,13 @@ public class SendEmailIntegTest {
         
         final Study study = studyService.getStudy(TEST_STUDY_IDENTIFIER);
         
+        StudyParticipant participant = new StudyParticipant.Builder().withTimeZone(DateTimeZone.UTC)
+                .withEmail("bridge-testing@sagebase.org").withEmailVerified(true).build();
+        
         Subpopulation subpopulation = subpopService.getSubpopulation(TEST_STUDY, SUBPOP_GUID);
         String htmlTemplate = studyConsentService.getActiveConsent(subpopulation).getDocumentContent();
-        ConsentPdf consentPdf = new ConsentPdf(study, DateTimeZone.UTC, "bridge-testing@sagebase.org", signature,
-                SharingScope.SPONSORS_AND_PARTNERS, htmlTemplate, consentBodyTemplate);
+        ConsentPdf consentPdf = new ConsentPdf(study, participant, signature, SharingScope.SPONSORS_AND_PARTNERS,
+                htmlTemplate, consentBodyTemplate);
         
         BasicEmailProvider provider = new BasicEmailProvider.Builder()
                 .withStudy(study)

--- a/test/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceConsentTest.java
+++ b/test/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceConsentTest.java
@@ -14,7 +14,6 @@ import java.util.List;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.simpleemail.model.MessageRejectedException;
 import org.apache.commons.io.IOUtils;
-import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -23,6 +22,7 @@ import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.time.DateUtils;
 import org.sagebionetworks.bridge.models.accounts.SharingScope;
+import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.studies.EmailTemplate;
 import org.sagebionetworks.bridge.models.studies.MimeType;
 import org.sagebionetworks.bridge.models.studies.Study;
@@ -46,8 +46,8 @@ import com.google.common.base.Charsets;
 public class SendMailViaAmazonServiceConsentTest {
     private static final String SUPPORT_EMAIL = "study-support-email@study.com";
     private static final String FROM_STUDY_AS_FORMATTED = "\"Test Study (Sage)\" <"+SUPPORT_EMAIL+">";
-    private static final DateTimeZone MSK = DateTimeZone.forID("Europe/Moscow");
-
+    private static final StudyParticipant PARTICIPANT = new StudyParticipant.Builder()
+            .withEmail("test-user@sagebase.org").withEmailVerified(true).build();;
     private SendMailViaAmazonService service;
     private AmazonSimpleEmailServiceClient emailClient;
     private StudyService studyService;
@@ -103,8 +103,8 @@ public class SendMailViaAmazonServiceConsentTest {
         
         String htmlTemplate = studyConsentService.getActiveConsent(subpopulation).getDocumentContent();
         
-        ConsentPdf consentPdf = new ConsentPdf(study, MSK, "test-user@sagebase.org", consent,
-                SharingScope.SPONSORS_AND_PARTNERS, htmlTemplate, consentBodyTemplate);
+        ConsentPdf consentPdf = new ConsentPdf(study, PARTICIPANT, consent, SharingScope.SPONSORS_AND_PARTNERS,
+                htmlTemplate, consentBodyTemplate);
         
         BasicEmailProvider provider = new BasicEmailProvider.Builder()
                 .withStudy(study)
@@ -144,7 +144,7 @@ public class SendMailViaAmazonServiceConsentTest {
         
         String htmlTemplate = studyConsentService.getActiveConsent(subpopulation).getDocumentContent();
         
-        ConsentPdf consentPdf = new ConsentPdf(study, MSK, "test-user@sagebase.org", consent,
+        ConsentPdf consentPdf = new ConsentPdf(study, PARTICIPANT, consent,
                 SharingScope.SPONSORS_AND_PARTNERS, htmlTemplate, consentBodyTemplate);
         
         BasicEmailProvider provider = new BasicEmailProvider.Builder()
@@ -191,8 +191,8 @@ public class SendMailViaAmazonServiceConsentTest {
         
         String htmlTemplate = studyConsentService.getActiveConsent(subpopulation).getDocumentContent();
         
-        ConsentPdf consentPdf = new ConsentPdf(study, MSK, "test-user@sagebase.org", consent,
-                SharingScope.SPONSORS_AND_PARTNERS, htmlTemplate, consentBodyTemplate);
+        ConsentPdf consentPdf = new ConsentPdf(study, PARTICIPANT, consent, SharingScope.SPONSORS_AND_PARTNERS,
+                htmlTemplate, consentBodyTemplate);
         
         BasicEmailProvider provider = new BasicEmailProvider.Builder()
                 .withStudy(study)
@@ -219,8 +219,8 @@ public class SendMailViaAmazonServiceConsentTest {
         
         String htmlTemplate = studyConsentService.getActiveConsent(subpopulation).getDocumentContent();
 
-        ConsentPdf consentPdf = new ConsentPdf(study, MSK, "test-user@sagebase.org", consent,
-                SharingScope.SPONSORS_AND_PARTNERS, htmlTemplate, consentBodyTemplate);
+        ConsentPdf consentPdf = new ConsentPdf(study, PARTICIPANT, consent, SharingScope.SPONSORS_AND_PARTNERS,
+                htmlTemplate, consentBodyTemplate);
         
         BasicEmailProvider provider = new BasicEmailProvider.Builder()
                 .withStudy(study)

--- a/test/org/sagebionetworks/bridge/services/email/WithdrawConsentEmailProviderTest.java
+++ b/test/org/sagebionetworks/bridge/services/email/WithdrawConsentEmailProviderTest.java
@@ -31,7 +31,7 @@ public class WithdrawConsentEmailProviderTest {
     public void before() {
         study = mock(Study.class);
         
-        account = new GenericAccount();
+        account = Account.create();
         account.setEmail("d@d.com");
         
         provider = new WithdrawConsentEmailProvider(study, EXTERNAL_ID, account, WITHDRAWAL, UNIX_TIMESTAMP);

--- a/test/org/sagebionetworks/bridge/upload/UploadHandlersEndToEndTest.java
+++ b/test/org/sagebionetworks/bridge/upload/UploadHandlersEndToEndTest.java
@@ -41,6 +41,7 @@ import org.sagebionetworks.bridge.file.InMemoryFileHelper;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.time.DateUtils;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolderImpl;
+import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.GenericAccount;
 import org.sagebionetworks.bridge.models.accounts.SharingScope;
 import org.sagebionetworks.bridge.models.healthdata.HealthDataRecord;
@@ -248,7 +249,7 @@ public class UploadHandlersEndToEndTest {
         strictValidationHandler.setStudyService(mockStudyService);
 
         // set up TranscribeConsentHandler
-        GenericAccount account = new GenericAccount();
+        Account account = Account.create();
         account.setDataGroups(ImmutableSet.of("parkinson","test_user"));
         account.setExternalId(EXTERNAL_ID);
         account.setSharingScope(SharingScope.SPONSORS_AND_PARTNERS);


### PR DESCRIPTION
BRIDGE-2182

1) always indicate that the date is in GMT, because it always is (we most likely don't know the user's time zone at this point);

2) If the account has a verified email, use it, else a verified phone, use it, else use an external ID if it exists, otherwise, just don't show an identifier on the final consent document

3) This uncovered a bug related to creating a consent record with a credential before it is verified; I've moved ITP processing from sign up to sign in to avoid this. There's more places it needs to be inserted, but works the same way... before throwing a consent exception, we check to see if there's a pending consent and process that first, then continue.

Also filed this issue based on functionality I uncovered working on this: https://sagebionetworks.jira.com/browse/BRIDGE-2191