### PR TITLE
Create means for admin user to sign in and switch between studies.

### DIFF
--- a/app/org/sagebionetworks/bridge/models/accounts/SignIn.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/SignIn.java
@@ -81,6 +81,16 @@ public final class SignIn implements BridgeEntity {
         private String token;
         private String reauthToken;
         
+        public Builder withSignIn(SignIn signIn) {
+            this.email = signIn.email;
+            this.phone = signIn.phone;
+            this.externalId = signIn.externalId;
+            this.password = signIn.password;
+            this.studyId = signIn.studyId;
+            this.token = signIn.token;
+            this.reauthToken = signIn.reauthToken;
+            return this;
+        }
         public Builder withUsername(String username) {
             this.username = username;    
             return this;

--- a/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
@@ -3,15 +3,12 @@ package org.sagebionetworks.bridge.play.controllers;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import org.sagebionetworks.bridge.BridgeConstants;
-import org.sagebionetworks.bridge.config.Environment;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.ConsentRequiredException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
-import org.sagebionetworks.bridge.time.DateUtils;
 import org.sagebionetworks.bridge.json.JsonUtils;
 import org.sagebionetworks.bridge.models.CriteriaContext;
-import org.sagebionetworks.bridge.models.RequestInfo;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.PasswordReset;
@@ -235,19 +232,6 @@ public class AuthenticationController extends BaseController {
         getStudyOrThrowException(passwordReset.getStudyIdentifier());
         authenticationService.resetPassword(passwordReset);
         return okResult("Password has been changed.");
-    }
-
-    private void setCookieAndRecordMetrics(UserSession session) {
-        writeSessionInfoToMetrics(session);  
-        RequestInfo requestInfo = getRequestInfoBuilder(session)
-                .withSignedInOn(DateUtils.getCurrentDateTime()).build();
-        cacheProvider.updateRequestInfo(requestInfo);
-        // only set cookie in local environment
-        if (bridgeConfig.getEnvironment() == Environment.LOCAL) {
-            response().setCookie(BridgeConstants.SESSION_TOKEN_HEADER, session.getSessionToken(),
-                    BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS, "/",
-                    bridgeConfig.get("domain"), false, false);
-        }
     }
 
     private Study getStudyOrThrowException(String studyId) {

--- a/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/BaseController.java
@@ -44,7 +44,7 @@ import org.sagebionetworks.bridge.play.interceptors.RequestUtils;
 import org.sagebionetworks.bridge.services.AuthenticationService;
 import org.sagebionetworks.bridge.services.SessionUpdateService;
 import org.sagebionetworks.bridge.services.StudyService;
-
+import org.sagebionetworks.bridge.time.DateUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -451,6 +451,22 @@ public abstract class BaseController extends Controller {
             metrics.setSessionId(session.getInternalSessionToken());
             metrics.setUserId(session.getId());
             metrics.setStudy(session.getStudyIdentifier().getIdentifier());
+        }
+    }
+    
+    /** Combines metrics logging with the setting of the session token as a cookie in local
+     * environments (useful for testing).
+     */
+    protected void setCookieAndRecordMetrics(UserSession session) {
+        writeSessionInfoToMetrics(session);  
+        RequestInfo requestInfo = getRequestInfoBuilder(session)
+                .withSignedInOn(DateUtils.getCurrentDateTime()).build();
+        cacheProvider.updateRequestInfo(requestInfo);
+        // only set cookie in local environment
+        if (bridgeConfig.getEnvironment() == Environment.LOCAL) {
+            response().setCookie(BridgeConstants.SESSION_TOKEN_HEADER, session.getSessionToken(),
+                    BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS, "/",
+                    bridgeConfig.get("domain"), false, false);
         }
     }
     

--- a/app/org/sagebionetworks/bridge/play/controllers/UserManagementController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/UserManagementController.java
@@ -71,7 +71,7 @@ public class UserManagementController extends BaseController {
         // Verify it's correct
         Study study = studyService.getStudy(studyId);
         sessionUpdateService.updateStudy(session, study.getStudyIdentifier());
-
+        
         return okResult(UserSessionInfo.toJSON(session));
     }
     

--- a/app/org/sagebionetworks/bridge/play/controllers/UserManagementController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/UserManagementController.java
@@ -2,16 +2,24 @@ package org.sagebionetworks.bridge.play.controllers;
 
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 
+import org.sagebionetworks.bridge.BridgeConstants;
+import org.sagebionetworks.bridge.Roles;
+import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import play.mvc.Result;
 
 import org.sagebionetworks.bridge.json.JsonUtils;
+import org.sagebionetworks.bridge.models.CriteriaContext;
+import org.sagebionetworks.bridge.models.accounts.SignIn;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.accounts.UserSessionInfo;
 import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.services.UserAdminService;
 
 @Controller
@@ -26,6 +34,47 @@ public class UserManagementController extends BaseController {
         this.userAdminService = userAdminService;
     }
 
+    public Result signInForAdmin() throws Exception {
+        SignIn originSignIn = parseJson(request(), SignIn.class);
+        
+        // Persist the requested study
+        StudyIdentifier originStudy = new StudyIdentifierImpl(originSignIn.getStudyId());
+        
+        // Adjust the sign in so it is always done against the API study.
+        SignIn signIn = new SignIn.Builder().withSignIn(originSignIn)
+                .withStudy(BridgeConstants.API_STUDY_ID_STRING).build();        
+        
+        Study study = studyService.getStudy(signIn.getStudyId());
+        CriteriaContext context = getCriteriaContext(study.getStudyIdentifier());
+
+        // We do not check consent, but do verify this is an administrator
+        UserSession session = authenticationService.signIn(study, context, signIn);
+
+        if (!session.isInRole(Roles.ADMIN)) {
+            throw new UnauthorizedException("Not an admin account");
+        }
+        
+        // Now act as if the user is in the study that was requested
+        sessionUpdateService.updateStudy(session, originStudy);
+        setCookieAndRecordMetrics(session);
+        
+        return okResult(UserSessionInfo.toJSON(session));
+    }
+    
+    public Result changeStudyForAdmin() throws Exception {
+        UserSession session = getAuthenticatedSession(ADMIN);
+
+        // The only part of this payload we care about is the study property
+        SignIn signIn = parseJson(request(), SignIn.class);
+        String studyId = signIn.getStudyId();
+
+        // Verify it's correct
+        Study study = studyService.getStudy(studyId);
+        sessionUpdateService.updateStudy(session, study.getStudyIdentifier());
+
+        return okResult(UserSessionInfo.toJSON(session));
+    }
+    
     public Result createUser() throws Exception {
         UserSession session = getAuthenticatedSession(ADMIN);
         Study study = studyService.getStudy(session.getStudyIdentifier());

--- a/app/org/sagebionetworks/bridge/services/SessionUpdateService.java
+++ b/app/org/sagebionetworks/bridge/services/SessionUpdateService.java
@@ -14,6 +14,7 @@ import org.sagebionetworks.bridge.models.accounts.ExternalIdentifier;
 import org.sagebionetworks.bridge.models.accounts.SharingScope;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 
 /**
@@ -39,6 +40,11 @@ public class SessionUpdateService {
     
     public void updateTimeZone(UserSession session, DateTimeZone timeZone) {
         session.setParticipant(builder(session).withTimeZone(timeZone).build());
+        cacheProvider.setUserSession(session);
+    }
+    
+    public void updateStudy(UserSession session, StudyIdentifier studyId) {
+        session.setStudyIdentifier(studyId);
         cacheProvider.setUserSession(session);
     }
     

--- a/conf/routes
+++ b/conf/routes
@@ -31,6 +31,8 @@ POST   /v3/auth/email/signIn            @org.sagebionetworks.bridge.play.control
 POST   /v3/auth/phone                   @org.sagebionetworks.bridge.play.controllers.AuthenticationController.requestPhoneSignIn
 POST   /v3/auth/phone/signIn            @org.sagebionetworks.bridge.play.controllers.AuthenticationController.phoneSignIn
 POST   /v4/auth/signIn                  @org.sagebionetworks.bridge.play.controllers.AuthenticationController.signIn
+POST   /v3/auth/admin/signIn            @org.sagebionetworks.bridge.play.controllers.UserManagementController.signInForAdmin
+POST   /v3/auth/admin/study             @org.sagebionetworks.bridge.play.controllers.UserManagementController.changeStudyForAdmin
 
 # OAuth
 POST /v3/oauth/:vendorId    @org.sagebionetworks.bridge.play.controllers.OAuthController.requestAccessToken(vendorId: String)

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoMockTest.java
@@ -43,9 +43,7 @@ import org.sagebionetworks.bridge.models.surveys.Survey;
 import org.sagebionetworks.bridge.models.surveys.SurveyElement;
 import org.sagebionetworks.bridge.models.surveys.SurveyInfoScreen;
 import org.sagebionetworks.bridge.models.surveys.SurveyQuestion;
-import org.sagebionetworks.bridge.models.surveys.TestSurvey;
 import org.sagebionetworks.bridge.models.upload.UploadSchema;
-import org.sagebionetworks.bridge.services.SurveyServiceMockTest;
 import org.sagebionetworks.bridge.services.UploadSchemaService;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/test/org/sagebionetworks/bridge/models/accounts/SignInTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/SignInTest.java
@@ -153,4 +153,30 @@ public class SignInTest {
             assertEquals("SignIn not constructed with enough information to retrieve an account", e.getMessage());
         }
     }
+    
+    @Test
+    public void fullCopy() {
+        SignIn origin = new SignIn.Builder()
+                .withUsername(TestConstants.EMAIL)
+                .withPhone(TestConstants.PHONE)
+                .withExternalId("externalId")
+                .withPassword("password")
+                .withStudy(TestConstants.TEST_STUDY_IDENTIFIER)
+                .withToken("token")
+                .withReauthToken("reauthToken").build();
+        
+        SignIn copy = new SignIn.Builder().withSignIn(origin).build();
+        assertEquals(TestConstants.EMAIL, copy.getEmail());
+        assertEquals(TestConstants.PHONE, copy.getPhone());
+        assertEquals("externalId", copy.getExternalId());
+        assertEquals("password", copy.getPassword());
+        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, copy.getStudyId());
+        assertEquals("token", copy.getToken());
+        assertEquals("reauthToken", copy.getReauthToken());
+        
+        // Also test the straight email-to-email copy as well as the username copy
+        assertEquals("email", new SignIn.Builder().withSignIn(
+                new SignIn.Builder().withEmail("email").build()
+            ).build().getEmail());
+    }
 }

--- a/test/org/sagebionetworks/bridge/play/controllers/UserManagementControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/UserManagementControllerTest.java
@@ -5,10 +5,10 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyObject;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
-import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 import static org.sagebionetworks.bridge.TestUtils.assertResult;
 import static org.sagebionetworks.bridge.TestUtils.mockPlayContextWithJson;
@@ -21,6 +21,8 @@ import com.google.common.collect.Sets;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -29,13 +31,19 @@ import play.mvc.Result;
 import play.test.Helpers;
 
 import org.sagebionetworks.bridge.BridgeConstants;
+import org.sagebionetworks.bridge.Roles;
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
+import org.sagebionetworks.bridge.cache.CacheProvider;
+import org.sagebionetworks.bridge.config.BridgeConfig;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.CriteriaContext;
+import org.sagebionetworks.bridge.models.accounts.SignIn;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.studies.Study;
-import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.services.AuthenticationService;
+import org.sagebionetworks.bridge.services.SessionUpdateService;
 import org.sagebionetworks.bridge.services.StudyService;
 import org.sagebionetworks.bridge.services.UserAdminService;
 
@@ -52,10 +60,23 @@ public class UserManagementControllerTest {
     UserAdminService userAdminService;
     
     @Mock
+    CacheProvider cacheProvider;
+    
+    @Mock
+    BridgeConfig bridgeConfig;
+    
+    @Mock
     Study study;
     
     @Spy
     UserManagementController controller;
+    
+    @Captor
+    ArgumentCaptor<SignIn> signInCaptor;
+    
+    private SessionUpdateService sessionUpdateService;
+    
+    private UserSession session;
     
     @Before
     public void before() throws Exception {
@@ -64,19 +85,27 @@ public class UserManagementControllerTest {
                 .withRoles(Sets.newHashSet(ADMIN))
                 .withEmail("email@email.com").build();
                 
-        UserSession session = new UserSession(participant);
-        session.setStudyIdentifier(new StudyIdentifierImpl("api"));
+        session = new UserSession(participant);
+        session.setStudyIdentifier(TestConstants.TEST_STUDY);
         session.setAuthenticated(true);
-        session.setStudyIdentifier(TEST_STUDY);
+        
+        sessionUpdateService = new SessionUpdateService();
+        sessionUpdateService.setCacheProvider(cacheProvider);
         
         controller.setStudyService(studyService);
         controller.setUserAdminService(userAdminService);
         controller.setAuthenticationService(authService);
+        controller.setSessionUpdateService(sessionUpdateService);
+        controller.setBridgeConfig(bridgeConfig);
+        controller.setCacheProvider(cacheProvider);
         
         doReturn(session).when(userAdminService).createUser(
                 anyObject(), anyObject(), anyObject(), anyBoolean(), anyBoolean());
         doReturn(session).when(authService).getSession(any(String.class));
-        doReturn(study).when(studyService).getStudy(new StudyIdentifierImpl("api"));
+        doReturn(study).when(studyService).getStudy(TestConstants.TEST_STUDY);
+        doReturn(study).when(studyService).getStudy("api");
+        
+        when(study.getStudyIdentifier()).thenReturn(TestConstants.TEST_STUDY);
 
         Map<String,String[]> map = Maps.newHashMap();
         map.put(BridgeConstants.SESSION_TOKEN_HEADER, new String[]{"AAA"});
@@ -86,6 +115,38 @@ public class UserManagementControllerTest {
         Http.Request request = context.request();
         when(request.headers()).thenReturn(map);
         doReturn(null).when(controller).getMetrics();
+    }
+
+    @Test
+    public void signInForAdmin() throws Exception {
+        SignIn signIn = new SignIn.Builder().withStudy("originalStudy")
+                .withEmail(TestConstants.EMAIL).withPassword("password").build();
+        TestUtils.mockPlayContextWithJson(signIn);
+
+        when(authService.signIn(eq(study), any(CriteriaContext.class), signInCaptor.capture())).thenReturn(session);
+        
+        Result result = controller.signInForAdmin();
+        TestUtils.assertResult(result, 200);
+        
+        // This isn't in the session that is returned to the user, but verify it has been changed
+        assertEquals("originalStudy", session.getStudyIdentifier().getIdentifier());
+        assertEquals("api", signInCaptor.getValue().getStudyId());
+    }
+    
+    @Test
+    public void changeStudyForAdmin() throws Exception {
+        doReturn(session).when(controller).getAuthenticatedSession(Roles.ADMIN);
+        
+        SignIn signIn = new SignIn.Builder().withStudy("nextStudy").build();
+        TestUtils.mockPlayContextWithJson(signIn);
+        
+        Study nextStudy = Study.create();
+        nextStudy.setIdentifier("nextStudy");
+        when(studyService.getStudy("nextStudy")).thenReturn(nextStudy);
+        
+        controller.changeStudyForAdmin();
+        assertEquals("nextStudy", session.getStudyIdentifier().getIdentifier());
+        verify(cacheProvider).setUserSession(session);
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/services/SessionUpdateServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SessionUpdateServiceTest.java
@@ -18,13 +18,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.accounts.ExternalIdentifier;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 
 import com.google.common.collect.Maps;
@@ -123,6 +125,19 @@ public class SessionUpdateServiceTest {
         
         verify(mockCacheProvider).setUserSession(session);
         assertEquals(dataGroups, session.getParticipant().getDataGroups());
+    }
+    
+    @Test
+    public void updateStudy() {
+        UserSession session = new UserSession();
+        session.setStudyIdentifier(TestConstants.TEST_STUDY);
+        
+        StudyIdentifier newStudy = new StudyIdentifierImpl("new-study");
+        
+        service.updateStudy(session, newStudy);
+        
+        verify(mockCacheProvider).setUserSession(session);
+        assertEquals(newStudy, session.getStudyIdentifier());
     }
     
     @Test


### PR DESCRIPTION
An API to authenticate as an administrator using an administrator account in the API study. It then switches the user to the study that was indicated in the sign in request. From that point on it should function like an admin in that study (though this has not been extensively tested and I have no UI to sign in this way at the moment, to flush out how well this will work). However, it should work well, as we almost always retrieve a study from the user's session. 

There is also an API to change study (without signing out). Again you must be an admin to do this... though if you sign in as an admin in a non-API study, you could then use this API to switch to another study. Eventually I envision deleting the admin accounts in all studies but the API study just to make management of these accounts easier.