### PR TITLE
Caching reauthentication token

### DIFF
--- a/app/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/app/org/sagebionetworks/bridge/BridgeConstants.java
@@ -68,9 +68,6 @@ public class BridgeConstants {
     // 5 minutes
     public static final int BRIDGE_UPDATE_ATTEMPT_EXPIRE_IN_SECONDS = 5 * 60;
     
-    // 1 minute
-    public static final int BRIDGE_REAUTH_GRACE_PERIOD = 1 * 60;
-    
     // 5 hrs
     public static final int BRIDGE_VIEW_EXPIRE_IN_SECONDS = 5 * 60 * 60;
     
@@ -79,6 +76,9 @@ public class BridgeConstants {
     
     // 1 minute
     public static final int BRIDGE_STUDY_EMAIL_STATUS_IN_SECONDS = 60;
+    
+    // 15 seconds
+    public static final int REAUTH_TOKEN_CACHE_LOOKUP_IN_SECONDS = 15;
 
     public static final String SCHEDULE_STRATEGY_PACKAGE = "org.sagebionetworks.bridge.models.schedules.";
 

--- a/app/org/sagebionetworks/bridge/cache/CacheKey.java
+++ b/app/org/sagebionetworks/bridge/cache/CacheKey.java
@@ -29,11 +29,13 @@ public final class CacheKey {
         }
         return false;
     }
-    
+
+    public static final CacheKey reauthTokenLookupKey(String userId, StudyIdentifier studyId) {
+        return new CacheKey(userId, studyId.getIdentifier(), "ReauthToken");
+    }
     public static final CacheKey shortenUrl(String token) {
         return new CacheKey(token, "ShortenedUrl");
     }
-    
     public static final CacheKey appConfigList(StudyIdentifier studyId) {
         return new CacheKey(studyId.getIdentifier(), "AppConfigList");
     }

--- a/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
@@ -399,11 +399,13 @@ public class HibernateAccountDao implements AccountDao {
     public Account getAccount(AccountId accountId) {
         HibernateAccount hibernateAccount = getHibernateAccount(accountId);
         if (hibernateAccount != null) {
-            boolean updated = validateHealthCode(hibernateAccount);
-            if (updated) {
-                hibernateHelper.update(hibernateAccount); 
+            boolean accountUpdated = validateHealthCode(hibernateAccount);
+            Account account = unmarshallAccount(hibernateAccount);
+            if (accountUpdated) {
+                HibernateAccount updated = hibernateHelper.update(hibernateAccount);
+                account.setVersion(updated.getVersion());
             }
-            return unmarshallAccount(hibernateAccount);
+            return account;
         } else {
             // In keeping with the email implementation, just return null
             return null;

--- a/app/org/sagebionetworks/bridge/models/accounts/Account.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/Account.java
@@ -137,4 +137,7 @@ public interface Account extends BridgeEntity {
     /** A flag used to track changes in the contents of the table across migrations. */
     int getMigrationVersion();
     void setMigrationVersion(int migrationVersion);
+    
+    int getVersion();
+    void setVersion(int version);
 }

--- a/app/org/sagebionetworks/bridge/models/accounts/GenericAccount.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/GenericAccount.java
@@ -361,11 +361,13 @@ public class GenericAccount implements Account {
     }
 
     /** Version number, used by Hibernate to handle optimistic locking. */
+    @Override
     public int getVersion() {
         return version;
     }
 
     /** @see #getVersion */
+    @Override
     public void setVersion(int version) {
         this.version = version;
     }

--- a/app/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -2,11 +2,9 @@ package org.sagebionetworks.bridge.services;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.sagebionetworks.bridge.BridgeConstants.NO_CALLER_ROLES;
+import static org.sagebionetworks.bridge.BridgeConstants.REAUTH_TOKEN_CACHE_LOOKUP_IN_SECONDS;
 
 import org.apache.commons.lang3.StringUtils;
-
-import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_REAUTH_GRACE_PERIOD;
-
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.PasswordGenerator;
 import org.sagebionetworks.bridge.Roles;
@@ -216,10 +214,11 @@ public class AuthenticationService {
         Account account = accountDao.reauthenticate(study, signIn);
 
         UserSession session = getSessionFromAccount(study, context, account);
-        
+
         Tuple<String> reauthTuple = new Tuple<>(session.getSessionToken(), session.getReauthToken());
         cacheProvider.setUserSession(session);
-        cacheProvider.setObject(reauthCacheKey, reauthTuple, BRIDGE_REAUTH_GRACE_PERIOD);
+        // Longer than the caching of the reauthentication token, which provides a grace period for sign ins.
+        cacheProvider.setObject(reauthCacheKey, reauthTuple,  REAUTH_TOKEN_CACHE_LOOKUP_IN_SECONDS*2);
         
         if (!session.doesConsent() && !session.isInRole(Roles.ADMINISTRATIVE_ROLES)) {
             throw new ConsentRequiredException(session);

--- a/test/org/sagebionetworks/bridge/cache/CacheKeyTest.java
+++ b/test/org/sagebionetworks/bridge/cache/CacheKeyTest.java
@@ -26,6 +26,11 @@ public class CacheKeyTest {
     }
     
     @Test
+    public void reauthTokenLookupKey() {
+        assertEquals("ABC:api:ReauthToken", CacheKey.reauthTokenLookupKey("ABC", TestConstants.TEST_STUDY).toString());
+    }
+    
+    @Test
     public void shortenUrl() {
         assertEquals("ABC:ShortenedUrl", CacheKey.shortenUrl("ABC").toString());
     }

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
@@ -383,7 +383,7 @@ public class AuthenticationServiceMockTest {
         assertEquals(RECIPIENT_EMAIL, captured.getParticipant().getEmail());
         assertEquals(REAUTH_TOKEN, captured.getReauthToken());
         verify(cacheProvider).setObject(eq(REAUTH_CACHE_TOKEN), tupleCaptor.capture(),
-                eq(BridgeConstants.BRIDGE_REAUTH_GRACE_PERIOD));
+                eq(BridgeConstants.REAUTH_TOKEN_CACHE_LOOKUP_IN_SECONDS*2));
         
         Tuple<String> tuple = tupleCaptor.getValue();
         assertEquals(session.getSessionToken(), tuple.getLeft());


### PR DESCRIPTION
Unlike reauthentication where we can cache the session under the reauthentication token, we should not cache a sign in session under a user's password, as this stores the password in memory, unhashed. A "stable" hashing algorithm like SHA-1 is not secure either. Yet if we don't cache under a unique value, someone could "sneak in" to this API after an authentication, and retrieve the session using something known like the email address. This just isn't secure.

Instead we cache the reauthentication token under the user's ID for 15 seconds, and reuse it rather than regenerating the token and updating the database, after we've authenticated the sign in request itself (every time).

Testing with a JMeter script, this makes multiple sign ins considerably more robust. Although it's still not impossible to get a 409 conflict, it's very difficult and rare in the JMeter tests (whereas all concurrent threads except the first reliably created 409s before).

We could refactor HibernateAccountDao so that 409s on updates could requery the cache for the just cached reauthentication token, returning that rather than a 409. However at this point, HibernateAccountDao is very complicated and maybe we should reduce some complexity, like refactoring to remove GenericAccount, before we include this.

As it stands right now, legacy applications should generate 409s much, much less frequently.