### PR TITLE
Moving a lot of business logic from controller and DAO into the service.

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDao.java
@@ -12,7 +12,6 @@ import org.sagebionetworks.bridge.dao.SurveyDao;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.exceptions.ConcurrentModificationException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
-import org.sagebionetworks.bridge.exceptions.PublishedSurveyException;
 import org.sagebionetworks.bridge.time.DateUtils;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolder;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;

--- a/app/org/sagebionetworks/bridge/play/controllers/SurveyController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/SurveyController.java
@@ -166,14 +166,14 @@ public class SurveyController extends BaseController {
         GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl(surveyGuid, createdOn);
         
         // This call will return logically deleted surveys, which allows them to be physically deleted.
-        Survey survey = surveyService.getSurvey(studyId, keys, false, false);
+        Survey survey = surveyService.getSurvey(session.getParticipant().getRoles(), studyId, keys, false, false);
         if (survey == null) {
             throw new EntityNotFoundException(Survey.class);
         }
         if ("true".equals(physical) && session.isInRole(ADMIN)) {
-            surveyService.deleteSurveyPermanently(studyId, survey);
+            surveyService.deleteSurveyPermanently(session.getParticipant().getRoles(), studyId, survey);
         } else {
-            surveyService.deleteSurvey(studyId, survey);    
+            surveyService.deleteSurvey(studyId, survey);
         }
         expireCache(surveyGuid, createdOnString, studyId);
         return okResult("Survey deleted.");

--- a/app/org/sagebionetworks/bridge/services/HealthDataService.java
+++ b/app/org/sagebionetworks/bridge/services/HealthDataService.java
@@ -198,7 +198,7 @@ public class HealthDataService {
             // specified.
             String surveyGuid = healthDataSubmission.getSurveyGuid();
             GuidCreatedOnVersionHolder surveyKeys = new GuidCreatedOnVersionHolderImpl(surveyGuid, surveyCreatedOnMillis);
-            Survey survey = surveyService.getSurvey(surveyKeys, false);
+            Survey survey = surveyService.getSurvey(studyId, surveyKeys, false, true);
             String schemaId = survey.getIdentifier();
             Integer schemaRev = survey.getSchemaRevision();
             if (StringUtils.isBlank(schemaId) || schemaRev == null) {

--- a/app/org/sagebionetworks/bridge/services/SchedulePlanService.java
+++ b/app/org/sagebionetworks/bridge/services/SchedulePlanService.java
@@ -173,7 +173,7 @@ public class SchedulePlanService {
                         .withPublishedSurvey(survey.getIdentifier(), survey.getGuid()).build();
             } else {
                 GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl(ref.getGuid(), ref.getCreatedOn().getMillis());
-                Survey survey = surveyService.getSurvey(keys, false);
+                Survey survey = surveyService.getSurvey(studyId, keys, false, true);
                 return new Activity.Builder().withActivity(activity)
                         .withSurvey(survey.getIdentifier(), ref.getGuid(), ref.getCreatedOn()).build();
             }

--- a/app/org/sagebionetworks/bridge/services/SharedModuleMetadataService.java
+++ b/app/org/sagebionetworks/bridge/services/SharedModuleMetadataService.java
@@ -95,7 +95,8 @@ public class SharedModuleMetadataService {
             long createdOn = metadata.getSurveyCreatedOn();
 
             // Metadata does not have study information
-            Survey survey = surveyService.getSurvey(null, new GuidCreatedOnVersionHolderImpl(surveyGuid, createdOn), false, false);
+            Survey survey = surveyService.getSurvey(SHARED_STUDY_ID,
+                    new GuidCreatedOnVersionHolderImpl(surveyGuid, createdOn), false, false);
             if (survey == null) {
                 throw new BadRequestException("Survey " + surveyGuid + " referred does not exist.");    
             }

--- a/app/org/sagebionetworks/bridge/services/SharedModuleMetadataService.java
+++ b/app/org/sagebionetworks/bridge/services/SharedModuleMetadataService.java
@@ -23,6 +23,7 @@ import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolderImpl;
 import org.sagebionetworks.bridge.models.sharedmodules.SharedModuleMetadata;
 import org.sagebionetworks.bridge.models.sharedmodules.SharedModuleType;
+import org.sagebionetworks.bridge.models.surveys.Survey;
 import org.sagebionetworks.bridge.validators.SharedModuleMetadataValidator;
 import org.sagebionetworks.bridge.validators.Validate;
 
@@ -93,10 +94,10 @@ public class SharedModuleMetadataService {
             String surveyGuid = metadata.getSurveyGuid();
             long createdOn = metadata.getSurveyCreatedOn();
 
-            try {
-                surveyService.getSurvey(new GuidCreatedOnVersionHolderImpl(surveyGuid, createdOn), false);
-            } catch (EntityNotFoundException e) {
-                throw new BadRequestException("Survey " + surveyGuid + " referred does not exist.");
+            // Metadata does not have study information
+            Survey survey = surveyService.getSurvey(null, new GuidCreatedOnVersionHolderImpl(surveyGuid, createdOn), false, false);
+            if (survey == null) {
+                throw new BadRequestException("Survey " + surveyGuid + " referred does not exist.");    
             }
         }
     }

--- a/app/org/sagebionetworks/bridge/services/SharedModuleService.java
+++ b/app/org/sagebionetworks/bridge/services/SharedModuleService.java
@@ -120,7 +120,7 @@ public class SharedModuleService {
             long sharedSurveyCreatedOn = metadata.getSurveyCreatedOn();
             GuidCreatedOnVersionHolder sharedSurveyKey = new GuidCreatedOnVersionHolderImpl(sharedSurveyGuid,
                     sharedSurveyCreatedOn);
-            Survey sharedSurvey = surveyService.getSurvey(studyId, sharedSurveyKey, true, true);
+            Survey sharedSurvey = surveyService.getSurvey(BridgeConstants.SHARED_STUDY_ID, sharedSurveyKey, true, true);
 
             // annotate survey with module ID and version
             sharedSurvey.setModuleId(moduleId);

--- a/app/org/sagebionetworks/bridge/services/SharedModuleService.java
+++ b/app/org/sagebionetworks/bridge/services/SharedModuleService.java
@@ -120,7 +120,7 @@ public class SharedModuleService {
             long sharedSurveyCreatedOn = metadata.getSurveyCreatedOn();
             GuidCreatedOnVersionHolder sharedSurveyKey = new GuidCreatedOnVersionHolderImpl(sharedSurveyGuid,
                     sharedSurveyCreatedOn);
-            Survey sharedSurvey = surveyService.getSurvey(sharedSurveyKey, true);
+            Survey sharedSurvey = surveyService.getSurvey(studyId, sharedSurveyKey, true, true);
 
             // annotate survey with module ID and version
             sharedSurvey.setModuleId(moduleId);

--- a/app/org/sagebionetworks/bridge/services/SurveyService.java
+++ b/app/org/sagebionetworks/bridge/services/SurveyService.java
@@ -317,7 +317,7 @@ public class SurveyService {
      * when they are deleting studies permanently.
      */
     private boolean isInStudy(Set<Roles> roles, StudyIdentifier studyId, Survey survey) {
-        if (studyId == null || (!roles.isEmpty() && roles.contains(Roles.ADMIN))) {
+        if (studyId == null || roles.contains(Roles.ADMIN)) {
             return true;
         }
         if (survey == null || survey.getStudyIdentifier() == null) {

--- a/app/org/sagebionetworks/bridge/upload/GenericUploadFormatHandler.java
+++ b/app/org/sagebionetworks/bridge/upload/GenericUploadFormatHandler.java
@@ -125,7 +125,7 @@ public class GenericUploadFormatHandler implements UploadValidationHandler {
             // Get survey. We use the survey identifier as the schema ID and the schema revision. Both of these must be
             // specified.
             GuidCreatedOnVersionHolder surveyKeys = new GuidCreatedOnVersionHolderImpl(surveyGuid, surveyCreatedOnMillis);
-            Survey survey = surveyService.getSurvey(surveyKeys, false);
+            Survey survey = surveyService.getSurvey(studyId, surveyKeys, false, true);
             String surveySchemaId = survey.getIdentifier();
             Integer surveySchemaRev = survey.getSchemaRevision();
             if (StringUtils.isBlank(surveySchemaId) || surveySchemaRev == null) {

--- a/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2.java
+++ b/app/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2.java
@@ -201,7 +201,7 @@ public class IosSchemaValidationHandler2 implements UploadValidationHandler {
         // Get survey. We use the survey identifier as the schema ID and the schema revision. Both of these must be
         // specified.
         GuidCreatedOnVersionHolder surveyKeys = new GuidCreatedOnVersionHolderImpl(surveyGuid, surveyCreatedOnMillis);
-        Survey survey = surveyService.getSurvey(surveyKeys, false);
+        Survey survey = surveyService.getSurvey(study, surveyKeys, false, true);
         String schemaId = survey.getIdentifier();
         Integer schemaRev = survey.getSchemaRevision();
         if (StringUtils.isBlank(schemaId) || schemaRev == null) {

--- a/app/org/sagebionetworks/bridge/validators/AppConfigValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/AppConfigValidator.java
@@ -85,14 +85,13 @@ public class AppConfigValidator implements Validator {
                 if (ref.getCreatedOn() == null) {
                     errors.rejectValue("createdOn", "is required");
                 } else {
-                    try {
-                        GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl(ref);
-                        Survey survey = surveyService.getSurvey(keys, false);
-                        if (!survey.isPublished()) {
-                            errors.rejectValue("", "has not been published");
-                        }
-                    } catch(EntityNotFoundException e) {
-                        errors.rejectValue("", "does not refer to a survey");
+                    StudyIdentifier studyId = new StudyIdentifierImpl(appConfig.getStudyId());
+                    GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl(ref);
+                    Survey survey = surveyService.getSurvey(studyId, keys, false, false);
+                    if (survey == null) {
+                        errors.rejectValue("", "does not refer to a survey");    
+                    } else if (!survey.isPublished()) {
+                        errors.rejectValue("", "has not been published");
                     }
                 }
                 errors.popNestedPath();

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoMockTest.java
@@ -34,8 +34,6 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.sagebionetworks.bridge.TestConstants;
-import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
-import org.sagebionetworks.bridge.exceptions.PublishedSurveyException;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolder;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolderImpl;
 import org.sagebionetworks.bridge.models.surveys.IntegerConstraints;
@@ -43,9 +41,7 @@ import org.sagebionetworks.bridge.models.surveys.Survey;
 import org.sagebionetworks.bridge.models.surveys.SurveyElement;
 import org.sagebionetworks.bridge.models.surveys.SurveyInfoScreen;
 import org.sagebionetworks.bridge.models.surveys.SurveyQuestion;
-import org.sagebionetworks.bridge.models.surveys.TestSurvey;
 import org.sagebionetworks.bridge.models.upload.UploadSchema;
-import org.sagebionetworks.bridge.services.SurveyServiceMockTest;
 import org.sagebionetworks.bridge.services.UploadSchemaService;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -117,19 +113,6 @@ public class DynamoSurveyDaoMockTest {
         // trying to test. Rather than over-specify our test and make our tests overly complicated, we'll just spy out
         // getSurvey().
         doReturn(survey).when(surveyDao).getSurvey(eq(SURVEY_KEY), anyBoolean());
-    }
-    
-    @Test(expected = EntityNotFoundException.class)
-    public void updateSurveyFailsOnDeletedSurvey() {
-        DynamoSurvey existing = new DynamoSurvey(SURVEY_GUID, SURVEY_CREATED_ON);
-        existing.setDeleted(true);
-        
-        List<Survey> results = Lists.newArrayList(existing);
-        doReturn(results).when(mockQueryResultPage).getResults();
-        doReturn(mockQueryResultPage).when(mockSurveyMapper).queryPage(eq(DynamoSurvey.class), any());
-        
-        survey.setDeleted(true);
-        surveyDao.updateSurvey(survey);
     }
     
     @Test
@@ -204,7 +187,7 @@ public class DynamoSurveyDaoMockTest {
         verify(mockSchemaService).deleteUploadSchemaById(TestConstants.TEST_STUDY, SURVEY_ID);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test
     public void deleteSurveyPermanentlyNoSurvey() {
         List<Survey> results = Lists.newArrayList();
         doReturn(results).when(mockQueryResultPage).getResults();
@@ -212,23 +195,8 @@ public class DynamoSurveyDaoMockTest {
         
         GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl("keys", DateTime.now().getMillis());
         surveyDao.deleteSurveyPermanently(keys);
-    }
-    
-    @Test(expected = EntityNotFoundException.class)
-    public void updateSurveyExistingDeletedNotFound() {
-        DynamoSurvey existing = new DynamoSurvey(SURVEY_GUID, SURVEY_CREATED_ON);
-        existing.setIdentifier(SURVEY_ID);
-        existing.setStudyIdentifier(TestConstants.TEST_STUDY_IDENTIFIER);
-        existing.setDeleted(true);
-        existing.setPublished(false);
         
-        List<Survey> results = Lists.newArrayList(existing);
-        doReturn(results).when(mockQueryResultPage).getResults();
-        doReturn(mockQueryResultPage).when(mockSurveyMapper).queryPage(eq(DynamoSurvey.class), any());
-        
-        // This is not an undelete, it fails with a not found exception
-        survey.setDeleted(true);
-        surveyDao.updateSurvey(survey);
+        verify(mockSurveyMapper, never()).delete(any());
     }
     
     @Test
@@ -245,49 +213,6 @@ public class DynamoSurveyDaoMockTest {
         
         survey.setDeleted(false);
         survey.getElements().add(SurveyInfoScreen.create());
-        surveyDao.updateSurvey(survey);
-
-        verify(mockSurveyMapper).save(surveyCaptor.capture());
-        assertFalse(surveyCaptor.getValue().isDeleted());
-        assertEquals(1, surveyCaptor.getValue().getElements().size());
-    }
-    
-    @Test(expected = PublishedSurveyException.class)
-    public void updateSurveyAlreadyPublishedThrowsException() {
-        DynamoSurvey existing = new DynamoSurvey(SURVEY_GUID, SURVEY_CREATED_ON);
-        existing.setIdentifier(SURVEY_ID);
-        existing.setStudyIdentifier(TestConstants.TEST_STUDY_IDENTIFIER);
-        existing.setDeleted(false);
-        existing.setPublished(true);
-        
-        List<Survey> results = Lists.newArrayList(existing);
-        doReturn(results).when(mockQueryResultPage).getResults();
-        doReturn(mockQueryResultPage).when(mockSurveyMapper).queryPage(eq(DynamoSurvey.class), any());
-        
-        // Not undeleting... should throw exception
-        survey.setDeleted(false);
-        survey.getElements().add(SurveyInfoScreen.create());
-        surveyDao.updateSurvey(survey);
-    }
-    
-    @Test
-    public void updateSurveyUndeletePublishedOK() {
-        DynamoSurvey existing = new DynamoSurvey(SURVEY_GUID, SURVEY_CREATED_ON);
-        existing.setIdentifier(SURVEY_ID);
-        existing.setStudyIdentifier(TestConstants.TEST_STUDY_IDENTIFIER);
-        existing.setDeleted(true);
-        existing.setPublished(true);
-        
-        List<Survey> results = Lists.newArrayList(existing);
-        doReturn(results).when(mockQueryResultPage).getResults();
-        doReturn(mockQueryResultPage).when(mockSurveyMapper).queryPage(eq(DynamoSurvey.class), any());
-        
-        // Verify that we load the elements for the update
-        List<SurveyElement> elementResults = Lists.newArrayList(SurveyInfoScreen.create());
-        doReturn(elementResults).when(mockElementQueryResultPage).getResults();
-        doReturn(mockElementQueryResultPage).when(mockSurveyElementMapper).queryPage(eq(DynamoSurveyElement.class), any());
-        
-        survey.setDeleted(false);
         surveyDao.updateSurvey(survey);
 
         verify(mockSurveyMapper).save(surveyCaptor.capture());

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.sagebionetworks.bridge.TestConstants.GSI_WAIT_DURATION;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
@@ -31,7 +30,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.exceptions.ConcurrentModificationException;
-import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.PublishedSurveyException;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolder;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolderImpl;
@@ -178,12 +176,8 @@ public class DynamoSurveyDaoTest {
         survey.setVersion(updatedSurvey.getVersion());
         surveyDao.deleteSurvey(survey);
 
-        try {
-            surveyDao.getSurveyMostRecentlyPublishedVersion(TEST_STUDY, survey.getGuid(), true);
-            fail("Should have thrown an exception");
-        } catch (EntityNotFoundException enfe) {
-            // expected exception
-        }
+        Survey retrieved = surveyDao.getSurveyMostRecentlyPublishedVersion(TEST_STUDY, survey.getGuid(), true);
+        assertNull(retrieved);
     }
 
     // UPDATE SURVEY
@@ -244,29 +238,6 @@ public class DynamoSurveyDaoTest {
 
         survey.setVersion(44L);
         surveyDao.updateSurvey(survey);
-    }
-
-    @Test(expected = PublishedSurveyException.class)
-    public void cannotUpdatePublishedSurveys() {
-        Survey survey = createSurvey(testSurvey);
-        publishSurvey(TEST_STUDY, survey);
-
-        survey.setName("This is a new name");
-        surveyDao.updateSurvey(survey);
-    }
-    
-    @Test
-    public void canUndeletePublishedSurveys() {
-        testSurvey.setDeleted(true);
-        Survey survey = createSurvey(testSurvey);
-        publishSurvey(TEST_STUDY, survey);
-        
-        surveyDao.deleteSurvey(survey);
-        assertTrue(survey.isDeleted());
-        
-        survey.setDeleted(false);
-        survey = surveyDao.updateSurvey(survey);
-        assertFalse(survey.isDeleted());
     }
 
     // VERSION SURVEY
@@ -471,10 +442,11 @@ public class DynamoSurveyDaoTest {
         assertEquals(0, result.getElements().size());
     }
     
-    @Test(expected = EntityNotFoundException.class)
-    public void getSurveyMostRecentlyPublishedVersionThrowsException() {
+    @Test
+    public void getSurveyMostRecentlyPublishedVersionReturnsNullWhenNotFound() {
         Survey firstVersion = createSurvey(new SimpleSurvey("First Survey"));
-        surveyDao.getSurveyMostRecentlyPublishedVersion(TEST_STUDY, firstVersion.getGuid(), true);
+        Survey retrieved = surveyDao.getSurveyMostRecentlyPublishedVersion(TEST_STUDY, firstVersion.getGuid(), true);
+        assertNull(retrieved);
     }
     
     @Test
@@ -646,18 +618,12 @@ public class DynamoSurveyDaoTest {
         surveyDao.deleteSurvey(survey);
         
         // This survey can only be retrieved by direct reference
-        try {
-            surveyDao.getSurveyMostRecentlyPublishedVersion(TEST_STUDY, survey.getGuid(), true);
-            fail("Should have thrown exception [1].");
-        } catch(EntityNotFoundException e) {
-            assertEquals("Survey not found.", e.getMessage());
-        }
-        try {
-            surveyDao.getSurveyMostRecentVersion(TEST_STUDY, survey.getGuid());
-            fail("Should have thrown exception [3].");
-        } catch(EntityNotFoundException e) {
-            assertEquals("Survey not found.", e.getMessage());
-        }
+        Survey retrieved = surveyDao.getSurveyMostRecentlyPublishedVersion(TEST_STUDY, survey.getGuid(), true);
+        assertNull(retrieved);
+
+        retrieved = surveyDao.getSurveyMostRecentVersion(TEST_STUDY, survey.getGuid());
+        assertNull(retrieved);
+        
         survey = surveyDao.getSurvey(survey, true);
         assertNotNull(survey);
     }
@@ -669,12 +635,23 @@ public class DynamoSurveyDaoTest {
         Survey savedSurvey = surveyDao.createSurvey(survey);
         surveyDao.deleteSurveyPermanently(savedSurvey);
         
-        try {
-            surveyDao.getSurvey(survey, true);
-            fail("Should have thrown exception");
-        } catch(EntityNotFoundException e) {
-            // expected exception
-        }
+        Survey retrieved = surveyDao.getSurvey(survey, true);
+        assertNull(retrieved);
+    }
+    
+    @Test
+    public void canDeleteThenPermanentlyDeleteSurvey() {
+        Survey survey = createSurvey(testSurvey);
+
+        Survey savedSurvey = surveyDao.createSurvey(survey);
+        surveyDao.deleteSurvey(savedSurvey);
+        
+        Survey deletedSurvey = surveyDao.getSurvey(savedSurvey, true);
+        assertTrue(deletedSurvey.isDeleted());
+        surveyDao.deleteSurveyPermanently(deletedSurvey);
+        
+        Survey retrievedSurvey = surveyDao.getSurvey(deletedSurvey, true);
+        assertNull(retrievedSurvey);
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoTest.java
@@ -30,7 +30,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.exceptions.ConcurrentModificationException;
-import org.sagebionetworks.bridge.exceptions.PublishedSurveyException;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolder;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolderImpl;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;

--- a/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
@@ -23,6 +23,7 @@ import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.joda.time.DateTime;
@@ -58,6 +59,7 @@ import org.sagebionetworks.bridge.models.surveys.TestSurvey;
 import org.sagebionetworks.bridge.services.StudyService;
 import org.sagebionetworks.bridge.services.SurveyService;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -76,17 +78,13 @@ public class SurveyControllerTest {
 
     private static final boolean CONSENTED = true;
     private static final boolean UNCONSENTED = false;
-            
     private static final StudyIdentifier API_STUDY_ID = TestConstants.TEST_STUDY;
-    
     private static final StudyIdentifier SECONDSTUDY_STUDY_ID = new StudyIdentifierImpl("secondstudy");
-    
     private static final String SURVEY_GUID = "bbb";
-    
     private static final DateTime CREATED_ON = DateTime.now();
-    
     private static final GuidCreatedOnVersionHolder KEYS = new GuidCreatedOnVersionHolderImpl(SURVEY_GUID, CREATED_ON.getMillis());
-            
+    private static final Set<Roles> ADMIN_ROLE = ImmutableSet.of(Roles.ADMIN);
+    
     private SurveyController controller;
     
     private SurveyService service;
@@ -360,12 +358,12 @@ public class SurveyControllerTest {
         setupContext(API_STUDY_ID, ADMIN, UNCONSENTED, null);
         
         Survey survey = getSurvey(false);
-        when(service.getSurvey(TestConstants.TEST_STUDY, KEYS, false, false)).thenReturn(survey);
+        when(service.getSurvey(ImmutableSet.of(ADMIN), TestConstants.TEST_STUDY, KEYS, false, false)).thenReturn(survey);
         
         Result result = controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "nonsense");
         TestUtils.assertResult(result, 200, "Survey deleted.");
         
-        verify(service).getSurvey(TestConstants.TEST_STUDY, KEYS, false, false);
+        verify(service).getSurvey(ImmutableSet.of(ADMIN), TestConstants.TEST_STUDY, KEYS, false, false);
         verify(service).deleteSurvey(TestConstants.TEST_STUDY, survey);
         verifyNoMoreInteractions(service);
     }
@@ -375,12 +373,12 @@ public class SurveyControllerTest {
         setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, null);
         
         Survey survey = getSurvey(false);
-        when(service.getSurvey(TestConstants.TEST_STUDY, KEYS, false, false)).thenReturn(survey);
+        when(service.getSurvey(ImmutableSet.of(DEVELOPER), TestConstants.TEST_STUDY, KEYS, false, false)).thenReturn(survey);
         
         Result result = controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "false");
         TestUtils.assertResult(result, 200, "Survey deleted.");
         
-        verify(service).getSurvey(TestConstants.TEST_STUDY, KEYS, false, false);
+        verify(service).getSurvey(ImmutableSet.of(DEVELOPER), TestConstants.TEST_STUDY, KEYS, false, false);
         verify(service).deleteSurvey(TestConstants.TEST_STUDY, survey);
         verifyNoMoreInteractions(service);
     }
@@ -390,12 +388,12 @@ public class SurveyControllerTest {
         setupContext(API_STUDY_ID, ADMIN, UNCONSENTED, null);
         
         Survey survey = getSurvey(false);
-        when(service.getSurvey(TestConstants.TEST_STUDY, KEYS, false, false)).thenReturn(survey);
+        when(service.getSurvey(ImmutableSet.of(ADMIN), TestConstants.TEST_STUDY, KEYS, false, false)).thenReturn(survey);
         
         Result result = controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "false");
         TestUtils.assertResult(result, 200, "Survey deleted.");
         
-        verify(service).getSurvey(TestConstants.TEST_STUDY, KEYS, false, false);
+        verify(service).getSurvey(ImmutableSet.of(ADMIN), TestConstants.TEST_STUDY, KEYS, false, false);
         verify(service).deleteSurvey(TestConstants.TEST_STUDY, survey);
         verifyNoMoreInteractions(service);
     }
@@ -412,12 +410,13 @@ public class SurveyControllerTest {
         setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, null);
         
         Survey survey = getSurvey(false);
-        when(service.getSurvey(TestConstants.TEST_STUDY, KEYS, false, false)).thenReturn(survey);
+        when(service.getSurvey(ImmutableSet.of(DEVELOPER), TestConstants.TEST_STUDY, KEYS, false, false))
+                .thenReturn(survey);
         
         Result result = controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "false");
         TestUtils.assertResult(result, 200, "Survey deleted.");
 
-        verify(service).getSurvey(TestConstants.TEST_STUDY, KEYS, false, false);
+        verify(service).getSurvey(ImmutableSet.of(DEVELOPER), TestConstants.TEST_STUDY, KEYS, false, false);
         verify(service).deleteSurvey(TestConstants.TEST_STUDY, survey);
         verifyNoMoreInteractions(service);
     }
@@ -427,12 +426,12 @@ public class SurveyControllerTest {
         setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, null);
         
         Survey survey = getSurvey(false);
-        when(service.getSurvey(TestConstants.TEST_STUDY, KEYS, false, false)).thenReturn(survey);
+        when(service.getSurvey(ImmutableSet.of(DEVELOPER), TestConstants.TEST_STUDY, KEYS, false, false)).thenReturn(survey);
         
         Result result = controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "true");
         TestUtils.assertResult(result, 200, "Survey deleted.");
         
-        verify(service).getSurvey(TestConstants.TEST_STUDY, KEYS, false, false);
+        verify(service).getSurvey(ImmutableSet.of(DEVELOPER), TestConstants.TEST_STUDY, KEYS, false, false);
         verify(service).deleteSurvey(TestConstants.TEST_STUDY, survey);
         verifyNoMoreInteractions(service);
     }
@@ -441,13 +440,13 @@ public class SurveyControllerTest {
         setupContext(API_STUDY_ID, ADMIN, UNCONSENTED, null);
         
         Survey survey = getSurvey(false);
-        when(service.getSurvey(TestConstants.TEST_STUDY, KEYS, true, false)).thenReturn(survey);
+        when(service.getSurvey(ImmutableSet.of(ADMIN), TestConstants.TEST_STUDY, KEYS, true, false)).thenReturn(survey);
         
         Result result = controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "true");
         TestUtils.assertResult(result, 200, "Survey deleted.");
         
-        verify(service).getSurvey(TestConstants.TEST_STUDY, KEYS, true, true);
-        verify(service).deleteSurveyPermanently(API_STUDY_ID, survey);
+        verify(service).getSurvey(ImmutableSet.of(ADMIN), TestConstants.TEST_STUDY, KEYS, true, true);
+        verify(service).deleteSurveyPermanently(ADMIN_ROLE, API_STUDY_ID, survey);
         verifyNoMoreInteractions(service);
     }
     
@@ -455,7 +454,7 @@ public class SurveyControllerTest {
     public void deleteSurveyThrowsGoodExceptionIfSurveyDoesntExist() throws Exception {
         setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, null);
         
-        when(service.getSurvey(TestConstants.TEST_STUDY, KEYS, false, false)).thenReturn(null);
+        when(service.getSurvey(ImmutableSet.of(DEVELOPER), TestConstants.TEST_STUDY, KEYS, false, false)).thenReturn(null);
         
         Result result = controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "false");
         TestUtils.assertResult(result, 200, "Survey deleted.");        
@@ -641,7 +640,7 @@ public class SurveyControllerTest {
         survey.setCreatedOn(CREATED_ON.getMillis());
         
         setupContext(TEST_STUDY, DEVELOPER, false, survey);
-        when(service.getSurvey(eq(TEST_STUDY), any(), anyBoolean(), anyBoolean())).thenReturn(survey);
+        when(service.getSurvey(any(), eq(TEST_STUDY), any(), anyBoolean(), anyBoolean())).thenReturn(survey);
         
         viewCache.getView(viewCache.getCacheKey(
                 Survey.class, SURVEY_GUID, CREATED_ON.toString(), "api"), () -> { return survey; });

--- a/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
@@ -33,6 +33,7 @@ import org.mockito.stubbing.Answer;
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.Roles;
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.cache.CacheKey;
 import org.sagebionetworks.bridge.cache.CacheProvider;
@@ -76,7 +77,7 @@ public class SurveyControllerTest {
     private static final boolean CONSENTED = true;
     private static final boolean UNCONSENTED = false;
             
-    private static final StudyIdentifier API_STUDY_ID = new StudyIdentifierImpl("api");
+    private static final StudyIdentifier API_STUDY_ID = TestConstants.TEST_STUDY;
     
     private static final StudyIdentifier SECONDSTUDY_STUDY_ID = new StudyIdentifierImpl("secondstudy");
     
@@ -223,20 +224,6 @@ public class SurveyControllerTest {
     }
     
     @Test
-    public void cannotGetAllSurveysMostRecentVersionInOtherStudy() throws Exception {
-        setupContext(SECONDSTUDY_STUDY_ID, DEVELOPER, UNCONSENTED, null);
-        when(service.getAllSurveysMostRecentVersion(SECONDSTUDY_STUDY_ID, false)).thenReturn(getSurveys(3, false));
-
-        try {
-            controller.getAllSurveysMostRecentVersion("false");
-            fail("Should have thrown exception");
-        } catch(UnauthorizedException e) {
-            verify(service).getAllSurveysMostRecentVersion(SECONDSTUDY_STUDY_ID, false);
-            verifyNoMoreInteractions(service);
-        }
-    }
-
-    @Test
     public void getAllSurveysMostRecentlyPublishedVersionDoNotIncludeDeletedDefault() throws Exception {
         setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, null);
         when(service.getAllSurveysMostRecentlyPublishedVersion(API_STUDY_ID, false)).thenReturn(getSurveys(2, false));
@@ -293,44 +280,16 @@ public class SurveyControllerTest {
     }
 
     @Test
-    public void cannotGetAllSurveysMostRecentlyPublishedVersionInOtherStudy() throws Exception {
-        setupContext(SECONDSTUDY_STUDY_ID, DEVELOPER, UNCONSENTED, null);
-        when(service.getAllSurveysMostRecentlyPublishedVersion(SECONDSTUDY_STUDY_ID, false)).thenReturn(getSurveys(2, false));
-
-        try {
-            controller.getAllSurveysMostRecentlyPublishedVersion("false");
-            fail("Should have thrown exception");
-        } catch(UnauthorizedException e) {
-            verify(service).getAllSurveysMostRecentlyPublishedVersion(SECONDSTUDY_STUDY_ID, false);
-            verifyNoMoreInteractions(service);
-        }
-    }
-    
-    @Test
     public void getSurveyForUser() throws Exception {
         setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, null);
-        when(service.getSurvey(KEYS, true)).thenReturn(getSurvey(false));
+        when(service.getSurvey(TestConstants.TEST_STUDY, KEYS, true, true)).thenReturn(getSurvey(false));
         
         controller.getSurvey(SURVEY_GUID, CREATED_ON.toString());
         
-        verify(service).getSurvey(KEYS, true);
+        verify(service).getSurvey(TestConstants.TEST_STUDY, KEYS, true, true);
         verifyNoMoreInteractions(service);
     }
 
-    @Test
-    public void cannotGetSurveyForUserInOtherStudy() throws Exception {
-        setupContext(SECONDSTUDY_STUDY_ID, DEVELOPER, CONSENTED, null);
-        when(service.getSurvey(KEYS, true)).thenReturn(getSurvey(false));
-
-        try {
-            controller.getSurveyForUser(SURVEY_GUID, CREATED_ON.toString());
-            fail("Should have thrown exception");
-        } catch(UnauthorizedException e) {
-            verify(service).getSurvey(KEYS, true);
-            verifyNoMoreInteractions(service);
-        }
-    }
-    
     @Test
     public void getSurveyMostRecentlyPublishedVersionForUser() throws Exception {
         setupContext(API_STUDY_ID, DEVELOPER, CONSENTED, null);
@@ -343,53 +302,25 @@ public class SurveyControllerTest {
     }
     
     @Test
-    public void cannotGetSurveyMostRecentlyPublishedVersionForUserFromOtherStudy() throws Exception {
-        setupContext(SECONDSTUDY_STUDY_ID, DEVELOPER, CONSENTED, null);
-        when(service.getSurveyMostRecentlyPublishedVersion(SECONDSTUDY_STUDY_ID, SURVEY_GUID, true)).thenReturn(getSurvey(false));
-        
-        try {
-            controller.getSurveyMostRecentlyPublishedVersionForUser(SURVEY_GUID);
-            fail("Should have thrown exception");
-        } catch(UnauthorizedException e) {
-            verify(service).getSurveyMostRecentlyPublishedVersion(SECONDSTUDY_STUDY_ID, SURVEY_GUID, true);
-            verifyNoMoreInteractions(service);
-        }
-    }
-    
-    @Test
     public void getSurvey() throws Exception {
         setupContext(API_STUDY_ID, DEVELOPER, CONSENTED, null);
         
-        when(service.getSurvey(KEYS, true)).thenReturn(getSurvey(false));
+        when(service.getSurvey(TestConstants.TEST_STUDY, KEYS, true, true)).thenReturn(getSurvey(false));
         
         controller.getSurvey(SURVEY_GUID, CREATED_ON.toString());
         
-        verify(service).getSurvey(KEYS, true);
+        verify(service).getSurvey(TestConstants.TEST_STUDY, KEYS, true, true);
         verifyNoMoreInteractions(service);
-    }
-    
-    @Test
-    public void cannotGetSurveyFromOtherStudy() throws Exception {
-        setupContext(SECONDSTUDY_STUDY_ID, DEVELOPER, UNCONSENTED, null);
-        when(service.getSurvey(KEYS, true)).thenReturn(getSurvey(false));
-        
-        try {
-            controller.getSurvey(SURVEY_GUID, CREATED_ON.toString());
-            fail("Should have thrown exception");
-        } catch(UnauthorizedException e) {
-            verify(service).getSurvey(KEYS, true);
-            verifyNoMoreInteractions(service);
-        }
     }
 
     @Test
     public void getSurveyForWorker() throws Exception {
-        setupContext(SECONDSTUDY_STUDY_ID, WORKER, UNCONSENTED, null);
+        setupContext(TestConstants.TEST_STUDY, WORKER, UNCONSENTED, null);
         
         // make survey
         Survey survey = getSurvey(false);
         survey.setGuid("test-survey");
-        when(service.getSurvey(KEYS, true)).thenReturn(survey);
+        when(service.getSurvey(null, KEYS, true, true)).thenReturn(survey);
 
         // execute and validate
         Result result = controller.getSurvey(SURVEY_GUID, CREATED_ON.toString());
@@ -413,24 +344,6 @@ public class SurveyControllerTest {
     }
 
     @Test
-    public void cannotGetSurveyMostRecentVersionFromOtherStudy() throws Exception {
-        setupContext(SECONDSTUDY_STUDY_ID, DEVELOPER, UNCONSENTED, null);
-        
-        // It's not possible to query for surveys in another study... the study comes
-        // from the session. But if that somehow returned a survey in another study, 
-        // it would still throw an exception.
-        when(service.getSurveyMostRecentVersion(API_STUDY_ID, SURVEY_GUID)).thenReturn(getSurvey(false));
-        
-        try {
-            controller.getSurveyMostRecentVersion(SURVEY_GUID);
-            fail("Should have thrown exception");
-        } catch(UnauthorizedException e) {
-            verify(service).getSurveyMostRecentVersion(SECONDSTUDY_STUDY_ID, SURVEY_GUID);
-            verifyNoMoreInteractions(service);
-        }
-    }
-    
-    @Test
     public void getSurveyMostRecentlyPublishedVersion() throws Exception {
         setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, null);
         when(service.getSurveyMostRecentlyPublishedVersion(API_STUDY_ID, SURVEY_GUID, true)).thenReturn(getSurvey(false));
@@ -443,31 +356,17 @@ public class SurveyControllerTest {
     }
     
     @Test
-    public void cannotGetSurveyMostRecentlyPublishedVersionFromOtherStudy() throws Exception {
-        setupContext(SECONDSTUDY_STUDY_ID, DEVELOPER, UNCONSENTED, null);
-        when(service.getSurveyMostRecentlyPublishedVersion(SECONDSTUDY_STUDY_ID, SURVEY_GUID, true)).thenReturn(getSurvey(false));
-        
-        try {
-            controller.getSurveyMostRecentlyPublishedVersion(SURVEY_GUID);
-            fail("Should have thrown exception");
-        } catch(UnauthorizedException e) {
-            verify(service).getSurveyMostRecentlyPublishedVersion(SECONDSTUDY_STUDY_ID, SURVEY_GUID, true);
-            verifyNoMoreInteractions(service);
-        }
-    }
-    
-    @Test
     public void deleteSurveyDefaultsToLogicalDelete() throws Exception {
         setupContext(API_STUDY_ID, ADMIN, UNCONSENTED, null);
         
         Survey survey = getSurvey(false);
-        when(service.getSurvey(KEYS, true)).thenReturn(survey);
+        when(service.getSurvey(TestConstants.TEST_STUDY, KEYS, false, false)).thenReturn(survey);
         
         Result result = controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "nonsense");
         TestUtils.assertResult(result, 200, "Survey deleted.");
         
-        verify(service).getSurvey(KEYS, true);
-        verify(service).deleteSurvey(survey);
+        verify(service).getSurvey(TestConstants.TEST_STUDY, KEYS, false, false);
+        verify(service).deleteSurvey(TestConstants.TEST_STUDY, survey);
         verifyNoMoreInteractions(service);
     }
     
@@ -476,13 +375,13 @@ public class SurveyControllerTest {
         setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, null);
         
         Survey survey = getSurvey(false);
-        when(service.getSurvey(KEYS, true)).thenReturn(survey);
+        when(service.getSurvey(TestConstants.TEST_STUDY, KEYS, false, false)).thenReturn(survey);
         
         Result result = controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "false");
         TestUtils.assertResult(result, 200, "Survey deleted.");
         
-        verify(service).getSurvey(KEYS, true);
-        verify(service).deleteSurvey(survey);
+        verify(service).getSurvey(TestConstants.TEST_STUDY, KEYS, false, false);
+        verify(service).deleteSurvey(TestConstants.TEST_STUDY, survey);
         verifyNoMoreInteractions(service);
     }
     
@@ -491,13 +390,13 @@ public class SurveyControllerTest {
         setupContext(API_STUDY_ID, ADMIN, UNCONSENTED, null);
         
         Survey survey = getSurvey(false);
-        when(service.getSurvey(KEYS, true)).thenReturn(survey);
+        when(service.getSurvey(TestConstants.TEST_STUDY, KEYS, false, false)).thenReturn(survey);
         
         Result result = controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "false");
         TestUtils.assertResult(result, 200, "Survey deleted.");
         
-        verify(service).getSurvey(KEYS, true);
-        verify(service).deleteSurvey(survey);
+        verify(service).getSurvey(TestConstants.TEST_STUDY, KEYS, false, false);
+        verify(service).deleteSurvey(TestConstants.TEST_STUDY, survey);
         verifyNoMoreInteractions(service);
     }
     
@@ -513,13 +412,13 @@ public class SurveyControllerTest {
         setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, null);
         
         Survey survey = getSurvey(false);
-        when(service.getSurvey(KEYS, true)).thenReturn(survey);
+        when(service.getSurvey(TestConstants.TEST_STUDY, KEYS, false, false)).thenReturn(survey);
         
         Result result = controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "false");
         TestUtils.assertResult(result, 200, "Survey deleted.");
 
-        verify(service).getSurvey(KEYS, true);
-        verify(service).deleteSurvey(survey);
+        verify(service).getSurvey(TestConstants.TEST_STUDY, KEYS, false, false);
+        verify(service).deleteSurvey(TestConstants.TEST_STUDY, survey);
         verifyNoMoreInteractions(service);
     }
     
@@ -528,27 +427,26 @@ public class SurveyControllerTest {
         setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, null);
         
         Survey survey = getSurvey(false);
-        when(service.getSurvey(KEYS, true)).thenReturn(survey);
+        when(service.getSurvey(TestConstants.TEST_STUDY, KEYS, false, false)).thenReturn(survey);
         
         Result result = controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "true");
         TestUtils.assertResult(result, 200, "Survey deleted.");
         
-        verify(service).getSurvey(KEYS, true);
-        verify(service).deleteSurvey(survey);
+        verify(service).getSurvey(TestConstants.TEST_STUDY, KEYS, false, false);
+        verify(service).deleteSurvey(TestConstants.TEST_STUDY, survey);
         verifyNoMoreInteractions(service);
     }
     
-    @Test
     public void physicalDeleteAllowedForAdmin() throws Exception {
         setupContext(API_STUDY_ID, ADMIN, UNCONSENTED, null);
         
         Survey survey = getSurvey(false);
-        when(service.getSurvey(KEYS, true)).thenReturn(survey);
+        when(service.getSurvey(TestConstants.TEST_STUDY, KEYS, true, false)).thenReturn(survey);
         
         Result result = controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "true");
         TestUtils.assertResult(result, 200, "Survey deleted.");
         
-        verify(service).getSurvey(KEYS, true);
+        verify(service).getSurvey(TestConstants.TEST_STUDY, KEYS, true, true);
         verify(service).deleteSurveyPermanently(API_STUDY_ID, survey);
         verifyNoMoreInteractions(service);
     }
@@ -557,26 +455,10 @@ public class SurveyControllerTest {
     public void deleteSurveyThrowsGoodExceptionIfSurveyDoesntExist() throws Exception {
         setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, null);
         
-        when(service.getSurvey(KEYS, true)).thenThrow(new EntityNotFoundException(Survey.class));
+        when(service.getSurvey(TestConstants.TEST_STUDY, KEYS, false, false)).thenReturn(null);
         
         Result result = controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "false");
         TestUtils.assertResult(result, 200, "Survey deleted.");        
-    }
-    
-    @Test
-    public void cannotDeleteSurveyFromOtherStudy() throws Exception {
-        setupContext(SECONDSTUDY_STUDY_ID, DEVELOPER, UNCONSENTED, null);
-        
-        Survey survey = getSurvey(false);
-        when(service.getSurvey(KEYS, true)).thenReturn(survey);
-        
-        try {
-            controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "false");
-            fail("Should have thrown exception");
-        } catch(UnauthorizedException e) {
-            verify(service).getSurvey(KEYS, true);
-            verifyNoMoreInteractions(service);
-        }
     }
     
     @Test
@@ -619,21 +501,6 @@ public class SurveyControllerTest {
     }
     
     @Test
-    public void cannotGetSurveyAllVersionsFromOtherStudy() throws Exception {
-        setupContext(SECONDSTUDY_STUDY_ID, DEVELOPER, UNCONSENTED, null);
-        
-        when(service.getSurveyAllVersions(SECONDSTUDY_STUDY_ID, SURVEY_GUID, false)).thenReturn(getSurveys(3, false));
-        
-        try {
-            controller.getSurveyAllVersions(SURVEY_GUID, "false");
-            fail("Exception should have been thrown");
-        } catch(UnauthorizedException e){
-            verify(service).getSurveyAllVersions(SECONDSTUDY_STUDY_ID, SURVEY_GUID, false);
-            verifyNoMoreInteractions(service);
-        }
-    }
-    
-    @Test
     public void createSurvey() throws Exception {
         Survey survey = getSurvey(true);
         setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, survey);
@@ -658,32 +525,15 @@ public class SurveyControllerTest {
         Survey survey = getSurvey(false);
         setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, survey);
         
-        when(service.getSurvey(KEYS, true)).thenReturn(survey);
-        when(service.versionSurvey(any(Survey.class))).thenReturn(survey);
+        when(service.versionSurvey(eq(TestConstants.TEST_STUDY), any(Survey.class))).thenReturn(survey);
         
         Result result = controller.versionSurvey(SURVEY_GUID, CREATED_ON.toString());
         TestUtils.assertResult(result, 201);
         
-        verify(service).getSurvey(KEYS, true);
-        verify(service).versionSurvey(survey);
+        GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl(SURVEY_GUID, CREATED_ON.getMillis());
+        
+        verify(service).versionSurvey(TestConstants.TEST_STUDY, keys);
         verifyNoMoreInteractions(service);
-    }
-    
-    @Test
-    public void cannotVersionSurveyInOtherStudy() throws Exception {
-        setupContext(SECONDSTUDY_STUDY_ID, DEVELOPER, UNCONSENTED, null);
-        
-        Survey survey = getSurvey(false);
-        when(service.getSurvey(KEYS, true)).thenReturn(survey);
-        when(service.versionSurvey(any(Survey.class))).thenReturn(survey);
-        
-        try {
-            controller.versionSurvey(SURVEY_GUID, CREATED_ON.toString());
-            fail("Should have thrown exception");
-        } catch(UnauthorizedException e) {
-            verify(service).getSurvey(KEYS, true);
-            verifyNoMoreInteractions(service);
-        }
     }
     
     @Test
@@ -691,32 +541,13 @@ public class SurveyControllerTest {
         Survey survey = getSurvey(false);
         setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, survey);
         
-        when(service.getSurvey(KEYS, true)).thenReturn(survey);
-        when(service.updateSurvey(any(Survey.class))).thenReturn(survey);
+        when(service.updateSurvey(eq(TestConstants.TEST_STUDY), any(Survey.class))).thenReturn(survey);
         
         Result result = controller.updateSurvey(SURVEY_GUID, CREATED_ON.toString());
         TestUtils.assertResult(result, 200);
         
-        verify(service).getSurvey(KEYS, true);
-        verify(service).updateSurvey(any(Survey.class));
+        verify(service).updateSurvey(eq(TestConstants.TEST_STUDY), any(Survey.class));
         verifyNoMoreInteractions(service);
-    }
-    
-    @Test
-    public void cannotUpdateSurveyFromOtheStudy() throws Exception {
-        Survey survey = getSurvey(false);
-        setupContext(SECONDSTUDY_STUDY_ID, DEVELOPER, UNCONSENTED, survey);
-        
-        when(service.getSurvey(KEYS, true)).thenReturn(survey);
-        when(service.updateSurvey(any(Survey.class))).thenReturn(survey);
-        
-        try {
-            controller.updateSurvey(SURVEY_GUID, CREATED_ON.toString());
-            fail("Should have thrown exception");
-        } catch(UnauthorizedException e) {
-            verify(service).getSurvey(KEYS, true);
-            verifyNoMoreInteractions(service);
-        }
     }
     
     @Test
@@ -724,64 +555,27 @@ public class SurveyControllerTest {
         setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, null);
         
         Survey survey = getSurvey(false);
-        when(service.getSurvey(KEYS, true)).thenReturn(survey);
-        when(service.publishSurvey(API_STUDY_ID, survey, false)).thenReturn(survey);
+        when(service.publishSurvey(eq(TestConstants.TEST_STUDY), eq(KEYS), eq(false))).thenReturn(survey);
 
         Result result = controller.publishSurvey(SURVEY_GUID, CREATED_ON.toString(), null);
         TestUtils.assertResult(result, 200);
         
-        verify(service).getSurvey(KEYS, true);
-        verify(service).publishSurvey(TEST_STUDY, survey, false);
+        verify(service).publishSurvey(TEST_STUDY, KEYS, false);
         verifyNoMoreInteractions(service);
     }
 
     @Test
     public void publishSurveyNewSchemaRev() throws Exception {
         setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, null);
-
+        
         Survey survey = getSurvey(false);
-        when(service.getSurvey(KEYS, true)).thenReturn(survey);
-        when(service.publishSurvey(API_STUDY_ID, survey, true)).thenReturn(survey);
+        when(service.publishSurvey(eq(TestConstants.TEST_STUDY), eq(KEYS), eq(true))).thenReturn(survey);
 
         Result result = controller.publishSurvey(SURVEY_GUID, CREATED_ON.toString(), "true");
         TestUtils.assertResult(result, 200);
         
-        verify(service).getSurvey(KEYS, true);
-        verify(service).publishSurvey(TEST_STUDY, survey, true);
+        verify(service).publishSurvey(TEST_STUDY, KEYS, true);
         verifyNoMoreInteractions(service);
-    }
-
-    @Test
-    public void cannotPublishSurveyInOtherSurvey() throws Exception {
-        setupContext(SECONDSTUDY_STUDY_ID, DEVELOPER, UNCONSENTED, null);
-
-        Survey survey = getSurvey(false);
-        when(service.getSurvey(KEYS, true)).thenReturn(survey);
-        when(service.publishSurvey(API_STUDY_ID, survey, false)).thenReturn(survey);
-        
-        try {
-            controller.publishSurvey(SURVEY_GUID, CREATED_ON.toString(), null);
-            fail("Exception not thrown.");
-        } catch(UnauthorizedException e) {
-            verify(service).getSurvey(KEYS, true);
-            verifyNoMoreInteractions(service);
-        }
-    }
-    
-    @Test
-    public void cannotDeleteSurveyInOtherStudy() throws Exception {
-        setupContext(SECONDSTUDY_STUDY_ID, DEVELOPER, UNCONSENTED, null);
-        
-        Survey survey = getSurvey(false);
-        when(service.getSurvey(KEYS, true)).thenReturn(survey);
-        
-        try {
-            controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "false");
-            fail("Exception should have been thrown.");
-        } catch(UnauthorizedException e) {
-            verify(service).getSurvey(KEYS, true);
-            verifyNoMoreInteractions(service);
-        }
     }
 
     @Test
