### PR TITLE
Add survey identifiers to survey references in an app config

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/SurveyDao.java
+++ b/app/org/sagebionetworks/bridge/dao/SurveyDao.java
@@ -60,7 +60,7 @@ public interface SurveyDao {
     void deleteSurveyPermanently(GuidCreatedOnVersionHolder keys);
 
     /**
-     * Get a specific version of a survey with its elements.
+     * Get a specific version of a survey with or without its elements.
      */
     Survey getSurvey(GuidCreatedOnVersionHolder keys, boolean includeElements);
     
@@ -77,8 +77,8 @@ public interface SurveyDao {
     Survey getSurveyMostRecentVersion(StudyIdentifier studyIdentifier, String guid);
     
     /**
-     * Get the most recent version of a survey that is published. More recent, unpublished 
-     * versions of the survey will be ignored. 
+     * Get the most recent version of a survey that is published, with or without its elements. 
+     * More recent, unpublished versions of the survey will be ignored. 
      */
     Survey getSurveyMostRecentlyPublishedVersion(StudyIdentifier studyIdentifier, String guid, boolean includeElements);
     

--- a/app/org/sagebionetworks/bridge/dao/SurveyDao.java
+++ b/app/org/sagebionetworks/bridge/dao/SurveyDao.java
@@ -60,9 +60,9 @@ public interface SurveyDao {
     void deleteSurveyPermanently(GuidCreatedOnVersionHolder keys);
 
     /**
-     * Get a specific version of a survey.
+     * Get a specific version of a survey with its elements.
      */
-    Survey getSurvey(GuidCreatedOnVersionHolder keys);
+    Survey getSurvey(GuidCreatedOnVersionHolder keys, boolean includeElements);
     
     /**
      * Get all versions of a specific survey, ordered by most recent version 
@@ -80,7 +80,7 @@ public interface SurveyDao {
      * Get the most recent version of a survey that is published. More recent, unpublished 
      * versions of the survey will be ignored. 
      */
-    Survey getSurveyMostRecentlyPublishedVersion(StudyIdentifier studyIdentifier, String guid);
+    Survey getSurveyMostRecentlyPublishedVersion(StudyIdentifier studyIdentifier, String guid, boolean includeElements);
     
     /**
      * Get the most recent version of each survey in the study, that has been published. 

--- a/app/org/sagebionetworks/bridge/play/controllers/SurveyController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/SurveyController.java
@@ -119,7 +119,7 @@ public class SurveyController extends BaseController {
     private Result getSurveyForWorker(String surveyGuid, String createdOnString) {
         long createdOn = DateUtils.convertToMillisFromEpoch(createdOnString);
         GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl(surveyGuid, createdOn);
-        Survey survey = surveyService.getSurvey(keys);
+        Survey survey = surveyService.getSurvey(keys, true);
         return okResult(survey);
     }
 
@@ -245,7 +245,7 @@ public class SurveyController extends BaseController {
         long createdOn = DateUtils.convertToMillisFromEpoch(createdOnString);
         GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl(surveyGuid, createdOn);
         
-        Survey survey = surveyService.getSurvey(keys);
+        Survey survey = surveyService.getSurvey(keys, true);
         verifySurveyIsInStudy(session, survey);
         return survey;
     }
@@ -258,7 +258,7 @@ public class SurveyController extends BaseController {
                 session.getStudyIdentifier().getIdentifier());
         
         String json = getView(cacheKey, session, () -> {
-            return surveyService.getSurvey(keys);
+            return surveyService.getSurvey(keys, true);
         });
 
         return ok(json).as(JSON_MIME_TYPE);
@@ -269,7 +269,7 @@ public class SurveyController extends BaseController {
                 session.getStudyIdentifier().getIdentifier());
         
         String json = getView(cacheKey, session, () -> {
-            return surveyService.getSurveyMostRecentlyPublishedVersion(session.getStudyIdentifier(), surveyGuid);
+            return surveyService.getSurveyMostRecentlyPublishedVersion(session.getStudyIdentifier(), surveyGuid, true);
         });
         
         return ok(json).as(JSON_MIME_TYPE);

--- a/app/org/sagebionetworks/bridge/services/AppConfigService.java
+++ b/app/org/sagebionetworks/bridge/services/AppConfigService.java
@@ -108,13 +108,16 @@ public class AppConfigService {
         return matched;
     }
 
+    // Survey and schema references in an app config are "hard" references... they must reference a 
+    // version or createdOn timestamp of a version and this has been validated when creating/
+    // updating the reference. We're only concerned with adding survey identifier here.
     SurveyReference resolveSurvey(SurveyReference surveyRef) {
-        GuidCreatedOnVersionHolder surveyKeys = new GuidCreatedOnVersionHolderImpl(surveyRef);
-        // Survey references can be bogus, and should be return unmodified if they don't reference an existing survey
         try {
-            Survey survey = surveyService.getSurvey(surveyKeys);
+            GuidCreatedOnVersionHolder surveyKeys = new GuidCreatedOnVersionHolderImpl(surveyRef);
+            Survey survey = surveyService.getSurvey(surveyKeys, false);
             return new SurveyReference(survey.getIdentifier(), survey.getGuid(), new DateTime(survey.getCreatedOn()));
         } catch(EntityNotFoundException e) {
+            // Survey references can be bogus, and should be return unmodified if they don't reference an existing survey
             return surveyRef;
         }
     }
@@ -128,7 +131,7 @@ public class AppConfigService {
         Study study = studyService.getStudy(studyId);
         Validator validator = new AppConfigValidator(study.getDataGroups(), true);
         Validate.entityThrowingException(validator, appConfig);
-        
+
         long timestamp = getCurrentTimestamp();
 
         DynamoAppConfig newAppConfig = new DynamoAppConfig();

--- a/app/org/sagebionetworks/bridge/services/AppConfigService.java
+++ b/app/org/sagebionetworks/bridge/services/AppConfigService.java
@@ -112,6 +112,9 @@ public class AppConfigService {
     // version or createdOn timestamp of a version and this has been validated when creating/
     // updating the reference. We're only concerned with adding survey identifier here.
     SurveyReference resolveSurvey(SurveyReference surveyRef) {
+        if (surveyRef.getIdentifier() != null) {
+            return surveyRef;
+        }
         try {
             GuidCreatedOnVersionHolder surveyKeys = new GuidCreatedOnVersionHolderImpl(surveyRef);
             Survey survey = surveyService.getSurvey(surveyKeys, false);

--- a/app/org/sagebionetworks/bridge/services/AppConfigService.java
+++ b/app/org/sagebionetworks/bridge/services/AppConfigService.java
@@ -108,9 +108,11 @@ public class AppConfigService {
         return matched;
     }
 
-    // Survey and schema references in an app config are "hard" references... they must reference a 
-    // version or createdOn timestamp of a version and this has been validated when creating/
-    // updating the reference. We're only concerned with adding survey identifier here.
+    /**
+     * Survey and schema references in an AppConfig are "hard" references... they must reference a
+     * specific version or createdOn timestamp of a version, and we validate this when creating/
+     * updating the app config. We're only concerned with adding the survey identifier here.
+     */
     SurveyReference resolveSurvey(SurveyReference surveyRef) {
         if (surveyRef.getIdentifier() != null) {
             return surveyRef;
@@ -120,7 +122,8 @@ public class AppConfigService {
             Survey survey = surveyService.getSurvey(surveyKeys, false);
             return new SurveyReference(survey.getIdentifier(), survey.getGuid(), new DateTime(survey.getCreatedOn()));
         } catch(EntityNotFoundException e) {
-            // Survey references can be bogus, and should be return unmodified if they don't reference an existing survey
+            // Survey references can be bogus or orphaned, and should be return unmodified if they don't reference
+            // an existing survey
             return surveyRef;
         }
     }

--- a/app/org/sagebionetworks/bridge/services/HealthDataService.java
+++ b/app/org/sagebionetworks/bridge/services/HealthDataService.java
@@ -197,7 +197,7 @@ public class HealthDataService {
             // specified.
             String surveyGuid = healthDataSubmission.getSurveyGuid();
             Survey survey = surveyService.getSurvey(new GuidCreatedOnVersionHolderImpl(surveyGuid,
-                    surveyCreatedOnMillis));
+                    surveyCreatedOnMillis), false);
             String schemaId = survey.getIdentifier();
             Integer schemaRev = survey.getSchemaRevision();
             if (StringUtils.isBlank(schemaId) || schemaRev == null) {

--- a/app/org/sagebionetworks/bridge/services/HealthDataService.java
+++ b/app/org/sagebionetworks/bridge/services/HealthDataService.java
@@ -14,6 +14,7 @@ import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.NotFoundException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolder;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolderImpl;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.healthdata.HealthDataRecord;
@@ -196,8 +197,8 @@ public class HealthDataService {
             // Get survey. We use the survey identifier as the schema ID and the schema revision. Both of these must be
             // specified.
             String surveyGuid = healthDataSubmission.getSurveyGuid();
-            Survey survey = surveyService.getSurvey(new GuidCreatedOnVersionHolderImpl(surveyGuid,
-                    surveyCreatedOnMillis), false);
+            GuidCreatedOnVersionHolder surveyKeys = new GuidCreatedOnVersionHolderImpl(surveyGuid, surveyCreatedOnMillis);
+            Survey survey = surveyService.getSurvey(surveyKeys, false);
             String schemaId = survey.getIdentifier();
             Integer schemaRev = survey.getSchemaRevision();
             if (StringUtils.isBlank(schemaId) || schemaRev == null) {

--- a/app/org/sagebionetworks/bridge/services/ReferenceResolver.java
+++ b/app/org/sagebionetworks/bridge/services/ReferenceResolver.java
@@ -102,7 +102,7 @@ class ReferenceResolver {
         }
     }
     // Helper method to resolve a compound activity reference from its definition.
-    CompoundActivity resolveCompoundActivity(CompoundActivity compoundActivity) {
+    private CompoundActivity resolveCompoundActivity(CompoundActivity compoundActivity) {
         String taskId = compoundActivity.getTaskIdentifier();
         
         CompoundActivity resolvedCompoundActivity = compoundActivityCache.get(taskId);
@@ -133,7 +133,7 @@ class ReferenceResolver {
     }
 
     // Helper method to resolve schema refs and survey refs inside of a compound activity.
-    CompoundActivity resolveListsInCompoundActivity(CompoundActivity compoundActivity) {
+    private CompoundActivity resolveListsInCompoundActivity(CompoundActivity compoundActivity) {
         // Resolve schemas.
         // Lists in CompoundActivity are always non-null, so we don't need to null-check.
         List<SchemaReference> schemaList = new ArrayList<>();
@@ -162,7 +162,7 @@ class ReferenceResolver {
     }
 
     // Helper method to resolve a schema ref to the latest revision for the client.
-    SchemaReference resolveSchema(SchemaReference schemaRef) {
+    private SchemaReference resolveSchema(SchemaReference schemaRef) {
         if (schemaRef.getRevision() != null) {
             // Already has a revision. No need to resolve. Return as is.
             return schemaRef;

--- a/app/org/sagebionetworks/bridge/services/ReferenceResolver.java
+++ b/app/org/sagebionetworks/bridge/services/ReferenceResolver.java
@@ -201,7 +201,7 @@ class ReferenceResolver {
         if (resolvedSurveyRef == null) {
             Survey survey;
             try {
-                survey = surveyService.getSurveyMostRecentlyPublishedVersion(studyId, surveyGuid);
+                survey = surveyService.getSurveyMostRecentlyPublishedVersion(studyId, surveyGuid, false);
             } catch (EntityNotFoundException ex) {
                 LOG.error("Schedule references non-existent survey " + surveyGuid);
                 return null;

--- a/app/org/sagebionetworks/bridge/services/ReferenceResolver.java
+++ b/app/org/sagebionetworks/bridge/services/ReferenceResolver.java
@@ -102,7 +102,7 @@ class ReferenceResolver {
         }
     }
     // Helper method to resolve a compound activity reference from its definition.
-    private CompoundActivity resolveCompoundActivity(CompoundActivity compoundActivity) {
+    CompoundActivity resolveCompoundActivity(CompoundActivity compoundActivity) {
         String taskId = compoundActivity.getTaskIdentifier();
         
         CompoundActivity resolvedCompoundActivity = compoundActivityCache.get(taskId);
@@ -133,7 +133,7 @@ class ReferenceResolver {
     }
 
     // Helper method to resolve schema refs and survey refs inside of a compound activity.
-    private CompoundActivity resolveListsInCompoundActivity(CompoundActivity compoundActivity) {
+    CompoundActivity resolveListsInCompoundActivity(CompoundActivity compoundActivity) {
         // Resolve schemas.
         // Lists in CompoundActivity are always non-null, so we don't need to null-check.
         List<SchemaReference> schemaList = new ArrayList<>();
@@ -162,7 +162,7 @@ class ReferenceResolver {
     }
 
     // Helper method to resolve a schema ref to the latest revision for the client.
-    private SchemaReference resolveSchema(SchemaReference schemaRef) {
+    SchemaReference resolveSchema(SchemaReference schemaRef) {
         if (schemaRef.getRevision() != null) {
             // Already has a revision. No need to resolve. Return as is.
             return schemaRef;
@@ -188,8 +188,8 @@ class ReferenceResolver {
     }
 
     // Helper method to resolve a published survey to a specific survey version.
-    private SurveyReference resolveSurvey(SurveyReference surveyRef) {
-        if (surveyRef.getCreatedOn() != null) {
+    SurveyReference resolveSurvey(SurveyReference surveyRef) {
+        if (surveyRef.getCreatedOn() != null && surveyRef.getIdentifier() != null) {
             return surveyRef;
         }
 

--- a/app/org/sagebionetworks/bridge/services/SchedulePlanService.java
+++ b/app/org/sagebionetworks/bridge/services/SchedulePlanService.java
@@ -160,12 +160,12 @@ public class SchedulePlanService {
             SurveyReference ref = activity.getSurvey();
             
             if (ref.getCreatedOn() == null) { // pointer to most recently published survey
-                Survey survey = surveyService.getSurveyMostRecentlyPublishedVersion(studyId, ref.getGuid());
+                Survey survey = surveyService.getSurveyMostRecentlyPublishedVersion(studyId, ref.getGuid(), false);
                 return new Activity.Builder().withActivity(activity)
                         .withPublishedSurvey(survey.getIdentifier(), survey.getGuid()).build();
             } else {
                 GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl(ref.getGuid(), ref.getCreatedOn().getMillis());
-                Survey survey = surveyService.getSurvey(keys);
+                Survey survey = surveyService.getSurvey(keys, false);
                 return new Activity.Builder().withActivity(activity)
                         .withSurvey(survey.getIdentifier(), ref.getGuid(), ref.getCreatedOn()).build();
             }

--- a/app/org/sagebionetworks/bridge/services/SharedModuleMetadataService.java
+++ b/app/org/sagebionetworks/bridge/services/SharedModuleMetadataService.java
@@ -94,7 +94,7 @@ public class SharedModuleMetadataService {
             long createdOn = metadata.getSurveyCreatedOn();
 
             try {
-                surveyService.getSurvey(new GuidCreatedOnVersionHolderImpl(surveyGuid, createdOn));
+                surveyService.getSurvey(new GuidCreatedOnVersionHolderImpl(surveyGuid, createdOn), false);
             } catch (EntityNotFoundException e) {
                 throw new BadRequestException("Survey " + surveyGuid + " referred does not exist.");
             }

--- a/app/org/sagebionetworks/bridge/services/SharedModuleService.java
+++ b/app/org/sagebionetworks/bridge/services/SharedModuleService.java
@@ -120,7 +120,7 @@ public class SharedModuleService {
             long sharedSurveyCreatedOn = metadata.getSurveyCreatedOn();
             GuidCreatedOnVersionHolder sharedSurveyKey = new GuidCreatedOnVersionHolderImpl(sharedSurveyGuid,
                     sharedSurveyCreatedOn);
-            Survey sharedSurvey = surveyService.getSurvey(sharedSurveyKey);
+            Survey sharedSurvey = surveyService.getSurvey(sharedSurveyKey, true);
 
             // annotate survey with module ID and version
             sharedSurvey.setModuleId(moduleId);

--- a/app/org/sagebionetworks/bridge/services/SurveyService.java
+++ b/app/org/sagebionetworks/bridge/services/SurveyService.java
@@ -80,11 +80,11 @@ public class SurveyService {
      * @param studyIdentifier
      * @return
      */
-    public Survey getSurvey(GuidCreatedOnVersionHolder keys) {
+    public Survey getSurvey(GuidCreatedOnVersionHolder keys, boolean includeElements) {
         checkArgument(StringUtils.isNotBlank(keys.getGuid()), "Survey GUID cannot be null/blank");
         checkArgument(keys.getCreatedOn() != 0L, "Survey createdOn timestamp cannot be 0");
         
-        return surveyDao.getSurvey(keys);
+        return surveyDao.getSurvey(keys, includeElements);
     }
 
     /**
@@ -146,7 +146,7 @@ public class SurveyService {
         checkArgument(StringUtils.isNotBlank(keys.getGuid()), "Survey GUID cannot be null/blank");
         checkArgument(keys.getCreatedOn() != 0L, "Survey createdOn timestamp cannot be 0");
 
-        Survey survey = surveyDao.getSurvey(keys);
+        Survey survey = surveyDao.getSurvey(keys, true);
         Validate.entityThrowingException(publishValidator, survey);
 
         return surveyDao.publishSurvey(study, survey, keys, newSchemaRev);
@@ -176,7 +176,7 @@ public class SurveyService {
         checkArgument(StringUtils.isNotBlank(keys.getGuid()), "Survey GUID cannot be null/blank");
         checkArgument(keys.getCreatedOn() != 0L, "Survey createdOn timestamp cannot be 0");
 
-        Survey existing = surveyDao.getSurvey(keys);
+        Survey existing = surveyDao.getSurvey(keys, false);
         if (existing.isDeleted()) {
             throw new EntityNotFoundException(Survey.class);
         }
@@ -256,13 +256,15 @@ public class SurveyService {
      * 
      * @param studyIdentifier
      * @param guid
+     * @param includeElements
+     *      if true, include the child elements, otherwise the collection is empty
      * @return
      */
-    public Survey getSurveyMostRecentlyPublishedVersion(StudyIdentifier studyIdentifier, String guid) {
+    public Survey getSurveyMostRecentlyPublishedVersion(StudyIdentifier studyIdentifier, String guid, boolean includeElements) {
         checkNotNull(studyIdentifier, Validate.CANNOT_BE_NULL, "study");
         checkArgument(isNotBlank(guid), Validate.CANNOT_BE_BLANK, "survey guid");
 
-        return surveyDao.getSurveyMostRecentlyPublishedVersion(studyIdentifier, guid);
+        return surveyDao.getSurveyMostRecentlyPublishedVersion(studyIdentifier, guid, includeElements);
     }
 
     /**

--- a/app/org/sagebionetworks/bridge/services/SurveyService.java
+++ b/app/org/sagebionetworks/bridge/services/SurveyService.java
@@ -176,7 +176,7 @@ public class SurveyService {
         checkArgument(StringUtils.isNotBlank(keys.getGuid()), "Survey GUID cannot be null/blank");
         checkArgument(keys.getCreatedOn() != 0L, "Survey createdOn timestamp cannot be 0");
 
-        Survey existing = surveyDao.getSurvey(keys, false);
+        Survey existing = surveyDao.getSurvey(keys, true);
         if (existing.isDeleted()) {
             throw new EntityNotFoundException(Survey.class);
         }

--- a/app/org/sagebionetworks/bridge/services/SurveyService.java
+++ b/app/org/sagebionetworks/bridge/services/SurveyService.java
@@ -83,7 +83,7 @@ public class SurveyService {
     public Survey getSurvey(GuidCreatedOnVersionHolder keys) {
         checkArgument(StringUtils.isNotBlank(keys.getGuid()), "Survey GUID cannot be null/blank");
         checkArgument(keys.getCreatedOn() != 0L, "Survey createdOn timestamp cannot be 0");
-
+        
         return surveyDao.getSurvey(keys);
     }
 

--- a/app/org/sagebionetworks/bridge/upload/GenericUploadFormatHandler.java
+++ b/app/org/sagebionetworks/bridge/upload/GenericUploadFormatHandler.java
@@ -21,6 +21,7 @@ import org.sagebionetworks.bridge.file.FileHelper;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.time.DateUtils;
 import org.sagebionetworks.bridge.json.JsonUtils;
+import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolder;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolderImpl;
 import org.sagebionetworks.bridge.models.healthdata.HealthDataRecord;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
@@ -123,8 +124,8 @@ public class GenericUploadFormatHandler implements UploadValidationHandler {
 
             // Get survey. We use the survey identifier as the schema ID and the schema revision. Both of these must be
             // specified.
-            Survey survey = surveyService.getSurvey(new GuidCreatedOnVersionHolderImpl(surveyGuid,
-                    surveyCreatedOnMillis), false);
+            GuidCreatedOnVersionHolder surveyKeys = new GuidCreatedOnVersionHolderImpl(surveyGuid, surveyCreatedOnMillis);
+            Survey survey = surveyService.getSurvey(surveyKeys, false);
             String surveySchemaId = survey.getIdentifier();
             Integer surveySchemaRev = survey.getSchemaRevision();
             if (StringUtils.isBlank(surveySchemaId) || surveySchemaRev == null) {

--- a/app/org/sagebionetworks/bridge/upload/GenericUploadFormatHandler.java
+++ b/app/org/sagebionetworks/bridge/upload/GenericUploadFormatHandler.java
@@ -124,7 +124,7 @@ public class GenericUploadFormatHandler implements UploadValidationHandler {
             // Get survey. We use the survey identifier as the schema ID and the schema revision. Both of these must be
             // specified.
             Survey survey = surveyService.getSurvey(new GuidCreatedOnVersionHolderImpl(surveyGuid,
-                    surveyCreatedOnMillis));
+                    surveyCreatedOnMillis), false);
             String surveySchemaId = survey.getIdentifier();
             Integer surveySchemaRev = survey.getSchemaRevision();
             if (StringUtils.isBlank(surveySchemaId) || surveySchemaRev == null) {

--- a/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2.java
+++ b/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2.java
@@ -28,6 +28,7 @@ import org.sagebionetworks.bridge.file.FileHelper;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.time.DateUtils;
 import org.sagebionetworks.bridge.json.JsonUtils;
+import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolder;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolderImpl;
 import org.sagebionetworks.bridge.models.healthdata.HealthDataRecord;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
@@ -199,7 +200,8 @@ public class IosSchemaValidationHandler2 implements UploadValidationHandler {
 
         // Get survey. We use the survey identifier as the schema ID and the schema revision. Both of these must be
         // specified.
-        Survey survey = surveyService.getSurvey(new GuidCreatedOnVersionHolderImpl(surveyGuid, surveyCreatedOnMillis), false);
+        GuidCreatedOnVersionHolder surveyKeys = new GuidCreatedOnVersionHolderImpl(surveyGuid, surveyCreatedOnMillis);
+        Survey survey = surveyService.getSurvey(surveyKeys, false);
         String schemaId = survey.getIdentifier();
         Integer schemaRev = survey.getSchemaRevision();
         if (StringUtils.isBlank(schemaId) || schemaRev == null) {

--- a/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2.java
+++ b/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2.java
@@ -199,7 +199,7 @@ public class IosSchemaValidationHandler2 implements UploadValidationHandler {
 
         // Get survey. We use the survey identifier as the schema ID and the schema revision. Both of these must be
         // specified.
-        Survey survey = surveyService.getSurvey(new GuidCreatedOnVersionHolderImpl(surveyGuid, surveyCreatedOnMillis));
+        Survey survey = surveyService.getSurvey(new GuidCreatedOnVersionHolderImpl(surveyGuid, surveyCreatedOnMillis), false);
         String schemaId = survey.getIdentifier();
         Integer schemaRev = survey.getSchemaRevision();
         if (StringUtils.isBlank(schemaId) || schemaRev == null) {

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoMockTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -86,7 +87,7 @@ public class DynamoSurveyDaoMockTest {
         // spy getSurvey() - There's a lot of complex logic in that query builder that's irrelevant to what we're
         // trying to test. Rather than over-specify our test and make our tests overly complicated, we'll just spy out
         // getSurvey().
-        doReturn(survey).when(surveyDao).getSurvey(SURVEY_KEY);
+        doReturn(survey).when(surveyDao).getSurvey(eq(SURVEY_KEY), anyBoolean());
     }
 
     @Test

--- a/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
@@ -181,12 +181,12 @@ public class SurveyControllerTest {
     @Test
     public void verifyViewCacheIsWorking() throws Exception {
         setupContext(API_STUDY_ID, DEVELOPER, CONSENTED, null);
-        when(service.getSurveyMostRecentlyPublishedVersion(any(StudyIdentifier.class), anyString())).thenReturn(getSurvey(false));
+        when(service.getSurveyMostRecentlyPublishedVersion(any(StudyIdentifier.class), anyString(), eq(true))).thenReturn(getSurvey(false));
         
         controller.getSurveyMostRecentlyPublishedVersionForUser(SURVEY_GUID);
         controller.getSurveyMostRecentlyPublishedVersionForUser(SURVEY_GUID);
         
-        verify(service, times(1)).getSurveyMostRecentlyPublishedVersion(API_STUDY_ID, SURVEY_GUID);
+        verify(service, times(1)).getSurveyMostRecentlyPublishedVersion(API_STUDY_ID, SURVEY_GUID, true);
         verifyNoMoreInteractions(service);
     }
 
@@ -266,24 +266,24 @@ public class SurveyControllerTest {
     @Test
     public void getSurveyForUser() throws Exception {
         setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, null);
-        when(service.getSurvey(KEYS)).thenReturn(getSurvey(false));
+        when(service.getSurvey(KEYS, true)).thenReturn(getSurvey(false));
         
         controller.getSurvey(SURVEY_GUID, CREATED_ON.toString());
         
-        verify(service).getSurvey(KEYS);
+        verify(service).getSurvey(KEYS, true);
         verifyNoMoreInteractions(service);
     }
 
     @Test
     public void cannotGetSurveyForUserInOtherStudy() throws Exception {
         setupContext(SECONDSTUDY_STUDY_ID, DEVELOPER, CONSENTED, null);
-        when(service.getSurvey(KEYS)).thenReturn(getSurvey(false));
+        when(service.getSurvey(KEYS, true)).thenReturn(getSurvey(false));
 
         try {
             controller.getSurveyForUser(SURVEY_GUID, CREATED_ON.toString());
             fail("Should have thrown exception");
         } catch(UnauthorizedException e) {
-            verify(service).getSurvey(KEYS);
+            verify(service).getSurvey(KEYS, true);
             verifyNoMoreInteractions(service);
         }
     }
@@ -291,24 +291,24 @@ public class SurveyControllerTest {
     @Test
     public void getSurveyMostRecentlyPublishedVersionForUser() throws Exception {
         setupContext(API_STUDY_ID, DEVELOPER, CONSENTED, null);
-        when(service.getSurveyMostRecentlyPublishedVersion(API_STUDY_ID, SURVEY_GUID)).thenReturn(getSurvey(false));
+        when(service.getSurveyMostRecentlyPublishedVersion(API_STUDY_ID, SURVEY_GUID, true)).thenReturn(getSurvey(false));
         
         controller.getSurveyMostRecentlyPublishedVersionForUser(SURVEY_GUID);
         
-        verify(service).getSurveyMostRecentlyPublishedVersion(API_STUDY_ID, SURVEY_GUID);
+        verify(service).getSurveyMostRecentlyPublishedVersion(API_STUDY_ID, SURVEY_GUID, true);
         verifyNoMoreInteractions(service);
     }
     
     @Test
     public void cannotGetSurveyMostRecentlyPublishedVersionForUserFromOtherStudy() throws Exception {
         setupContext(SECONDSTUDY_STUDY_ID, DEVELOPER, CONSENTED, null);
-        when(service.getSurveyMostRecentlyPublishedVersion(SECONDSTUDY_STUDY_ID, SURVEY_GUID)).thenReturn(getSurvey(false));
+        when(service.getSurveyMostRecentlyPublishedVersion(SECONDSTUDY_STUDY_ID, SURVEY_GUID, true)).thenReturn(getSurvey(false));
         
         try {
             controller.getSurveyMostRecentlyPublishedVersionForUser(SURVEY_GUID);
             fail("Should have thrown exception");
         } catch(UnauthorizedException e) {
-            verify(service).getSurveyMostRecentlyPublishedVersion(SECONDSTUDY_STUDY_ID, SURVEY_GUID);
+            verify(service).getSurveyMostRecentlyPublishedVersion(SECONDSTUDY_STUDY_ID, SURVEY_GUID, true);
             verifyNoMoreInteractions(service);
         }
     }
@@ -317,24 +317,24 @@ public class SurveyControllerTest {
     public void getSurvey() throws Exception {
         setupContext(API_STUDY_ID, DEVELOPER, CONSENTED, null);
         
-        when(service.getSurvey(KEYS)).thenReturn(getSurvey(false));
+        when(service.getSurvey(KEYS, true)).thenReturn(getSurvey(false));
         
         controller.getSurvey(SURVEY_GUID, CREATED_ON.toString());
         
-        verify(service).getSurvey(KEYS);
+        verify(service).getSurvey(KEYS, true);
         verifyNoMoreInteractions(service);
     }
     
     @Test
     public void cannotGetSurveyFromOtherStudy() throws Exception {
         setupContext(SECONDSTUDY_STUDY_ID, DEVELOPER, UNCONSENTED, null);
-        when(service.getSurvey(KEYS)).thenReturn(getSurvey(false));
+        when(service.getSurvey(KEYS, true)).thenReturn(getSurvey(false));
         
         try {
             controller.getSurvey(SURVEY_GUID, CREATED_ON.toString());
             fail("Should have thrown exception");
         } catch(UnauthorizedException e) {
-            verify(service).getSurvey(KEYS);
+            verify(service).getSurvey(KEYS, true);
             verifyNoMoreInteractions(service);
         }
     }
@@ -346,7 +346,7 @@ public class SurveyControllerTest {
         // make survey
         Survey survey = getSurvey(false);
         survey.setGuid("test-survey");
-        when(service.getSurvey(KEYS)).thenReturn(survey);
+        when(service.getSurvey(KEYS, true)).thenReturn(survey);
 
         // execute and validate
         Result result = controller.getSurvey(SURVEY_GUID, CREATED_ON.toString());
@@ -390,25 +390,25 @@ public class SurveyControllerTest {
     @Test
     public void getSurveyMostRecentlyPublishedVersion() throws Exception {
         setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, null);
-        when(service.getSurveyMostRecentlyPublishedVersion(API_STUDY_ID, SURVEY_GUID)).thenReturn(getSurvey(false));
+        when(service.getSurveyMostRecentlyPublishedVersion(API_STUDY_ID, SURVEY_GUID, true)).thenReturn(getSurvey(false));
         
         Result result = controller.getSurveyMostRecentlyPublishedVersion(SURVEY_GUID);
         TestUtils.assertResult(result, 200);
 
-        verify(service).getSurveyMostRecentlyPublishedVersion(API_STUDY_ID, SURVEY_GUID);
+        verify(service).getSurveyMostRecentlyPublishedVersion(API_STUDY_ID, SURVEY_GUID, true);
         verifyNoMoreInteractions(service);
     }
     
     @Test
     public void cannotGetSurveyMostRecentlyPublishedVersionFromOtherStudy() throws Exception {
         setupContext(SECONDSTUDY_STUDY_ID, DEVELOPER, UNCONSENTED, null);
-        when(service.getSurveyMostRecentlyPublishedVersion(SECONDSTUDY_STUDY_ID, SURVEY_GUID)).thenReturn(getSurvey(false));
+        when(service.getSurveyMostRecentlyPublishedVersion(SECONDSTUDY_STUDY_ID, SURVEY_GUID, true)).thenReturn(getSurvey(false));
         
         try {
             controller.getSurveyMostRecentlyPublishedVersion(SURVEY_GUID);
             fail("Should have thrown exception");
         } catch(UnauthorizedException e) {
-            verify(service).getSurveyMostRecentlyPublishedVersion(SECONDSTUDY_STUDY_ID, SURVEY_GUID);
+            verify(service).getSurveyMostRecentlyPublishedVersion(SECONDSTUDY_STUDY_ID, SURVEY_GUID, true);
             verifyNoMoreInteractions(service);
         }
     }
@@ -418,12 +418,12 @@ public class SurveyControllerTest {
         setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, null);
         
         Survey survey = getSurvey(false);
-        when(service.getSurvey(KEYS)).thenReturn(survey);
+        when(service.getSurvey(KEYS, true)).thenReturn(survey);
         
         Result result = controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "false");
         TestUtils.assertResult(result, 200, "Survey deleted.");
 
-        verify(service).getSurvey(KEYS);
+        verify(service).getSurvey(KEYS, true);
         verify(service).deleteSurvey(survey);
         verifyNoMoreInteractions(service);
     }
@@ -433,12 +433,12 @@ public class SurveyControllerTest {
         setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, null);
         
         Survey survey = getSurvey(false);
-        when(service.getSurvey(KEYS)).thenReturn(survey);
+        when(service.getSurvey(KEYS, true)).thenReturn(survey);
         
         Result result = controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "true");
         TestUtils.assertResult(result, 200, "Survey deleted.");
         
-        verify(service).getSurvey(KEYS);
+        verify(service).getSurvey(KEYS, true);
         verify(service).deleteSurvey(survey);
         verifyNoMoreInteractions(service);
     }
@@ -448,12 +448,12 @@ public class SurveyControllerTest {
         setupContext(API_STUDY_ID, ADMIN, UNCONSENTED, null);
         
         Survey survey = getSurvey(false);
-        when(service.getSurvey(KEYS)).thenReturn(survey);
+        when(service.getSurvey(KEYS, true)).thenReturn(survey);
         
         Result result = controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "true");
         TestUtils.assertResult(result, 200, "Survey deleted.");
         
-        verify(service).getSurvey(KEYS);
+        verify(service).getSurvey(KEYS, true);
         verify(service).deleteSurveyPermanently(API_STUDY_ID, survey);
         verifyNoMoreInteractions(service);
     }
@@ -463,13 +463,13 @@ public class SurveyControllerTest {
         setupContext(API_STUDY_ID, ADMIN, UNCONSENTED, null);
         
         Survey survey = getSurvey(false);
-        when(service.getSurvey(KEYS)).thenReturn(survey);
+        when(service.getSurvey(KEYS, true)).thenReturn(survey);
         
         try {
             controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "false");
             fail("This should have thrown an exception");
         } catch(UnauthorizedException e) {
-            verify(service).getSurvey(KEYS);
+            verify(service).getSurvey(KEYS, true);
             verifyNoMoreInteractions(service);
         }
     }
@@ -478,7 +478,7 @@ public class SurveyControllerTest {
     public void deleteSurveyThrowsGoodExceptionIfSurveyDoesntExist() throws Exception {
         setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, null);
         
-        when(service.getSurvey(KEYS)).thenThrow(new EntityNotFoundException(Survey.class));
+        when(service.getSurvey(KEYS, true)).thenThrow(new EntityNotFoundException(Survey.class));
         
         Result result = controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "false");
         TestUtils.assertResult(result, 200, "Survey deleted.");        
@@ -489,13 +489,13 @@ public class SurveyControllerTest {
         setupContext(SECONDSTUDY_STUDY_ID, DEVELOPER, UNCONSENTED, null);
         
         Survey survey = getSurvey(false);
-        when(service.getSurvey(KEYS)).thenReturn(survey);
+        when(service.getSurvey(KEYS, true)).thenReturn(survey);
         
         try {
             controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "false");
             fail("Should have thrown exception");
         } catch(UnauthorizedException e) {
-            verify(service).getSurvey(KEYS);
+            verify(service).getSurvey(KEYS, true);
             verifyNoMoreInteractions(service);
         }
     }
@@ -553,13 +553,13 @@ public class SurveyControllerTest {
         Survey survey = getSurvey(false);
         setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, survey);
         
-        when(service.getSurvey(KEYS)).thenReturn(survey);
+        when(service.getSurvey(KEYS, true)).thenReturn(survey);
         when(service.versionSurvey(any(Survey.class))).thenReturn(survey);
         
         Result result = controller.versionSurvey(SURVEY_GUID, CREATED_ON.toString());
         TestUtils.assertResult(result, 201);
         
-        verify(service).getSurvey(KEYS);
+        verify(service).getSurvey(KEYS, true);
         verify(service).versionSurvey(survey);
         verifyNoMoreInteractions(service);
     }
@@ -569,14 +569,14 @@ public class SurveyControllerTest {
         setupContext(SECONDSTUDY_STUDY_ID, DEVELOPER, UNCONSENTED, null);
         
         Survey survey = getSurvey(false);
-        when(service.getSurvey(KEYS)).thenReturn(survey);
+        when(service.getSurvey(KEYS, true)).thenReturn(survey);
         when(service.versionSurvey(any(Survey.class))).thenReturn(survey);
         
         try {
             controller.versionSurvey(SURVEY_GUID, CREATED_ON.toString());
             fail("Should have thrown exception");
         } catch(UnauthorizedException e) {
-            verify(service).getSurvey(KEYS);
+            verify(service).getSurvey(KEYS, true);
             verifyNoMoreInteractions(service);
         }
     }
@@ -586,13 +586,13 @@ public class SurveyControllerTest {
         Survey survey = getSurvey(false);
         setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, survey);
         
-        when(service.getSurvey(KEYS)).thenReturn(survey);
+        when(service.getSurvey(KEYS, true)).thenReturn(survey);
         when(service.updateSurvey(any(Survey.class))).thenReturn(survey);
         
         Result result = controller.updateSurvey(SURVEY_GUID, CREATED_ON.toString());
         TestUtils.assertResult(result, 200);
         
-        verify(service).getSurvey(KEYS);
+        verify(service).getSurvey(KEYS, true);
         verify(service).updateSurvey(any(Survey.class));
         verifyNoMoreInteractions(service);
     }
@@ -602,14 +602,14 @@ public class SurveyControllerTest {
         Survey survey = getSurvey(false);
         setupContext(SECONDSTUDY_STUDY_ID, DEVELOPER, UNCONSENTED, survey);
         
-        when(service.getSurvey(KEYS)).thenReturn(survey);
+        when(service.getSurvey(KEYS, true)).thenReturn(survey);
         when(service.updateSurvey(any(Survey.class))).thenReturn(survey);
         
         try {
             controller.updateSurvey(SURVEY_GUID, CREATED_ON.toString());
             fail("Should have thrown exception");
         } catch(UnauthorizedException e) {
-            verify(service).getSurvey(KEYS);
+            verify(service).getSurvey(KEYS, true);
             verifyNoMoreInteractions(service);
         }
     }
@@ -619,13 +619,13 @@ public class SurveyControllerTest {
         setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, null);
         
         Survey survey = getSurvey(false);
-        when(service.getSurvey(KEYS)).thenReturn(survey);
+        when(service.getSurvey(KEYS, true)).thenReturn(survey);
         when(service.publishSurvey(eq(TEST_STUDY), any(Survey.class), anyBoolean())).thenReturn(survey);
 
         Result result = controller.publishSurvey(SURVEY_GUID, CREATED_ON.toString(), null);
         TestUtils.assertResult(result, 200);
         
-        verify(service).getSurvey(KEYS);
+        verify(service).getSurvey(KEYS, true);
         verify(service).publishSurvey(TEST_STUDY, survey, false);
         verifyNoMoreInteractions(service);
     }
@@ -635,13 +635,13 @@ public class SurveyControllerTest {
         setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, null);
 
         Survey survey = getSurvey(false);
-        when(service.getSurvey(KEYS)).thenReturn(survey);
+        when(service.getSurvey(KEYS, true)).thenReturn(survey);
         when(service.publishSurvey(eq(TEST_STUDY), any(Survey.class), anyBoolean())).thenReturn(survey);
 
         Result result = controller.publishSurvey(SURVEY_GUID, CREATED_ON.toString(), "true");
         TestUtils.assertResult(result, 200);
         
-        verify(service).getSurvey(KEYS);
+        verify(service).getSurvey(KEYS, true);
         verify(service).publishSurvey(TEST_STUDY, survey, true);
         verifyNoMoreInteractions(service);
     }
@@ -651,14 +651,14 @@ public class SurveyControllerTest {
         setupContext(SECONDSTUDY_STUDY_ID, DEVELOPER, UNCONSENTED, null);
 
         Survey survey = getSurvey(false);
-        when(service.getSurvey(KEYS)).thenReturn(survey);
+        when(service.getSurvey(KEYS, true)).thenReturn(survey);
         when(service.publishSurvey(eq(TEST_STUDY), any(Survey.class), anyBoolean())).thenReturn(survey);
         
         try {
             controller.publishSurvey(SURVEY_GUID, CREATED_ON.toString(), null);
             fail("Exception not thrown.");
         } catch(UnauthorizedException e) {
-            verify(service).getSurvey(KEYS);
+            verify(service).getSurvey(KEYS, true);
             verifyNoMoreInteractions(service);
         }
     }
@@ -668,13 +668,13 @@ public class SurveyControllerTest {
         setupContext(SECONDSTUDY_STUDY_ID, DEVELOPER, UNCONSENTED, null);
         
         Survey survey = getSurvey(false);
-        when(service.getSurvey(KEYS)).thenReturn(survey);
+        when(service.getSurvey(KEYS, true)).thenReturn(survey);
         
         try {
             controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "false");
             fail("Exception should have been thrown.");
         } catch(UnauthorizedException e) {
-            verify(service).getSurvey(KEYS);
+            verify(service).getSurvey(KEYS, true);
             verifyNoMoreInteractions(service);
         }
     }
@@ -684,7 +684,7 @@ public class SurveyControllerTest {
         setupContext(API_STUDY_ID, ADMIN, UNCONSENTED, null);
         
         Survey survey = getSurvey(false);
-        when(service.getSurvey(KEYS)).thenReturn(survey);
+        when(service.getSurvey(KEYS, true)).thenReturn(survey);
         
         try {
             controller.getSurvey(SURVEY_GUID, CREATED_ON.toString());
@@ -699,7 +699,7 @@ public class SurveyControllerTest {
         setupContext(API_STUDY_ID, null, UNCONSENTED, null);
 
         Survey survey = getSurvey(false);
-        when(service.getSurvey(KEYS)).thenReturn(survey);
+        when(service.getSurvey(KEYS, true)).thenReturn(survey);
         
         try {
             controller.getSurvey(SURVEY_GUID, CREATED_ON.toString());
@@ -716,7 +716,7 @@ public class SurveyControllerTest {
     @Test
     public void cannotGetCachedSurveyByUserOfOtherStudy() throws Exception {
         setupContext(API_STUDY_ID, null, CONSENTED, null);
-        when(service.getSurvey(KEYS)).thenReturn(getSurvey(false));
+        when(service.getSurvey(KEYS, true)).thenReturn(getSurvey(false));
         
         Result result = controller.getSurveyForUser(SURVEY_GUID, CREATED_ON.toString());
         TestUtils.assertResult(result, 200);
@@ -726,14 +726,14 @@ public class SurveyControllerTest {
             controller.getSurveyForUser(SURVEY_GUID, CREATED_ON.toString());
             fail("Should have thrown exception");
         } catch(UnauthorizedException e) {
-            verify(service, times(2)).getSurvey(KEYS);
+            verify(service, times(2)).getSurvey(KEYS, true);
         }
     }
 
     @Test
     public void cannotGetCachedSurveyMostRecentlyPublishedVersionForUserFromOtherStudy() throws Exception {
         setupContext(API_STUDY_ID, null, CONSENTED, null);
-        when(service.getSurveyMostRecentlyPublishedVersion(API_STUDY_ID, SURVEY_GUID)).thenReturn(getSurvey(false));
+        when(service.getSurveyMostRecentlyPublishedVersion(API_STUDY_ID, SURVEY_GUID, true)).thenReturn(getSurvey(false));
         
         Result result = controller.getSurveyMostRecentlyPublishedVersionForUser(SURVEY_GUID);
         TestUtils.assertResult(result, 200);
@@ -743,8 +743,8 @@ public class SurveyControllerTest {
             controller.getSurveyMostRecentlyPublishedVersionForUser(SURVEY_GUID);
             fail("Should have thrown exception");
         } catch(UnauthorizedException e) {
-            verify(service).getSurveyMostRecentlyPublishedVersion(API_STUDY_ID, SURVEY_GUID);
-            verify(service).getSurveyMostRecentlyPublishedVersion(SECONDSTUDY_STUDY_ID, SURVEY_GUID);
+            verify(service).getSurveyMostRecentlyPublishedVersion(API_STUDY_ID, SURVEY_GUID, true);
+            verify(service).getSurveyMostRecentlyPublishedVersion(SECONDSTUDY_STUDY_ID, SURVEY_GUID, true);
         }
     }
     
@@ -752,7 +752,7 @@ public class SurveyControllerTest {
     public void cannotGetCachedSurveyFromOtherStudy() throws Exception {
         setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, null);
         
-        when(service.getSurvey(KEYS)).thenReturn(getSurvey(false));
+        when(service.getSurvey(KEYS, true)).thenReturn(getSurvey(false));
         Result result = controller.getSurvey(SURVEY_GUID, CREATED_ON.toString());
         TestUtils.assertResult(result, 200);
         
@@ -761,7 +761,7 @@ public class SurveyControllerTest {
             controller.getSurvey(SURVEY_GUID, CREATED_ON.toString());
             fail("Should have thrown exception");
         } catch(UnauthorizedException e) {
-            verify(service, times(2)).getSurvey(KEYS);
+            verify(service, times(2)).getSurvey(KEYS, true);
         }
     }
     
@@ -788,7 +788,7 @@ public class SurveyControllerTest {
     public void cannotGetCachedSurveyMostRecentlyPublishedVersionFromOtherStudy() throws Exception {
         setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, null);
         
-        when(service.getSurveyMostRecentlyPublishedVersion(API_STUDY_ID, SURVEY_GUID)).thenReturn(getSurvey(false));
+        when(service.getSurveyMostRecentlyPublishedVersion(API_STUDY_ID, SURVEY_GUID, true)).thenReturn(getSurvey(false));
         Result result = controller.getSurveyMostRecentlyPublishedVersion(SURVEY_GUID);
         TestUtils.assertResult(result, 200);
         
@@ -797,8 +797,8 @@ public class SurveyControllerTest {
             controller.getSurveyMostRecentlyPublishedVersion(SURVEY_GUID);
             fail("Should have thrown exception");
         } catch (UnauthorizedException e) {
-            verify(service).getSurveyMostRecentlyPublishedVersion(API_STUDY_ID, SURVEY_GUID);
-            verify(service).getSurveyMostRecentlyPublishedVersion(SECONDSTUDY_STUDY_ID, SURVEY_GUID);
+            verify(service).getSurveyMostRecentlyPublishedVersion(API_STUDY_ID, SURVEY_GUID, true);
+            verify(service).getSurveyMostRecentlyPublishedVersion(SECONDSTUDY_STUDY_ID, SURVEY_GUID, true);
         }
     }
 
@@ -846,18 +846,18 @@ public class SurveyControllerTest {
 
         // Now mock the service because the *next* call (publish/delete/etc) will require it. The 
         // calls under test do not reference the cache, they clear it.
-        when(service.getSurvey(any())).thenReturn(survey);
+        when(service.getSurvey(any(), eq(true))).thenReturn(survey);
         when(service.publishSurvey(any(), any(), anyBoolean())).thenReturn(survey);
         when(service.versionSurvey(any())).thenReturn(survey);
         when(service.updateSurvey(any())).thenReturn(survey);
         
         // execute the test method, this should delete the cache
         executeSurvey.execute(SURVEY_GUID, CREATED_ON.toString());
-        verify(service).getSurvey(any());
+        verify(service).getSurvey(any(), eq(true));
         
         // This call now hits the service, not the cache, for a total of two calls to the service
         controller.getSurvey(SURVEY_GUID, CREATED_ON.toString());
-        verify(service, times(2)).getSurvey(any());
+        verify(service, times(2)).getSurvey(any(), eq(true));
     }
     
     private Survey getSurvey(boolean makeNew) {

--- a/test/org/sagebionetworks/bridge/services/AppConfigServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AppConfigServiceTest.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -194,6 +196,21 @@ public class AppConfigServiceTest {
         assertEquals(appConfig2, match);
         
         assertEquals(SURVEY_REF_LIST.get(0), match.getSurveyReferences().get(0));        
+    }
+    
+    @Test
+    public void getAppConfigForUserSurveyIdentifierAlreadySet() throws Exception {
+        CriteriaContext context = new CriteriaContext.Builder()
+                .withClientInfo(ClientInfo.fromUserAgentCache("app/7 (Motorola Flip-Phone; Android/14) BridgeJavaSDK/10"))
+                .withStudyIdentifier(TEST_STUDY).build();
+        
+        AppConfig appConfig2 = setupConfigsForUser();
+        appConfig2.setSurveyReferences(Lists.newArrayList(new SurveyReference("anIdentifier", "guid", DateTime.now())));
+        
+        AppConfig match = service.getAppConfigForUser(context, true);
+        
+        assertEquals("anIdentifier", match.getSurveyReferences().get(0).getIdentifier());
+        verify(surveyService, never()).getSurvey(any(), anyBoolean());
     }
     
     @Test(expected = EntityNotFoundException.class)

--- a/test/org/sagebionetworks/bridge/services/AppConfigServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AppConfigServiceTest.java
@@ -86,7 +86,6 @@ public class AppConfigServiceTest {
         
         when(service.getCurrentTimestamp()).thenReturn(TIMESTAMP.getMillis());
         when(service.getGUID()).thenReturn(GUID);
-        //doReturn(referenceResolver).when(service).getReferenceResolver(any(), any());
         
         AppConfig savedAppConfig = AppConfig.create();
         savedAppConfig.setLabel("AppConfig");
@@ -166,7 +165,7 @@ public class AppConfigServiceTest {
         survey.setIdentifier("theIdentifier");
         survey.setGuid(SURVEY_REF_LIST.get(0).getGuid());
         survey.setCreatedOn(SURVEY_REF_LIST.get(0).getCreatedOn().getMillis());
-        when(surveyService.getSurvey(SURVEY_KEY)).thenReturn(survey);
+        when(surveyService.getSurvey(SURVEY_KEY, false)).thenReturn(survey);
         
         CriteriaContext context = new CriteriaContext.Builder()
                 .withClientInfo(ClientInfo.fromUserAgentCache("app/7 (Motorola Flip-Phone; Android/14) BridgeJavaSDK/10"))
@@ -181,6 +180,22 @@ public class AppConfigServiceTest {
         assertEquals("theIdentifier", match.getSurveyReferences().get(0).getIdentifier());
     }
 
+    @Test
+    public void getAppConfigForUserSurveyDoesNotExist() throws Exception {
+        when(surveyService.getSurvey(SURVEY_KEY, false)).thenThrow(new EntityNotFoundException(Survey.class));
+        
+        CriteriaContext context = new CriteriaContext.Builder()
+                .withClientInfo(ClientInfo.fromUserAgentCache("app/7 (Motorola Flip-Phone; Android/14) BridgeJavaSDK/10"))
+                .withStudyIdentifier(TEST_STUDY).build();
+        
+        AppConfig appConfig2 = setupConfigsForUser();
+        
+        AppConfig match = service.getAppConfigForUser(context, true);
+        assertEquals(appConfig2, match);
+        
+        assertEquals(SURVEY_REF_LIST.get(0), match.getSurveyReferences().get(0));        
+    }
+    
     @Test(expected = EntityNotFoundException.class)
     public void getAppConfigForUserThrowsException() {
         CriteriaContext context = new CriteriaContext.Builder()
@@ -208,7 +223,7 @@ public class AppConfigServiceTest {
         survey.setIdentifier("theIdentifier");
         survey.setGuid(SURVEY_REF_LIST.get(0).getGuid());
         survey.setCreatedOn(SURVEY_REF_LIST.get(0).getCreatedOn().getMillis());
-        when(surveyService.getSurvey(SURVEY_KEY)).thenReturn(survey);
+        when(surveyService.getSurvey(SURVEY_KEY, false)).thenReturn(survey);
         
         CriteriaContext context = new CriteriaContext.Builder()
                 .withClientInfo(ClientInfo.fromUserAgentCache("iPhone/6 (Motorola Flip-Phone; Android/14) BridgeJavaSDK/10"))

--- a/test/org/sagebionetworks/bridge/services/HealthDataServiceSubmitHealthDataTest.java
+++ b/test/org/sagebionetworks/bridge/services/HealthDataServiceSubmitHealthDataTest.java
@@ -250,7 +250,7 @@ public class HealthDataServiceSubmitHealthDataTest {
         survey.setSchemaRevision(SCHEMA_REV);
 
         SurveyService mockSurveyService = mock(SurveyService.class);
-        when(mockSurveyService.getSurvey(new GuidCreatedOnVersionHolderImpl(SURVEY_GUID, SURVEY_CREATED_ON_MILLIS)))
+        when(mockSurveyService.getSurvey(new GuidCreatedOnVersionHolderImpl(SURVEY_GUID, SURVEY_CREATED_ON_MILLIS), false))
                 .thenReturn(survey);
 
         // mock handlers
@@ -302,7 +302,7 @@ public class HealthDataServiceSubmitHealthDataTest {
         assertEquals("C", recordData.get("answer-me").textValue());
 
         // validate we did in fact call SurveyService
-        verify(mockSurveyService).getSurvey(new GuidCreatedOnVersionHolderImpl(SURVEY_GUID, SURVEY_CREATED_ON_MILLIS));
+        verify(mockSurveyService).getSurvey(new GuidCreatedOnVersionHolderImpl(SURVEY_GUID, SURVEY_CREATED_ON_MILLIS), false);
     }
 
     @Test(expected = EntityNotFoundException.class)
@@ -313,7 +313,7 @@ public class HealthDataServiceSubmitHealthDataTest {
         survey.setCreatedOn(SURVEY_CREATED_ON_MILLIS);
 
         SurveyService mockSurveyService = mock(SurveyService.class);
-        when(mockSurveyService.getSurvey(new GuidCreatedOnVersionHolderImpl(SURVEY_GUID, SURVEY_CREATED_ON_MILLIS)))
+        when(mockSurveyService.getSurvey(new GuidCreatedOnVersionHolderImpl(SURVEY_GUID, SURVEY_CREATED_ON_MILLIS), false))
                 .thenReturn(survey);
 
         // set up service

--- a/test/org/sagebionetworks/bridge/services/ReferenceResolverTest.java
+++ b/test/org/sagebionetworks/bridge/services/ReferenceResolverTest.java
@@ -167,7 +167,7 @@ public class ReferenceResolverTest {
     @Test
     public void surveyResolvedFromServiceAndCached() {
         scheduledActivity.setActivity(activityBuilder.withSurvey(UNRESOLVED_SURVEY_REF).build());
-        when(surveyService.getSurveyMostRecentlyPublishedVersion(STUDY_ID, SURVEY_GUID)).thenReturn(SURVEY);
+        when(surveyService.getSurveyMostRecentlyPublishedVersion(STUDY_ID, SURVEY_GUID, false)).thenReturn(SURVEY);
         
         resolver.resolve(scheduledActivity);
         
@@ -175,7 +175,7 @@ public class ReferenceResolverTest {
         
         resolver.resolve(scheduledActivity);
         
-        verify(surveyService, times(1)).getSurveyMostRecentlyPublishedVersion(STUDY_ID, SURVEY_GUID);
+        verify(surveyService, times(1)).getSurveyMostRecentlyPublishedVersion(STUDY_ID, SURVEY_GUID, false);
     }
     
     @Test
@@ -231,7 +231,7 @@ public class ReferenceResolverTest {
         scheduledActivity.setActivity(activityBuilder.withCompoundActivity(COMPOUND_ACTIVITY_SKINNY_REF).build());
         when(compoundActivityDefinitionService.getCompoundActivityDefinition(STUDY_ID, TASK_ID))
                 .thenReturn(UNRESOLVED_COMPOUND_ACTIVITY_DEF);
-        when(surveyService.getSurveyMostRecentlyPublishedVersion(STUDY_ID, SURVEY_GUID)).thenReturn(SURVEY);
+        when(surveyService.getSurveyMostRecentlyPublishedVersion(STUDY_ID, SURVEY_GUID, false)).thenReturn(SURVEY);
         when(schemaService.getLatestUploadSchemaRevisionForAppVersion(STUDY_ID, SCHEMA_ID, CLIENT_INFO)).thenReturn(SCHEMA);
 
         resolver.resolve(scheduledActivity);
@@ -269,7 +269,7 @@ public class ReferenceResolverTest {
         // to fully resolve. 
         schemaReferences.put(SCHEMA_ID, RESOLVED_SCHEMA_REF);
         scheduledActivity.setActivity(activityBuilder.withCompoundActivity(UNRESOLVED_COMPOUND_ACTIVITY).build());
-        when(surveyService.getSurveyMostRecentlyPublishedVersion(STUDY_ID, SURVEY_GUID)).thenReturn(SURVEY);
+        when(surveyService.getSurveyMostRecentlyPublishedVersion(STUDY_ID, SURVEY_GUID, false)).thenReturn(SURVEY);
         
         resolver.resolve(scheduledActivity);
         
@@ -277,7 +277,7 @@ public class ReferenceResolverTest {
         assertEquals(RESOLVED_SCHEMA_REF, compoundActivity.getSchemaList().get(0));
         assertEquals(RESOLVED_SURVEY_REF, compoundActivity.getSurveyList().get(0));
         
-        verify(surveyService).getSurveyMostRecentlyPublishedVersion(STUDY_ID, SURVEY_GUID);
+        verify(surveyService).getSurveyMostRecentlyPublishedVersion(STUDY_ID, SURVEY_GUID, false);
         verifyNoMoreInteractions(schemaService);
         verify(surveyReferences).get(SURVEY_GUID);
         verify(schemaReferences).get(SCHEMA_ID);
@@ -306,7 +306,7 @@ public class ReferenceResolverTest {
     @Test
     public void compoundActivityResolvedFromServiceAndCached() {
         scheduledActivity.setActivity(activityBuilder.withCompoundActivity(UNRESOLVED_COMPOUND_ACTIVITY).build());
-        when(surveyService.getSurveyMostRecentlyPublishedVersion(STUDY_ID, SURVEY_GUID)).thenReturn(SURVEY);
+        when(surveyService.getSurveyMostRecentlyPublishedVersion(STUDY_ID, SURVEY_GUID, false)).thenReturn(SURVEY);
         when(schemaService.getLatestUploadSchemaRevisionForAppVersion(STUDY_ID, SCHEMA_ID, CLIENT_INFO)).thenReturn(SCHEMA);
         
         resolver.resolve(scheduledActivity);
@@ -318,14 +318,14 @@ public class ReferenceResolverTest {
         resolver.resolve(scheduledActivity);
         
         verify(compoundActivityDefinitionService, never()).getCompoundActivityDefinition(STUDY_ID, TASK_ID);
-        verify(surveyService, times(1)).getSurveyMostRecentlyPublishedVersion(STUDY_ID, SURVEY_GUID);
+        verify(surveyService, times(1)).getSurveyMostRecentlyPublishedVersion(STUDY_ID, SURVEY_GUID, false);
         verify(schemaService, times(1)).getLatestUploadSchemaRevisionForAppVersion(STUDY_ID, SCHEMA_ID, CLIENT_INFO);
     }
     
     @Test
     public void unresolvableSurveyReturnedAsIs() {
         scheduledActivity.setActivity(activityBuilder.withSurvey(UNRESOLVED_SURVEY_REF).build());
-        when(surveyService.getSurveyMostRecentlyPublishedVersion(STUDY_ID, SURVEY_GUID)).thenThrow(new EntityNotFoundException(Survey.class));
+        when(surveyService.getSurveyMostRecentlyPublishedVersion(STUDY_ID, SURVEY_GUID, false)).thenThrow(new EntityNotFoundException(Survey.class));
         
         resolver.resolve(scheduledActivity);
         
@@ -367,7 +367,7 @@ public class ReferenceResolverTest {
     public void compoundActivityWithUnresolvableReferencesReturnedAsIs() {
         scheduledActivity.setActivity(activityBuilder.withCompoundActivity(COMPOUND_ACTIVITY_SKINNY_REF).build());
         when(compoundActivityDefinitionService.getCompoundActivityDefinition(STUDY_ID, TASK_ID)).thenReturn(UNRESOLVED_COMPOUND_ACTIVITY_DEF);
-        when(surveyService.getSurveyMostRecentlyPublishedVersion(STUDY_ID, SURVEY_GUID))
+        when(surveyService.getSurveyMostRecentlyPublishedVersion(STUDY_ID, SURVEY_GUID, false))
                 .thenThrow(new EntityNotFoundException(Survey.class));
         when(schemaService.getLatestUploadSchemaRevisionForAppVersion(STUDY_ID, SCHEMA_ID, CLIENT_INFO))
                 .thenThrow(new EntityNotFoundException(CompoundActivityDefinition.class));

--- a/test/org/sagebionetworks/bridge/services/SchedulePlanServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/SchedulePlanServiceMockTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -67,8 +68,8 @@ public class SchedulePlanServiceMockTest {
         survey1.setIdentifier("identifier1");
         Survey survey2 = new TestSurvey(SchedulePlanServiceMockTest.class, false);
         survey2.setIdentifier("identifier2");
-        when(mockSurveyService.getSurveyMostRecentlyPublishedVersion(any(), any())).thenReturn(survey1);
-        when(mockSurveyService.getSurvey(any())).thenReturn(survey2);
+        when(mockSurveyService.getSurveyMostRecentlyPublishedVersion(any(), any(), anyBoolean())).thenReturn(survey1);
+        when(mockSurveyService.getSurvey(any(), anyBoolean())).thenReturn(survey2);
         surveyGuid1 = survey1.getGuid();
         surveyGuid2 = survey2.getGuid();
     }
@@ -80,8 +81,8 @@ public class SchedulePlanServiceMockTest {
         ArgumentCaptor<SchedulePlan> spCaptor = ArgumentCaptor.forClass(SchedulePlan.class);
         
         service.createSchedulePlan(study, plan);
-        verify(mockSurveyService).getSurveyMostRecentlyPublishedVersion(any(), any());
-        verify(mockSurveyService).getSurvey(any());
+        verify(mockSurveyService).getSurveyMostRecentlyPublishedVersion(any(), any(), anyBoolean());
+        verify(mockSurveyService).getSurvey(any(), anyBoolean());
         verify(mockSchedulePlanDao).createSchedulePlan(any(), spCaptor.capture());
         
         List<Activity> activities = spCaptor.getValue().getStrategy().getAllPossibleSchedules().get(0).getActivities();
@@ -99,8 +100,8 @@ public class SchedulePlanServiceMockTest {
         when(mockSchedulePlanDao.updateSchedulePlan(any(), any())).thenReturn(plan);
         
         service.updateSchedulePlan(study, plan);
-        verify(mockSurveyService).getSurveyMostRecentlyPublishedVersion(any(), any());
-        verify(mockSurveyService).getSurvey(any());
+        verify(mockSurveyService).getSurveyMostRecentlyPublishedVersion(any(), any(), anyBoolean());
+        verify(mockSurveyService).getSurvey(any(), anyBoolean());
         verify(mockSchedulePlanDao).getSchedulePlan(study, plan.getGuid());
         verify(mockSchedulePlanDao).updateSchedulePlan(any(), spCaptor.capture());
         
@@ -130,8 +131,8 @@ public class SchedulePlanServiceMockTest {
         when(mockSchedulePlanDao.updateSchedulePlan(any(), any())).thenReturn(plan);
         
         service.updateSchedulePlan(study, plan);
-        verify(mockSurveyService).getSurveyMostRecentlyPublishedVersion(any(), any());
-        verify(mockSurveyService).getSurvey(any());
+        verify(mockSurveyService).getSurveyMostRecentlyPublishedVersion(any(), any(), anyBoolean());
+        verify(mockSurveyService).getSurvey(any(), anyBoolean());
         verify(mockSchedulePlanDao).getSchedulePlan(study, plan.getGuid());
         verify(mockSchedulePlanDao).updateSchedulePlan(any(), spCaptor.capture());
         

--- a/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceMockTest.java
@@ -154,7 +154,7 @@ public class ScheduledActivityServiceMockTest {
         doReturn(SURVEY_CREATED_ON.getMillis()).when(survey).getCreatedOn();
         doReturn("identifier").when(survey).getIdentifier();
         when(surveyService.getSurveyMostRecentlyPublishedVersion(
-                eq(TEST_STUDY), any())).thenReturn(survey);
+                eq(TEST_STUDY), any(), eq(false))).thenReturn(survey);
         
         service.setSchedulePlanService(schedulePlanService);
         service.setScheduledActivityDao(activityDao);
@@ -896,7 +896,7 @@ public class ScheduledActivityServiceMockTest {
         DynamoSurvey survey = new DynamoSurvey();
         survey.setIdentifier("surveyId");
         survey.setGuid("guid");
-        doReturn(survey).when(surveyService).getSurveyMostRecentlyPublishedVersion(any(), any());
+        doReturn(survey).when(surveyService).getSurveyMostRecentlyPublishedVersion(any(), any(), eq(false));
         
         ScheduleContext context = new ScheduleContext.Builder()
                 .withInitialTimeZone(DateTimeZone.UTC)
@@ -931,7 +931,7 @@ public class ScheduledActivityServiceMockTest {
             assertEquals("guid", act.getActivity().getSurvey().getGuid());
         }
         
-        verify(surveyService, times(1)).getSurveyMostRecentlyPublishedVersion(any(), any());
+        verify(surveyService, times(1)).getSurveyMostRecentlyPublishedVersion(any(), any(), eq(false));
     }
     
     // These cases suggested by Dwayne, there all good to verify further we don't have a date change

--- a/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceResolveLinksTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceResolveLinksTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -99,7 +101,7 @@ public class ScheduledActivityServiceResolveLinksTest {
         survey.setCreatedOn(SURVEY_CREATED_ON_MILLIS);
 
         mockSurveyService = mock(SurveyService.class);
-        when(mockSurveyService.getSurveyMostRecentlyPublishedVersion(TestConstants.TEST_STUDY, SURVEY_GUID))
+        when(mockSurveyService.getSurveyMostRecentlyPublishedVersion(TestConstants.TEST_STUDY, SURVEY_GUID, false))
                 .thenReturn(survey);
         
         appConfigService = mock(AppConfigService.class);
@@ -173,7 +175,7 @@ public class ScheduledActivityServiceResolveLinksTest {
         // Validate backends. We only called compound activity, schema, and survey services once.
         verify(mockCompoundActivityDefinitionService, times(1)).getCompoundActivityDefinition(any(), any());
         verify(mockSchemaService, times(1)).getLatestUploadSchemaRevisionForAppVersion(any(), any(), any());
-        verify(mockSurveyService, times(1)).getSurveyMostRecentlyPublishedVersion(any(), any());
+        verify(mockSurveyService, times(1)).getSurveyMostRecentlyPublishedVersion(any(), any(), eq(false));
     }
 
     @Test
@@ -221,7 +223,7 @@ public class ScheduledActivityServiceResolveLinksTest {
         // Validate backends. We only called schema and survey services once. We never call compound activity service.
         verify(mockCompoundActivityDefinitionService, never()).getCompoundActivityDefinition(any(), any());
         verify(mockSchemaService, times(1)).getLatestUploadSchemaRevisionForAppVersion(any(), any(), any());
-        verify(mockSurveyService, times(1)).getSurveyMostRecentlyPublishedVersion(any(), any());
+        verify(mockSurveyService, times(1)).getSurveyMostRecentlyPublishedVersion(any(), any(), eq(false));
     }
 
     @Test
@@ -244,7 +246,7 @@ public class ScheduledActivityServiceResolveLinksTest {
         // Validate we never call any backends.
         verify(mockCompoundActivityDefinitionService, never()).getCompoundActivityDefinition(any(), any());
         verify(mockSchemaService, never()).getLatestUploadSchemaRevisionForAppVersion(any(), any(), any());
-        verify(mockSurveyService, never()).getSurveyMostRecentlyPublishedVersion(any(), any());
+        verify(mockSurveyService, never()).getSurveyMostRecentlyPublishedVersion(any(), any(), eq(false));
     }
 
     @Test
@@ -274,7 +276,7 @@ public class ScheduledActivityServiceResolveLinksTest {
         // Validate backends.
         verify(mockCompoundActivityDefinitionService, times(2)).getCompoundActivityDefinition(any(), any());
         verify(mockSchemaService, never()).getLatestUploadSchemaRevisionForAppVersion(any(), any(), any());
-        verify(mockSurveyService, never()).getSurveyMostRecentlyPublishedVersion(any(), any());
+        verify(mockSurveyService, never()).getSurveyMostRecentlyPublishedVersion(any(), any(), eq(false));
     }
 
     @Test
@@ -292,7 +294,7 @@ public class ScheduledActivityServiceResolveLinksTest {
         // Mock schema and survey services to throw.
         when(mockSchemaService.getLatestUploadSchemaRevisionForAppVersion(TestConstants.TEST_STUDY, SCHEMA_ID,
                 ClientInfo.UNKNOWN_CLIENT)).thenThrow(EntityNotFoundException.class);
-        when(mockSurveyService.getSurveyMostRecentlyPublishedVersion(TestConstants.TEST_STUDY, SURVEY_GUID))
+        when(mockSurveyService.getSurveyMostRecentlyPublishedVersion(TestConstants.TEST_STUDY, SURVEY_GUID, false))
                 .thenThrow(EntityNotFoundException.class);
 
         // Execute and validate. We have 2 activities (because of how the test is set up), and the activities have
@@ -312,7 +314,7 @@ public class ScheduledActivityServiceResolveLinksTest {
         // schemaService and surveyService still only get called once.
         verify(mockCompoundActivityDefinitionService, never()).getCompoundActivityDefinition(any(), any());
         verify(mockSchemaService, times(1)).getLatestUploadSchemaRevisionForAppVersion(any(), any(), any());
-        verify(mockSurveyService, times(1)).getSurveyMostRecentlyPublishedVersion(any(), any());
+        verify(mockSurveyService, times(1)).getSurveyMostRecentlyPublishedVersion(any(), any(), eq(false));
     }
 
     private static void verifyCompoundActivities(List<ScheduledActivity> scheduledActivityList) {
@@ -345,7 +347,7 @@ public class ScheduledActivityServiceResolveLinksTest {
         verifySurveys(scheduledActivityList);
 
         // We call survey service once.
-        verify(mockSurveyService, times(1)).getSurveyMostRecentlyPublishedVersion(any(), any());
+        verify(mockSurveyService, times(1)).getSurveyMostRecentlyPublishedVersion(any(), any(), eq(false));
 
         // Validate that we never call compound activity service or schema service (not like we have any reason to).
         verify(mockCompoundActivityDefinitionService, never()).getCompoundActivityDefinition(any(), any());
@@ -365,7 +367,7 @@ public class ScheduledActivityServiceResolveLinksTest {
         verifySurveys(scheduledActivityList);
 
         // We never call survey service.
-        verify(mockSurveyService, never()).getSurveyMostRecentlyPublishedVersion(any(), any());
+        verify(mockSurveyService, never()).getSurveyMostRecentlyPublishedVersion(any(), any(), eq(false));
 
         // Validate that we never call compound activity service or schema service (not like we have any reason to).
         verify(mockCompoundActivityDefinitionService, never()).getCompoundActivityDefinition(any(), any());
@@ -379,7 +381,7 @@ public class ScheduledActivityServiceResolveLinksTest {
         setupSchedulePlanServiceWithActivity(activity);
 
         // Mock survey service to throw.
-        when(mockSurveyService.getSurveyMostRecentlyPublishedVersion(TestConstants.TEST_STUDY, SURVEY_GUID))
+        when(mockSurveyService.getSurveyMostRecentlyPublishedVersion(TestConstants.TEST_STUDY, SURVEY_GUID, false))
                 .thenThrow(EntityNotFoundException.class);
 
         // Execute and validate. We have 2 activities (because of how the test is set up), but the activities don't
@@ -395,7 +397,7 @@ public class ScheduledActivityServiceResolveLinksTest {
         }
 
         // We call survey service twice (because we don't cache exception).
-        verify(mockSurveyService, times(2)).getSurveyMostRecentlyPublishedVersion(any(), any());
+        verify(mockSurveyService, times(2)).getSurveyMostRecentlyPublishedVersion(any(), any(), eq(false));
 
         // Validate that we never call compound activity service or schema service (not like we have any reason to).
         verify(mockCompoundActivityDefinitionService, never()).getCompoundActivityDefinition(any(), any());
@@ -430,7 +432,7 @@ public class ScheduledActivityServiceResolveLinksTest {
 
         // Validate that we never call compound activity service or survey service (not like we have any reason to).
         verify(mockCompoundActivityDefinitionService, never()).getCompoundActivityDefinition(any(), any());
-        verify(mockSurveyService, never()).getSurveyMostRecentlyPublishedVersion(any(), any());
+        verify(mockSurveyService, never()).getSurveyMostRecentlyPublishedVersion(any(), any(), eq(false));
     }
 
     @Test
@@ -451,7 +453,7 @@ public class ScheduledActivityServiceResolveLinksTest {
 
         // Validate that we never call compound activity service or survey service (not like we have any reason to).
         verify(mockCompoundActivityDefinitionService, never()).getCompoundActivityDefinition(any(), any());
-        verify(mockSurveyService, never()).getSurveyMostRecentlyPublishedVersion(any(), any());
+        verify(mockSurveyService, never()).getSurveyMostRecentlyPublishedVersion(any(), any(), eq(false));
     }
 
     @Test
@@ -482,7 +484,7 @@ public class ScheduledActivityServiceResolveLinksTest {
 
         // Validate that we never call compound activity service or survey service (not like we have any reason to).
         verify(mockCompoundActivityDefinitionService, never()).getCompoundActivityDefinition(any(), any());
-        verify(mockSurveyService, never()).getSurveyMostRecentlyPublishedVersion(any(), any());
+        verify(mockSurveyService, never()).getSurveyMostRecentlyPublishedVersion(any(), any(), eq(false));
     }
 
     private static void verifySchemas(List<ScheduledActivity> scheduledActivityList) {
@@ -516,7 +518,7 @@ public class ScheduledActivityServiceResolveLinksTest {
         // No resolution happens, so we never call any of the backends.
         verify(mockCompoundActivityDefinitionService, never()).getCompoundActivityDefinition(any(), any());
         verify(mockSchemaService, never()).getLatestUploadSchemaRevisionForAppVersion(any(), any(), any());
-        verify(mockSurveyService, never()).getSurveyMostRecentlyPublishedVersion(any(), any());
+        verify(mockSurveyService, never()).getSurveyMostRecentlyPublishedVersion(any(), any(), anyBoolean());
     }
 
     private static void verifyActivityListSizeAndLabels(List<ScheduledActivity> scheduledActivityList) {

--- a/test/org/sagebionetworks/bridge/services/SharedModuleMetadataServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SharedModuleMetadataServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -56,7 +57,7 @@ public class SharedModuleMetadataServiceTest {
         mockSurveyService = mock(SurveyService.class);
 
         Survey fakeSurvey = new TestSurvey(SharedModuleMetadataServiceTest.class, true);
-        when(mockSurveyService.getSurvey(any())).thenReturn(fakeSurvey);
+        when(mockSurveyService.getSurvey(any(), anyBoolean())).thenReturn(fakeSurvey);
 
         svc = spy(new SharedModuleMetadataService());
         svc.setMetadataDao(mockDao);
@@ -101,7 +102,7 @@ public class SharedModuleMetadataServiceTest {
         svcInputMetadata.setSurveyCreatedOn(1L);
         svcInputMetadata.setSurveyGuid("test-survey-guid");
         GuidCreatedOnVersionHolder holder = new GuidCreatedOnVersionHolderImpl("test-survey-guid", 1L);
-        when(mockSurveyService.getSurvey(eq(holder))).thenThrow(EntityNotFoundException.class);
+        when(mockSurveyService.getSurvey(eq(holder), eq(false))).thenThrow(EntityNotFoundException.class);
         svc.createMetadata(svcInputMetadata);
     }
 
@@ -540,7 +541,7 @@ public class SharedModuleMetadataServiceTest {
     @Test(expected = BadRequestException.class)
     public void updateNotFoundSurvey() {
         SharedModuleMetadata svcInputMetadata = makeValidMetadata();
-        when(mockSurveyService.getSurvey(any())).thenThrow(EntityNotFoundException.class);
+        when(mockSurveyService.getSurvey(any(), anyBoolean())).thenThrow(EntityNotFoundException.class);
         when(mockDao.getMetadataByIdAndVersion(anyString(), anyInt())).thenReturn(svcInputMetadata);
         svcInputMetadata.setSchemaId(null);
         svcInputMetadata.setSchemaRevision(null);

--- a/test/org/sagebionetworks/bridge/services/SharedModuleServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SharedModuleServiceTest.java
@@ -119,7 +119,7 @@ public class SharedModuleServiceTest {
 
         // mock survey service
         Survey sharedSurvey = Survey.create();
-        when(mockSurveyService.getSurvey(SHARED_SURVEY_KEY)).thenReturn(sharedSurvey);
+        when(mockSurveyService.getSurvey(SHARED_SURVEY_KEY, true)).thenReturn(sharedSurvey);
 
         Survey localSurvey = Survey.create();
         localSurvey.setGuid(LOCAL_SURVEY_GUID);

--- a/test/org/sagebionetworks/bridge/services/SurveyServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/SurveyServiceMockTest.java
@@ -86,13 +86,29 @@ public class SurveyServiceMockTest {
     }
     
     @Test
+    public void getSurveyWithoutElements() {
+        GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl("test-guid", 1337);
+        
+        service.getSurvey(keys, false);
+        
+        verify(mockSurveyDao).getSurvey(keys, false);
+    }
+    
+    @Test
+    public void getSurveyMostRecentlyPublishedWithoutElements() {
+        service.getSurveyMostRecentlyPublishedVersion(TEST_STUDY, SURVEY_GUID, false);
+        
+        verify(mockSurveyDao).getSurveyMostRecentlyPublishedVersion(TEST_STUDY, SURVEY_GUID, false);
+    }
+    
+    @Test
     public void publishSurvey() {
         // test inputs and outputs
-        GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl("test-guid", 1337);
+        GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl(SURVEY_GUID, 1337);
         Survey survey = new DynamoSurvey();
 
         // mock DAO
-        when(mockSurveyDao.getSurvey(keys)).thenReturn(survey);
+        when(mockSurveyDao.getSurvey(keys, true)).thenReturn(survey);
         when(mockSurveyDao.publishSurvey(TEST_STUDY, survey, keys, true)).thenReturn(survey);
 
         // mock publish validator
@@ -114,7 +130,7 @@ public class SurveyServiceMockTest {
         
         doReturn(plans).when(mockSchedulePlanService).getSchedulePlans(ClientInfo.UNKNOWN_CLIENT, TEST_STUDY);
         Survey survey = createSurvey();
-        doReturn(survey).when(mockSurveyDao).getSurvey(any());
+        doReturn(survey).when(mockSurveyDao).getSurvey(any(), anyBoolean());
         
         service.deleteSurvey(survey);
 
@@ -169,7 +185,7 @@ public class SurveyServiceMockTest {
                 anySetOf(String.class))).thenReturn(ImmutableList.of(makeValidMetadata()));
 
         Survey survey = createSurvey();
-        doReturn(survey).when(mockSurveyDao).getSurvey(any());
+        doReturn(survey).when(mockSurveyDao).getSurvey(any(), anyBoolean());
         service.deleteSurvey(survey);
     }
 
@@ -188,7 +204,7 @@ public class SurveyServiceMockTest {
     public void deleteSurveySucceedsOnPublishedSurvey() {
         Survey survey = createSurvey();
         survey.setPublished(true);
-        doReturn(survey).when(mockSurveyDao).getSurvey(any());
+        doReturn(survey).when(mockSurveyDao).getSurvey(any(), anyBoolean());
         
         service.deleteSurvey(survey);
         verify(mockSurveyDao).deleteSurvey(survey);
@@ -199,7 +215,7 @@ public class SurveyServiceMockTest {
         Survey survey = createSurvey();
         survey.setPublished(false);
         survey.setDeleted(true);
-        doReturn(survey).when(mockSurveyDao).getSurvey(any());
+        doReturn(survey).when(mockSurveyDao).getSurvey(any(), anyBoolean());
         
         try {
             service.deleteSurvey(survey);

--- a/test/org/sagebionetworks/bridge/services/SurveyServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SurveyServiceTest.java
@@ -145,13 +145,13 @@ public class SurveyServiceTest {
 
         survey.setIdentifier("newIdentifier");
         surveyService.updateSurvey(survey);
-        survey = surveyService.getSurvey(survey);
+        survey = surveyService.getSurvey(survey, true);
         assertEquals("Identifier has been changed", "newIdentifier", survey.getIdentifier());
         assertEquals("Be honest: do you have high blood pressue?", question.getPromptDetail());
         surveyService.deleteSurvey(survey);
 
         try {
-            surveyService.getSurveyMostRecentlyPublishedVersion(TEST_STUDY, survey.getGuid());
+            surveyService.getSurveyMostRecentlyPublishedVersion(TEST_STUDY, survey.getGuid(), false);
             fail("Should have thrown an exception");
         } catch (EntityNotFoundException enfe) {
             // expected exception
@@ -207,13 +207,13 @@ public class SurveyServiceTest {
         survey.setName("C");
 
         surveyService.updateSurvey(survey);
-        survey = surveyService.getSurvey(survey);
+        survey = surveyService.getSurvey(survey, true);
 
         assertEquals("Identifier can be updated", "B", survey.getIdentifier());
         assertEquals("Name can be updated", "C", survey.getName());
 
         // Now verify the nextVersion has not been changed
-        Survey finalVersion = surveyService.getSurvey(nextVersion);
+        Survey finalVersion = surveyService.getSurvey(nextVersion, true);
         assertEquals("Next version has same identifier", nextVersion.getIdentifier(), finalVersion.getIdentifier());
         assertEquals("Next name has not changed", nextVersion.getName(), finalVersion.getName());
     }
@@ -230,7 +230,7 @@ public class SurveyServiceTest {
         survey.getElements().get(6).setIdentifier("new gender");
         surveyService.updateSurvey(survey);
 
-        survey = surveyService.getSurvey(survey);
+        survey = surveyService.getSurvey(survey, true);
 
         assertEquals("Survey has one less question", count-1, survey.getElements().size());
         
@@ -306,7 +306,7 @@ public class SurveyServiceTest {
 
         assertTrue("Survey is marked published", survey.isPublished());
 
-        Survey pubSurvey = surveyService.getSurveyMostRecentlyPublishedVersion(TEST_STUDY, survey.getGuid());
+        Survey pubSurvey = surveyService.getSurveyMostRecentlyPublishedVersion(TEST_STUDY, survey.getGuid(), true);
 
         assertEquals("Same testSurvey GUID", survey.getGuid(), pubSurvey.getGuid());
         assertEquals("Same testSurvey createdOn", survey.getCreatedOn(), pubSurvey.getCreatedOn());
@@ -314,7 +314,7 @@ public class SurveyServiceTest {
 
         // Publishing again is harmless
         survey = surveyService.publishSurvey(TEST_STUDY, survey, false);
-        pubSurvey = surveyService.getSurveyMostRecentlyPublishedVersion(TEST_STUDY, survey.getGuid());
+        pubSurvey = surveyService.getSurveyMostRecentlyPublishedVersion(TEST_STUDY, survey.getGuid(), true);
         assertEquals("Same testSurvey GUID", survey.getGuid(), pubSurvey.getGuid());
         assertEquals("Same testSurvey createdOn", survey.getCreatedOn(), pubSurvey.getCreatedOn());
         assertTrue("Published testSurvey is marked published", pubSurvey.isPublished());
@@ -333,7 +333,7 @@ public class SurveyServiceTest {
 
         laterSurvey = surveyService.publishSurvey(TEST_STUDY, laterSurvey, false);
 
-        Survey pubSurvey = surveyService.getSurveyMostRecentlyPublishedVersion(TEST_STUDY, survey.getGuid());
+        Survey pubSurvey = surveyService.getSurveyMostRecentlyPublishedVersion(TEST_STUDY, survey.getGuid(), true);
         assertEquals("Later testSurvey is the published testSurvey", laterSurvey.getCreatedOn(), pubSurvey.getCreatedOn());
     }
 

--- a/test/org/sagebionetworks/bridge/upload/GenericUploadFormatHandlerGetSchemaTest.java
+++ b/test/org/sagebionetworks/bridge/upload/GenericUploadFormatHandlerGetSchemaTest.java
@@ -51,7 +51,7 @@ public class GenericUploadFormatHandlerGetSchemaTest {
         Survey survey = Survey.create();
         survey.setIdentifier(SCHEMA_ID);
         survey.setSchemaRevision(SCHEMA_REV);
-        when(mockSurveyService.getSurvey(new GuidCreatedOnVersionHolderImpl(SURVEY_GUID, SURVEY_CREATED_ON_MILLIS)))
+        when(mockSurveyService.getSurvey(new GuidCreatedOnVersionHolderImpl(SURVEY_GUID, SURVEY_CREATED_ON_MILLIS), false))
                 .thenReturn(survey);
 
         // make info.json
@@ -71,7 +71,7 @@ public class GenericUploadFormatHandlerGetSchemaTest {
         Survey survey = Survey.create();
         survey.setIdentifier(SCHEMA_ID);
         survey.setSchemaRevision(null);
-        when(mockSurveyService.getSurvey(new GuidCreatedOnVersionHolderImpl(SURVEY_GUID, SURVEY_CREATED_ON_MILLIS)))
+        when(mockSurveyService.getSurvey(new GuidCreatedOnVersionHolderImpl(SURVEY_GUID, SURVEY_CREATED_ON_MILLIS), false))
                 .thenReturn(survey);
 
         // make info.json

--- a/test/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2GetSchemaTest.java
+++ b/test/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2GetSchemaTest.java
@@ -38,7 +38,7 @@ public class IosSchemaValidationHandler2GetSchemaTest {
 
         SurveyService mockSurveyService = mock(SurveyService.class);
         when(mockSurveyService.getSurvey(
-                eq(new GuidCreatedOnVersionHolderImpl("test-guid", TEST_SURVEY_CREATED_ON_MILLIS))))
+                eq(new GuidCreatedOnVersionHolderImpl("test-guid", TEST_SURVEY_CREATED_ON_MILLIS)), eq(false)))
                 .thenReturn(survey);
 
         // mock upload schema service
@@ -72,7 +72,7 @@ public class IosSchemaValidationHandler2GetSchemaTest {
 
         SurveyService mockSurveyService = mock(SurveyService.class);
         when(mockSurveyService.getSurvey(
-                eq(new GuidCreatedOnVersionHolderImpl("test-guid", TEST_SURVEY_CREATED_ON_MILLIS))))
+                eq(new GuidCreatedOnVersionHolderImpl("test-guid", TEST_SURVEY_CREATED_ON_MILLIS)), eq(false)))
                 .thenReturn(survey);
 
         // set up test handler
@@ -98,7 +98,7 @@ public class IosSchemaValidationHandler2GetSchemaTest {
 
         SurveyService mockSurveyService = mock(SurveyService.class);
         when(mockSurveyService.getSurvey(
-                eq(new GuidCreatedOnVersionHolderImpl("test-guid", TEST_SURVEY_CREATED_ON_MILLIS))))
+                eq(new GuidCreatedOnVersionHolderImpl("test-guid", TEST_SURVEY_CREATED_ON_MILLIS)), eq(false)))
                 .thenReturn(survey);
 
         // set up test handler

--- a/test/org/sagebionetworks/bridge/upload/UploadHandlersEndToEndTest.java
+++ b/test/org/sagebionetworks/bridge/upload/UploadHandlersEndToEndTest.java
@@ -217,7 +217,7 @@ public class UploadHandlersEndToEndTest {
         SurveyService mockSurveyService = mock(SurveyService.class);
         if (survey != null) {
             when(mockSurveyService.getSurvey(new GuidCreatedOnVersionHolderImpl(survey.getGuid(),
-                    survey.getCreatedOn()))).thenReturn(survey);
+                    survey.getCreatedOn()), false)).thenReturn(survey);
         }
 
         // set up IosSchemaValidationHandler


### PR DESCRIPTION
When calling through the public-facing app config API, add survey identifiers. Clients use these interchangeably with GUIDs as the primary key for the survey.

See https://sagebionetworks.jira.com/browse/BRIDGE-2229 which specifically references the app configs. There are integration tests to go with this change.