### PR TITLE
Remove the cookie.

### DIFF
--- a/app/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/app/org/sagebionetworks/bridge/BridgeConstants.java
@@ -42,7 +42,7 @@ public class BridgeConstants {
 
     public static final String CLEAR_SITE_DATA_HEADER = "Clear-Site-Data";
     
-    public static final String CLEAR_SITE_DATA_VALUE = "\"cache\", \"cookies\", \"storage\", \"executionContexts\"";
+    public static final String CLEAR_SITE_DATA_VALUE = "\"cache\", \"storage\", \"executionContexts\"";
 
     /** Used by Heroku to pass in the request ID */
     public static final String X_REQUEST_ID_HEADER = "X-Request-Id";

--- a/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
@@ -22,7 +22,6 @@ import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.config.BridgeConfig;
-import org.sagebionetworks.bridge.config.Environment;
 import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.exceptions.UnsupportedVersionException;
 import org.sagebionetworks.bridge.exceptions.ConsentRequiredException;
@@ -54,7 +53,6 @@ import play.cache.Cache;
 import play.libs.Json;
 import play.mvc.Controller;
 import play.mvc.Http;
-import play.mvc.Http.Cookie;
 import play.mvc.Http.Request;
 import play.mvc.Result;
 
@@ -215,15 +213,6 @@ public abstract class BaseController extends Controller {
         String[] session = request().headers().get(SESSION_TOKEN_HEADER);
         if (session != null && session.length > 0 && !session[0].isEmpty()) {
             return session[0];
-        }
-        Cookie sessionCookie = request().cookie(SESSION_TOKEN_HEADER);
-        if (sessionCookie != null && sessionCookie.value() != null && !"".equals(sessionCookie.value())) {
-            String sessionToken = sessionCookie.value();
-            boolean useSsl = bridgeConfig.getEnvironment() != Environment.LOCAL;
-            response().setCookie(BridgeConstants.SESSION_TOKEN_HEADER, sessionToken,
-                    BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS, "/",
-                    bridgeConfig.get("domain"), useSsl, useSsl);
-            return sessionToken;
         }
         return null;
     }

--- a/app/org/sagebionetworks/bridge/play/interceptors/StaticHeadersInterceptor.java
+++ b/app/org/sagebionetworks/bridge/play/interceptors/StaticHeadersInterceptor.java
@@ -16,7 +16,7 @@ public class StaticHeadersInterceptor implements MethodInterceptor {
     public static Map<String,String> HEADERS = new ImmutableMap.Builder<String,String>()
             // Limits what a web browser will include or execute in a page; only applies to our html pages
             .put("Content-Security-Policy", "default-src 'self' 'unsafe-inline' assets.sagebridge.org")
-            // Do not send a cookie across a connection that is not HTTPS
+            // Do not send a cookie across a connection that is not HTTPS. Leave this even though we've removed cookies
             .put("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
             // Do not allow Mime-Type content "sniffing," when we say something is JSON, it's JSON
             .put("X-Content-Type-Options", "nosniff")

--- a/test/org/sagebionetworks/bridge/play/controllers/AuthenticationControllerMockTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/AuthenticationControllerMockTest.java
@@ -480,7 +480,6 @@ public class AuthenticationControllerMockTest {
         Http.Response mockResponse = controller.response();
 
         verify(authenticationService).signOut(session);
-        verify(mockResponse).discardCookie(BridgeConstants.SESSION_TOKEN_HEADER);
         verifyMetrics();
     }
     
@@ -503,7 +502,6 @@ public class AuthenticationControllerMockTest {
         Http.Response mockResponse = controller.response();
 
         verify(authenticationService).signOut(session);
-        verify(mockResponse).discardCookie(BridgeConstants.SESSION_TOKEN_HEADER);
         verify(mockResponse).setHeader(BridgeConstants.CLEAR_SITE_DATA_HEADER, BridgeConstants.CLEAR_SITE_DATA_VALUE);
         verifyMetrics();
     }
@@ -525,7 +523,6 @@ public class AuthenticationControllerMockTest {
         
         @SuppressWarnings("static-access")
         Http.Response mockResponse = controller.response();
-        verify(mockResponse).discardCookie(BridgeConstants.SESSION_TOKEN_HEADER);
         verify(mockResponse).setHeader(BridgeConstants.CLEAR_SITE_DATA_HEADER, BridgeConstants.CLEAR_SITE_DATA_VALUE);
         // We do not send metrics if you don't have a session, for better or worse.
     }
@@ -593,23 +590,6 @@ public class AuthenticationControllerMockTest {
         study.getMinSupportedAppVersions().put(OperatingSystem.IOS, 20);
         
         controller.signInV3();
-    }
-    
-    @Test
-    public void signInOnLocalDoesNotSetCookieWithSSL() throws Exception {
-        String json = TestUtils.createJson(
-                "{'study':'" + TEST_STUDY_ID_STRING + 
-                "','email':'email@email.com','password':'bar'}");
-        response = mockPlayContextWithJson(json);
-        when(controller.bridgeConfig.getEnvironment()).thenReturn(Environment.LOCAL);
-        
-        UserSession session = createSession(null, null);
-        when(authenticationService.signIn(any(), any(), any())).thenReturn(session);
-        
-        controller.signIn();
-        
-        verify(response).setCookie(BridgeConstants.SESSION_TOKEN_HEADER, TEST_SESSION_TOKEN,
-                BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS, "/", DOMAIN, false, false);
     }
     
     @Test(expected = UnsupportedVersionException.class)
@@ -1005,11 +985,6 @@ public class AuthenticationControllerMockTest {
     
     private void verifyCommonLoggingForSignIns() throws Exception {
         verifyMetrics();
-        
-        // For ssl to be true here, we mock the bridge configuration and set the environment
-        // to something besides local. There is a separate test for when the environment is local.
-        verify(response).setCookie(BridgeConstants.SESSION_TOKEN_HEADER, TEST_SESSION_TOKEN,
-                BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS, "/", DOMAIN, true, true);
         
         verify(cacheProvider).updateRequestInfo(requestInfoCaptor.capture());
         RequestInfo info = requestInfoCaptor.getValue();

--- a/test/org/sagebionetworks/bridge/play/controllers/BaseControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/BaseControllerTest.java
@@ -752,66 +752,6 @@ public class BaseControllerTest {
     }
     
     @Test
-    public void ifClientSendsCookieRetrieveAndResetIt() {
-        Http.Cookie mockCookie = mock(Http.Cookie.class);
-        doReturn("ABC").when(mockCookie).value();
-        
-        Http.Request mockRequest = mock(Http.Request.class);
-        doReturn(mockCookie).when(mockRequest).cookie(BridgeConstants.SESSION_TOKEN_HEADER);
-        
-        Http.Context context = mock(Http.Context.class);
-        when(context.request()).thenReturn(mockRequest);
-
-        Http.Response mockResponse = mock(Http.Response.class);
-        when(context.response()).thenReturn(mockResponse);
-        
-        Http.Context.current.set(context);
-        
-        BridgeConfig mockConfig = mock(BridgeConfig.class);
-        when(mockConfig.get("domain")).thenReturn(DOMAIN);
-        when(mockConfig.getEnvironment()).thenReturn(Environment.LOCAL);
-        
-        BaseController controller = new SchedulePlanController();
-        controller.setBridgeConfig(mockConfig);
-        
-        String token = controller.getSessionToken();
-        assertEquals("ABC", token);
-        
-        verify(mockResponse).setCookie(BridgeConstants.SESSION_TOKEN_HEADER, "ABC",
-                BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS, "/", DOMAIN, false, false);
-    }
-    
-    @Test
-    public void requireSslOnCookies() {
-        Http.Cookie mockCookie = mock(Http.Cookie.class);
-        doReturn("ABC").when(mockCookie).value();
-        
-        Http.Request mockRequest = mock(Http.Request.class);
-        doReturn(mockCookie).when(mockRequest).cookie(BridgeConstants.SESSION_TOKEN_HEADER);
-        
-        Http.Context context = mock(Http.Context.class);
-        when(context.request()).thenReturn(mockRequest);
-
-        Http.Response mockResponse = mock(Http.Response.class);
-        when(context.response()).thenReturn(mockResponse);
-        
-        Http.Context.current.set(context);
-        
-        BaseController controller = new SchedulePlanController();
-
-        BridgeConfig mockConfig = mock(BridgeConfig.class);
-        when(mockConfig.get("domain")).thenReturn(DOMAIN);
-        when(mockConfig.getEnvironment()).thenReturn(Environment.PROD);
-        controller.setBridgeConfig(mockConfig);
-        
-        String token = controller.getSessionToken();
-        assertEquals("ABC", token);
-        
-        verify(mockResponse).setCookie(BridgeConstants.SESSION_TOKEN_HEADER, "ABC",
-                BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS, "/", DOMAIN, true, true);
-    }
-    
-    @Test
     public void getRequestInfoBuilder() throws Exception {
         // Set the dates and verify they are retrieved from cache and added to response
         RequestInfo persistedInfo = new RequestInfo.Builder()


### PR DESCRIPTION
No longer send the session in a cookie. This further protects us from the security risks described in BRIDGE-2181.