### PR TITLE
Hibernate fixes for metadata modules

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/SharedModuleMetadataDao.java
+++ b/app/org/sagebionetworks/bridge/dao/SharedModuleMetadataDao.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge.dao;
 
 import java.util.List;
 
+import org.sagebionetworks.bridge.hibernate.HqlWhereClause;
 import org.sagebionetworks.bridge.models.sharedmodules.SharedModuleMetadata;
 
 /** DAO for Shared Module Metadata. */
@@ -20,13 +21,16 @@ public interface SharedModuleMetadataDao {
 
     /**
      * <p>
-     * Queries module metadata using the given SQL-like WHERE clause.
+     * Queries module metadata using the given HqlWhereClause clause.
      * </p>
      * <p>
-     * Example: "published = true AND os = 'iOS'"
+     * Example: "published = true AND os = 'iOS'" would be written as:
+     * clause.addExpression("published = :published").setParameter("published", true)
+     *      .addExpression("os = :os").setParameter("os","iOS");
+     * 
      * </p>
      */
-    List<SharedModuleMetadata> queryMetadata(String whereClause);
+    List<SharedModuleMetadata> queryMetadata(HqlWhereClause clause);
 
     /** Updates the specified metadata object. */
     SharedModuleMetadata updateMetadata(SharedModuleMetadata metadata);

--- a/app/org/sagebionetworks/bridge/hibernate/HqlWhereClause.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HqlWhereClause.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.hibernate;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -17,7 +18,7 @@ public final class HqlWhereClause {
     private static final Joiner AND_JOINER = Joiner.on(" AND ");
     private static final Joiner OR_JOINER = Joiner.on(" OR ");
     private final List<String> expressions = new ArrayList<>();
-    private final ImmutableMap.Builder<String,Object> parameters = new ImmutableMap.Builder<>();
+    private final Map<String,Object> parameters = new HashMap<>();
     private final boolean useOrOperator;
     
     public HqlWhereClause(boolean useOrOperator) {
@@ -52,7 +53,7 @@ public final class HqlWhereClause {
     }
     
     public Map<String,Object> getParameters() {
-        return parameters.build();
+        return parameters;
     }
     
     private String extractParameterName(String expr) {

--- a/app/org/sagebionetworks/bridge/hibernate/HqlWhereClause.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HqlWhereClause.java
@@ -1,0 +1,84 @@
+package org.sagebionetworks.bridge.hibernate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+
+public final class HqlWhereClause {
+    
+    private static final Pattern PATTERN = Pattern.compile(":[^\\\b]+");
+    private static final Joiner AND_JOINER = Joiner.on(" AND ");
+    private static final Joiner OR_JOINER = Joiner.on(" OR ");
+    private final List<String> expressions = new ArrayList<>();
+    private final ImmutableMap.Builder<String,Object> parameters = new ImmutableMap.Builder<>();
+    private final boolean useOrOperator;
+    
+    public HqlWhereClause(boolean useOrOperator) {
+        this.useOrOperator = useOrOperator;
+    }
+    
+    public HqlWhereClause addExpression(String expr) {
+        Preconditions.checkNotNull(expr);
+        expressions.add(expr);
+        return this;
+    }
+    
+    public HqlWhereClause addExpression(String expr, Object value) {
+        Preconditions.checkNotNull(expr);
+        if (value != null) {
+            expressions.add(expr);
+            // All like queries are infix queries.
+            if (expr.toLowerCase().contains(" like ")) {
+                value = "%" + value + "%";
+            }
+            String paramName = extractParameterName(expr);
+            parameters.put(paramName, value);
+        }
+        return this;
+    }
+    
+    public String getClause() {
+        if (expressions.isEmpty()) {
+            return null;
+        }
+        return (useOrOperator) ? OR_JOINER.join(expressions) : AND_JOINER.join(expressions);
+    }
+    
+    public Map<String,Object> getParameters() {
+        return parameters.build();
+    }
+    
+    private String extractParameterName(String expr) {
+        Matcher matcher = PATTERN.matcher(expr);
+        matcher.find();
+        return matcher.group().substring(1);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parameters, expressions, useOrOperator);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null || getClass() != obj.getClass())
+            return false;
+        HqlWhereClause other = (HqlWhereClause) obj;
+        return Objects.equals(parameters, other.parameters) && Objects.equals(expressions, other.expressions)
+                && Objects.equals(useOrOperator, other.useOrOperator);
+    }
+
+    @Override
+    public String toString() {
+        return "HqlWhereClause [expressions=" + expressions + ", parameters=" + parameters + "]";
+    }
+}

--- a/app/org/sagebionetworks/bridge/play/controllers/SharedModuleMetadataController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/SharedModuleMetadataController.java
@@ -13,6 +13,7 @@ import play.mvc.Result;
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
+import org.sagebionetworks.bridge.hibernate.HqlWhereClause;
 import org.sagebionetworks.bridge.models.ResourceList;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.sharedmodules.SharedModuleMetadata;
@@ -68,21 +69,25 @@ public class SharedModuleMetadataController extends BaseController {
      * Queries module metadata using the set of given parameters. See
      * {@link SharedModuleMetadataService#queryAllMetadata} for details.
      */
-    public Result queryAllMetadata(String mostRecentString, String publishedString, String where, String tagsString) {
+    public Result queryAllMetadata(String mostRecentString, String publishedString, String q, String tagsString) {
         // Parse inputs
         boolean mostRecent = Boolean.parseBoolean(mostRecentString);
         boolean published = Boolean.parseBoolean(publishedString);
         Set<String> tagSet = parseTags(tagsString);
 
         // Call service
-        List<SharedModuleMetadata> metadataList = metadataService.queryAllMetadata(mostRecent, published, where,
+        HqlWhereClause clause = new HqlWhereClause(true);
+        clause.addExpression("name like :name", q);
+        clause.addExpression("notes like :notes", q);
+        
+        List<SharedModuleMetadata> metadataList = metadataService.queryAllMetadata(mostRecent, published, clause,
                 tagSet);
         ResourceList<SharedModuleMetadata> resourceList = new ResourceList<>(metadataList);
         return okResult(resourceList);
     }
-
+    
     /** Similar to queryAllMetadata, except this only queries on module versions of the specified ID. */
-    public Result queryMetadataById(String id, String mostRecentString, String publishedString, String where,
+    public Result queryMetadataById(String id, String mostRecentString, String publishedString, String q,
             String tagsString) {
         // Parse inputs
         boolean mostRecent = Boolean.parseBoolean(mostRecentString);
@@ -90,12 +95,17 @@ public class SharedModuleMetadataController extends BaseController {
         Set<String> tagSet = parseTags(tagsString);
 
         // Call service
-        List<SharedModuleMetadata> metadataList = metadataService.queryMetadataById(id, mostRecent, published, where,
+        HqlWhereClause clause = new HqlWhereClause(true);
+        clause.addExpression("name like :name", q);
+        clause.addExpression("notes like :notes", q);
+
+        List<SharedModuleMetadata> metadataList = metadataService.queryMetadataById(id, mostRecent, published, clause,
                 tagSet);
+
         ResourceList<SharedModuleMetadata> resourceList = new ResourceList<>(metadataList);
         return okResult(resourceList);
     }
-
+    
     // Helper method to parse tags from URL query params. Package-scoped for unit tests.
     static Set<String> parseTags(String tagsString) {
         // Parse set of tags from a comma-delimited list.

--- a/app/org/sagebionetworks/bridge/services/SharedModuleMetadataService.java
+++ b/app/org/sagebionetworks/bridge/services/SharedModuleMetadataService.java
@@ -208,8 +208,7 @@ public class SharedModuleMetadataService {
         if (clause == null) {
             clause = new HqlWhereClause(false);
         }
-        //if (mostRecent && clause.getClause() != null) {
-        if (mostRecent && !clause.getParameters().isEmpty()) {
+        if (mostRecent && clause.getClause() != null) {
             // This is disallowed because of the confusion (both from Bridge developers and from Study managers) on
             // how this would actually work.
             throw new BadRequestException("mostrecent=true cannot be specified with where clause");

--- a/app/org/sagebionetworks/bridge/services/SurveyService.java
+++ b/app/org/sagebionetworks/bridge/services/SurveyService.java
@@ -16,6 +16,7 @@ import org.sagebionetworks.bridge.dao.SurveyDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.ConstraintViolationException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
+import org.sagebionetworks.bridge.hibernate.HqlWhereClause;
 import org.sagebionetworks.bridge.time.DateUtils;
 import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolder;
@@ -208,8 +209,11 @@ public class SurveyService {
 
     // Helper method to verify if there is any shared module related to specified survey
     private void verifySharedModuleExistence(GuidCreatedOnVersionHolder keys) {
+        HqlWhereClause clause = new HqlWhereClause(false);
+        clause.addExpression("surveyGuid=:surveyGuid", keys.getGuid());
+        clause.addExpression("surveyCreatedOn=:surveyCreatedOn", keys.getCreatedOn());
         List<SharedModuleMetadata> sharedModuleMetadataList = sharedModuleMetadataService.queryAllMetadata(false, false,
-                "surveyGuid=\'" + keys.getGuid() + "\' AND surveyCreatedOn=" + keys.getCreatedOn(), null);
+                clause, null);
 
         if (sharedModuleMetadataList.size() != 0) {
             throw new BadRequestException("Cannot delete specified survey because a shared module still refers to it.");

--- a/conf/routes
+++ b/conf/routes
@@ -110,10 +110,10 @@ POST   /v3/sharedmodules/:id/import                   @org.sagebionetworks.bridg
 POST   /v3/sharedmodules/:id/versions/:version/import @org.sagebionetworks.bridge.play.controllers.SharedModuleController.importModuleByIdAndVersion(id: String, version: Int)
 
 # Shared Module Metadata
-GET    /v3/sharedmodules/metadata                       @org.sagebionetworks.bridge.play.controllers.SharedModuleMetadataController.queryAllMetadata(mostrecent: String ?= "true", published: String ?= "false", where: String ?= null, tags: String ?= null)
+GET    /v3/sharedmodules/metadata                       @org.sagebionetworks.bridge.play.controllers.SharedModuleMetadataController.queryAllMetadata(mostrecent: String ?= "true", published: String ?= "false", q: String ?= null, tags: String ?= null)
 POST   /v3/sharedmodules/metadata                       @org.sagebionetworks.bridge.play.controllers.SharedModuleMetadataController.createMetadata
 GET    /v3/sharedmodules/metadata/:id                   @org.sagebionetworks.bridge.play.controllers.SharedModuleMetadataController.getMetadataByIdLatestVersion(id: String)
-GET    /v3/sharedmodules/metadata/:id/versions          @org.sagebionetworks.bridge.play.controllers.SharedModuleMetadataController.queryMetadataById(id:String, mostrecent: String ?= "true", published: String ?= "false", where: String ?= null, tags: String ?= null)
+GET    /v3/sharedmodules/metadata/:id/versions          @org.sagebionetworks.bridge.play.controllers.SharedModuleMetadataController.queryMetadataById(id:String, mostrecent: String ?= "true", published: String ?= "false", q: String ?= null, tags: String ?= null)
 DELETE /v3/sharedmodules/metadata/:id/versions          @org.sagebionetworks.bridge.play.controllers.SharedModuleMetadataController.deleteMetadataByIdAllVersions(id: String)
 GET    /v3/sharedmodules/metadata/:id/versions/:version @org.sagebionetworks.bridge.play.controllers.SharedModuleMetadataController.getMetadataByIdAndVersion(id: String, version: Int)
 POST   /v3/sharedmodules/metadata/:id/versions/:version @org.sagebionetworks.bridge.play.controllers.SharedModuleMetadataController.updateMetadata(id: String, version: Int)

--- a/test/org/sagebionetworks/bridge/hibernate/HibernateSharedModuleMetadataDaoTest.java
+++ b/test/org/sagebionetworks/bridge/hibernate/HibernateSharedModuleMetadataDaoTest.java
@@ -29,6 +29,7 @@ import org.sagebionetworks.bridge.models.sharedmodules.SharedModuleMetadata;
 public class HibernateSharedModuleMetadataDaoTest {
     private static final String MODULE_ID = "test-module";
     private static final int MODULE_VERSION = 3;
+    private static final HqlWhereClause FOOBAR_CLAUSE = new HqlWhereClause(false).addExpression("foo='bar'");
 
     private HibernateSharedModuleMetadataDao dao;
     private Session mockSession;
@@ -91,7 +92,7 @@ public class HibernateSharedModuleMetadataDaoTest {
     public void deleteByIdAllVersions() {
         // mock query
         Query mockQuery = mock(Query.class);
-        when(mockSession.createQuery("delete from HibernateSharedModuleMetadata where id='" + MODULE_ID + "'"))
+        when(mockSession.createQuery("delete from HibernateSharedModuleMetadata where id=:id"))
                 .thenReturn(mockQuery);
 
         // execute
@@ -106,8 +107,8 @@ public class HibernateSharedModuleMetadataDaoTest {
     public void deleteByIdAndVersion() {
         // mock query
         Query mockQuery = mock(Query.class);
-        when(mockSession.createQuery("delete from HibernateSharedModuleMetadata where id='" + MODULE_ID +
-                "' and version=" + MODULE_VERSION)).thenReturn(mockQuery);
+        when(mockSession.createQuery("delete from HibernateSharedModuleMetadata where id=:id and version=:version"))
+                .thenReturn(mockQuery);
 
         // execute
         dao.deleteMetadataByIdAndVersion(MODULE_ID, MODULE_VERSION);
@@ -143,7 +144,7 @@ public class HibernateSharedModuleMetadataDaoTest {
         when(mockQuery.list()).thenReturn(hibernateOutputMetadataList);
 
         // execute and validate
-        List<SharedModuleMetadata> daoOutputMetadataList = dao.queryMetadata("foo='bar'");
+        List<SharedModuleMetadata> daoOutputMetadataList = dao.queryMetadata(FOOBAR_CLAUSE);
         assertSame(hibernateOutputMetadataList, daoOutputMetadataList);
 
         // validate backends
@@ -172,14 +173,14 @@ public class HibernateSharedModuleMetadataDaoTest {
     public void queryBadQuery() {
         when(mockSession.createQuery("from HibernateSharedModuleMetadata where blargg", SharedModuleMetadata.class))
                 .thenThrow(new IllegalArgumentException(new QuerySyntaxException("error message")));
-        dao.queryMetadata("blargg");
+        dao.queryMetadata(new HqlWhereClause(false).addExpression("blargg"));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void queryOtherException() {
         when(mockSession.createQuery("from HibernateSharedModuleMetadata where foo='bar'", SharedModuleMetadata.class))
                 .thenThrow(new IllegalArgumentException());
-        dao.queryMetadata("foo='bar'");
+        dao.queryMetadata(FOOBAR_CLAUSE);
     }
 
     @Test

--- a/test/org/sagebionetworks/bridge/hibernate/HqlWhereClauseTest.java
+++ b/test/org/sagebionetworks/bridge/hibernate/HqlWhereClauseTest.java
@@ -1,0 +1,70 @@
+package org.sagebionetworks.bridge.hibernate;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+public class HqlWhereClauseTest {
+    
+    HqlWhereClause clause;
+    
+    @Before
+    public void before() {
+        clause = new HqlWhereClause(false);
+    }
+    
+    @Test
+    public void equalsHashCode() {
+        EqualsVerifier.forClass(HqlWhereClause.class).allFieldsShouldBeUsed().verify();
+    }
+    
+    @Test
+    public void concatenatesExpressions() {
+        clause.addExpression("boolean=true");
+        clause.addExpression("notes=:notes", "notes");
+        assertEquals("boolean=true AND notes=:notes", clause.getClause());
+        
+        clause = new HqlWhereClause(true);
+        clause.addExpression("boolean=true");
+        clause.addExpression("notes=:notes", "notes");
+        assertEquals("boolean=true OR notes=:notes", clause.getClause());
+    }
+    
+    @Test
+    public void acceptsParameters() {
+        clause.addExpression("one=:one", "string");
+        clause.addExpression("two=:two", 2);
+        clause.addExpression("three=:three", 3L);
+        clause.addExpression("four=:four", true);
+        clause.addExpression("five=:five", ImmutableList.of(1,2,3));
+        
+        assertEquals(5, clause.getParameters().size());
+        assertEquals("string", clause.getParameters().get("one"));
+        assertEquals(new Integer(2), (Integer)clause.getParameters().get("two"));
+        assertEquals(new Long(3), (Long)clause.getParameters().get("three"));
+        assertEquals(true, (Boolean)clause.getParameters().get("four"));
+        assertEquals(ImmutableList.of(1,2,3), (List<?>)clause.getParameters().get("five"));
+    }
+    
+    @Test
+    public void transformsLikeParameters() {
+        clause.addExpression("one like :one", "notes");
+        assertEquals("%notes%", clause.getParameters().get("one"));
+    }
+    
+    @Test
+    public void ignoresNulls() {
+        clause.addExpression("boolean=true", null);
+        assertNull(clause.getClause());
+        assertTrue(clause.getParameters().isEmpty());
+    }
+}

--- a/test/org/sagebionetworks/bridge/hibernate/HqlWhereClauseTest.java
+++ b/test/org/sagebionetworks/bridge/hibernate/HqlWhereClauseTest.java
@@ -25,6 +25,10 @@ public class HqlWhereClauseTest {
     @Test
     public void equalsHashCode() {
         EqualsVerifier.forClass(HqlWhereClause.class).allFieldsShouldBeUsed().verify();
+        
+        // I tried using an ImmutableMap.Builder at one point, and it broke equality although
+        // EqualsVerifier was passing.
+        assertEquals(new HqlWhereClause(false), new HqlWhereClause(false));
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/services/SharedModuleMetadataServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SharedModuleMetadataServiceTest.java
@@ -388,8 +388,9 @@ public class SharedModuleMetadataServiceTest {
         when(mockDao.queryMetadata(expectedWhereClause)).thenReturn(daoOutputMetadataList);
 
         // execute and validate
-        List<SharedModuleMetadata> svcOutputMetadataList = svc.queryAllMetadata(false, published, inputWhereClause,
-                null);
+        List<SharedModuleMetadata> svcOutputMetadataList = svc.queryAllMetadata(
+                false, published, inputWhereClause, null);
+        
         assertSame(daoOutputMetadataList, svcOutputMetadataList);
     }
 

--- a/test/org/sagebionetworks/bridge/services/SurveyServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SurveyServiceTest.java
@@ -5,9 +5,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anySetOf;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.TestConstants.GSI_WAIT_DURATION;
@@ -35,6 +35,7 @@ import org.sagebionetworks.bridge.exceptions.ConcurrentModificationException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.exceptions.PublishedSurveyException;
+import org.sagebionetworks.bridge.hibernate.HqlWhereClause;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolder;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolderImpl;
@@ -69,8 +70,8 @@ public class SurveyServiceTest {
     @Before
     public void before() {
         mockSharedModuleMetadataService = mock(SharedModuleMetadataService.class);
-        when(mockSharedModuleMetadataService.queryAllMetadata(anyBoolean(), anyBoolean(), anyString(), anySetOf(String.class))).thenReturn(
-                ImmutableList.of());
+        when(mockSharedModuleMetadataService.queryAllMetadata(anyBoolean(), anyBoolean(), any(HqlWhereClause.class),
+                anySetOf(String.class))).thenReturn(ImmutableList.of());
         testSurvey = new TestSurvey(SurveyServiceTest.class, true);
         surveysToDelete = new HashSet<>();
         surveyService.setSharedModuleMetadataService(mockSharedModuleMetadataService);


### PR DESCRIPTION
These have been tested against the BSM's use of the API to search for stuff. In that search, the where clause was an "OR" clause looking for text in either name or notes, so I implemented that here. We can do more sophisticated if/when we need it.