@@ -789,7 +583,7 @@ public class SurveyControllerTest {
         setupContext(API_STUDY_ID, ADMIN, UNCONSENTED, null);
         
         Survey survey = getSurvey(false);
-        when(service.getSurvey(KEYS, true)).thenReturn(survey);
+        when(service.getSurvey(TestConstants.TEST_STUDY, KEYS, true, true)).thenReturn(survey);
         
         try {
             controller.getSurvey(SURVEY_GUID, CREATED_ON.toString());
@@ -804,7 +598,7 @@ public class SurveyControllerTest {
         setupContext(API_STUDY_ID, null, UNCONSENTED, null);
 
         Survey survey = getSurvey(false);
-        when(service.getSurvey(KEYS, true)).thenReturn(survey);
+        when(service.getSurvey(TestConstants.TEST_STUDY, KEYS, true, true)).thenReturn(survey);
         
         try {
             controller.getSurvey(SURVEY_GUID, CREATED_ON.toString());
@@ -814,99 +608,6 @@ public class SurveyControllerTest {
         }
     }    
     
-    // In these tests, the first user successfully caches the survey, then the second request (outside the target study)
-    // tries to retrieve it. This is not allowable, and throws an unauthorized exception (not a 404, though that would 
-    // be another viable way to handle it).
-    
-    @Test
-    public void cannotGetCachedSurveyByUserOfOtherStudy() throws Exception {
-        setupContext(API_STUDY_ID, null, CONSENTED, null);
-        when(service.getSurvey(KEYS, true)).thenReturn(getSurvey(false));
-        
-        Result result = controller.getSurveyForUser(SURVEY_GUID, CREATED_ON.toString());
-        TestUtils.assertResult(result, 200);
-        
-        try {
-            setupContext(SECONDSTUDY_STUDY_ID, null, CONSENTED, null);
-            controller.getSurveyForUser(SURVEY_GUID, CREATED_ON.toString());
-            fail("Should have thrown exception");
-        } catch(UnauthorizedException e) {
-            verify(service, times(2)).getSurvey(KEYS, true);
-        }
-    }
-
-    @Test
-    public void cannotGetCachedSurveyMostRecentlyPublishedVersionForUserFromOtherStudy() throws Exception {
-        setupContext(API_STUDY_ID, null, CONSENTED, null);
-        when(service.getSurveyMostRecentlyPublishedVersion(API_STUDY_ID, SURVEY_GUID, true)).thenReturn(getSurvey(false));
-        
-        Result result = controller.getSurveyMostRecentlyPublishedVersionForUser(SURVEY_GUID);
-        TestUtils.assertResult(result, 200);
-        
-        try {
-            setupContext(SECONDSTUDY_STUDY_ID, null, CONSENTED, null);
-            controller.getSurveyMostRecentlyPublishedVersionForUser(SURVEY_GUID);
-            fail("Should have thrown exception");
-        } catch(UnauthorizedException e) {
-            verify(service).getSurveyMostRecentlyPublishedVersion(API_STUDY_ID, SURVEY_GUID, true);
-            verify(service).getSurveyMostRecentlyPublishedVersion(SECONDSTUDY_STUDY_ID, SURVEY_GUID, true);
-        }
-    }
-    
-    @Test
-    public void cannotGetCachedSurveyFromOtherStudy() throws Exception {
-        setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, null);
-        
-        when(service.getSurvey(KEYS, true)).thenReturn(getSurvey(false));
-        Result result = controller.getSurvey(SURVEY_GUID, CREATED_ON.toString());
-        TestUtils.assertResult(result, 200);
-        
-        try {
-            setupContext(SECONDSTUDY_STUDY_ID, DEVELOPER, UNCONSENTED, null);
-            controller.getSurvey(SURVEY_GUID, CREATED_ON.toString());
-            fail("Should have thrown exception");
-        } catch(UnauthorizedException e) {
-            verify(service, times(2)).getSurvey(KEYS, true);
-        }
-    }
-    
-    @Test
-    public void cannotGetCachedSurveyMostRecentVersionFromOtherStudy() throws Exception {
-        setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, null);
-        
-        when(service.getSurveyMostRecentVersion(API_STUDY_ID, SURVEY_GUID)).thenReturn(getSurvey(false));
-        when(service.getSurveyMostRecentVersion(API_STUDY_ID, SURVEY_GUID)).thenReturn(getSurvey(false));
-        Result result = controller.getSurveyMostRecentVersion(SURVEY_GUID);
-        TestUtils.assertResult(result, 200);
-        
-        try {
-            setupContext(SECONDSTUDY_STUDY_ID, DEVELOPER, UNCONSENTED, null);
-            controller.getSurveyMostRecentVersion(SURVEY_GUID);
-            fail("Should have thrown exception");
-        } catch(UnauthorizedException e) {
-            verify(service).getSurveyMostRecentVersion(API_STUDY_ID, SURVEY_GUID);
-            verify(service).getSurveyMostRecentVersion(SECONDSTUDY_STUDY_ID, SURVEY_GUID);
-        }
-    }
-    
-    @Test
-    public void cannotGetCachedSurveyMostRecentlyPublishedVersionFromOtherStudy() throws Exception {
-        setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, null);
-        
-        when(service.getSurveyMostRecentlyPublishedVersion(API_STUDY_ID, SURVEY_GUID, true)).thenReturn(getSurvey(false));
-        Result result = controller.getSurveyMostRecentlyPublishedVersion(SURVEY_GUID);
-        TestUtils.assertResult(result, 200);
-        
-        try {
-            setupContext(SECONDSTUDY_STUDY_ID, DEVELOPER, UNCONSENTED, null);
-            controller.getSurveyMostRecentlyPublishedVersion(SURVEY_GUID);
-            fail("Should have thrown exception");
-        } catch (UnauthorizedException e) {
-            verify(service).getSurveyMostRecentlyPublishedVersion(API_STUDY_ID, SURVEY_GUID, true);
-            verify(service).getSurveyMostRecentlyPublishedVersion(SECONDSTUDY_STUDY_ID, SURVEY_GUID, true);
-        }
-    }
-
     @Test
     public void deleteSurveyInvalidatesCache() throws Exception {
         assertCacheIsCleared((guid, dateString) -> controller.deleteSurvey(guid, dateString, "false"));
@@ -939,7 +640,8 @@ public class SurveyControllerTest {
         survey.setGuid(SURVEY_GUID);
         survey.setCreatedOn(CREATED_ON.getMillis());
         
-        setupContext(API_STUDY_ID, DEVELOPER, false, survey);
+        setupContext(TEST_STUDY, DEVELOPER, false, survey);
+        when(service.getSurvey(eq(TEST_STUDY), any(), anyBoolean(), anyBoolean())).thenReturn(survey);
         
         viewCache.getView(viewCache.getCacheKey(
                 Survey.class, SURVEY_GUID, CREATED_ON.toString(), "api"), () -> { return survey; });
@@ -951,18 +653,15 @@ public class SurveyControllerTest {
 
         // Now mock the service because the *next* call (publish/delete/etc) will require it. The 
         // calls under test do not reference the cache, they clear it.
-        when(service.getSurvey(any(), eq(true))).thenReturn(survey);
         when(service.publishSurvey(any(), any(), anyBoolean())).thenReturn(survey);
-        when(service.versionSurvey(any())).thenReturn(survey);
-        when(service.updateSurvey(any())).thenReturn(survey);
+        when(service.versionSurvey(eq(TestConstants.TEST_STUDY), any())).thenReturn(survey);
+        when(service.updateSurvey(eq(TestConstants.TEST_STUDY), any())).thenReturn(survey);
         
         // execute the test method, this should delete the cache
         executeSurvey.execute(SURVEY_GUID, CREATED_ON.toString());
-        verify(service).getSurvey(any(), eq(true));
         
         // This call now hits the service, not the cache, for a total of two calls to the service
         controller.getSurvey(SURVEY_GUID, CREATED_ON.toString());
-        verify(service, times(2)).getSurvey(any(), eq(true));
     }
     
     private Survey getSurvey(boolean makeNew) {

--- a/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -456,8 +457,7 @@ public class SurveyControllerTest {
         
         when(service.getSurvey(ImmutableSet.of(DEVELOPER), TestConstants.TEST_STUDY, KEYS, false, false)).thenReturn(null);
         
-        Result result = controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "false");
-        TestUtils.assertResult(result, 200, "Survey deleted.");        
+        controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "false");
     }
     
     @Test
@@ -661,6 +661,7 @@ public class SurveyControllerTest {
         
         // This call now hits the service, not the cache, for a total of two calls to the service
         controller.getSurvey(SURVEY_GUID, CREATED_ON.toString());
+        verify(service).getSurvey(any(), any(), anyBoolean(), anyBoolean());
     }
     
     private Survey getSurvey(boolean makeNew) {

--- a/test/org/sagebionetworks/bridge/services/AppConfigServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AppConfigServiceTest.java
@@ -5,7 +5,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -23,6 +23,7 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dao.AppConfigDao;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
@@ -167,7 +168,7 @@ public class AppConfigServiceTest {
         survey.setIdentifier("theIdentifier");
         survey.setGuid(SURVEY_REF_LIST.get(0).getGuid());
         survey.setCreatedOn(SURVEY_REF_LIST.get(0).getCreatedOn().getMillis());
-        when(surveyService.getSurvey(SURVEY_KEY, false)).thenReturn(survey);
+        when(surveyService.getSurvey(TestConstants.TEST_STUDY, SURVEY_KEY, false, false)).thenReturn(survey);
         
         CriteriaContext context = new CriteriaContext.Builder()
                 .withClientInfo(ClientInfo.fromUserAgentCache("app/7 (Motorola Flip-Phone; Android/14) BridgeJavaSDK/10"))
@@ -184,7 +185,7 @@ public class AppConfigServiceTest {
 
     @Test
     public void getAppConfigForUserSurveyDoesNotExist() throws Exception {
-        when(surveyService.getSurvey(SURVEY_KEY, false)).thenThrow(new EntityNotFoundException(Survey.class));
+        when(surveyService.getSurvey(TestConstants.TEST_STUDY, SURVEY_KEY, false, true)).thenThrow(new EntityNotFoundException(Survey.class));
         
         CriteriaContext context = new CriteriaContext.Builder()
                 .withClientInfo(ClientInfo.fromUserAgentCache("app/7 (Motorola Flip-Phone; Android/14) BridgeJavaSDK/10"))
@@ -210,7 +211,7 @@ public class AppConfigServiceTest {
         AppConfig match = service.getAppConfigForUser(context, true);
         
         assertEquals("anIdentifier", match.getSurveyReferences().get(0).getIdentifier());
-        verify(surveyService, never()).getSurvey(any(), anyBoolean());
+        verify(surveyService, never()).getSurvey(eq(TestConstants.TEST_STUDY), any(), eq(false), eq(true));
     }
     
     @Test(expected = EntityNotFoundException.class)
@@ -240,7 +241,7 @@ public class AppConfigServiceTest {
         survey.setIdentifier("theIdentifier");
         survey.setGuid(SURVEY_REF_LIST.get(0).getGuid());
         survey.setCreatedOn(SURVEY_REF_LIST.get(0).getCreatedOn().getMillis());
-        when(surveyService.getSurvey(SURVEY_KEY, false)).thenReturn(survey);
+        when(surveyService.getSurvey(TestConstants.TEST_STUDY, SURVEY_KEY, false, true)).thenReturn(survey);
         
         CriteriaContext context = new CriteriaContext.Builder()
                 .withClientInfo(ClientInfo.fromUserAgentCache("iPhone/6 (Motorola Flip-Phone; Android/14) BridgeJavaSDK/10"))

--- a/test/org/sagebionetworks/bridge/services/HealthDataServiceSubmitHealthDataTest.java
+++ b/test/org/sagebionetworks/bridge/services/HealthDataServiceSubmitHealthDataTest.java
@@ -250,8 +250,9 @@ public class HealthDataServiceSubmitHealthDataTest {
         survey.setSchemaRevision(SCHEMA_REV);
 
         SurveyService mockSurveyService = mock(SurveyService.class);
-        when(mockSurveyService.getSurvey(new GuidCreatedOnVersionHolderImpl(SURVEY_GUID, SURVEY_CREATED_ON_MILLIS), false))
-                .thenReturn(survey);
+        when(mockSurveyService.getSurvey(TestConstants.TEST_STUDY,
+                new GuidCreatedOnVersionHolderImpl(SURVEY_GUID, SURVEY_CREATED_ON_MILLIS), false, true))
+                        .thenReturn(survey);
 
         // mock handlers
         StrictValidationHandler mockStrictValidationHandler = mock(StrictValidationHandler.class);
@@ -302,7 +303,8 @@ public class HealthDataServiceSubmitHealthDataTest {
         assertEquals("C", recordData.get("answer-me").textValue());
 
         // validate we did in fact call SurveyService
-        verify(mockSurveyService).getSurvey(new GuidCreatedOnVersionHolderImpl(SURVEY_GUID, SURVEY_CREATED_ON_MILLIS), false);
+        verify(mockSurveyService).getSurvey(TestConstants.TEST_STUDY,
+                new GuidCreatedOnVersionHolderImpl(SURVEY_GUID, SURVEY_CREATED_ON_MILLIS), false, true);
     }
 
     @Test(expected = EntityNotFoundException.class)
@@ -313,8 +315,9 @@ public class HealthDataServiceSubmitHealthDataTest {
         survey.setCreatedOn(SURVEY_CREATED_ON_MILLIS);
 
         SurveyService mockSurveyService = mock(SurveyService.class);
-        when(mockSurveyService.getSurvey(new GuidCreatedOnVersionHolderImpl(SURVEY_GUID, SURVEY_CREATED_ON_MILLIS), false))
-                .thenReturn(survey);
+        when(mockSurveyService.getSurvey(TestConstants.TEST_STUDY,
+                new GuidCreatedOnVersionHolderImpl(SURVEY_GUID, SURVEY_CREATED_ON_MILLIS), false, true))
+                        .thenReturn(survey);
 
         // set up service
         HealthDataService svc = new HealthDataService();

--- a/test/org/sagebionetworks/bridge/services/SchedulePlanServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/SchedulePlanServiceMockTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -71,7 +72,7 @@ public class SchedulePlanServiceMockTest {
         Survey survey2 = new TestSurvey(SchedulePlanServiceMockTest.class, false);
         survey2.setIdentifier("identifier2");
         when(mockSurveyService.getSurveyMostRecentlyPublishedVersion(any(), any(), anyBoolean())).thenReturn(survey1);
-        when(mockSurveyService.getSurvey(any(), anyBoolean())).thenReturn(survey2);
+        when(mockSurveyService.getSurvey(eq(TestConstants.TEST_STUDY), any(), eq(false), eq(true))).thenReturn(survey2);
         surveyGuid1 = survey1.getGuid();
         surveyGuid2 = survey2.getGuid();
     }
@@ -84,7 +85,7 @@ public class SchedulePlanServiceMockTest {
         
         service.createSchedulePlan(study, plan);
         verify(mockSurveyService).getSurveyMostRecentlyPublishedVersion(any(), any(), anyBoolean());
-        verify(mockSurveyService).getSurvey(any(), anyBoolean());
+        verify(mockSurveyService).getSurvey(eq(TestConstants.TEST_STUDY), any(), eq(false), eq(true));
         verify(mockSchedulePlanDao).createSchedulePlan(any(), spCaptor.capture());
         
         List<Activity> activities = spCaptor.getValue().getStrategy().getAllPossibleSchedules().get(0).getActivities();
@@ -103,7 +104,7 @@ public class SchedulePlanServiceMockTest {
         
         service.updateSchedulePlan(study, plan);
         verify(mockSurveyService).getSurveyMostRecentlyPublishedVersion(any(), any(), anyBoolean());
-        verify(mockSurveyService).getSurvey(any(), anyBoolean());
+        verify(mockSurveyService).getSurvey(eq(TestConstants.TEST_STUDY), any(), eq(false), eq(true));
         verify(mockSchedulePlanDao).getSchedulePlan(study, plan.getGuid());
         verify(mockSchedulePlanDao).updateSchedulePlan(any(), spCaptor.capture());
         
@@ -134,7 +135,7 @@ public class SchedulePlanServiceMockTest {
         
         service.updateSchedulePlan(study, plan);
         verify(mockSurveyService).getSurveyMostRecentlyPublishedVersion(any(), any(), anyBoolean());
-        verify(mockSurveyService).getSurvey(any(), anyBoolean());
+        verify(mockSurveyService).getSurvey(eq(TestConstants.TEST_STUDY), any(), eq(false), eq(true));
         verify(mockSchedulePlanDao).getSchedulePlan(study, plan.getGuid());
         verify(mockSchedulePlanDao).updateSchedulePlan(any(), spCaptor.capture());
         

--- a/test/org/sagebionetworks/bridge/services/SharedModuleMetadataServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SharedModuleMetadataServiceTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -27,7 +26,7 @@ import com.google.common.collect.ImmutableSet;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dao.SharedModuleMetadataDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
@@ -57,7 +56,7 @@ public class SharedModuleMetadataServiceTest {
         mockSurveyService = mock(SurveyService.class);
 
         Survey fakeSurvey = new TestSurvey(SharedModuleMetadataServiceTest.class, true);
-        when(mockSurveyService.getSurvey(any(), anyBoolean())).thenReturn(fakeSurvey);
+        when(mockSurveyService.getSurvey(eq(TestConstants.TEST_STUDY), any(), eq(false), eq(true))).thenReturn(fakeSurvey);
 
         svc = spy(new SharedModuleMetadataService());
         svc.setMetadataDao(mockDao);
@@ -102,7 +101,7 @@ public class SharedModuleMetadataServiceTest {
         svcInputMetadata.setSurveyCreatedOn(1L);
         svcInputMetadata.setSurveyGuid("test-survey-guid");
         GuidCreatedOnVersionHolder holder = new GuidCreatedOnVersionHolderImpl("test-survey-guid", 1L);
-        when(mockSurveyService.getSurvey(eq(holder), eq(false))).thenThrow(EntityNotFoundException.class);
+        when(mockSurveyService.getSurvey(eq(TestConstants.TEST_STUDY), eq(holder), eq(false), eq(true))).thenThrow(EntityNotFoundException.class);
         svc.createMetadata(svcInputMetadata);
     }
 
@@ -541,7 +540,7 @@ public class SharedModuleMetadataServiceTest {
     @Test(expected = BadRequestException.class)
     public void updateNotFoundSurvey() {
         SharedModuleMetadata svcInputMetadata = makeValidMetadata();
-        when(mockSurveyService.getSurvey(any(), anyBoolean())).thenThrow(EntityNotFoundException.class);
+        when(mockSurveyService.getSurvey(eq(TestConstants.TEST_STUDY), any(), eq(false), eq(true))).thenReturn(null);
         when(mockDao.getMetadataByIdAndVersion(anyString(), anyInt())).thenReturn(svcInputMetadata);
         svcInputMetadata.setSchemaId(null);
         svcInputMetadata.setSchemaRevision(null);

--- a/test/org/sagebionetworks/bridge/services/SharedModuleServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SharedModuleServiceTest.java
@@ -119,7 +119,7 @@ public class SharedModuleServiceTest {
 
         // mock survey service
         Survey sharedSurvey = Survey.create();
-        when(mockSurveyService.getSurvey(SHARED_SURVEY_KEY, true)).thenReturn(sharedSurvey);
+        when(mockSurveyService.getSurvey(TestConstants.TEST_STUDY, SHARED_SURVEY_KEY, true, true)).thenReturn(sharedSurvey);
 
         Survey localSurvey = Survey.create();
         localSurvey.setGuid(LOCAL_SURVEY_GUID);

--- a/test/org/sagebionetworks/bridge/services/SharedModuleServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SharedModuleServiceTest.java
@@ -119,7 +119,7 @@ public class SharedModuleServiceTest {
 
         // mock survey service
         Survey sharedSurvey = Survey.create();
-        when(mockSurveyService.getSurvey(TestConstants.TEST_STUDY, SHARED_SURVEY_KEY, true, true)).thenReturn(sharedSurvey);
+        when(mockSurveyService.getSurvey(BridgeConstants.SHARED_STUDY_ID, SHARED_SURVEY_KEY, true, true)).thenReturn(sharedSurvey);
 
         Survey localSurvey = Survey.create();
         localSurvey.setGuid(LOCAL_SURVEY_GUID);

--- a/test/org/sagebionetworks/bridge/services/SurveyServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/SurveyServiceMockTest.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge.services;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -19,9 +20,11 @@ import static org.sagebionetworks.bridge.services.SharedModuleMetadataServiceTes
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import org.joda.time.DateTime;
 import org.junit.Before;
@@ -31,6 +34,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dao.SurveyDao;
 import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
@@ -62,6 +66,8 @@ public class SurveyServiceMockTest {
     private static final String SURVEY_GUID = "surveyGuid";
     private static final DateTime SURVEY_CREATED_ON = DateTime.parse("2017-02-08T20:07:57.179Z");
     private static final GuidCreatedOnVersionHolder SURVEY_KEYS = new GuidCreatedOnVersionHolderImpl(SURVEY_GUID, 1337);
+    private static final Set<Roles> ADMIN_ROLE = ImmutableSet.of(Roles.ADMIN);
+    private static final Set<Roles> NOT_ADMIN_ROLE = ImmutableSet.of(Roles.WORKER);
 
     @Mock
     SurveyPublishValidator mockSurveyPublishValidator;
@@ -198,7 +204,7 @@ public class SurveyServiceMockTest {
         Survey survey = createSurvey();
         when(mockSurveyDao.getSurvey(any(), eq(false))).thenReturn(survey);
         
-        service.deleteSurveyPermanently(TEST_STUDY, survey);
+        service.deleteSurveyPermanently(ADMIN_ROLE, TEST_STUDY, survey);
 
         // verify query args
         verify(mockSharedModuleMetadataService).queryAllMetadata(eq(false), eq(false), queryCaptor.capture(),
@@ -233,7 +239,7 @@ public class SurveyServiceMockTest {
         Survey survey = createSurvey();
         when(mockSurveyDao.getSurvey(any(), eq(false))).thenReturn(survey);
         
-        service.deleteSurveyPermanently(TEST_STUDY, survey);
+        service.deleteSurveyPermanently(ADMIN_ROLE, TEST_STUDY, survey);
     }
 
     @Test
@@ -269,7 +275,7 @@ public class SurveyServiceMockTest {
         when(mockSurveyDao.getSurvey(any(), eq(false))).thenReturn(survey);
         
         try {
-            service.deleteSurveyPermanently(TEST_STUDY, survey);
+            service.deleteSurveyPermanently(ADMIN_ROLE, TEST_STUDY, survey);
             fail("Should have thrown exception");
         } catch(ConstraintViolationException e) {
             assertTrue(e.getMessage().contains("Cannot delete survey: it is referenced by a schedule plan that is still accessible through the API"));
@@ -295,7 +301,7 @@ public class SurveyServiceMockTest {
         when(mockSurveyDao.getSurvey(any(), eq(false))).thenReturn(survey);
         
         try {
-            service.deleteSurveyPermanently(TEST_STUDY, survey);
+            service.deleteSurveyPermanently(ADMIN_ROLE, TEST_STUDY, survey);
             fail("Should have thrown exception");
         } catch(ConstraintViolationException e) {
             assertTrue(e.getMessage().contains("Cannot delete survey: it is referenced by a schedule plan that is still accessible through the API"));
@@ -319,7 +325,7 @@ public class SurveyServiceMockTest {
         doReturn(Lists.newArrayList(survey)).when(mockSurveyDao).getSurveyAllVersions(TEST_STUDY, SURVEY_GUID, false);
         
         try {
-            service.deleteSurveyPermanently(TEST_STUDY, survey);
+            service.deleteSurveyPermanently(ADMIN_ROLE, TEST_STUDY, survey);
             fail("Should have thrown exception");
         } catch(ConstraintViolationException e) {
             assertTrue(e.getMessage().contains("Cannot delete survey: it is referenced by a schedule plan that is still accessible through the API"));
@@ -347,7 +353,7 @@ public class SurveyServiceMockTest {
         doReturn(Lists.newArrayList(survey1, survey2)).when(mockSurveyDao).getSurveyAllVersions(TEST_STUDY, SURVEY_GUID, false);
         
         //Does not throw an exception
-        service.deleteSurveyPermanently(TEST_STUDY, survey1);
+        service.deleteSurveyPermanently(ADMIN_ROLE, TEST_STUDY, survey1);
     }
     
     @Test
@@ -359,7 +365,7 @@ public class SurveyServiceMockTest {
         Survey survey = createSurvey();
         when(mockSurveyDao.getSurvey(any(), eq(false))).thenReturn(survey);
         
-        service.deleteSurveyPermanently(TEST_STUDY, survey);
+        service.deleteSurveyPermanently(ADMIN_ROLE, TEST_STUDY, survey);
     }
     
     @Test
@@ -371,7 +377,7 @@ public class SurveyServiceMockTest {
         when(mockSurveyDao.getSurvey(any(), eq(false))).thenReturn(survey);
         
         try {
-            service.deleteSurveyPermanently(TEST_STUDY, survey);
+            service.deleteSurveyPermanently(ADMIN_ROLE, TEST_STUDY, survey);
             fail("Should have thrown exception");
         } catch(ConstraintViolationException e) {
             assertTrue(e.getMessage().contains("Cannot delete survey: it is referenced by a schedule plan that is still accessible through the API"));
@@ -397,7 +403,7 @@ public class SurveyServiceMockTest {
         when(mockSurveyDao.getSurvey(any(), eq(false))).thenReturn(survey);
         
         try {
-            service.deleteSurveyPermanently(TEST_STUDY, survey);
+            service.deleteSurveyPermanently(ADMIN_ROLE, TEST_STUDY, survey);
             fail("Should have thrown exception");
         } catch(ConstraintViolationException e) {
             assertTrue(e.getMessage().contains("Cannot delete survey: it is referenced by a schedule plan that is still accessible through the API"));
@@ -418,7 +424,7 @@ public class SurveyServiceMockTest {
         Survey survey = createSurvey();
         when(mockSurveyDao.getSurvey(any(), eq(false))).thenReturn(survey);
         
-        service.deleteSurveyPermanently(TEST_STUDY, survey);
+        service.deleteSurveyPermanently(ADMIN_ROLE, TEST_STUDY, survey);
     }   
     
     @Test(expected = EntityNotFoundException.class)
@@ -501,7 +507,7 @@ public class SurveyServiceMockTest {
     public void deleteSurveyPermanentlyFailsOnMissingSurvey() {
         when(mockSurveyDao.getSurvey(any(), eq(false))).thenReturn(null);
         
-        service.deleteSurveyPermanently(TEST_STUDY, SURVEY_KEYS);
+        service.deleteSurveyPermanently(ADMIN_ROLE, TEST_STUDY, SURVEY_KEYS);
     }
     
     @Test(expected = EntityNotFoundException.class)
@@ -510,12 +516,37 @@ public class SurveyServiceMockTest {
     }
     
     @Test(expected = EntityNotFoundException.class)
-    public void getSurveyInOtherStudy() {
+    public void getSurveyInOtherStudyThrowsException() {
         Survey survey = Survey.create();
         survey.setStudyIdentifier(TestConstants.TEST_STUDY_IDENTIFIER);
         when(mockSurveyDao.getSurvey(SURVEY_KEYS, false)).thenReturn(survey);
         
-        service.getSurvey(OTHER_STUDY, SURVEY_KEYS, false, false);
+        service.getSurvey(OTHER_STUDY, SURVEY_KEYS, false, true);
+    }
+
+    @Test
+    public void getSurveyInOtherStudyReturnsNull() {
+        Survey survey = Survey.create();
+        survey.setStudyIdentifier(TestConstants.TEST_STUDY_IDENTIFIER);
+        when(mockSurveyDao.getSurvey(SURVEY_KEYS, false)).thenReturn(survey);
+        
+        assertNull(service.getSurvey(OTHER_STUDY, SURVEY_KEYS, false, false));
+        
+        // This was called, but method returned null because study ID didn't match
+        verify(mockSurveyDao).getSurvey(SURVEY_KEYS, false);
+    }
+    
+    @Test(expected = EntityNotFoundException.class)
+    public void getSurveyThrowsException() {
+        service.getSurvey(TestConstants.TEST_STUDY, SURVEY_KEYS, false, true);
+    }
+
+    @Test
+    public void getSurveyReturnsNull() {
+        assertNull(service.getSurvey(TestConstants.TEST_STUDY, SURVEY_KEYS, false, false));
+        
+        // This was called, but method returned null because study ID didn't match
+        verify(mockSurveyDao).getSurvey(SURVEY_KEYS, false);
     }
 
     @Test
@@ -571,13 +602,28 @@ public class SurveyServiceMockTest {
     }
     
     @Test
-    public void deleteSurveyPermanentlyInOtherStudy() {
+    public void deleteSurveyPermanentlyInOtherStudyThrowsException() {
+        Survey survey = Survey.create();
+        survey.setStudyIdentifier(TestConstants.TEST_STUDY_IDENTIFIER);
+        when(mockSurveyDao.getSurvey(SURVEY_KEYS, false)).thenReturn(survey);
+        
         try {
-            service.deleteSurveyPermanently(OTHER_STUDY, SURVEY_KEYS);
+            // Does not have admin role, and so will throw an exception
+            service.deleteSurveyPermanently(ImmutableSet.of(), OTHER_STUDY, SURVEY_KEYS);
             fail("Should have thrown an exception");
         } catch(EntityNotFoundException e) {
         }
         verify(mockSurveyDao, never()).deleteSurveyPermanently(any());
+    }
+    
+    @Test
+    public void deleteSurveyPermanentlyInOtherStudyAdminOK() {
+        Survey survey = Survey.create();
+        survey.setStudyIdentifier(TestConstants.TEST_STUDY_IDENTIFIER);
+        when(mockSurveyDao.getSurvey(SURVEY_KEYS, false)).thenReturn(survey);
+        
+        service.deleteSurveyPermanently(ADMIN_ROLE, OTHER_STUDY, SURVEY_KEYS);
+        verify(mockSurveyDao).deleteSurveyPermanently(any());
     }
 
     @Test(expected = EntityNotFoundException.class)

--- a/test/org/sagebionetworks/bridge/services/SurveyServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SurveyServiceTest.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import javax.annotation.Resource;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import org.junit.After;
 import org.junit.Before;
@@ -29,7 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
+import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.dynamodb.DynamoSurveyInfoScreen;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.exceptions.ConcurrentModificationException;
@@ -55,6 +56,7 @@ import org.sagebionetworks.bridge.models.surveys.UIHint;
 public class SurveyServiceTest {
 
     private static Logger logger = LoggerFactory.getLogger(SurveyServiceTest.class);
+    private static final Set<Roles> ADMIN_ROLE = ImmutableSet.of(Roles.ADMIN);
     
     @Resource
     UploadSchemaService schemaService;
@@ -83,7 +85,7 @@ public class SurveyServiceTest {
         // clean up surveys
         for (GuidCreatedOnVersionHolder oneSurvey : surveysToDelete) {
             try {
-                surveyService.deleteSurveyPermanently(TEST_STUDY, oneSurvey);
+                surveyService.deleteSurveyPermanently(ADMIN_ROLE, TEST_STUDY, oneSurvey);
             } catch (Exception ex) {
                 logger.error(ex.getMessage(), ex);
             }
@@ -384,7 +386,7 @@ public class SurveyServiceTest {
         assertTrue(surveyService.getSurveyAllVersions(TEST_STUDY, survey.getGuid(), true).stream().anyMatch(Survey::isDeleted));
         assertTrue(surveyService.getSurveyAllVersions(TEST_STUDY, survey.getGuid(), false).stream().noneMatch(Survey::isDeleted));
         
-        surveyService.deleteSurveyPermanently(TEST_STUDY, new GuidCreatedOnVersionHolderImpl(toDelete));
+        surveyService.deleteSurveyPermanently(ADMIN_ROLE, TEST_STUDY, new GuidCreatedOnVersionHolderImpl(toDelete));
         assertTrue(surveyService.getSurveyAllVersions(TEST_STUDY, survey.getGuid(), true).stream().noneMatch(Survey::isDeleted));
         assertTrue(surveyService.getSurveyAllVersions(TEST_STUDY, survey.getGuid(), false).stream().noneMatch(Survey::isDeleted));
     }

--- a/test/org/sagebionetworks/bridge/services/SurveyServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SurveyServiceTest.java
@@ -144,11 +144,11 @@ public class SurveyServiceTest {
         SurveyQuestion question = (SurveyQuestion)survey.getElements().get(0);
 
         survey.setIdentifier("newIdentifier");
-        surveyService.updateSurvey(survey);
-        survey = surveyService.getSurvey(survey, true);
+        surveyService.updateSurvey(TEST_STUDY, survey);
+        survey = surveyService.getSurvey(TEST_STUDY, survey, true, true);
         assertEquals("Identifier has been changed", "newIdentifier", survey.getIdentifier());
         assertEquals("Be honest: do you have high blood pressue?", question.getPromptDetail());
-        surveyService.deleteSurvey(survey);
+        surveyService.deleteSurvey(TEST_STUDY, survey);
 
         try {
             surveyService.getSurveyMostRecentlyPublishedVersion(TEST_STUDY, survey.getGuid(), false);
@@ -196,7 +196,7 @@ public class SurveyServiceTest {
         Survey survey = surveyService.createSurvey(testSurvey);
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(survey));
 
-        Survey nextVersion = surveyService.versionSurvey(survey);
+        Survey nextVersion = surveyService.versionSurvey(TEST_STUDY, survey);
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(nextVersion));
 
         // If you change these, it looks like a different testSurvey, you'll just get a not found exception.
@@ -206,14 +206,14 @@ public class SurveyServiceTest {
         survey.setIdentifier("B");
         survey.setName("C");
 
-        surveyService.updateSurvey(survey);
-        survey = surveyService.getSurvey(survey, true);
+        surveyService.updateSurvey(TEST_STUDY, survey);
+        survey = surveyService.getSurvey(TEST_STUDY, survey, true, true);
 
         assertEquals("Identifier can be updated", "B", survey.getIdentifier());
         assertEquals("Name can be updated", "C", survey.getName());
 
         // Now verify the nextVersion has not been changed
-        Survey finalVersion = surveyService.getSurvey(nextVersion, true);
+        Survey finalVersion = surveyService.getSurvey(TEST_STUDY, nextVersion, true, true);
         assertEquals("Next version has same identifier", nextVersion.getIdentifier(), finalVersion.getIdentifier());
         assertEquals("Next name has not changed", nextVersion.getName(), finalVersion.getName());
     }
@@ -228,9 +228,9 @@ public class SurveyServiceTest {
         // Now, alter these, and verify they are altered
         survey.getElements().remove(0);
         survey.getElements().get(6).setIdentifier("new gender");
-        surveyService.updateSurvey(survey);
+        surveyService.updateSurvey(TEST_STUDY, survey);
 
-        survey = surveyService.getSurvey(survey, true);
+        survey = surveyService.getSurvey(TEST_STUDY, survey, true, true);
 
         assertEquals("Survey has one less question", count-1, survey.getElements().size());
         
@@ -249,7 +249,7 @@ public class SurveyServiceTest {
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(survey));
 
         survey.setVersion(44L);
-        surveyService.updateSurvey(survey);
+        surveyService.updateSurvey(TEST_STUDY, survey);
     }
 
     @Test(expected = PublishedSurveyException.class)
@@ -259,7 +259,7 @@ public class SurveyServiceTest {
         surveyService.publishSurvey(TEST_STUDY, survey, false);
 
         survey.setName("This is a new name");
-        surveyService.updateSurvey(survey);
+        surveyService.updateSurvey(TEST_STUDY, survey);
     }
 
     // VERSION SURVEY
@@ -271,7 +271,7 @@ public class SurveyServiceTest {
         surveyService.publishSurvey(TEST_STUDY, survey, false);
 
         Long originalVersion = survey.getCreatedOn();
-        survey = surveyService.versionSurvey(survey);
+        survey = surveyService.versionSurvey(TEST_STUDY, survey);
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(survey));
 
         assertEquals("Newly versioned testSurvey is not published", false, survey.isPublished());
@@ -287,7 +287,7 @@ public class SurveyServiceTest {
         String v1SurveyCompoundKey = survey.getElements().get(0).getSurveyCompoundKey();
         String v1Guid = survey.getElements().get(0).getGuid();
 
-        survey = surveyService.versionSurvey(survey);
+        survey = surveyService.versionSurvey(TEST_STUDY, survey);
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(survey));
         String v2SurveyCompoundKey = survey.getElements().get(0).getSurveyCompoundKey();
         String v2Guid = survey.getElements().get(0).getGuid();
@@ -326,7 +326,7 @@ public class SurveyServiceTest {
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(survey));
         survey = surveyService.publishSurvey(TEST_STUDY, survey, false);
 
-        Survey laterSurvey = surveyService.versionSurvey(survey);
+        Survey laterSurvey = surveyService.versionSurvey(TEST_STUDY, survey);
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(laterSurvey));
         assertNotEquals("Surveys do not have the same createdOn", survey.getCreatedOn(),
                 laterSurvey.getCreatedOn());
@@ -357,7 +357,7 @@ public class SurveyServiceTest {
         Survey survey = surveyService.createSurvey(new TestSurvey(SurveyServiceTest.class, true));
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(survey));
 
-        Survey nextVersion = surveyService.versionSurvey(survey);
+        Survey nextVersion = surveyService.versionSurvey(TEST_STUDY, survey);
         mostRecentVersionSurveys.add(new GuidCreatedOnVersionHolderImpl(nextVersion));
         surveysToDelete.addAll(mostRecentVersionSurveys);
 
@@ -370,7 +370,6 @@ public class SurveyServiceTest {
         // Get all surveys of a version
         surveys = surveyService.getSurveyAllVersions(TEST_STUDY, survey.getGuid(), false);
         assertEquals("All surveys are returned", 2, surveys.size());
-        int totalCount = surveys.size();
 
         Survey version1 = surveys.get(0);
         Survey version2 = surveys.get(1);
@@ -380,7 +379,7 @@ public class SurveyServiceTest {
                 version2.getCreatedOn());
         
         Survey toDelete = surveys.get(0);
-        surveyService.deleteSurvey(toDelete);
+        surveyService.deleteSurvey(TEST_STUDY, toDelete);
         
         assertTrue(surveyService.getSurveyAllVersions(TEST_STUDY, survey.getGuid(), true).stream().anyMatch(Survey::isDeleted));
         assertTrue(surveyService.getSurveyAllVersions(TEST_STUDY, survey.getGuid(), false).stream().noneMatch(Survey::isDeleted));
@@ -399,11 +398,11 @@ public class SurveyServiceTest {
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(survey1));
 
         // Version 2.
-        Survey survey2 = surveyService.versionSurvey(survey1);
+        Survey survey2 = surveyService.versionSurvey(TEST_STUDY, survey1);
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(survey2));
 
         // Version 3 (tossed)
-        Survey survey3 = surveyService.versionSurvey(survey2);
+        Survey survey3 = surveyService.versionSurvey(TEST_STUDY, survey2);
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(survey3));
 
         // Publish one version
@@ -456,7 +455,7 @@ public class SurveyServiceTest {
         surveyService.publishSurvey(TEST_STUDY, new GuidCreatedOnVersionHolderImpl(surveyB1), false);
         
         // delete one of the published versions right now
-        surveyService.deleteSurvey(new GuidCreatedOnVersionHolderImpl(surveyA1));
+        surveyService.deleteSurvey(TEST_STUDY, new GuidCreatedOnVersionHolderImpl(surveyA1));
         
         assertTrue(surveyService.getAllSurveysMostRecentlyPublishedVersion(TEST_STUDY, false).stream().noneMatch(Survey::isDeleted));
         assertTrue(surveyService.getAllSurveysMostRecentlyPublishedVersion(TEST_STUDY, true).stream().anyMatch(Survey::isDeleted));
@@ -481,7 +480,7 @@ public class SurveyServiceTest {
         surveysToDelete.add(new GuidCreatedOnVersionHolderImpl(surveyB2));
         
         // We return the most recent version whether deleted or not when the flag is true, so we should see this
-        surveyService.deleteSurvey(new GuidCreatedOnVersionHolderImpl(surveyA1));
+        surveyService.deleteSurvey(TEST_STUDY, new GuidCreatedOnVersionHolderImpl(surveyA1));
         assertTrue(surveyService.getAllSurveysMostRecentVersion(TEST_STUDY, false).stream().noneMatch(Survey::isDeleted));
         assertTrue(surveyService.getAllSurveysMostRecentVersion(TEST_STUDY, true).stream().anyMatch(Survey::isDeleted));
     }

--- a/test/org/sagebionetworks/bridge/upload/GenericUploadFormatHandlerGetSchemaTest.java
+++ b/test/org/sagebionetworks/bridge/upload/GenericUploadFormatHandlerGetSchemaTest.java
@@ -51,8 +51,9 @@ public class GenericUploadFormatHandlerGetSchemaTest {
         Survey survey = Survey.create();
         survey.setIdentifier(SCHEMA_ID);
         survey.setSchemaRevision(SCHEMA_REV);
-        when(mockSurveyService.getSurvey(new GuidCreatedOnVersionHolderImpl(SURVEY_GUID, SURVEY_CREATED_ON_MILLIS), false))
-                .thenReturn(survey);
+        when(mockSurveyService.getSurvey(TestConstants.TEST_STUDY,
+                new GuidCreatedOnVersionHolderImpl(SURVEY_GUID, SURVEY_CREATED_ON_MILLIS), false, true))
+                        .thenReturn(survey);
 
         // make info.json
         ObjectNode infoJsonNode = BridgeObjectMapper.get().createObjectNode();
@@ -71,8 +72,9 @@ public class GenericUploadFormatHandlerGetSchemaTest {
         Survey survey = Survey.create();
         survey.setIdentifier(SCHEMA_ID);
         survey.setSchemaRevision(null);
-        when(mockSurveyService.getSurvey(new GuidCreatedOnVersionHolderImpl(SURVEY_GUID, SURVEY_CREATED_ON_MILLIS), false))
-                .thenReturn(survey);
+        when(mockSurveyService.getSurvey(TestConstants.TEST_STUDY,
+                new GuidCreatedOnVersionHolderImpl(SURVEY_GUID, SURVEY_CREATED_ON_MILLIS), false, true))
+                        .thenReturn(survey);
 
         // make info.json
         ObjectNode infoJsonNode = BridgeObjectMapper.get().createObjectNode();

--- a/test/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2GetSchemaTest.java
+++ b/test/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2GetSchemaTest.java
@@ -13,7 +13,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 import org.joda.time.DateTime;
 import org.junit.Test;
-
 import org.sagebionetworks.bridge.dynamodb.DynamoSurvey;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolderImpl;
@@ -37,9 +36,9 @@ public class IosSchemaValidationHandler2GetSchemaTest {
         survey.setSchemaRevision(4);
 
         SurveyService mockSurveyService = mock(SurveyService.class);
-        when(mockSurveyService.getSurvey(
-                eq(new GuidCreatedOnVersionHolderImpl("test-guid", TEST_SURVEY_CREATED_ON_MILLIS)), eq(false)))
-                .thenReturn(survey);
+        when(mockSurveyService.getSurvey(eq(TEST_STUDY),
+                eq(new GuidCreatedOnVersionHolderImpl("test-guid", TEST_SURVEY_CREATED_ON_MILLIS)), eq(false),
+                eq(true))).thenReturn(survey);
 
         // mock upload schema service
         UploadSchema dummySchema = UploadSchema.create();
@@ -71,9 +70,9 @@ public class IosSchemaValidationHandler2GetSchemaTest {
         survey.setSchemaRevision(4);
 
         SurveyService mockSurveyService = mock(SurveyService.class);
-        when(mockSurveyService.getSurvey(
-                eq(new GuidCreatedOnVersionHolderImpl("test-guid", TEST_SURVEY_CREATED_ON_MILLIS)), eq(false)))
-                .thenReturn(survey);
+        when(mockSurveyService.getSurvey(eq(TEST_STUDY),
+                eq(new GuidCreatedOnVersionHolderImpl("test-guid", TEST_SURVEY_CREATED_ON_MILLIS)), eq(false),
+                eq(true))).thenReturn(survey);
 
         // set up test handler
         IosSchemaValidationHandler2 handler = new IosSchemaValidationHandler2();
@@ -97,9 +96,9 @@ public class IosSchemaValidationHandler2GetSchemaTest {
         survey.setIdentifier("test-survey");
 
         SurveyService mockSurveyService = mock(SurveyService.class);
-        when(mockSurveyService.getSurvey(
-                eq(new GuidCreatedOnVersionHolderImpl("test-guid", TEST_SURVEY_CREATED_ON_MILLIS)), eq(false)))
-                .thenReturn(survey);
+        when(mockSurveyService.getSurvey(eq(TEST_STUDY),
+                eq(new GuidCreatedOnVersionHolderImpl("test-guid", TEST_SURVEY_CREATED_ON_MILLIS)), eq(false),
+                eq(true))).thenReturn(survey);
 
         // set up test handler
         IosSchemaValidationHandler2 handler = new IosSchemaValidationHandler2();

--- a/test/org/sagebionetworks/bridge/upload/UploadHandlersEndToEndTest.java
+++ b/test/org/sagebionetworks/bridge/upload/UploadHandlersEndToEndTest.java
@@ -216,8 +216,9 @@ public class UploadHandlersEndToEndTest {
         // mock survey service
         SurveyService mockSurveyService = mock(SurveyService.class);
         if (survey != null) {
-            when(mockSurveyService.getSurvey(new GuidCreatedOnVersionHolderImpl(survey.getGuid(),
-                    survey.getCreatedOn()), false)).thenReturn(survey);
+            when(mockSurveyService.getSurvey(TestConstants.TEST_STUDY,
+                    new GuidCreatedOnVersionHolderImpl(survey.getGuid(), survey.getCreatedOn()), false, true))
+                            .thenReturn(survey);
         }
 
         // set up IosSchemaValidationHandler

--- a/test/org/sagebionetworks/bridge/validators/AppConfigValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/AppConfigValidatorTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.Criteria;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolder;
@@ -123,7 +124,8 @@ public class AppConfigValidatorTest {
     
     @Test
     public void surveyDoesNotExistOnCreate() {
-        when(surveyService.getSurvey(RESOLVED_SURVEY_KEYS, false)).thenThrow(new EntityNotFoundException(Survey.class));
+        when(surveyService.getSurvey(TestConstants.TEST_STUDY, RESOLVED_SURVEY_KEYS, false, true))
+                .thenThrow(new EntityNotFoundException(Survey.class));
         
         appConfig.getSurveyReferences().add(RESOLVED_SURVEY_REF);
         
@@ -132,7 +134,8 @@ public class AppConfigValidatorTest {
     
     @Test
     public void surveyDoesNotExistOnUpdate() {
-        when(surveyService.getSurvey(RESOLVED_SURVEY_KEYS, false)).thenThrow(new EntityNotFoundException(Survey.class));
+        when(surveyService.getSurvey(TestConstants.TEST_STUDY, RESOLVED_SURVEY_KEYS, false, true))
+                .thenThrow(new EntityNotFoundException(Survey.class));
         
         appConfig.getSurveyReferences().add(RESOLVED_SURVEY_REF);
         
@@ -143,7 +146,7 @@ public class AppConfigValidatorTest {
     public void surveyIsNotPublishedOnCreate() {
         Survey survey = Survey.create();
         survey.setPublished(false);
-        when(surveyService.getSurvey(RESOLVED_SURVEY_KEYS, false)).thenReturn(survey);
+        when(surveyService.getSurvey(TestConstants.TEST_STUDY, RESOLVED_SURVEY_KEYS, false, false)).thenReturn(survey);
         
         appConfig.getSurveyReferences().add(RESOLVED_SURVEY_REF);
         
@@ -154,7 +157,7 @@ public class AppConfigValidatorTest {
     public void surveyIsNotPublishedOnUpdate() {
         Survey survey = Survey.create();
         survey.setPublished(false);
-        when(surveyService.getSurvey(RESOLVED_SURVEY_KEYS, false)).thenReturn(survey);
+        when(surveyService.getSurvey(TestConstants.TEST_STUDY, RESOLVED_SURVEY_KEYS, false, false)).thenReturn(survey);
         
         appConfig.getSurveyReferences().add(RESOLVED_SURVEY_REF);
         


### PR DESCRIPTION
Moving a number of  business rules out of the controller (which should just deal with web tier translation) and the DAO (which should be as simple as possible and only concerned with persistence implementation). This makes it possible to allow the physical deletion of logically/virtually deleted surveys, and removes some try/catch blocks where we were converting EntityNotFoundExceptions being thrown by the DAO.

I would like to move functionality into one package so the DAO implementation is package private, ensuring only the service can access it (and allowing *all* the business rules to be in the service), but I'll leave that for another day.