### PR TITLE
Add empty body parser to all controller methods that are POSTSs without body content.

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/BackfillController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/BackfillController.java
@@ -11,6 +11,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.stereotype.Controller;
 
+import play.mvc.BodyParser;
 import play.mvc.Result;
 
 @Controller
@@ -29,6 +30,7 @@ public class BackfillController extends BaseController implements ApplicationCon
         return ok(views.html.backfill.render(name));
     }
 
+    @BodyParser.Of(BodyParser.Empty.class)
     public Result start(final String name) throws Exception {
         final String user = checkUser();
         final BackfillService backfillService = appContext.getBean(name, BackfillService.class);

--- a/app/org/sagebionetworks/bridge/play/controllers/ExportController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ExportController.java
@@ -6,6 +6,8 @@ import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+
+import play.mvc.BodyParser;
 import play.mvc.Result;
 
 import org.sagebionetworks.bridge.models.accounts.UserSession;
@@ -24,6 +26,7 @@ public class ExportController extends BaseController {
     }
 
     /** Kicks off an on-demand export for the given study. */
+    @BodyParser.Of(BodyParser.Empty.class)
     public Result startOnDemandExport() throws JsonProcessingException {
         UserSession session = getAuthenticatedSession(DEVELOPER, RESEARCHER);
         StudyIdentifier studyId = session.getStudyIdentifier();

--- a/app/org/sagebionetworks/bridge/play/controllers/ExternalIdController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ExternalIdController.java
@@ -9,6 +9,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.Lists;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+
+import play.mvc.BodyParser;
 import play.mvc.Result;
 
 import org.sagebionetworks.bridge.Roles;
@@ -69,6 +71,7 @@ public class ExternalIdController extends BaseController {
         return okResult("External identifiers deleted.");
     }
     
+    @BodyParser.Of(BodyParser.Empty.class)
     public Result generatePassword(String externalId, boolean createAccount) throws Exception {
         UserSession session = getAuthenticatedSession(Roles.RESEARCHER);
         

--- a/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
@@ -157,7 +157,6 @@ public class ParticipantController extends BaseController {
                 offsetKey, pageSize);
     }
     
-    
     public Result updateIdentifiers() throws Exception {
         UserSession session = getAuthenticatedSession();
         
@@ -290,6 +289,7 @@ public class ParticipantController extends BaseController {
         return okResult("User signed out.");
     }
 
+    @BodyParser.Of(BodyParser.Empty.class)
     public Result requestResetPassword(String userId) throws Exception {
         UserSession session = getAuthenticatedSession(RESEARCHER);
         Study study = studyService.getStudy(session.getStudyIdentifier());
@@ -325,6 +325,7 @@ public class ParticipantController extends BaseController {
         return okResult("Scheduled activities deleted.");
     }
     
+    @BodyParser.Of(BodyParser.Empty.class)
     public Result resendEmailVerification(String userId) {
         UserSession session = getAuthenticatedSession(RESEARCHER);
         Study study = studyService.getStudy(session.getStudyIdentifier());
@@ -334,6 +335,7 @@ public class ParticipantController extends BaseController {
         return okResult("Email verification request has been resent to user.");
     }
     
+    @BodyParser.Of(BodyParser.Empty.class)
     public Result resendPhoneVerification(String userId) {
         UserSession session = getAuthenticatedSession(RESEARCHER);
         Study study = studyService.getStudy(session.getStudyIdentifier());
@@ -343,6 +345,7 @@ public class ParticipantController extends BaseController {
         return okResult("Phone verification request has been resent to user.");
     }
     
+    @BodyParser.Of(BodyParser.Empty.class)
     public Result resendConsentAgreement(String userId, String subpopulationGuid) {
         UserSession session = getAuthenticatedSession(RESEARCHER);
         Study study = studyService.getStudy(session.getStudyIdentifier());

--- a/app/org/sagebionetworks/bridge/play/controllers/SharedModuleController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/SharedModuleController.java
@@ -4,6 +4,8 @@ import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+
+import play.mvc.BodyParser;
 import play.mvc.Result;
 
 import org.sagebionetworks.bridge.models.accounts.UserSession;
@@ -23,6 +25,7 @@ public class SharedModuleController extends BaseController {
     }
 
     /** Imports a specific module version into the current study. */
+    @BodyParser.Of(BodyParser.Empty.class)
     public Result importModuleByIdAndVersion(String moduleId, int moduleVersion) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
         StudyIdentifier studyId = session.getStudyIdentifier();
@@ -32,6 +35,7 @@ public class SharedModuleController extends BaseController {
     }
 
     /** Imports the latest published version of a module into the current study. */
+    @BodyParser.Of(BodyParser.Empty.class)
     public Result importModuleByIdLatestPublishedVersion(String moduleId) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
         StudyIdentifier studyId = session.getStudyIdentifier();


### PR DESCRIPTION
I believe the Swagger code generation libraries have changed over time in terms of whether or not they POST an empty JSON body on POST calls that have the content type application/json. As of our most recent update, they send no body and calls fail against BridgePF unless it declares an annotation for that method that the system should not look for body content, despite the fact that the HTTP call is a POST.

Went through and added the necessary annotation to all the empty body POST calls in BridgePF. This must be merged for integration tests to succeed (along with some changes to the integration tests that are also due to changes in the Swagger codegen libraries).