### PR TITLE
increase upload limit to 50mb

### DIFF
--- a/app/org/sagebionetworks/bridge/validators/UploadValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/UploadValidator.java
@@ -11,7 +11,7 @@ import org.springframework.validation.Validator;
 @Component
 public class UploadValidator implements Validator {
 
-    private static final long MAX_UPLOAD_SIZE = 20L * 1000L * 1000L; // 20 MB
+    private static final long MAX_UPLOAD_SIZE = 50L * 1000L * 1000L; // 50 MB
 
     @Override
     public boolean supports(Class<?> clazz) {

--- a/test/org/sagebionetworks/bridge/validators/UploadValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/UploadValidatorTest.java
@@ -85,7 +85,7 @@ public class UploadValidatorTest {
             ObjectNode node = JsonNodeFactory.instance.objectNode();
             node.put("name", this.getClass().getSimpleName());
             node.put("contentType", "text/plain");
-            node.put("contentLength", 21000000L);
+            node.put("contentLength", 51000000L);
             node.put("contentMd5", Base64.encodeBase64String(DigestUtils.md5(message)));
             UploadRequest uploadRequest = UploadRequest.fromJson(node);
             


### PR DESCRIPTION
We now process uploads almost entirely on disk (and limit what we read into memory), so we can safely increase the upload limit (size of zipped files).

Testing done: Upload unit tests and upload integ tests.