### PR TITLE
Phone sign in on existing fix

### DIFF
--- a/app/org/sagebionetworks/bridge/services/AccountWorkflowService.java
+++ b/app/org/sagebionetworks/bridge/services/AccountWorkflowService.java
@@ -397,10 +397,10 @@ public class AccountWorkflowService {
         builder.withExpirationPeriod(RESET_PASSWORD_EXPIRATION_PERIOD, VERIFY_OR_RESET_EXPIRE_IN_SECONDS);
         
         // When phone workflow is fully supported, this will only be done if phone sign in is enabled
-        if (includePhoneSignIn /* && study.isPhoneSignInEnabled()*/) {
+        if (includePhoneSignIn && study.isPhoneSignInEnabled()) {
             SignIn signIn = new SignIn.Builder().withPhone(phone).withStudy(study.getIdentifier()).build();
             requestChannelSignIn(PHONE, PHONE_SIGNIN_REQUEST, phoneSignInRequestInMillis,
-                signIn, false, this::getNextToken, (theStudy, token) -> {
+                signIn, false, this::getNextPhoneToken, (theStudy, token) -> {
                     String formattedToken = token.substring(0,3) + "-" + token.substring(3,6);
                     builder.withToken(TOKEN_KEY, formattedToken);
                     builder.withExpirationPeriod(PHONE_SIGNIN_EXPIRATION_PERIOD, SIGNIN_EXPIRE_IN_SECONDS);

--- a/app/org/sagebionetworks/bridge/services/AccountWorkflowService.java
+++ b/app/org/sagebionetworks/bridge/services/AccountWorkflowService.java
@@ -396,7 +396,6 @@ public class AccountWorkflowService {
         builder.withToken(RESET_PASSWORD_URL_KEY, url);
         builder.withExpirationPeriod(RESET_PASSWORD_EXPIRATION_PERIOD, VERIFY_OR_RESET_EXPIRE_IN_SECONDS);
         
-        // When phone workflow is fully supported, this will only be done if phone sign in is enabled
         if (includePhoneSignIn && study.isPhoneSignInEnabled()) {
             SignIn signIn = new SignIn.Builder().withPhone(phone).withStudy(study.getIdentifier()).build();
             requestChannelSignIn(PHONE, PHONE_SIGNIN_REQUEST, phoneSignInRequestInMillis,


### PR DESCRIPTION
This was creating an alphanumeric token that you couldn't enter on a keypad, and which doesn't work anyway. Fixed, also we don't generate any of this unless phone sign in pathway is enabled (as already true for email sign in pathway).