### PR TITLE
Flip this test so that existing configs with NO value for deleted are treated as not deleted.

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoAppConfigDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoAppConfigDao.java
@@ -65,8 +65,8 @@ public class DynamoAppConfigDao implements AppConfigDao {
                 .withHashKeyValues(key);
         if (!includeDeleted) {
             query.withQueryFilterEntry("deleted", new Condition()
-                .withComparisonOperator(ComparisonOperator.EQ)
-                .withAttributeValueList(new AttributeValue().withN("0")));
+                .withComparisonOperator(ComparisonOperator.NE)
+                .withAttributeValueList(new AttributeValue().withN("1")));
         }
         PaginatedQueryList<DynamoAppConfig> results = mapper.query(DynamoAppConfig.class, query);
         

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoAppConfigDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoAppConfigDaoTest.java
@@ -53,7 +53,7 @@ public class DynamoAppConfigDaoTest {
     
     @After
     public void after() {
-        List<AppConfig> appConfigs = dao.getAppConfigs(STUDY_ID, false);
+        List<AppConfig> appConfigs = dao.getAppConfigs(STUDY_ID, true);
         for (AppConfig oneConfig : appConfigs) {
             dao.deleteAppConfigPermanently(STUDY_ID, oneConfig.getGuid());
         }


### PR DESCRIPTION
Otherwise, existing configs don't show up correctly in Bridge study manager.

Also finding all configs, including logically deleted configs to really delete them in the test.