### PR TITLE
Do not allow sign in (email/phone + password) if email/phone is not verified. Even if account is active.

### DIFF
--- a/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
@@ -162,7 +162,7 @@ public class HibernateAccountDao implements AccountDao {
     public Account authenticate(Study study, SignIn signIn) {
         HibernateAccount hibernateAccount = fetchHibernateAccount(signIn);
         return authenticateInternal(study, hibernateAccount, hibernateAccount.getPasswordAlgorithm(),
-                hibernateAccount.getPasswordHash(), signIn.getPassword(), "password");
+                hibernateAccount.getPasswordHash(), signIn.getPassword(), "password", signIn);
     }
 
     /** {@inheritDoc} */
@@ -173,20 +173,25 @@ public class HibernateAccountDao implements AccountDao {
         }
         HibernateAccount hibernateAccount = fetchHibernateAccount(signIn);
         return authenticateInternal(study, hibernateAccount, hibernateAccount.getReauthTokenAlgorithm(),
-                hibernateAccount.getReauthTokenHash(), signIn.getReauthToken(), "reauth token");
+                hibernateAccount.getReauthTokenHash(), signIn.getReauthToken(), "reauth token", signIn);
     }
     
     private Account authenticateInternal(Study study, HibernateAccount hibernateAccount, PasswordAlgorithm algorithm,
-            String hash, String credentialValue, String credentialName) {
+            String hash, String credentialValue, String credentialName, SignIn signIn) {
 
         // First check and throw an entity not found exception if the password is wrong.
         verifyCredential(hibernateAccount.getId(), credentialName, algorithm, hash, credentialValue);
         
         // Password successful, you can now leak further information about the account through other exceptions.
+        // For email/phone sign ins, the specific credential must have been verified.
         if (hibernateAccount.getStatus() == AccountStatus.UNVERIFIED) {
             throw new UnauthorizedException("Email or phone number have not been verified");
         } else if (hibernateAccount.getStatus() == AccountStatus.DISABLED) {
             throw new AccountDisabledException();
+        } else if (signIn.getPhone() != null && !Boolean.TRUE.equals(hibernateAccount.getPhoneVerified())) {
+            throw new UnauthorizedException("Phone number has not been verified");
+        } else if (signIn.getEmail() != null && !Boolean.TRUE.equals(hibernateAccount.getEmailVerified())) {
+            throw new UnauthorizedException("Email has not been verified");
         }
         
         // Unmarshall account

--- a/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
@@ -183,14 +183,16 @@ public class HibernateAccountDao implements AccountDao {
         verifyCredential(hibernateAccount.getId(), credentialName, algorithm, hash, credentialValue);
         
         // Password successful, you can now leak further information about the account through other exceptions.
-        // For email/phone sign ins, the specific credential must have been verified.
+        // For email/phone sign ins, the specific credential must have been verified (unless we've disabled
+        // email verification for older studies that didn't have full external ID support).
         if (hibernateAccount.getStatus() == AccountStatus.UNVERIFIED) {
             throw new UnauthorizedException("Email or phone number have not been verified");
         } else if (hibernateAccount.getStatus() == AccountStatus.DISABLED) {
             throw new AccountDisabledException();
         } else if (signIn.getPhone() != null && !Boolean.TRUE.equals(hibernateAccount.getPhoneVerified())) {
             throw new UnauthorizedException("Phone number has not been verified");
-        } else if (signIn.getEmail() != null && !Boolean.TRUE.equals(hibernateAccount.getEmailVerified())) {
+        } else if (study.isEmailVerificationEnabled() && 
+                signIn.getEmail() != null && !Boolean.TRUE.equals(hibernateAccount.getEmailVerified())) {
             throw new UnauthorizedException("Email has not been verified");
         }
         


### PR DESCRIPTION
BRIDGE-2191

This is an odd loophole in our system where you could activate the account with an email, and then sign in via phone, or vice versa. If you're using either with a password, you need to verify it. 

Unless we've disabled email verification. Then don't do this.

NOTE: This change require a change in one of the integration tests.