### PR TITLE
Do not check external ID exists if createParticipant includes a participant with roles.

### DIFF
--- a/app/org/sagebionetworks/bridge/DefaultStudyBootstrapper.java
+++ b/app/org/sagebionetworks/bridge/DefaultStudyBootstrapper.java
@@ -21,7 +21,7 @@ public class DefaultStudyBootstrapper {
     /**
      * The data group set in the test (api) study. This includes groups that are required for the SDK integration tests.
      */
-    public static final Set<String> TEST_DATA_GROUPS = Sets.newHashSet("sdk-int-1", "sdk-int-2", "group1");
+    public static final Set<String> TEST_DATA_GROUPS = Sets.newHashSet("sdk-int-1", "sdk-int-2", "group1", BridgeConstants.TEST_USER_GROUP);
 
     /**
      * The task identifiers set in the test (api) study. This includes task identifiers that are required for the SDK

--- a/app/org/sagebionetworks/bridge/Roles.java
+++ b/app/org/sagebionetworks/bridge/Roles.java
@@ -10,7 +10,6 @@ public enum Roles {
     DEVELOPER,
     RESEARCHER,
     ADMIN,
-    TEST_USERS,
     WORKER;
     
     /**
@@ -29,6 +28,5 @@ public enum Roles {
         .put(WORKER, EnumSet.of(ADMIN))
         .put(RESEARCHER, EnumSet.of(ADMIN, RESEARCHER))
         .put(DEVELOPER, EnumSet.of(ADMIN, RESEARCHER, DEVELOPER))
-        .put(TEST_USERS, EnumSet.of(ADMIN, RESEARCHER, DEVELOPER))
         .build();
 }

--- a/app/org/sagebionetworks/bridge/services/StudyService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyService.java
@@ -375,7 +375,7 @@ public class StudyService {
 
         // validate roles for each user
         for (StudyParticipant user: users) {
-            if (!Collections.disjoint(user.getRoles(), ImmutableSet.of(Roles.ADMIN, Roles.TEST_USERS, Roles.WORKER))) {
+            if (!Collections.disjoint(user.getRoles(), ImmutableSet.of(Roles.ADMIN, Roles.WORKER))) {
                 throw new BadRequestException("User can only have roles developer and/or researcher.");
             }
             if (user.getRoles().isEmpty()) {

--- a/app/org/sagebionetworks/bridge/validators/StudyParticipantValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/StudyParticipantValidator.java
@@ -54,7 +54,10 @@ public class StudyParticipantValidator implements Validator {
             if (email != null && !EMAIL_VALIDATOR.isValid(email)) {
                 errors.rejectValue("email", "does not appear to be an email address");
             }
-            if (study.isExternalIdRequiredOnSignup() && isBlank(participant.getExternalId())) {
+            // External ID is required for non-administrative accounts when it is required on sign-up. Whether you're 
+            // a researcher or not, however, if you add an external ID and we're managing them, we're going to validate
+            // that yours is correct.
+            if (participant.getRoles().isEmpty() && study.isExternalIdRequiredOnSignup() && isBlank(participant.getExternalId())) {
                 errors.rejectValue("externalId", "is required");
             }
             // Password is optional, but validation is applied if supplied, any time it is 

--- a/test/org/sagebionetworks/bridge/TestUserAdminHelper.java
+++ b/test/org/sagebionetworks/bridge/TestUserAdminHelper.java
@@ -1,9 +1,9 @@
 package org.sagebionetworks.bridge;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.sagebionetworks.bridge.Roles.TEST_USERS;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -165,7 +165,6 @@ public class TestUserAdminHelper {
         }
         public Builder withRoles(Roles... roles) {
             this.roles = Sets.newHashSet(roles);
-            this.roles.add(TEST_USERS);
             return this;
         }
         public Builder withDataGroups(Set<String> dataGroups) {
@@ -191,6 +190,13 @@ public class TestUserAdminHelper {
             Study finalStudy = (study == null) ? studyService.getStudy(TEST_STUDY_IDENTIFIER) : study;
             String finalEmail = (email == null) ? TestUtils.makeRandomTestEmail(cls) : email;
             String finalPassword = (password == null) ? PASSWORD : password;
+            
+            // Add the "test_user" data group to all test users.
+            if (dataGroups == null) {
+                dataGroups = new HashSet<String>();
+            }
+            dataGroups.add(BridgeConstants.TEST_USER_GROUP);
+            
             StudyParticipant finalParticipant = new StudyParticipant.Builder().withEmail(finalEmail)
                     .withPassword(finalPassword).withRoles(roles).withLanguages(languages).withDataGroups(dataGroups)
                     .build();

--- a/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
+++ b/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
@@ -1633,7 +1633,7 @@ public class HibernateAccountDaoTest {
         genericAccount.setReauthTokenAlgorithm(PasswordAlgorithm.DEFAULT_PASSWORD_ALGORITHM);
         genericAccount.setReauthTokenHash(DUMMY_REAUTH_TOKEN_HASH);
         genericAccount.setReauthTokenModifiedOn(CREATED_ON.getMillis());
-        genericAccount.setRoles(EnumSet.of(Roles.DEVELOPER, Roles.TEST_USERS));
+        genericAccount.setRoles(EnumSet.of(Roles.DEVELOPER, Roles.RESEARCHER));
         genericAccount.setStatus(AccountStatus.ENABLED);
         genericAccount.setClientData(TestUtils.getClientData());
         genericAccount.setVersion(VERSION);
@@ -1690,7 +1690,7 @@ public class HibernateAccountDaoTest {
         assertEquals(PasswordAlgorithm.DEFAULT_PASSWORD_ALGORITHM, hibernateAccount.getReauthTokenAlgorithm());
         assertEquals(DUMMY_REAUTH_TOKEN_HASH, hibernateAccount.getReauthTokenHash());
         assertEquals(new Long(CREATED_ON.getMillis()), hibernateAccount.getReauthTokenModifiedOn());
-        assertEquals(EnumSet.of(Roles.DEVELOPER, Roles.TEST_USERS), hibernateAccount.getRoles());
+        assertEquals(EnumSet.of(Roles.DEVELOPER, Roles.RESEARCHER), hibernateAccount.getRoles());
         assertEquals(AccountStatus.ENABLED, hibernateAccount.getStatus());
         assertEquals(TestUtils.getClientData().toString(), hibernateAccount.getClientData());
         assertEquals(VERSION, hibernateAccount.getVersion());
@@ -1758,7 +1758,7 @@ public class HibernateAccountDaoTest {
         hibernateAccount.setReauthTokenAlgorithm(PasswordAlgorithm.DEFAULT_PASSWORD_ALGORITHM);
         hibernateAccount.setReauthTokenHash(DUMMY_REAUTH_TOKEN_HASH);
         hibernateAccount.setReauthTokenModifiedOn(CREATED_ON.getMillis());
-        hibernateAccount.setRoles(EnumSet.of(Roles.DEVELOPER, Roles.TEST_USERS));
+        hibernateAccount.setRoles(EnumSet.of(Roles.DEVELOPER, Roles.RESEARCHER));
         hibernateAccount.setStatus(AccountStatus.ENABLED);
         hibernateAccount.setClientData(TestUtils.getClientData().toString());
         hibernateAccount.setVersion(VERSION);
@@ -1832,7 +1832,7 @@ public class HibernateAccountDaoTest {
         assertEquals(PasswordAlgorithm.DEFAULT_PASSWORD_ALGORITHM, genericAccount.getReauthTokenAlgorithm());
         assertEquals(DUMMY_REAUTH_TOKEN_HASH, genericAccount.getReauthTokenHash());
         assertEquals(new Long(CREATED_ON.getMillis()), genericAccount.getReauthTokenModifiedOn());
-        assertEquals(EnumSet.of(Roles.DEVELOPER, Roles.TEST_USERS), genericAccount.getRoles());
+        assertEquals(EnumSet.of(Roles.DEVELOPER, Roles.RESEARCHER), genericAccount.getRoles());
         assertEquals(AccountStatus.ENABLED, genericAccount.getStatus());
         assertEquals(TestUtils.getClientData(), genericAccount.getClientData());
         assertEquals(VERSION, genericAccount.getVersion());

--- a/test/org/sagebionetworks/bridge/json/JsonUtilsTest.java
+++ b/test/org/sagebionetworks/bridge/json/JsonUtilsTest.java
@@ -3,7 +3,6 @@ package org.sagebionetworks.bridge.json;
 import static org.junit.Assert.*;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
-import static org.sagebionetworks.bridge.Roles.TEST_USERS;
 
 import java.util.Set;
 
@@ -230,9 +229,9 @@ public class JsonUtilsTest {
 
     @Test
     public void asRolesSet() throws Exception {
-        Set<Roles> set = Sets.newHashSet(ADMIN, RESEARCHER, TEST_USERS);
+        Set<Roles> set = Sets.newHashSet(ADMIN, RESEARCHER);
         
-        JsonNode node = mapper.readTree(esc("{'key':['admin','researcher','test_users']}"));
+        JsonNode node = mapper.readTree(esc("{'key':['admin','researcher']}"));
 
         assertEquals(Sets.newHashSet(), JsonUtils.asRolesSet(node, null));
         assertEquals(Sets.newHashSet(), JsonUtils.asRolesSet(node, "badProp"));

--- a/test/org/sagebionetworks/bridge/models/accounts/GenericAccountTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/GenericAccountTest.java
@@ -128,17 +128,17 @@ public class GenericAccountTest {
         // Initially empty.
         GenericAccount account = new GenericAccount();
         assertTrue(account.getRoles().isEmpty());
-        TestUtils.assertSetIsImmutable(account.getRoles(), Roles.TEST_USERS);
+        TestUtils.assertSetIsImmutable(account.getRoles(), Roles.DEVELOPER);
 
         // Set works.
         account.setRoles(EnumSet.of(Roles.ADMIN, Roles.DEVELOPER));
         assertEquals(EnumSet.of(Roles.ADMIN, Roles.DEVELOPER), account.getRoles());
-        TestUtils.assertSetIsImmutable(account.getRoles(), Roles.TEST_USERS);
+        TestUtils.assertSetIsImmutable(account.getRoles(), Roles.DEVELOPER);
 
         // Setting to null makes it an empty set.
         account.setRoles(null);
         assertTrue(account.getRoles().isEmpty());
-        TestUtils.assertSetIsImmutable(account.getRoles(), Roles.TEST_USERS);
+        TestUtils.assertSetIsImmutable(account.getRoles(), Roles.DEVELOPER);
 
         // Set to non-empty, then set to empty and verify that it works.
         account.setRoles(EnumSet.of(Roles.RESEARCHER));
@@ -146,7 +146,7 @@ public class GenericAccountTest {
 
         account.setRoles(EnumSet.noneOf(Roles.class));
         assertTrue(account.getRoles().isEmpty());
-        TestUtils.assertSetIsImmutable(account.getRoles(), Roles.TEST_USERS);
+        TestUtils.assertSetIsImmutable(account.getRoles(), Roles.DEVELOPER);
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
@@ -343,7 +343,8 @@ public class AuthenticationServiceTest {
                 .withDataGroups(DefaultStudyBootstrapper.TEST_DATA_GROUPS).build();
 
         UserSession session = authService.signIn(testUser.getStudy(), TEST_CONTEXT, testUser.getSignIn());
-        // Verify we created a list and the anticipated group was not null
+        // Verify we created a list and the anticipated group was not null; the test user will 
+        // have one extra data group, because "test_user" is added to each user.
         assertEquals(numOfGroups, session.getParticipant().getDataGroups().size()); 
         assertEquals(DefaultStudyBootstrapper.TEST_DATA_GROUPS, session.getParticipant().getDataGroups());
     }

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -1352,6 +1352,16 @@ public class ParticipantServiceTest {
         mockHealthCodeAndAccountRetrieval();
         STUDY.setExternalIdRequiredOnSignup(true);
         
+        StudyParticipant participant = new StudyParticipant.Builder().copyOf(PARTICIPANT).withRoles(Sets.newHashSet())
+                .withExternalId(null).build();
+        
+        participantService.createParticipant(STUDY, CALLER_ROLES, participant, false);
+    }
+
+    public void createRequiredExternalIdWithRolesOK() {
+        mockHealthCodeAndAccountRetrieval();
+        STUDY.setExternalIdRequiredOnSignup(true);
+        
         StudyParticipant participant = new StudyParticipant.Builder().copyOf(PARTICIPANT).withExternalId(null).build();
         
         participantService.createParticipant(STUDY, CALLER_ROLES, participant, false);

--- a/test/org/sagebionetworks/bridge/validators/StudyParticipantValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/StudyParticipantValidatorTest.java
@@ -13,6 +13,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.models.accounts.ExternalIdentifier;
@@ -287,6 +288,17 @@ public class StudyParticipantValidatorTest {
         
         validator = new StudyParticipantValidator(externalIdService, study, true);
         assertValidatorMessage(validator, participant, "externalId", "is required");
+    }
+    @Test
+    public void createWithoutExternalIdManagedButHasRolesOK() {
+        study.setExternalIdValidationEnabled(true);
+        study.setExternalIdRequiredOnSignup(true);
+        
+        StudyParticipant participant = new StudyParticipant.Builder().withEmail("email@email.com")
+                .withRoles(Sets.newHashSet(Roles.DEVELOPER)).build();
+        
+        validator = new StudyParticipantValidator(externalIdService, study, true);
+        Validate.entityThrowingException(validator, participant);
     }
     @Test
     public void createWithoutExternalIdUnmanagedOk() {


### PR DESCRIPTION
This is pretty simple to manage through the validator.