### PR TITLE
Remove unused parameters

### DIFF
--- a/conf/bridge-server.conf
+++ b/conf/bridge-server.conf
@@ -37,9 +37,6 @@ sysops.email = Bridge IT <bridge-testing+sysops@sagebase.org>
 
 email.unsubscribe.token = dummy-value
 
-admin.email = dummy-value
-admin.password = dummy-value
-
 bridge.healthcode.key = KST6Md7/phHLZg+1FBgbmngKi53K/e7gLptQOEDii0M=
 bridge.healthcode.redis.key = zEjhUL/FVsN8vti6HO27XgrM32i1a3huEuXWD4Hq06I=
 


### PR DESCRIPTION
Clean up these parameters because they are no longer referenced in the
code base and are not longer used.