### PR TITLE
increase limit for files in zip archive

### DIFF
--- a/conf/bridge-server.conf
+++ b/conf/bridge-server.conf
@@ -115,8 +115,8 @@ prod.upload.cms.priv.bucket = org-sagebridge-upload-cms-priv-prod
 # Studies in this comma-separated list ignore upload dedupe logic
 upload.dupe.study.whitelist = api
 
-// Maximum 50 MB per zip entry
-max.zip.entry.size = 50000000
+// Maximum 100 MB per zip entry
+max.zip.entry.size = 100000000
 // Maximum 100 zip entries per archive
 max.num.zip.entries = 100
 


### PR DESCRIPTION
Now that we do most of our processing on disk, it's okay to have larger files in the zip archive. In particular, we're starting to see some CRF files get this big.