### PR TITLE
Prevent addition of a blank external ID to an account.

### DIFF
--- a/app/org/sagebionetworks/bridge/validators/StudyParticipantValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/StudyParticipantValidator.java
@@ -4,6 +4,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.routines.EmailValidator;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
@@ -71,12 +72,16 @@ public class StudyParticipantValidator implements Validator {
         // External ID can be updated during creation or on update. We validate it if IDs are 
         // managed. If it's already assigned to another user, the database constraints will 
         // prevent this record's persistence.
-        if (study.isExternalIdValidationEnabled() && participant.getExternalId() != null) {
+        if (study.isExternalIdValidationEnabled() && StringUtils.isNotBlank(participant.getExternalId())) {
             ExternalIdentifier externalId = externalIdService.getExternalId(study.getStudyIdentifier(),
                     participant.getExternalId());
             if (externalId == null) {
                 errors.rejectValue("externalId", "is not a valid external ID");
             }
+        }
+        // Never okay to have a blank external ID. It can produce errors later when querying for ext IDs
+        if (participant.getExternalId() != null && StringUtils.isBlank(participant.getExternalId())) {
+            errors.rejectValue("externalId", "cannot be blank");
         }
                 
         for (String dataGroup : participant.getDataGroups()) {

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -1420,6 +1420,22 @@ public class ParticipantServiceTest {
     }
     
     @Test
+    public void updatingBlankExternalIdFails() {
+        mockHealthCodeAndAccountRetrieval();
+        
+        StudyParticipant participant = new StudyParticipant.Builder()
+                .copyOf(PARTICIPANT)
+                .withExternalId("").build();
+        try {
+            participantService.updateParticipant(STUDY, CALLER_ROLES, participant);
+            fail("Should have thrown exception");
+        } catch(InvalidEntityException e) {
+            
+        }
+        verify(externalIdService, never()).assignExternalId(STUDY, EXTERNAL_ID, HEALTH_CODE);
+    }
+    
+    @Test
     public void changingManagedExternalIdIgnored() {
         mockHealthCodeAndAccountRetrieval();
         STUDY.setExternalIdValidationEnabled(true);

--- a/test/org/sagebionetworks/bridge/validators/StudyParticipantValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/StudyParticipantValidatorTest.java
@@ -339,6 +339,20 @@ public class StudyParticipantValidatorTest {
         validator = new StudyParticipantValidator(externalIdService, study, false);
         Validate.entityThrowingException(validator, participant);
     }
+    @Test
+    public void emptyExternalIdInvalidOnCreate() {
+        StudyParticipant participant = withExternalId(" ");
+        
+        validator = new StudyParticipantValidator(externalIdService, study, true);
+        assertValidatorMessage(validator, participant, "externalId", "cannot be blank");
+    }
+    @Test
+    public void emptyExternalIdInvalidOnUpdate() {
+        StudyParticipant participant = withExternalId(" ");
+        
+        validator = new StudyParticipantValidator(externalIdService, study, false);
+        assertValidatorMessage(validator, participant, "externalId", "cannot be blank");
+    }
     
     private StudyParticipant withPhone(String phone, String phoneRegion) {
         return new StudyParticipant.Builder().withPhone(new Phone(phone, phoneRegion)).build();


### PR DESCRIPTION
Probably both BRIDGE-2206 and BRIDGE-2208.

You could get a participant to have an empty external ID, which would be used as a range key, generating a DDB error and a 500 return. We now prevent this through validation on create/update.