### PR TITLE
Allow reset password to be sent by admins for an unverified user, 

### DIFF
--- a/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
@@ -157,9 +157,11 @@ public class HibernateAccountDao implements AccountDao {
         hibernateAccount.setPasswordModifiedOn(modifiedOn);
         // One of these (the channel used to reset the password) is also verified by resetting the password.
         if (channelType == ChannelType.EMAIL) {
+            hibernateAccount.setStatus(AccountStatus.ENABLED);
             hibernateAccount.setEmailVerified(true);    
         }
         if (channelType == ChannelType.PHONE) {
+            hibernateAccount.setStatus(AccountStatus.ENABLED);
             hibernateAccount.setPhoneVerified(true);    
         }
         hibernateHelper.update(hibernateAccount);

--- a/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
@@ -225,7 +225,7 @@ public class AuthenticationController extends BaseController {
         Study study = studyService.getStudy(signIn.getStudyId());
         verifySupportedVersionOrThrowException(study);
         
-        authenticationService.requestResetPassword(study, signIn);
+        authenticationService.requestResetPassword(study, false, signIn);
 
         return okResult("If registered with the study, we'll send you instructions on how to change your password.");
     }

--- a/app/org/sagebionetworks/bridge/services/AccountWorkflowService.java
+++ b/app/org/sagebionetworks/bridge/services/AccountWorkflowService.java
@@ -31,6 +31,7 @@ import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
+import org.sagebionetworks.bridge.models.accounts.AccountStatus;
 import org.sagebionetworks.bridge.models.accounts.Verification;
 import org.sagebionetworks.bridge.models.accounts.PasswordReset;
 import org.sagebionetworks.bridge.models.accounts.Phone;
@@ -327,20 +328,26 @@ public class AccountWorkflowService {
     }
     
     /**
-     * Request that a token be sent to the user's email address that can be used to 
-     * submit a password change to the server. This method will fail silently if 
-     * the email does not map to an account, in order to prevent account enumeration 
-     * attacks.
+     * Request that a token be sent to the user's email address or phone number that can be 
+     * used to submit a password change to the server. Users who administer participants in 
+     * the study can trigger this request whether the channel used is verified or not, 
+     * but normal users must have already verified the channel to prevent abuse. In addition, 
+     * this method fails silently if the email or phone number cannot be found in the system, 
+     * to prevent account enumeration attacks. 
      */
-    public void requestResetPassword(Study study, AccountId accountId) {
+    public void requestResetPassword(Study study, boolean isStudyAdmin, AccountId accountId) {
         checkNotNull(accountId);
         checkArgument(study.getIdentifier().equals(accountId.getStudyId()));
         
         Account account = accountDao.getAccount(accountId);
-        if (account != null) {
-            if (account.getEmail() != null && account.getEmailVerified()) {
-                sendPasswordResetRelatedEmail(study, account.getEmail(), false, study.getResetPasswordTemplate());    
-            } else if (account.getPhone() != null && account.getPhoneVerified()) {
+        // We are going to change the status of the account if this succeeds, so we must also
+        // ignore disabled accounts.
+        if (account != null && account.getStatus() != AccountStatus.DISABLED) {
+            boolean emailVerified = isStudyAdmin || Boolean.TRUE.equals(account.getEmailVerified());
+            boolean phoneVerified = isStudyAdmin || Boolean.TRUE.equals(account.getPhoneVerified());
+            if (account.getEmail() != null && emailVerified) {
+                sendPasswordResetRelatedEmail(study, account.getEmail(), false, study.getResetPasswordTemplate());
+            } else if (account.getPhone() != null && phoneVerified) {
                 sendPasswordResetRelatedSMS(study, account.getPhone(), false, study.getResetPasswordSmsTemplate());
             }
         }

--- a/app/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -284,14 +284,14 @@ public class AuthenticationService {
         }
     }
     
-    public void requestResetPassword(Study study, SignIn signIn) throws BridgeServiceException {
+    public void requestResetPassword(Study study, boolean isStudyAdmin, SignIn signIn) throws BridgeServiceException {
         checkNotNull(study);
         checkNotNull(signIn);
         
         // validate the data in signIn, then convert it to an account ID which we know will be valid.
         Validate.entityThrowingException(SignInValidator.REQUEST_RESET_PASSWORD, signIn);
         try {
-            accountWorkflowService.requestResetPassword(study, signIn.getAccountId());    
+            accountWorkflowService.requestResetPassword(study, isStudyAdmin, signIn.getAccountId());    
         } catch(EntityNotFoundException e) {
             // Suppress this. Otherwise it reveals if the account does not exist
             LOG.info("Request reset password request for unregistered email in study '"+signIn.getStudyId()+"'");

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -355,7 +355,7 @@ public class ParticipantService {
         // Don't throw an exception here, you'd be exposing that an email/phone number is in the system.
         AccountId accountId = AccountId.forId(study.getIdentifier(), userId);
 
-        accountWorkflowService.requestResetPassword(study, accountId);
+        accountWorkflowService.requestResetPassword(study, true, accountId);
     }
 
     public ForwardCursorPagedResourceList<ScheduledActivity> getActivityHistory(Study study, String userId,

--- a/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
+++ b/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
@@ -347,6 +347,7 @@ public class HibernateAccountDaoTest {
         // mock hibernate
         HibernateAccount hibernateAccount = new HibernateAccount();
         hibernateAccount.setId(ACCOUNT_ID);
+        hibernateAccount.setStatus(AccountStatus.UNVERIFIED);
         when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(hibernateAccount);
 
         // Set up test account
@@ -365,6 +366,7 @@ public class HibernateAccountDaoTest {
         assertEquals(MOCK_NOW_MILLIS, updatedAccount.getPasswordModifiedOn().longValue());
         assertTrue(updatedAccount.getEmailVerified());
         assertNull(updatedAccount.getPhoneVerified());
+        assertEquals(AccountStatus.ENABLED, updatedAccount.getStatus());
 
         // validate password hash
         assertTrue(PasswordAlgorithm.DEFAULT_PASSWORD_ALGORITHM.checkHash(updatedAccount.getPasswordHash(),
@@ -376,6 +378,7 @@ public class HibernateAccountDaoTest {
         // mock hibernate
         HibernateAccount hibernateAccount = new HibernateAccount();
         hibernateAccount.setId(ACCOUNT_ID);
+        hibernateAccount.setStatus(AccountStatus.UNVERIFIED);
         when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(hibernateAccount);
 
         // Set up test account
@@ -391,6 +394,7 @@ public class HibernateAccountDaoTest {
         HibernateAccount updatedAccount = updatedAccountCaptor.getValue();
         assertNull(updatedAccount.getEmailVerified());
         assertTrue(updatedAccount.getPhoneVerified());
+        assertEquals(AccountStatus.ENABLED, updatedAccount.getStatus());
     }
     
     @Test(expected = EntityNotFoundException.class)

--- a/test/org/sagebionetworks/bridge/play/controllers/AuthenticationControllerMockTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/AuthenticationControllerMockTest.java
@@ -745,7 +745,7 @@ public class AuthenticationControllerMockTest {
         
         controller.requestResetPassword();
         
-        verify(authenticationService).requestResetPassword(eq(study), signInCaptor.capture());
+        verify(authenticationService).requestResetPassword(eq(study), eq(false), signInCaptor.capture());
         SignIn deser = signInCaptor.getValue();
         assertEquals(TEST_STUDY_ID_STRING, deser.getStudyId());
         assertEquals(TEST_EMAIL, deser.getEmail());
@@ -758,7 +758,7 @@ public class AuthenticationControllerMockTest {
         
         controller.requestResetPassword();
         
-        verify(authenticationService).requestResetPassword(eq(study), signInCaptor.capture());
+        verify(authenticationService).requestResetPassword(eq(study), eq(false), signInCaptor.capture());
         SignIn deser = signInCaptor.getValue();
         assertEquals(TEST_STUDY_ID_STRING, deser.getStudyId());
         assertEquals(TestConstants.PHONE.getNumber(), deser.getPhone().getNumber());

--- a/test/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
@@ -46,6 +46,7 @@ import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
+import org.sagebionetworks.bridge.models.accounts.AccountStatus;
 import org.sagebionetworks.bridge.models.accounts.Verification;
 import org.sagebionetworks.bridge.models.accounts.PasswordReset;
 import org.sagebionetworks.bridge.models.accounts.Phone;
@@ -747,7 +748,7 @@ public class AccountWorkflowServiceTest {
         when(mockAccount.getEmailVerified()).thenReturn(Boolean.TRUE);        
         when(mockAccount.getStudyIdentifier()).thenReturn(TEST_STUDY);
         
-        service.requestResetPassword(study, ACCOUNT_ID_WITH_EMAIL);
+        service.requestResetPassword(study, false, ACCOUNT_ID_WITH_EMAIL);
         
         verify(mockCacheProvider).setObject(PASSWORD_RESET_FOR_EMAIL, EMAIL, 60*60*2);
         verify(mockSendMailService).sendEmail(emailProviderCaptor.capture());
@@ -777,7 +778,7 @@ public class AccountWorkflowServiceTest {
         when(mockAccount.getPhoneVerified()).thenReturn(Boolean.TRUE);        
         when(mockAccount.getStudyIdentifier()).thenReturn(TEST_STUDY);
         
-        service.requestResetPassword(study, ACCOUNT_ID_WITH_PHONE);
+        service.requestResetPassword(study, false, ACCOUNT_ID_WITH_PHONE);
         
         verify(mockCacheProvider).setObject(eq(PASSWORD_RESET_FOR_PHONE), stringCaptor.capture(), eq(60*60*2));
         verify(mockNotificationsService).sendSmsMessage(smsMessageProviderCaptor.capture());
@@ -802,7 +803,7 @@ public class AccountWorkflowServiceTest {
         when(mockAccount.getEmailVerified()).thenReturn(Boolean.FALSE);
         when(mockAccount.getStudyIdentifier()).thenReturn(TEST_STUDY);
 
-        service.requestResetPassword(study, ACCOUNT_ID_WITH_PHONE);
+        service.requestResetPassword(study, false, ACCOUNT_ID_WITH_PHONE);
         
         verify(mockCacheProvider, never()).setObject(any(), any(), anyInt());
         verify(mockNotificationsService, never()).sendSmsMessage(any());
@@ -817,7 +818,7 @@ public class AccountWorkflowServiceTest {
         when(mockAccount.getEmailVerified()).thenReturn(Boolean.FALSE);
         when(mockAccount.getStudyIdentifier()).thenReturn(TEST_STUDY);
         
-        service.requestResetPassword(study, ACCOUNT_ID_WITH_PHONE);
+        service.requestResetPassword(study, false, ACCOUNT_ID_WITH_PHONE);
         
         verify(mockCacheProvider, never()).setObject(any(), any(), anyInt());
         verify(mockNotificationsService, never()).sendSmsMessage(any());
@@ -829,7 +830,7 @@ public class AccountWorkflowServiceTest {
         when(service.getNextToken()).thenReturn(TOKEN);
         when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(null);
         
-        service.requestResetPassword(study, ACCOUNT_ID_WITH_EMAIL);
+        service.requestResetPassword(study, false, ACCOUNT_ID_WITH_EMAIL);
         
         verify(mockCacheProvider, never()).setObject(any(), any(), anyInt());
         verify(mockSendMailService, never()).sendEmail(any());
@@ -842,7 +843,7 @@ public class AccountWorkflowServiceTest {
         when(mockAccount.getEmail()).thenReturn(EMAIL);
         when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(mockAccount);
         
-        service.requestResetPassword(study, ACCOUNT_ID_WITH_EMAIL);
+        service.requestResetPassword(study, false, ACCOUNT_ID_WITH_EMAIL);
         
         verifyNoMoreInteractions(mockSendMailService);
         verifyNoMoreInteractions(mockNotificationsService);
@@ -855,10 +856,52 @@ public class AccountWorkflowServiceTest {
         when(mockAccount.getPhone()).thenReturn(TestConstants.PHONE);
         when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
         
-        service.requestResetPassword(study, ACCOUNT_ID_WITH_PHONE);
+        service.requestResetPassword(study, false, ACCOUNT_ID_WITH_PHONE);
         
         verifyNoMoreInteractions(mockSendMailService);
         verifyNoMoreInteractions(mockNotificationsService);
+        verifyNoMoreInteractions(mockCacheProvider);
+    }
+    
+    @Test
+    public void requestResetPasswordByAdminDoesNotRequireEmailVerification() throws Exception {
+        when(service.getNextToken()).thenReturn(SPTOKEN);
+        when(mockAccount.getEmail()).thenReturn(EMAIL);
+        when(mockAccount.getEmailVerified()).thenReturn(false);
+        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
+        
+        service.requestResetPassword(study, true, ACCOUNT_ID_WITH_PHONE);
+        
+        verify(mockCacheProvider).setObject(PASSWORD_RESET_FOR_EMAIL, EMAIL, 60*60*2);
+        verify(mockSendMailService).sendEmail(any());
+    }
+    
+    @Test
+    public void requestResetPasswordByAdminDoesNotRequirePhoneVerification() throws Exception {
+        when(service.getNextToken()).thenReturn(SPTOKEN);
+        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
+        when(mockAccount.getPhone()).thenReturn(TestConstants.PHONE);
+        when(mockAccount.getPhoneVerified()).thenReturn(false);        
+        
+        service.requestResetPassword(study, true, ACCOUNT_ID_WITH_PHONE);
+        
+        verify(mockCacheProvider).setObject(eq(PASSWORD_RESET_FOR_PHONE), stringCaptor.capture(), eq(60*60*2));
+        verify(mockNotificationsService).sendSmsMessage(any());
+    }
+    
+    @Test
+    public void requestResetPasswordQuietlyFailsForDisabledAccount() throws Exception {
+        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
+        when(mockAccount.getPhone()).thenReturn(TestConstants.PHONE);
+        when(mockAccount.getPhoneVerified()).thenReturn(Boolean.TRUE);
+        when(mockAccount.getEmailVerified()).thenReturn(Boolean.TRUE);
+        when(mockAccount.getStudyIdentifier()).thenReturn(TEST_STUDY);
+        when(mockAccount.getStatus()).thenReturn(AccountStatus.DISABLED);
+        
+        service.requestResetPassword(study, false, ACCOUNT_ID_WITH_PHONE);
+        
+        verify(mockCacheProvider, never()).setObject(any(), any(), anyInt());
+        verify(mockNotificationsService, never()).sendSmsMessage(any());
         verifyNoMoreInteractions(mockCacheProvider);
     }
     

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
@@ -434,16 +434,16 @@ public class AuthenticationServiceMockTest {
     public void requestResetInvalid() throws Exception {
         SignIn signIn = new SignIn.Builder().withStudy(STUDY_ID).withPhone(TestConstants.PHONE)
                 .withEmail(RECIPIENT_EMAIL).build();
-        service.requestResetPassword(study, signIn);
+        service.requestResetPassword(study, false, signIn);
     }
     
     @Test
     public void requestResetPassword() throws Exception {
         SignIn signIn = new SignIn.Builder().withStudy(STUDY_ID).withEmail(RECIPIENT_EMAIL).build();
         
-        service.requestResetPassword(study, signIn);
+        service.requestResetPassword(study, false, signIn);
         
-        verify(accountWorkflowService).requestResetPassword(study, signIn.getAccountId());
+        verify(accountWorkflowService).requestResetPassword(study, false, signIn.getAccountId());
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
@@ -230,13 +230,13 @@ public class AuthenticationServiceTest {
 
     @Test(expected = NullPointerException.class)
     public void requestPasswordResetFailsOnNull() throws Exception {
-        authService.requestResetPassword(study, null);
+        authService.requestResetPassword(study, false, null);
     }
 
     @Test(expected = InvalidEntityException.class)
     public void requestPasswordResetFailsOnEmptyString() throws Exception {
         SignIn signIn = new SignIn.Builder().withStudy(TEST_STUDY_IDENTIFIER).build();
-        authService.requestResetPassword(study, signIn);
+        authService.requestResetPassword(study, false, signIn);
     }
     
     @Test(expected = BadRequestException.class)
@@ -386,7 +386,7 @@ public class AuthenticationServiceTest {
     public void requestResetPasswordLooksSuccessfulWhenNoAccount() throws Exception {
         SignIn signIn = new SignIn.Builder().withStudy(TEST_STUDY_IDENTIFIER).withEmail("notarealaccount@sagebase.org")
                 .build();
-        authService.requestResetPassword(study, signIn);
+        authService.requestResetPassword(study, false, signIn);
     }
     
     // Consent statuses passed on to sessionInfo

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -1199,6 +1199,12 @@ public class ParticipantServiceTest {
     }
     
     @Test(expected = InvalidEntityException.class)
+    public void updateIdentifiersValidates() {
+        IdentifierUpdate update = new IdentifierUpdate(EMAIL_PASSWORD_SIGN_IN, null, null, null);
+        participantService.updateIdentifiers(STUDY, CONTEXT, update);
+    }
+    
+    @Test(expected = InvalidEntityException.class)
     public void updateIdentifiersValidatesWithBlanks() {
         IdentifierUpdate update = new IdentifierUpdate(EMAIL_PASSWORD_SIGN_IN, "", null, "");
         participantService.updateIdentifiers(STUDY, CONTEXT, update);

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -940,7 +940,7 @@ public class ParticipantServiceTest {
         
         participantService.requestResetPassword(STUDY, ID);
         
-        verify(accountWorkflowService).requestResetPassword(eq(STUDY), eq(ACCOUNT_ID));
+        verify(accountWorkflowService).requestResetPassword(STUDY, true, ACCOUNT_ID);
     }
     
     @Test
@@ -1205,8 +1205,14 @@ public class ParticipantServiceTest {
     }
     
     @Test(expected = InvalidEntityException.class)
-    public void updateIdentifiersValidatesWithBlanks() {
-        IdentifierUpdate update = new IdentifierUpdate(EMAIL_PASSWORD_SIGN_IN, "", null, "");
+    public void updateIdentifiersValidatesWithBlankEmail() {
+        IdentifierUpdate update = new IdentifierUpdate(EMAIL_PASSWORD_SIGN_IN, "", null, null);
+        participantService.updateIdentifiers(STUDY, CONTEXT, update);
+    }
+
+    @Test(expected = InvalidEntityException.class)
+    public void updateIdentifiersValidatesWithInvalidPhone() {
+        IdentifierUpdate update = new IdentifierUpdate(EMAIL_PASSWORD_SIGN_IN, null, new Phone("US", "1231231234"), null);
         participantService.updateIdentifiers(STUDY, CONTEXT, update);
     }
     

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -1199,20 +1199,8 @@ public class ParticipantServiceTest {
     }
     
     @Test(expected = InvalidEntityException.class)
-    public void updateIdentifiersValidates() {
-        IdentifierUpdate update = new IdentifierUpdate(EMAIL_PASSWORD_SIGN_IN, null, null, null);
-        participantService.updateIdentifiers(STUDY, CONTEXT, update);
-    }
-    
-    @Test(expected = InvalidEntityException.class)
-    public void updateIdentifiersValidatesWithBlankEmail() {
-        IdentifierUpdate update = new IdentifierUpdate(EMAIL_PASSWORD_SIGN_IN, "", null, null);
-        participantService.updateIdentifiers(STUDY, CONTEXT, update);
-    }
-
-    @Test(expected = InvalidEntityException.class)
-    public void updateIdentifiersValidatesWithInvalidPhone() {
-        IdentifierUpdate update = new IdentifierUpdate(EMAIL_PASSWORD_SIGN_IN, null, new Phone("US", "1231231234"), null);
+    public void updateIdentifiersValidatesWithBlanks() {
+        IdentifierUpdate update = new IdentifierUpdate(EMAIL_PASSWORD_SIGN_IN, "", null, "");
         participantService.updateIdentifiers(STUDY, CONTEXT, update);
     }
     


### PR DESCRIPTION
and toggle status to active when the credential is verified through reset password. I've also adjusted the BSM so you can trigger a reset password email regardless of the account status.