### PR TITLE
increase data group limit

### DIFF
--- a/app/org/sagebionetworks/bridge/validators/StudyValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/StudyValidator.java
@@ -35,7 +35,7 @@ import org.springframework.validation.Validator;
 public class StudyValidator implements Validator {
     public static final StudyValidator INSTANCE = new StudyValidator();
     
-    private static final int MAX_SYNAPSE_LENGTH = 100;
+    private static final int MAX_SYNAPSE_LENGTH = 250;
     private static final Pattern FINGERPRINT_PATTERN = Pattern.compile("^[0-9a-fA-F:]{95,95}$");
     
     /**

--- a/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
@@ -3,11 +3,14 @@ package org.sagebionetworks.bridge.validators;
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
 
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 
 import com.google.common.collect.ImmutableList;
 import org.junit.Before;
 import org.junit.Test;
 import org.sagebionetworks.bridge.BridgeConstants;
+import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
 import org.sagebionetworks.bridge.models.studies.AndroidAppLink;
@@ -386,8 +389,14 @@ public class StudyValidatorTest {
     
     @Test
     public void longListOfDataGroupsInvalid() {
-        study.setDataGroups(Sets.newTreeSet(Lists.newArrayList("Antwerp", "Ghent", "Charleroi", "Liege", "Brussels-City", "Bruges", "Schaerbeek", "Anderlecht", "Namur", "Leuven", "Mons", "Molenbeek-Saint-Jean")));
-        assertValidatorMessage(INSTANCE, study, "dataGroups", "will not export to Synapse (string is over 100 characters: 'Anderlecht, Antwerp, Bruges, Brussels-City, Charleroi, Ghent, Leuven, Liege, Molenbeek-Saint-Jean, Mons, Namur, Schaerbeek')");
+        // Make 25 data groups, each with at least 10 chars in length. This will be long enough to hit the limit.
+        Set<String> dataGroupSet = new TreeSet<>();
+        for (int i = 0; i < 25; i++) {
+            dataGroupSet.add("data-group-" + i);
+        }
+        study.setDataGroups(dataGroupSet);
+        assertValidatorMessage(INSTANCE, study, "dataGroups", "will not export to Synapse (string is over 250 characters: '" +
+                BridgeUtils.COMMA_SPACE_JOINER.join(dataGroupSet) + "')");
     }
     
     @Test


### PR DESCRIPTION
Depends on https://github.com/Sage-Bionetworks/Bridge-Exporter/pull/69 Should not be pushed out until BridgeEX is pushed out, but this only matters if someone adds a bunch of data groups to a study.

EDIT: The BridgeEX changes have been pushed to Prod.