### PR TITLE
Increase survey size limit to 3kb

### DIFF
--- a/app/org/sagebionetworks/bridge/upload/UploadUtil.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadUtil.java
@@ -50,7 +50,7 @@ public class UploadUtil {
     public static final String FIELD_SCHEMA_REV = "schemaRevision";
     public static final String FIELD_SURVEY_GUID = "surveyGuid";
     public static final String FIELD_SURVEY_CREATED_ON = "surveyCreatedOn";
-    public static final int FILE_SIZE_LIMIT_SURVEY_ANSWER = 1024;
+    public static final int FILE_SIZE_LIMIT_SURVEY_ANSWER = 3 * 1024;
     public static final int FILE_SIZE_LIMIT_INLINE_FIELD = 10 * 1024;
     public static final int FILE_SIZE_LIMIT_DATA_FILE = 2 * 1024 * 1024;
     public static final int WARNING_LIMIT_PARSED_JSON = 5 * 1024 * 1024;


### PR DESCRIPTION
This occurs because we sometimes have freeform survey text questions up to 1000 chars in length, and for whatever reason, ResearchKit duplicates this in the survey answer file. This happens to on average 1 upload per month. This change increases the limit from 1kb to 3kb so that those files can still be parsed.