### PR TITLE
Fix a 500 error

### DIFF
--- a/app/org/sagebionetworks/bridge/services/StudyService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyService.java
@@ -610,7 +610,7 @@ public class StudyService {
         if (!originalStudy.getSupportEmail().equals(study.getSupportEmail())) {
             emailVerificationService.verifyEmailAddress(study.getSupportEmail());
         }
-        if (consentHasChanged && StringUtils.isNotBlank(study.getConsentNotificationEmail())) {
+        if (consentHasChanged && study.getConsentNotificationEmail() != null) {
             sendVerifyEmail(study, StudyEmailType.CONSENT_NOTIFICATION);    
         }
         return updatedStudy;

--- a/app/org/sagebionetworks/bridge/services/StudyService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyService.java
@@ -610,7 +610,7 @@ public class StudyService {
         if (!originalStudy.getSupportEmail().equals(study.getSupportEmail())) {
             emailVerificationService.verifyEmailAddress(study.getSupportEmail());
         }
-        if (consentHasChanged && study.getConsentNotificationEmail() != null) {
+        if (consentHasChanged && StringUtils.isNotBlank(study.getConsentNotificationEmail())) {
             sendVerifyEmail(study, StudyEmailType.CONSENT_NOTIFICATION);    
         }
         return updatedStudy;

--- a/app/org/sagebionetworks/bridge/services/StudyService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyService.java
@@ -447,8 +447,9 @@ public class StudyService {
         
         emailVerificationService.verifyEmailAddress(study.getSupportEmail());
 
-        sendVerifyEmail(study, StudyEmailType.CONSENT_NOTIFICATION);
-
+        if (study.getConsentNotificationEmail() != null) {
+            sendVerifyEmail(study, StudyEmailType.CONSENT_NOTIFICATION);    
+        }
         cacheProvider.setStudy(study);
 
         return study;
@@ -836,6 +837,9 @@ public class StudyService {
             default:
                 // Impossible code path, but put it in for future-proofing.
                 throw new BadRequestException("Unrecognized email type \"" + type.toString() + "\"");
+        }
+        if (email == null) {
+            throw new BadRequestException("Email not set for study");
         }
 
         // Generate and save token.

--- a/app/org/sagebionetworks/bridge/validators/StudyValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/StudyValidator.java
@@ -285,15 +285,6 @@ public class StudyValidator implements Validator {
     private boolean isInRange(int value, int min) {
         return (value >= min && value <= PasswordPolicy.FIXED_MAX_LENGTH);
     }
-    /*
-    private void validateEmails(Errors errors, String value, String fieldName) {
-        Set<String> emails = BridgeUtils.commaListToOrderedSet(value);
-        for (String email : emails) {
-            if (!EmailValidator.getInstance().isValid(email)) {
-                errors.rejectValue(fieldName, fieldName + " '%s' is not a valid email address", new Object[]{email}, null);
-            }
-        }
-    }*/
     
     private void validateEmailTemplate(Errors errors, EmailTemplate template, String fieldName, String... templateVariables) {
         if (template == null) {

--- a/app/org/sagebionetworks/bridge/validators/StudyValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/StudyValidator.java
@@ -37,6 +37,7 @@ public class StudyValidator implements Validator {
     
     private static final int MAX_SYNAPSE_LENGTH = 250;
     private static final Pattern FINGERPRINT_PATTERN = Pattern.compile("^[0-9a-fA-F:]{95,95}$");
+    protected static final String EMAIL_ERROR = "is not a comma-separated list of email addresses";
     
     /**
      * Inspect StudyParticipant for its field names; these cannot be used as user profile attributes because UserProfile
@@ -152,9 +153,6 @@ public class StudyValidator implements Validator {
                 errors.rejectValue("userProfileAttributes", msg);
             }
         }
-        validateEmails(errors, study.getSupportEmail(), "supportEmail");
-        validateEmails(errors, study.getTechnicalEmail(), "technicalEmail");
-        validateEmails(errors, study.getConsentNotificationEmail(), "consentNotificationEmail");
         validateDataGroupNamesAndFitForSynapseExport(errors, study.getDataGroups());
 
         // emailVerificationEnabled=true (public study):
@@ -251,13 +249,13 @@ public class StudyValidator implements Validator {
     private void validateEmail(Errors errors, String emailString, String fieldName) {
         if (emailString != null) {
             Set<String> emails = BridgeUtils.commaListToOrderedSet(emailString);
-            // The "if" clause catches cases like "" which are weeded out of a the ordered set
+            // The "if" clause catches cases like "" which are weeded out of the ordered set
             if (emails.isEmpty()) {
-                errors.rejectValue(fieldName, "does not appear to contain one or more valid email addresses");
+                errors.rejectValue(fieldName, EMAIL_ERROR);
             } else {
                 for (String email : emails) {
                     if (!EmailValidator.getInstance().isValid(email)) {
-                        errors.rejectValue(fieldName, "does not appear to contain one or more valid email addresses");
+                        errors.rejectValue(fieldName, EMAIL_ERROR);
                     }
                 }
             }
@@ -287,7 +285,7 @@ public class StudyValidator implements Validator {
     private boolean isInRange(int value, int min) {
         return (value >= min && value <= PasswordPolicy.FIXED_MAX_LENGTH);
     }
-    
+    /*
     private void validateEmails(Errors errors, String value, String fieldName) {
         Set<String> emails = BridgeUtils.commaListToOrderedSet(value);
         for (String email : emails) {
@@ -295,7 +293,7 @@ public class StudyValidator implements Validator {
                 errors.rejectValue(fieldName, fieldName + " '%s' is not a valid email address", new Object[]{email}, null);
             }
         }
-    }
+    }*/
     
     private void validateEmailTemplate(Errors errors, EmailTemplate template, String fieldName, String... templateVariables) {
         if (template == null) {

--- a/test/org/sagebionetworks/bridge/play/controllers/ActivityEventControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ActivityEventControllerTest.java
@@ -68,7 +68,6 @@ public class ActivityEventControllerTest {
                 eventTimeCaptor.capture());
 
         DateTime eventTime = eventTimeCaptor.getValue();
-        System.out.println("eventTime=" + eventTime);
         TestUtils.assertDatesWithTimeZoneEqual(EVENT_TIMESTAMP, eventTime);
     }
 }

--- a/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
@@ -289,7 +289,7 @@ public class StudyServiceMockTest {
 
         MimeTypeEmail email = emailProviderCaptor.getValue().getMimeTypeEmail();
         String body = (String) email.getMessageParts().get(0).getContent();
-        System.out.println(body);
+
         assertTrue(body.contains("/vse?study="+ TEST_STUDY_ID + "&token=" +
                 VERIFICATION_TOKEN + "&type=consent_notification"));
         assertTrue(email.getSenderAddress().contains(SUPPORT_EMAIL));
@@ -803,6 +803,16 @@ public class StudyServiceMockTest {
         
         Study retStudy = service.createStudy(study);
         assertNotNull(retStudy.getSignedConsentSmsTemplate());
+    }
+    
+    @Test
+    public void createStudyWithoutConsentNotificationEmailDoesNotSendNotification() {
+        Study study = TestUtils.getValidStudy(StudyServiceMockTest.class);
+        study.setConsentNotificationEmail(null);
+        
+        service.createStudy(study);
+        
+        verify(sendMailService, never()).sendEmail(any());
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
@@ -370,6 +370,17 @@ public class StudyServiceMockTest {
         service.sendVerifyEmail(TEST_STUDY_IDENTIFIER, null);
     }
 
+    // This can be manually triggered through the API even though there's no consent
+    // email to confirm... so return a 400 in this case.
+    @Test(expected = BadRequestException.class)
+    public void sendVerifyEmailNoConsentEmail() throws Exception {
+        Study study = getTestStudy();
+        study.setConsentNotificationEmail(null);
+        when(studyDao.getStudy(TEST_STUDY_ID)).thenReturn(study);
+        
+        service.sendVerifyEmail(TEST_STUDY_IDENTIFIER, StudyEmailType.CONSENT_NOTIFICATION);
+    }
+    
     @Test
     public void sendVerifyEmailSuccess() throws Exception {
         // Mock getStudy().

--- a/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
@@ -444,7 +444,7 @@ public class StudyServiceMockTest {
         // Execute. Will throw.
         service.verifyEmail(TEST_STUDY_IDENTIFIER, VERIFICATION_TOKEN, StudyEmailType.CONSENT_NOTIFICATION);
     }
-    
+
     @Test(expected = BadRequestException.class)
     public void verifyEmailMismatchedEmail() {
         // Mock Cache Provider.
@@ -1550,7 +1550,6 @@ public class StudyServiceMockTest {
         setupConsentEmailChangeTest(null, newEmail, true, true);
         setupConsentEmailChangeTest(originalEmail, null, true, false);
         setupConsentEmailChangeTest(originalEmail, newEmail, true, true);
-        setupConsentEmailChangeTest(originalEmail, "", true, false);
     }
     
     private void setupConsentEmailChangeTest(String originalEmail, String newEmail, boolean shouldBeChanged,

--- a/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
@@ -444,7 +444,7 @@ public class StudyServiceMockTest {
         // Execute. Will throw.
         service.verifyEmail(TEST_STUDY_IDENTIFIER, VERIFICATION_TOKEN, StudyEmailType.CONSENT_NOTIFICATION);
     }
-
+    
     @Test(expected = BadRequestException.class)
     public void verifyEmailMismatchedEmail() {
         // Mock Cache Provider.
@@ -1550,6 +1550,7 @@ public class StudyServiceMockTest {
         setupConsentEmailChangeTest(null, newEmail, true, true);
         setupConsentEmailChangeTest(originalEmail, null, true, false);
         setupConsentEmailChangeTest(originalEmail, newEmail, true, true);
+        setupConsentEmailChangeTest(originalEmail, "", true, false);
     }
     
     private void setupConsentEmailChangeTest(String originalEmail, String newEmail, boolean shouldBeChanged,

--- a/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
@@ -142,7 +142,7 @@ public class StudyValidatorTest {
     @Test
     public void rejectsInvalidSupportEmailAddresses() {
         study.setSupportEmail("test@test.com,asdf,test2@test.com");
-        assertValidatorMessage(INSTANCE, study, "supportEmail", "'asdf' is not a valid email address");
+        assertValidatorMessage(INSTANCE, study, "supportEmail", StudyValidator.EMAIL_ERROR);
     }
     
     @Test
@@ -160,14 +160,13 @@ public class StudyValidatorTest {
     @Test
     public void rejectsInvalidTechnicalEmailAddresses() {
         study.setTechnicalEmail("test@test.com,asdf,test2@test.com");
-        assertValidatorMessage(INSTANCE, study, "technicalEmail", "'asdf' is not a valid email address");
+        assertValidatorMessage(INSTANCE, study, "technicalEmail", StudyValidator.EMAIL_ERROR);
     }
     
     @Test
     public void supportEmailMustsBeValid() {
         study.setSupportEmail("email@email.com,email2@email.com,b");
-        assertValidatorMessage(INSTANCE, study, "supportEmail",
-                "does not appear to contain one or more valid email addresses");
+        assertValidatorMessage(INSTANCE, study, "supportEmail", StudyValidator.EMAIL_ERROR);
         
         study.setSupportEmail("email@email.com,email2@email.com");
         Validate.entityThrowingException(INSTANCE, study);
@@ -183,12 +182,10 @@ public class StudyValidatorTest {
     @Test
     public void technicalEmailsMustBeValid() {
         study.setTechnicalEmail("");
-        assertValidatorMessage(INSTANCE, study, "technicalEmail",
-                "does not appear to contain one or more valid email addresses");
+        assertValidatorMessage(INSTANCE, study, "technicalEmail", StudyValidator.EMAIL_ERROR);
 
         study.setTechnicalEmail("email@email.com,email2@email.com,b");
-        assertValidatorMessage(INSTANCE, study, "technicalEmail",
-                "does not appear to contain one or more valid email addresses");
+        assertValidatorMessage(INSTANCE, study, "technicalEmail", StudyValidator.EMAIL_ERROR);
         
         study.setTechnicalEmail("email@email.com,email2@email.com");
         Validate.entityThrowingException(INSTANCE, study);
@@ -201,12 +198,10 @@ public class StudyValidatorTest {
     @Test
     public void consentEmailsMustBeValid() {
         study.setConsentNotificationEmail("");
-        assertValidatorMessage(INSTANCE, study, "consentNotificationEmail",
-                "does not appear to contain one or more valid email addresses");
+        assertValidatorMessage(INSTANCE, study, "consentNotificationEmail", StudyValidator.EMAIL_ERROR);
 
         study.setConsentNotificationEmail("email@email.com,email2@email.com,b");
-        assertValidatorMessage(INSTANCE, study, "consentNotificationEmail",
-                "does not appear to contain one or more valid email addresses");
+        assertValidatorMessage(INSTANCE, study, "consentNotificationEmail", StudyValidator.EMAIL_ERROR);
         
         study.setConsentNotificationEmail("email@email.com,email2@email.com");
         Validate.entityThrowingException(INSTANCE, study);
@@ -235,7 +230,7 @@ public class StudyValidatorTest {
     @Test
     public void rejectsInvalidConsentEmailAddresses() {
         study.setConsentNotificationEmail("test@test.com,asdf,test2@test.com");
-        assertValidatorMessage(INSTANCE, study, "consentNotificationEmail", "'asdf' is not a valid email address");
+        assertValidatorMessage(INSTANCE, study, "consentNotificationEmail", StudyValidator.EMAIL_ERROR);
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
@@ -164,6 +164,12 @@ public class StudyValidatorTest {
     }
     
     @Test
+    public void technicalEmailIsOptional() {
+        study.setTechnicalEmail(null);
+        Validate.entityThrowingException(INSTANCE, study);        
+    }
+    
+    @Test
     public void supportEmailMustsBeValid() {
         study.setSupportEmail("email@email.com,email2@email.com,b");
         assertValidatorMessage(INSTANCE, study, "supportEmail", StudyValidator.EMAIL_ERROR);

--- a/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
@@ -164,11 +164,58 @@ public class StudyValidatorTest {
     }
     
     @Test
-    public void requiresMissingTechnicalEmail() {
+    public void supportEmailMustsBeValid() {
+        study.setSupportEmail("email@email.com,email2@email.com,b");
+        assertValidatorMessage(INSTANCE, study, "supportEmail",
+                "does not appear to contain one or more valid email addresses");
+        
+        study.setSupportEmail("email@email.com,email2@email.com");
+        Validate.entityThrowingException(INSTANCE, study);
+        
+        // it is also required
+        study.setSupportEmail("");
+        assertValidatorMessage(INSTANCE, study, "supportEmail", "is required");
+        
+        study.setSupportEmail(null);
+        assertValidatorMessage(INSTANCE, study, "supportEmail", "is required");
+    }
+    
+    @Test
+    public void technicalEmailsMustBeValid() {
+        study.setTechnicalEmail("");
+        assertValidatorMessage(INSTANCE, study, "technicalEmail",
+                "does not appear to contain one or more valid email addresses");
+
+        study.setTechnicalEmail("email@email.com,email2@email.com,b");
+        assertValidatorMessage(INSTANCE, study, "technicalEmail",
+                "does not appear to contain one or more valid email addresses");
+        
+        study.setTechnicalEmail("email@email.com,email2@email.com");
+        Validate.entityThrowingException(INSTANCE, study);
+        
+        // however they are not required
         study.setTechnicalEmail(null);
-        assertValidatorMessage(INSTANCE, study, "technicalEmail", "is required");
+        Validate.entityThrowingException(INSTANCE, study);
     }
 
+    @Test
+    public void consentEmailsMustBeValid() {
+        study.setConsentNotificationEmail("");
+        assertValidatorMessage(INSTANCE, study, "consentNotificationEmail",
+                "does not appear to contain one or more valid email addresses");
+
+        study.setConsentNotificationEmail("email@email.com,email2@email.com,b");
+        assertValidatorMessage(INSTANCE, study, "consentNotificationEmail",
+                "does not appear to contain one or more valid email addresses");
+        
+        study.setConsentNotificationEmail("email@email.com,email2@email.com");
+        Validate.entityThrowingException(INSTANCE, study);
+        
+        // however they are not required
+        study.setConsentNotificationEmail(null);
+        Validate.entityThrowingException(INSTANCE, study);
+    }
+    
     @Test
     public void validFieldDefList() {
         study.setUploadMetadataFieldDefinitions(ImmutableList.of(new UploadFieldDefinition.Builder()


### PR DESCRIPTION
Fix a 500 error that occurs when you remove the formerly required consent email, and you send an empty string. We really want that to fail validation so it doesn't become bad data in the system (later we'll try and use it to send email... this fails).

Also return a 400 instead of a 500 when you manually trigger a consent email verification through the API, and that field is null.