### PR TITLE
Do not recreate activities in the scheduler if they have clientData, regardless of their status.

### DIFF
--- a/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
+++ b/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
@@ -228,11 +228,13 @@ public class ScheduledActivityService {
             ScheduledActivity activity = scheduledActivities.get(i);
             ScheduledActivity dbActivity = dbMap.remove(activity.getGuid());
             
-            if (dbActivity != null && !UPDATABLE_STATUSES.contains(dbActivity.getStatus())) {
-                // Once the activity is in the database and is in a non-updatable state, we should use the one from the
-                // database. Otherwise, either (a) it doesn't exist yet and needs to be persisted or (b) the user
-                // hasn't interacted with it yet, so we can safely replace it with the newly generated one, which may
-                // have updated schemas or surveys.
+            boolean updatableStatus = dbActivity != null && UPDATABLE_STATUSES.contains(dbActivity.getStatus());
+            
+            if (dbActivity != null && (!updatableStatus || dbActivity.getClientData() != null)) {
+                // Once the activity is in the database and is in a non-updatable state (and that includes attaching
+                // client data to the activity), we should use the one from the database. Otherwise, either (a) it
+                // doesn't exist yet and needs to be persisted or (b) the user hasn't interacted with it yet, so we 
+                // can safely replace it with the newly generated one, which may have updated schemas or surveys.
                 //
                 // Note that this only works because the scheduled activity guid is actually the schedule plan's
                 // activity guid concatenated with scheduled time. So when the scheduler regenerates the scheduled

--- a/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
+++ b/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
@@ -228,9 +228,7 @@ public class ScheduledActivityService {
             ScheduledActivity activity = scheduledActivities.get(i);
             ScheduledActivity dbActivity = dbMap.remove(activity.getGuid());
             
-            boolean updatableStatus = dbActivity != null && UPDATABLE_STATUSES.contains(dbActivity.getStatus());
-            
-            if (dbActivity != null && (!updatableStatus || dbActivity.getClientData() != null)) {
+            if (dbActivity != null && (!UPDATABLE_STATUSES.contains(dbActivity.getStatus()) || dbActivity.getClientData() != null)) {
                 // Once the activity is in the database and is in a non-updatable state (and that includes attaching
                 // client data to the activity), we should use the one from the database. Otherwise, either (a) it
                 // doesn't exist yet and needs to be persisted or (b) the user hasn't interacted with it yet, so we 

--- a/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceMockTest.java
@@ -617,7 +617,7 @@ public class ScheduledActivityServiceMockTest {
     @Test
     public void taskNotStartedWithClientDataNotUpdated() {
         // Activity in DDB has survey reference pointing to createdOn 1234. Newly created activity has survey reference
-        // pointing to createdOn 5678. Activity in DDB hasn't been started. We should update the activity in DDB.
+        // pointing to createdOn 5678. Activity in DDB has client data. DB activity should be in returned activities.
 
         // Create task references and activities.
         // Schedule plan has been updated with a new activity that will be used in scheduled activity
@@ -649,7 +649,7 @@ public class ScheduledActivityServiceMockTest {
     @Test
     public void taskNotStartedWithClientDataNotUpdatedV4() {
         // Activity in DDB has survey reference pointing to createdOn 1234. Newly created activity has survey reference
-        // pointing to createdOn 5678. Activity in DDB hasn't been started. We should update the activity in DDB.
+        // pointing to createdOn 5678. Activity in DDB has client data. DB activity should be in returned activities.
 
         // Create task references and activities.
         // Schedule plan has been updated with a new activity that will be used in scheduled activity

--- a/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceMockTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -579,6 +580,8 @@ public class ScheduledActivityServiceMockTest {
         List<ScheduledActivity> returnedActivities = service.getScheduledActivities(createScheduleContext(NOW).build());
         assertEquals(1, returnedActivities.size());
         assertEquals(5678, returnedActivities.get(0).getActivity().getSurvey().getCreatedOn().getMillis());
+        
+        verify(activityDao).getActivities(eq(TIME_ZONE), any());
     }
 
     @Test
@@ -600,11 +603,81 @@ public class ScheduledActivityServiceMockTest {
                 .withSurvey("my-survey", "my-survey-guid", new DateTime(1234)).build();
         List<ScheduledActivity> db = createNewActivities("CCC"+TIME_PORTION);
         db.get(0).setActivity(oldActivity);
-        when(activityDao.getActivities(eq(TIME_ZONE), any())).thenReturn(db);
+        
+        ForwardCursorPagedResourceList<ScheduledActivity> page = new ForwardCursorPagedResourceList<>(db, null);
+        when(activityDao.getActivityHistoryV2(any(), any(), any(), any(), any(), anyInt())).thenReturn(page);
         
         List<ScheduledActivity> returnedActivities = service.getScheduledActivitiesV4(createScheduleContext(NOW).build());
         assertEquals(1, returnedActivities.size());
         assertEquals(5678, returnedActivities.get(0).getActivity().getSurvey().getCreatedOn().getMillis());
+        
+        verify(activityDao).getActivityHistoryV2(any(), any(), any(), any(), any(), anyInt());
+    }
+    
+    @Test
+    public void taskNotStartedWithClientDataNotUpdated() {
+        // Activity in DDB has survey reference pointing to createdOn 1234. Newly created activity has survey reference
+        // pointing to createdOn 5678. Activity in DDB hasn't been started. We should update the activity in DDB.
+
+        // Create task references and activities.
+        // Schedule plan has been updated with a new activity that will be used in scheduled activity
+        Activity newActivity = new Activity.Builder().withGuid("CCC")
+                .withSurvey("my-survey", "my-survey-guid", new DateTime(5678)).build();
+        SchedulePlan ccc = schedulePlan(newActivity);
+        
+        // This is the schedule plan returned from the DB with the new Activity
+        when(schedulePlanService.getSchedulePlans(ClientInfo.UNKNOWN_CLIENT, TEST_STUDY)).thenReturn(Lists.newArrayList(ccc));
+        
+        // This is the persisted activity with the oldActivity
+        Activity oldActivity = new Activity.Builder().withGuid("CCC")
+                .withSurvey("my-survey", "my-survey-guid", new DateTime(1234)).build();
+        List<ScheduledActivity> db = createNewActivities("CCC"+TIME_PORTION);
+        for (ScheduledActivity activity : db) {
+            activity.setClientData(TestUtils.getClientData());
+        }
+        db.get(0).setActivity(oldActivity);
+        when(activityDao.getActivities(eq(TIME_ZONE), any())).thenReturn(db);
+        
+        List<ScheduledActivity> returnedActivities = service.getScheduledActivities(createScheduleContext(NOW).build());
+        assertEquals(1, returnedActivities.size());
+        assertEquals(1234, returnedActivities.get(0).getActivity().getSurvey().getCreatedOn().getMillis());
+        assertNotNull(returnedActivities.get(0).getClientData());
+        
+        verify(activityDao).getActivities(eq(TIME_ZONE), any());
+    }
+
+    @Test
+    public void taskNotStartedWithClientDataNotUpdatedV4() {
+        // Activity in DDB has survey reference pointing to createdOn 1234. Newly created activity has survey reference
+        // pointing to createdOn 5678. Activity in DDB hasn't been started. We should update the activity in DDB.
+
+        // Create task references and activities.
+        // Schedule plan has been updated with a new activity that will be used in scheduled activity
+        Activity newActivity = new Activity.Builder().withGuid("CCC")
+                .withSurvey("my-survey", "my-survey-guid", new DateTime(5678)).build();
+        SchedulePlan ccc = schedulePlan(newActivity);
+        
+        // This is the schedule plan returned from the DB with the new Activity
+        when(schedulePlanService.getSchedulePlans(ClientInfo.UNKNOWN_CLIENT, TEST_STUDY)).thenReturn(Lists.newArrayList(ccc));
+        
+        // This is the persisted activity with the oldActivity
+        Activity oldActivity = new Activity.Builder().withGuid("CCC")
+                .withSurvey("my-survey", "my-survey-guid", new DateTime(1234)).build();
+        List<ScheduledActivity> db = createNewActivities("CCC"+TIME_PORTION);
+        for (ScheduledActivity activity : db) {
+            activity.setClientData(TestUtils.getClientData());
+        }
+        db.get(0).setActivity(oldActivity);
+        
+        ForwardCursorPagedResourceList<ScheduledActivity> page = new ForwardCursorPagedResourceList<>(db, null);
+        when(activityDao.getActivityHistoryV2(any(), any(), any(), any(), any(), anyInt())).thenReturn(page);
+        
+        List<ScheduledActivity> returnedActivities = service.getScheduledActivitiesV4(createScheduleContext(NOW).build());
+        assertEquals(1, returnedActivities.size());
+        assertEquals(1234, returnedActivities.get(0).getActivity().getSurvey().getCreatedOn().getMillis());
+        assertNotNull(returnedActivities.get(0).getClientData());
+        
+        verify(activityDao).getActivityHistoryV2(any(), any(), any(), any(), any(), anyInt());
     }
     
     @Test


### PR DESCRIPTION
Client developers noticed that if you added client data to an unstarted activity and saved it, you would not get the client data back. That's because we were recreating the activity, assuming it could be updated from the status alone. Now also checks that there's no client data... once there is, we no longer regenerate the DB activity, we return it to the user.