### PR TITLE
increase activity max date range to 32 days

### DIFF
--- a/app/org/sagebionetworks/bridge/validators/ScheduleContextValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/ScheduleContextValidator.java
@@ -6,14 +6,11 @@ import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
 public class ScheduleContextValidator implements Validator {
-    
     /**
-     * We allow up to four days and that's what we document. Unfortunately, we also adjust endsOn
-     * in the controller to the end of the day, so if you pass in 4 days, it is not valid. Add 
-     * one day for now... the exact amount is not that critical, we're just trying to prevent
-     * something like daysAhead=10000.
+     * Limit the number of days you can request for activities. The date range must be less than (not equal to) this
+     * amount. We set this to 32 so that you can get activities for a whole month at a time.
      */
-    public static final int MAX_DATE_RANGE_IN_DAYS = 15;
+    public static final int MAX_DATE_RANGE_IN_DAYS = 32;
     
     /**
      * The maximum number of tasks you can force when scheduling. For our use case it's hard to argue 
@@ -50,7 +47,7 @@ public class ScheduleContextValidator implements Validator {
         } else if (context.getEndsOn().isBefore(startsOn)) {
             errors.rejectValue("endsOn", "must be after startsOn");
         } else if (context.getEndsOn().minusDays(MAX_DATE_RANGE_IN_DAYS).isAfter(startsOn)) {
-            errors.rejectValue("endsOn", "must be "+MAX_DATE_RANGE_IN_DAYS+" days or less");
+            errors.rejectValue("endsOn", "must be less than " + MAX_DATE_RANGE_IN_DAYS + " days");
         }
         if (context.getMinimumPerSchedule() < 0) {
             errors.rejectValue("minimumPerSchedule", "cannot be negative");

--- a/test/org/sagebionetworks/bridge/validators/ScheduleContextValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/ScheduleContextValidatorTest.java
@@ -70,7 +70,7 @@ public class ScheduleContextValidatorTest {
             Validate.nonEntityThrowingException(validator, context);
             fail("Should have thrown exception");
         } catch(BadRequestException e) {
-            assertTrue(e.getMessage().contains("endsOn must be 15 days or less"));
+            assertTrue(e.getMessage().contains("endsOn must be less than 32 days"));
         }
     }
     


### PR DESCRIPTION
This is useful for 2 reasons:

1. Study bursts are 19 days long, so being able to get all activities in a single call is useful.
2. It's super convenient to be able to get activities a month at a time instead of just 15 days at a time, especially if you need to bootstrap 2 years worth of activities.

Note that there's a weird quirk of Joda which means the max date range is an exclusive upper bound (ie, it needs to be less than 32 days, not less than or equal to 32 days). Not sure why that is, but I figured it was easier to just set it to 32 days than figure out why I can't make it <=31 days.