### PR TITLE
improved logging for emails

### DIFF
--- a/app/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/app/org/sagebionetworks/bridge/BridgeUtils.java
@@ -60,13 +60,28 @@ public class BridgeUtils {
     private static final int ONE_MINUTE = 60;
     
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
-    
+
+    // ThreadLocals are weird. They are basically a container that allows us to hold "global variables" for each
+    // thread. This can be used, for example, to provide the request ID to any class without having to plumb a
+    // "request context" object into every method of every class.
+    private static final ThreadLocal<String> REQUEST_ID_THREAD_LOCAL = ThreadLocal.withInitial(() -> null);
+
     public static boolean isExternalIdAccount(StudyParticipant participant) {
         return (StringUtils.isNotBlank(participant.getExternalId()) && 
                 StringUtils.isBlank(participant.getEmail()) && 
                 participant.getPhone() == null);
     }
-    
+
+    /** Gets the request ID for the current thread. See also RequestIdInterceptor. */
+    public static String getRequestId() {
+        return REQUEST_ID_THREAD_LOCAL.get();
+    }
+
+    /** @see #getRequestId */
+    public static void setRequestId(String requestId) {
+        REQUEST_ID_THREAD_LOCAL.set(requestId);
+    }
+
     /**
      * Convert expiration measures in seconds to an English language explanation of
      * the expiration time. This is not intended to cover odd cases--our expirations 

--- a/app/org/sagebionetworks/bridge/play/interceptors/RequestIdInterceptor.java
+++ b/app/org/sagebionetworks/bridge/play/interceptors/RequestIdInterceptor.java
@@ -1,0 +1,31 @@
+package org.sagebionetworks.bridge.play.interceptors;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+import org.springframework.stereotype.Component;
+import play.mvc.Http;
+
+import org.sagebionetworks.bridge.BridgeUtils;
+
+/**
+ * This interceptor grabs the request ID from the request (see {@link RequestUtils#getRequestId}) and writes it to
+ * ThreadLocal storage (see {@link BridgeUtils#getRequestId}, then un-sets it when the request is finished.
+ */
+@Component("requestIdInterceptor")
+public class RequestIdInterceptor implements MethodInterceptor {
+    @Override
+    public Object invoke(MethodInvocation method) throws Throwable {
+        // Set request ID.
+        Http.Request request = Http.Context.current().request();
+        String requestId = RequestUtils.getRequestId(request);
+        BridgeUtils.setRequestId(requestId);
+
+        // Proceed with method invocation.
+        try {
+            return method.proceed();
+        } finally {
+            // Unset request Id when finished.
+            BridgeUtils.setRequestId(null);
+        }
+    }
+}

--- a/app/org/sagebionetworks/bridge/services/AccountWorkflowService.java
+++ b/app/org/sagebionetworks/bridge/services/AccountWorkflowService.java
@@ -42,6 +42,7 @@ import org.sagebionetworks.bridge.redis.JedisOps;
 import org.sagebionetworks.bridge.redis.JedisTransaction;
 import org.sagebionetworks.bridge.services.AuthenticationService.ChannelType;
 import org.sagebionetworks.bridge.services.email.BasicEmailProvider;
+import org.sagebionetworks.bridge.services.email.EmailType;
 import org.sagebionetworks.bridge.sms.SmsMessageProvider;
 import org.sagebionetworks.bridge.validators.Validate;
 
@@ -227,6 +228,7 @@ public class AccountWorkflowService {
                 .withToken(OLD_SHORT_URL_KEY, newUrl) // new URL is short
                 .withToken(EMAIL_VERIFICATION_URL_KEY, newUrl)
                 .withExpirationPeriod(EMAIL_VERIFICATION_EXPIRATION_PERIOD, VERIFY_OR_RESET_EXPIRE_IN_SECONDS)
+                .withType(EmailType.VERIFY_EMAIL)
                 .build();
         sendMailService.sendEmail(provider);
     }
@@ -366,7 +368,8 @@ public class AccountWorkflowService {
             .withToken(OLD_EXP_WINDOW_TOKEN, Integer.toString(VERIFY_OR_RESET_EXPIRE_IN_SECONDS/60/60))
             .withExpirationPeriod(OLD_EXPIRATION_PERIOD, VERIFY_OR_RESET_EXPIRE_IN_SECONDS)
             .withToken(RESET_PASSWORD_URL_KEY, shortUrl)
-            .withExpirationPeriod(RESET_PASSWORD_EXPIRATION_PERIOD, VERIFY_OR_RESET_EXPIRE_IN_SECONDS);
+            .withExpirationPeriod(RESET_PASSWORD_EXPIRATION_PERIOD, VERIFY_OR_RESET_EXPIRE_IN_SECONDS)
+            .withType(EmailType.RESET_PASSWORD);
             
         if (includeEmailSignIn && study.isEmailSignInEnabled()) {
             SignIn signIn = new SignIn.Builder().withEmail(email).withStudy(study.getIdentifier()).build();
@@ -502,6 +505,7 @@ public class AccountWorkflowService {
                 .withToken(OLD_SHORT_URL_KEY, shortUrl)
                 .withToken(EMAIL_SIGNIN_URL_KEY, shortUrl)
                 .withExpirationPeriod(EMAIL_SIGNIN_EXPIRATION_PERIOD, SIGNIN_EXPIRE_IN_SECONDS)
+                .withType(EmailType.EMAIL_SIGN_IN)
                 .build();
             sendMailService.sendEmail(provider);
         });

--- a/app/org/sagebionetworks/bridge/services/SendMailViaAmazonService.java
+++ b/app/org/sagebionetworks/bridge/services/SendMailViaAmazonService.java
@@ -14,6 +14,7 @@ import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
 
+import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.services.email.MimeTypeEmail;
 import org.sagebionetworks.bridge.services.email.MimeTypeEmailProvider;
@@ -64,7 +65,7 @@ public class SendMailViaAmazonService implements SendMailService {
             String fullSenderEmail = provider.getMimeTypeEmail().getSenderAddress();
             MimeTypeEmail email = provider.getMimeTypeEmail();
             for (String recipient: email.getRecipientAddresses()) {
-                sendEmail(fullSenderEmail, recipient, email, provider.getStudy().getIdentifier(), provider.getClass());
+                sendEmail(fullSenderEmail, recipient, email, provider.getStudy().getIdentifier());
             }
         } catch (MessageRejectedException ex) {
             // This happens if the sender email is not verified in SES. In general, it's not useful to app users to
@@ -77,8 +78,7 @@ public class SendMailViaAmazonService implements SendMailService {
         }
     }
 
-    private void sendEmail(String senderEmail, String recipient, MimeTypeEmail email, String studyId,
-            Class<? extends MimeTypeEmailProvider> providerClass)
+    private void sendEmail(String senderEmail, String recipient, MimeTypeEmail email, String studyId)
             throws AmazonClientException, MessagingException, IOException {
         
         Session mailSession = Session.getInstance(new Properties(), null);
@@ -107,7 +107,7 @@ public class SendMailViaAmazonService implements SendMailService {
         SendRawEmailResult result = emailClient.sendRawEmail(req);
 
         logger.info("Sent email to SES with messageID " + result.getMessageId() + " with type " +
-                        providerClass.getSimpleName() + " for study " + studyId);
+                        email.getType() + " for study " + studyId + " and request " + BridgeUtils.getRequestId());
     }
     
 }

--- a/app/org/sagebionetworks/bridge/services/StudyService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyService.java
@@ -77,6 +77,7 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
 import org.sagebionetworks.bridge.models.upload.UploadValidationStrictness;
 import org.sagebionetworks.bridge.services.email.BasicEmailProvider;
+import org.sagebionetworks.bridge.services.email.EmailType;
 import org.sagebionetworks.bridge.validators.StudyParticipantValidator;
 import org.sagebionetworks.bridge.validators.StudyValidator;
 import org.sagebionetworks.bridge.validators.Validate;
@@ -84,7 +85,7 @@ import org.sagebionetworks.bridge.validators.Validate;
 @Component("studyService")
 @PropertySource("classpath:study-defaults/sms-messages.properties")
 public class StudyService {
-    private static Logger LOG = LoggerFactory.getLogger(StudyService.class);
+    private static final Logger LOG = LoggerFactory.getLogger(StudyService.class);
 
     private static final String BASE_URL = BridgeConfigFactory.getConfig().get("webservices.url");
     static final String CONFIG_KEY_SUPPORT_EMAIL_PLAIN = "support.email.plain";
@@ -861,6 +862,7 @@ public class StudyService {
                 .withOverrideSenderEmail(bridgeSupportEmailPlain).withRecipientEmail(email)
                 .withToken(STUDY_EMAIL_VERIFICATION_URL, shortUrl)
                 .withExpirationPeriod(STUDY_EMAIL_VERIFICATION_EXPIRATION_PERIOD, VERIFY_STUDY_EMAIL_EXPIRE_IN_SECONDS)
+                .withType(EmailType.VERIFY_CONSENT_EMAIL)
                 .build();
         sendMailService.sendEmail(provider);
     }

--- a/app/org/sagebionetworks/bridge/services/email/EmailType.java
+++ b/app/org/sagebionetworks/bridge/services/email/EmailType.java
@@ -1,0 +1,13 @@
+package org.sagebionetworks.bridge.services.email;
+
+/** Enumerates the different type of emails. The main purpose of this class is logging and analytics. */
+public enum EmailType {
+    EMAIL_SIGN_IN,
+    RESEND_CONSENT,
+    RESET_PASSWORD,
+    SIGN_CONSENT,
+    UNKNOWN,
+    VERIFY_CONSENT_EMAIL,
+    VERIFY_EMAIL,
+    WITHDRAW_CONSENT,
+}

--- a/app/org/sagebionetworks/bridge/services/email/MimeTypeEmail.java
+++ b/app/org/sagebionetworks/bridge/services/email/MimeTypeEmail.java
@@ -5,10 +5,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.util.List;
-
+import java.util.function.Function;
 import javax.mail.internet.MimeBodyPart;
 
-import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
@@ -17,29 +16,28 @@ import com.google.common.collect.Lists;
  * message using the Java mail API.
  */
 public final class MimeTypeEmail {
-    
     private static final String QUOTE = "\"";
     private static final String QUOTED_QUOTE = "\\\\\"";
-    private static final Function<String,String> APPLY_EMAIL_ESCAPER = new Function<String,String>() {
-        @Override public String apply(final String address) {
-            return escapeEmailAddress(address);
-        }
-    };
+    private static final Function<String, String> APPLY_EMAIL_ESCAPER = MimeTypeEmail::escapeEmailAddress;
 
     private final String subject;
     private final String senderAddress;
     private final List<String> recipientAddresses;
     private final List<MimeBodyPart> messageParts;
+    private final EmailType type;
     
-    MimeTypeEmail(String subject, String senderAddress, List<String> recipientAddresses, List<MimeBodyPart> messageParts) {
+    MimeTypeEmail(String subject, String senderAddress, List<String> recipientAddresses,
+            List<MimeBodyPart> messageParts, EmailType type) {
         checkArgument(isNotBlank(subject));
         checkNotNull(recipientAddresses);
         checkArgument(messageParts != null && !messageParts.isEmpty());
+        checkNotNull(type);
         
         this.subject = subject;
         this.senderAddress = (senderAddress != null) ? escapeEmailAddress(senderAddress) : null;
-        this.recipientAddresses = Lists.transform(recipientAddresses, APPLY_EMAIL_ESCAPER);
+        this.recipientAddresses = Lists.transform(recipientAddresses, APPLY_EMAIL_ESCAPER::apply);
         this.messageParts = ImmutableList.copyOf(messageParts);
+        this.type = type;
     }
     
     public String getSubject() {
@@ -54,11 +52,15 @@ public final class MimeTypeEmail {
     public List<MimeBodyPart> getMessageParts() {
         return messageParts;
     }
+
+    /** Email type. Examples include email verification, sign-in, consent, etc. */
+    public EmailType getType() {
+        return type;
+    }
+
     /**
      * Addresses can be submitted in forms such as "Study A, B, and C <study@study.com>" and need to be escaped. This 
      * method will do that if necessary.
-     * @param address
-     * @return
      */
     private static String escapeEmailAddress(String address) {
         if (address.matches("^.+<.*>$")) {

--- a/app/org/sagebionetworks/bridge/services/email/MimeTypeEmailBuilder.java
+++ b/app/org/sagebionetworks/bridge/services/email/MimeTypeEmailBuilder.java
@@ -8,16 +8,14 @@ import javax.mail.internet.MimeBodyPart;
 import com.google.common.collect.Lists;
 
 class MimeTypeEmailBuilder {
-
     private String subject;
     private String senderAddress;
     private List<String> recipientAddresses = Lists.newArrayList();
     private List<MimeBodyPart> messageParts = Lists.newArrayList();
+    private EmailType type;
     
     /**
      * The subject of the email. Required.
-     * @param subject
-     * @return
      */
     MimeTypeEmailBuilder withSubject(String subject) {
         this.subject = subject;
@@ -26,8 +24,6 @@ class MimeTypeEmailBuilder {
     /**
      * The sender of the email. This value is optional (if not supplied, the server's 
      * default support email address will be used).
-     * @param senderAddress
-     * @return
      */
     MimeTypeEmailBuilder withSender(String senderAddress) {
         this.senderAddress = senderAddress;
@@ -35,8 +31,6 @@ class MimeTypeEmailBuilder {
     }
     /**
      * One or more recipients for this email (may call this more than once and values will be accumulated).
-     * @param recipientAddress
-     * @return
      */
     MimeTypeEmailBuilder withRecipients(Collection<String> recipients) {
         this.recipientAddresses.addAll(recipients);
@@ -44,8 +38,6 @@ class MimeTypeEmailBuilder {
     }
     /**
      * A recipient for this email (may call this more than once and values will be accumulated).
-     * @param recipientAddress
-     * @return
      */
     MimeTypeEmailBuilder withRecipient(String recipient) {
         this.recipientAddresses.add(recipient);
@@ -54,8 +46,6 @@ class MimeTypeEmailBuilder {
     /**
      * A body part for a MIME-based email message (may call this more than once and the body parts 
      * will be accumulated).
-     * @param parts
-     * @return
      */
     MimeTypeEmailBuilder withMessageParts(MimeBodyPart... parts) {
         if (parts != null) {
@@ -67,12 +57,21 @@ class MimeTypeEmailBuilder {
         }
         return this;
     }
-    /**
-     * Construct this MimeTypeEmail instance.
-     * @return
-     */
-    MimeTypeEmail build() {
-        return new MimeTypeEmail(subject, senderAddress, recipientAddresses, messageParts);
+
+    /** @see MimeTypeEmail#getType */
+    MimeTypeEmailBuilder withType(EmailType type) {
+        this.type = type;
+        return this;
     }
 
+    /**
+     * Construct this MimeTypeEmail instance.
+     */
+    MimeTypeEmail build() {
+        if (type == null) {
+            type = EmailType.UNKNOWN;
+        }
+
+        return new MimeTypeEmail(subject, senderAddress, recipientAddresses, messageParts, type);
+    }
 }

--- a/app/org/sagebionetworks/bridge/services/email/WithdrawConsentEmailProvider.java
+++ b/app/org/sagebionetworks/bridge/services/email/WithdrawConsentEmailProvider.java
@@ -22,7 +22,6 @@ import org.sagebionetworks.bridge.models.studies.Study;
 import com.google.common.collect.Lists;
 
 public class WithdrawConsentEmailProvider extends MimeTypeEmailProvider {
-    
     private static final DateTimeFormatter FORMATTER = DateTimeFormat.forPattern("MMMM d, yyyy");
     private static final String CONSENT_EMAIL_SUBJECT = "Notification of consent withdrawal for %s";
     private static final String SUB_TYPE_HTML = "html";
@@ -78,6 +77,9 @@ public class WithdrawConsentEmailProvider extends MimeTypeEmailProvider {
         final MimeBodyPart bodyPart = new MimeBodyPart();
         bodyPart.setText(content, StandardCharsets.UTF_8.name(), SUB_TYPE_HTML);
         builder.withMessageParts(bodyPart);
+
+        // Set type
+        builder.withType(EmailType.WITHDRAW_CONSENT);
 
         return builder.build();
     }

--- a/conf/bridge-server.conf
+++ b/conf/bridge-server.conf
@@ -1,4 +1,4 @@
-channel.throttle.max.requests = 2
+channel.throttle.max.requests = 1
 channel.throttle.timeout.seconds = 300
 
 ses.notification.topic.arn = arn:aws:sns:us-east-1:649232250620:SNSBounces

--- a/conf/shared-config.xml
+++ b/conf/shared-config.xml
@@ -76,6 +76,7 @@
                 <value>deprecationInterceptor</value>
                 <value>staticHeadersInterceptor</value>
                 <value>exceptionInterceptor</value>
+                <value>requestIdInterceptor</value>
             </list>
         </property>
     </bean>

--- a/test/org/sagebionetworks/bridge/BridgeUtilsTest.java
+++ b/test/org/sagebionetworks/bridge/BridgeUtilsTest.java
@@ -48,7 +48,31 @@ public class BridgeUtilsTest {
         StudyParticipant participant = new StudyParticipant.Builder().withEmail("email@email.com").withExternalId("id").build();
         assertFalse(BridgeUtils.isExternalIdAccount(participant));
     }
-    
+
+    @Test
+    public void getRequestId() throws Exception {
+        // Can set request ID in this thread.
+        BridgeUtils.setRequestId("main request ID");
+        assertEquals("main request ID", BridgeUtils.getRequestId());
+
+        // Request ID is thread local, so a separate thread should see a different request ID.
+        Runnable runnable = () -> {
+            assertNull(BridgeUtils.getRequestId());
+            BridgeUtils.setRequestId("other request ID");
+            assertEquals("other request ID", BridgeUtils.getRequestId());
+        };
+        Thread otherThread = new Thread(runnable);
+        otherThread.start();
+        otherThread.join();
+
+        // Other thread doesn't affect this thread.
+        assertEquals("main request ID", BridgeUtils.getRequestId());
+
+        // Setting request ID to null is fine.
+        BridgeUtils.setRequestId(null);
+        assertNull(BridgeUtils.getRequestId());
+    }
+
     @Test
     public void secondsToPeriodString() {
         assertEquals("30 seconds", BridgeUtils.secondsToPeriodString(30));

--- a/test/org/sagebionetworks/bridge/play/interceptors/RequestIdInterceptorTest.java
+++ b/test/org/sagebionetworks/bridge/play/interceptors/RequestIdInterceptorTest.java
@@ -1,0 +1,51 @@
+package org.sagebionetworks.bridge.play.interceptors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
+import org.aopalliance.intercept.MethodInvocation;
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.BridgeConstants;
+import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.TestUtils;
+
+public class RequestIdInterceptorTest {
+    private static final String REQUEST_ID = "request-id";
+
+    @Test
+    public void test() throws Throwable {
+        // Mock Play headers. Note that we don't actually care about JSON body, but this helper method is the simplest
+        // way to mock all things Play.
+        Map<String, String[]> headerMap = ImmutableMap.of(BridgeConstants.X_REQUEST_ID_HEADER,
+                new String[] { REQUEST_ID });
+        TestUtils.mockPlayContextWithJson("{}", headerMap);
+
+        // Mock method invocation.
+        Object expectedReturnValue = new Object();
+        MethodInvocation mockMethod = mock(MethodInvocation.class);
+        when(mockMethod.proceed()).thenAnswer(invocation -> {
+            // Verify that we set the request ID.
+            assertEquals(REQUEST_ID, BridgeUtils.getRequestId());
+            return expectedReturnValue;
+        });
+
+        // Execute.
+        RequestIdInterceptor interceptor = new RequestIdInterceptor();
+        Object returnValue = interceptor.invoke(mockMethod);
+        assertSame(expectedReturnValue, returnValue);
+
+        // Verify the method was _actually_ called.
+        verify(mockMethod).proceed();
+
+        // Verify we reset the request ID afterwards.
+        assertNull(BridgeUtils.getRequestId());
+    }
+}

--- a/test/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
@@ -57,6 +57,7 @@ import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.redis.InMemoryJedisOps;
 import org.sagebionetworks.bridge.services.AuthenticationService.ChannelType;
 import org.sagebionetworks.bridge.services.email.BasicEmailProvider;
+import org.sagebionetworks.bridge.services.email.EmailType;
 import org.sagebionetworks.bridge.services.email.MimeTypeEmail;
 import org.sagebionetworks.bridge.sms.SmsMessageProvider;
 import org.sagebionetworks.bridge.validators.SignInValidator;
@@ -129,10 +130,7 @@ public class AccountWorkflowServiceTest {
     
     @Captor
     private ArgumentCaptor<String> stringCaptor;
-    
-    @Captor
-    private ArgumentCaptor<String> secondStringCaptor;
-    
+
     @Captor
     private ArgumentCaptor<SmsMessageProvider> smsMessageProviderCaptor;
     
@@ -212,6 +210,7 @@ public class AccountWorkflowServiceTest {
         String bodyString = (String)body.getContent();
         assertTrue(bodyString.contains("/mobile/verifyEmail.html?study=api&sptoken="+SPTOKEN));
         assertTrue(bodyString.contains("/ve?study=api&sptoken="+SPTOKEN));
+        assertEquals(EmailType.VERIFY_EMAIL, email.getType());
         verifyNoMoreInteractions(mockCacheProvider);
     }
     
@@ -490,6 +489,7 @@ public class AccountWorkflowServiceTest {
         assertEquals(1, email.getRecipientAddresses().size());
         assertEquals(EMAIL, email.getRecipientAddresses().get(0));
         assertEquals("AE This study name", email.getSubject());
+        assertEquals(EmailType.RESET_PASSWORD, email.getType());
         
         MimeBodyPart body = email.getMessageParts().get(0);
         String bodyString = (String)body.getContent();
@@ -765,6 +765,7 @@ public class AccountWorkflowServiceTest {
         MimeBodyPart body = email.getMessageParts().get(0);
         String bodyString = (String)body.getContent();
         assertTrue(bodyString.contains("/rp?study=api&sptoken="+SPTOKEN));
+        assertEquals(EmailType.RESET_PASSWORD, email.getType());
         verifyNoMoreInteractions(mockCacheProvider);
     }
     
@@ -961,6 +962,7 @@ public class AccountWorkflowServiceTest {
         assertEquals(EMAIL, Iterables.getFirst(provider.getRecipientEmails(), null));
         assertEquals("Body " + provider.getTokenMap().get("token"),
                 provider.getMimeTypeEmail().getMessageParts().get(0).getContent());
+        assertEquals(EmailType.EMAIL_SIGN_IN, provider.getType());
         verifyNoMoreInteractions(mockCacheProvider);
     }
     

--- a/test/org/sagebionetworks/bridge/services/ConsentServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/ConsentServiceMockTest.java
@@ -55,6 +55,7 @@ import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 import org.sagebionetworks.bridge.s3.S3Helper;
 import org.sagebionetworks.bridge.services.email.BasicEmailProvider;
+import org.sagebionetworks.bridge.services.email.EmailType;
 import org.sagebionetworks.bridge.services.email.MimeTypeEmail;
 import org.sagebionetworks.bridge.services.email.MimeTypeEmailProvider;
 import org.sagebionetworks.bridge.services.email.WithdrawConsentEmailProvider;
@@ -209,7 +210,10 @@ public class ConsentServiceMockTest {
         verify(sendMailService).sendEmail(emailCaptor.capture());
         
         // We notify the study administrator and send a copy to the user.
-        Set<String> recipients = emailCaptor.getValue().getRecipientEmails();
+        BasicEmailProvider email = emailCaptor.getValue();
+        assertEquals(EmailType.SIGN_CONSENT, email.getType());
+
+        Set<String> recipients = email.getRecipientEmails();
         assertEquals(2, recipients.size());
         assertTrue(recipients.contains(study.getConsentNotificationEmail()));
         assertTrue(recipients.contains(PARTICIPANT.getEmail()));
@@ -222,8 +226,10 @@ public class ConsentServiceMockTest {
         consentService.resendConsentAgreement(study, SUBPOP_GUID, PARTICIPANT);
         
         verify(sendMailService).sendEmail(emailCaptor.capture());
-        assertEquals(1, emailCaptor.getValue().getRecipientEmails().size());
-        assertTrue(emailCaptor.getValue().getRecipientEmails().contains(PARTICIPANT.getEmail()));
+        BasicEmailProvider email = emailCaptor.getValue();
+        assertEquals(1, email.getRecipientEmails().size());
+        assertTrue(email.getRecipientEmails().contains(PARTICIPANT.getEmail()));
+        assertEquals(EmailType.RESEND_CONSENT, email.getType());
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
@@ -80,6 +80,7 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
 import org.sagebionetworks.bridge.models.upload.UploadFieldType;
 import org.sagebionetworks.bridge.services.email.BasicEmailProvider;
+import org.sagebionetworks.bridge.services.email.EmailType;
 import org.sagebionetworks.bridge.services.email.MimeTypeEmail;
 import org.sagebionetworks.bridge.validators.StudyValidator;
 
@@ -288,6 +289,7 @@ public class StudyServiceMockTest {
         verify(sendMailService).sendEmail(emailProviderCaptor.capture());
 
         MimeTypeEmail email = emailProviderCaptor.getValue().getMimeTypeEmail();
+        assertEquals(EmailType.VERIFY_CONSENT_EMAIL, email.getType());
         String body = (String) email.getMessageParts().get(0).getContent();
 
         assertTrue(body.contains("/vse?study="+ TEST_STUDY_ID + "&token=" +

--- a/test/org/sagebionetworks/bridge/services/email/BasicEmailProviderTest.java
+++ b/test/org/sagebionetworks/bridge/services/email/BasicEmailProviderTest.java
@@ -41,10 +41,13 @@ public class BasicEmailProviderTest {
             .withRecipientEmail("recipient2@recipient.com")
             .withEmailTemplate(template)
             .withExpirationPeriod("expirationPeriod", 60*60)
-            .withToken("url", "some-url").build();
+            .withToken("url", "some-url")
+            .withType(EmailType.EMAIL_SIGN_IN)
+            .build();
 
         // Check provider attributes
         assertEquals("Name <support@email.com>", provider.getFormattedSenderEmail());
+        assertEquals(EmailType.EMAIL_SIGN_IN, provider.getType());
 
         // Check email
         MimeTypeEmail email = provider.getMimeTypeEmail();
@@ -52,8 +55,9 @@ public class BasicEmailProviderTest {
         assertEquals("\"Name\" <support@email.com>", email.getSenderAddress());
         assertEquals(Sets.newHashSet("recipient@recipient.com", "recipient2@recipient.com"),
                 Sets.newHashSet(email.getRecipientAddresses()));
+        assertEquals(EmailType.EMAIL_SIGN_IN, email.getType());
+
         MimeBodyPart body = email.getMessageParts().get(0);
-        
         String bodyString = (String)body.getContent();
         assertEquals("Name ShortName id SponsorName support@email.com tech@email.com consent@email.com some-url 1 hour", 
                 bodyString);

--- a/test/org/sagebionetworks/bridge/services/email/MimeTypeEmailTest.java
+++ b/test/org/sagebionetworks/bridge/services/email/MimeTypeEmailTest.java
@@ -3,30 +3,45 @@ package org.sagebionetworks.bridge.services.email;
 import static org.junit.Assert.assertEquals;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeBodyPart;
 
+import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 
-import com.google.common.collect.Lists;
-
 public class MimeTypeEmailTest {
+    private static final String SUBJECT = "subject";
 
-    private MimeTypeEmail makeEmailWithSender(String sender) throws MessagingException {
-        MimeBodyPart bodyPart = new MimeBodyPart();
-        bodyPart.setText("", StandardCharsets.UTF_8.name(), "text/plain");
+    private static MimeTypeEmail makeEmailWithSender(String sender) throws MessagingException {
         String recipient = "bridge-testing@sagebase.org";
-        return new MimeTypeEmail("subject", sender, Lists.<String> newArrayList(recipient), Lists.<MimeBodyPart> newArrayList(bodyPart));
+        return new MimeTypeEmailBuilder().withSubject(SUBJECT).withSender(sender).withRecipient(recipient)
+                .withMessageParts(makeBodyPart("dummy content")).withType(EmailType.EMAIL_SIGN_IN).build();
     }
     
-    private MimeTypeEmail makeEmailWithRecipient(String recipient) throws MessagingException {
-        MimeBodyPart bodyPart = new MimeBodyPart();
-        bodyPart.setText("", StandardCharsets.UTF_8.name(), "text/plain");
+    private static MimeTypeEmail makeEmailWithRecipient(String recipient) throws MessagingException {
         String sender = "bridge-testing@sagebase.org";
-        return new MimeTypeEmail("subject", sender, Lists.<String> newArrayList(recipient), Lists.<MimeBodyPart> newArrayList(bodyPart));
+        return new MimeTypeEmailBuilder().withSubject(SUBJECT).withSender(sender).withRecipient(recipient)
+                .withMessageParts(makeBodyPart("dummy content")).withType(EmailType.EMAIL_SIGN_IN).build();
     }
-    
+
+    private static MimeBodyPart makeBodyPart(String content) throws MessagingException {
+        MimeBodyPart bodyPart = new MimeBodyPart();
+        bodyPart.setText(content, StandardCharsets.UTF_8.name(), "text/plain");
+        return bodyPart;
+    }
+
+    @Test
+    public void testAttributes() throws Exception {
+        MimeTypeEmail email = makeEmailWithSender("test@example.com");
+        assertEquals(SUBJECT, email.getSubject());
+        assertEquals(EmailType.EMAIL_SIGN_IN, email.getType());
+
+        assertEquals(1, email.getMessageParts().size());
+        assertEquals("dummy content", email.getMessageParts().get(0).getContent());
+    }
+
     @Test
     public void senderUnadornedEmailNotChanged() throws Exception {
         MimeTypeEmail email = makeEmailWithSender("test@test.com");
@@ -67,5 +82,44 @@ public class MimeTypeEmailTest {
     public void recipientAddressWithNameWithQuotesItsAllQuoted() throws Exception {
         MimeTypeEmail email = makeEmailWithRecipient("The \"Fun Guys\" at UofW <test@test.com>");
         assertEquals("\"The \\\"Fun Guys\\\" at UofW\" <test@test.com>", email.getRecipientAddresses().get(0));
+    }
+
+    @Test
+    public void multipleRecipients() throws Exception {
+        List<String> recipientList = ImmutableList.of("recipient1@example.com", "recipient2@example.com",
+                "recipient3@example.com");
+        MimeTypeEmail email = new MimeTypeEmailBuilder().withSubject(SUBJECT).withSender("sender@example.com")
+                .withRecipients(recipientList).withMessageParts(makeBodyPart("dummy content"))
+                .withType(EmailType.EMAIL_SIGN_IN).build();
+        assertEquals(recipientList, email.getRecipientAddresses());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void filterOutNullMessagePartVarargs() {
+        // This will throw an IllegalArgumentException, since we don't allow null message parts list.
+        new MimeTypeEmailBuilder().withSubject(SUBJECT).withSender("sender@example.com")
+                .withRecipient("recipient@example.com").withMessageParts((MimeBodyPart[]) null)
+                .withType(EmailType.EMAIL_SIGN_IN).build();
+    }
+
+    @Test
+    public void filterOutNullMessageParts() throws Exception {
+        MimeTypeEmail email = new MimeTypeEmailBuilder().withSubject(SUBJECT).withSender("sender@example.com")
+                .withRecipient("recipient@example.com")
+                .withMessageParts(null, makeBodyPart("foo"), null, makeBodyPart("bar"), null)
+                .withType(EmailType.EMAIL_SIGN_IN).build();
+
+        List<MimeBodyPart> partList = email.getMessageParts();
+        assertEquals(2, partList.size());
+        assertEquals("foo", partList.get(0).getContent());
+        assertEquals("bar", partList.get(1).getContent());
+    }
+
+    @Test
+    public void defaultType() throws Exception {
+        MimeTypeEmail email = new MimeTypeEmailBuilder().withSubject(SUBJECT).withSender("sender@example.com")
+                .withRecipient("recipient@example.com").withMessageParts(makeBodyPart("dummy content"))
+                .withType(null).build();
+        assertEquals(EmailType.UNKNOWN, email.getType());
     }
 }

--- a/test/org/sagebionetworks/bridge/services/email/WithdrawConsentEmailProviderTest.java
+++ b/test/org/sagebionetworks/bridge/services/email/WithdrawConsentEmailProviderTest.java
@@ -45,6 +45,7 @@ public class WithdrawConsentEmailProviderTest {
 
         provider = new WithdrawConsentEmailProvider(study, null, account, new Withdrawal(null), UNIX_TIMESTAMP);
         MimeTypeEmail email = provider.getMimeTypeEmail();
+        assertEquals(EmailType.WITHDRAW_CONSENT, email.getType());
         
         List<String> recipients = email.getRecipientAddresses();
         assertEquals(1, recipients.size());
@@ -70,7 +71,8 @@ public class WithdrawConsentEmailProviderTest {
 
         provider = new WithdrawConsentEmailProvider(study, EXTERNAL_ID, account, WITHDRAWAL, UNIX_TIMESTAMP);
         MimeTypeEmail email = provider.getMimeTypeEmail();
-        
+        assertEquals(EmailType.WITHDRAW_CONSENT, email.getType());
+
         List<String> recipients = email.getRecipientAddresses();
         assertEquals(2, recipients.size());
         assertEquals("a@a.com", recipients.get(0));


### PR DESCRIPTION
Contains the following changes:
* Adds Request ID to ThreadLocal storage. This allows us to tie certain log messages to MetricsInterceptor logs. Currently used by the SendMailService to track which requests send which emails.
* Adds the EmailType enum and plumbs it through all relevant classes. Used so we can easily determine the type of each email sent.
* Reduce email throttling from 2 per 5 min to 1 per 5 min. This reduces the number of duplicate emails and reduces the chance of users marking multiple emails as spam.

Testing done:
* Updated unit tests.
* Ran integ tests (no changes, mainly as a sanity test).
* Manually tested each email type and verified logs.