### PR TITLE
Improve notification reporting

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
@@ -60,6 +60,8 @@ import org.sagebionetworks.bridge.services.UserAdminService;
 @Controller
 public class ParticipantController extends BaseController {
     
+    private static final String NOTIFY_SUCCESS_MESSAGE = "Message has been sent to external notification service.";
+
     private ParticipantService participantService;
     
     private UserAdminService userAdminService;
@@ -410,9 +412,13 @@ public class ParticipantController extends BaseController {
         
         NotificationMessage message = parseJson(request(), NotificationMessage.class);
         
-        participantService.sendNotification(study, userId, message);
+        Set<String> erroredNotifications = participantService.sendNotification(study, userId, message);
         
-        return acceptedResult("Message has been sent to external notification service.");
+        if (erroredNotifications.isEmpty()) {
+            return acceptedResult(NOTIFY_SUCCESS_MESSAGE);                    
+        }
+        return acceptedResult(NOTIFY_SUCCESS_MESSAGE + " Some registrations returned errors: "
+                + BridgeUtils.COMMA_SPACE_JOINER.join(erroredNotifications) + ".");
     }
 
     public Result getActivityEvents(String userId) {

--- a/app/org/sagebionetworks/bridge/services/NotificationsService.java
+++ b/app/org/sagebionetworks/bridge/services/NotificationsService.java
@@ -5,6 +5,7 @@ import static org.sagebionetworks.bridge.BridgeUtils.SEMICOLON_SPACE_JOINER;
 
 import java.nio.charset.Charset;
 import java.util.List;
+import java.util.Set;
 
 import javax.annotation.Resource;
 
@@ -32,7 +33,7 @@ import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.sns.AmazonSNSClient;
 import com.amazonaws.services.sns.model.PublishRequest;
 import com.amazonaws.services.sns.model.PublishResult;
-import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 /**
  * Service for managing client registration to receive push notifications, integrated into the 
@@ -138,7 +139,7 @@ public class NotificationsService {
      * to many accounts.</i> Create a topic, ask your users to subscribe to that topic in your application, and message 
      * them via that topic.
      */
-    public void sendNotificationToUser(StudyIdentifier studyId, String healthCode, NotificationMessage message) {
+    public Set<String> sendNotificationToUser(StudyIdentifier studyId, String healthCode, NotificationMessage message) {
         checkNotNull(studyId);
         checkNotNull(healthCode);
         checkNotNull(message);
@@ -150,26 +151,28 @@ public class NotificationsService {
             throw new BadRequestException("Participant has not registered to receive push notifications.");
         }
         
-        List<String> errorMessages = Lists.newArrayListWithCapacity(registrations.size());
+        Set<String> erroredRegistrations = Sets.newHashSet();
         for (NotificationRegistration registration : registrations) {
             String endpointARN = registration.getEndpointARN();
             
             PublishRequest request = new PublishRequest().withTargetArn(endpointARN)
                     .withSubject(message.getSubject()).withMessage(message.getMessage());
-            
+
             try {
                 PublishResult result = snsClient.publish(request);
                 LOG.debug("Sent message to participant, study=" + studyId.getIdentifier() + ", endpointARN="
                         + endpointARN + ", message ID=" + result.getMessageId());
             } catch(AmazonServiceException e) {
                 LOG.warn("Error publishing SNS message to participant", e);
-                errorMessages.add(e.getErrorMessage());
+                erroredRegistrations.add(registration.getGuid());
             }
         }
-        if (!errorMessages.isEmpty()) {
-            throw new BadRequestException("Error sending push notification: " + 
-                SEMICOLON_SPACE_JOINER.join(errorMessages) + ".");
+        // If none of the registrations succeeds, then throw an error.
+        if (erroredRegistrations.size() == registrations.size()) {
+            throw new BadRequestException("Error sending push notification to registration(s): "
+                    + SEMICOLON_SPACE_JOINER.join(erroredRegistrations) + ".");
         }
+        return erroredRegistrations;
     }
     
     public void sendSmsMessage(SmsMessageProvider provider) {

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -488,14 +488,14 @@ public class ParticipantService {
         return notificationsService.listRegistrations(account.getHealthCode());
     }
 
-    public void sendNotification(Study study, String userId, NotificationMessage message) {
+    public Set<String> sendNotification(Study study, String userId, NotificationMessage message) {
         checkNotNull(study);
         checkNotNull(userId);
         checkNotNull(message);
 
         Account account = getAccountThrowingException(study, userId);
 
-        notificationsService.sendNotificationToUser(study.getStudyIdentifier(), account.getHealthCode(), message);
+        return notificationsService.sendNotificationToUser(study.getStudyIdentifier(), account.getHealthCode(), message);
     }
 
     /**

--- a/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -839,6 +840,19 @@ public class ParticipantControllerTest {
         
         assertEquals("a subject", captured.getSubject());
         assertEquals("a message", captured.getMessage());
+    }
+    
+    @Test
+    public void sendMessageWithSomeErrors() throws Exception {
+        NotificationMessage message = TestUtils.getNotificationMessage();
+        
+        Set<String> erroredRegistrations = ImmutableSet.of("123", "456");
+        when(mockParticipantService.sendNotification(study, ID, message)).thenReturn(erroredRegistrations);
+        
+        TestUtils.mockPlayContextWithJson(message);
+        Result result = controller.sendNotification(ID);
+        
+        assertResult(result, 202, "Message has been sent to external notification service. Some registrations returned errors: 123, 456.");
     }
 
     @SuppressWarnings("deprecation")

--- a/test/org/sagebionetworks/bridge/services/NotificationsServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/NotificationsServiceTest.java
@@ -41,10 +41,9 @@ import com.amazonaws.services.sns.AmazonSNSClient;
 import com.amazonaws.services.sns.model.InvalidParameterException;
 import com.amazonaws.services.sns.model.PublishRequest;
 import com.amazonaws.services.sns.model.PublishResult;
-
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.newrelic.agent.deps.com.google.common.collect.Iterables;
 
 @RunWith(MockitoJUnitRunner.class)
 public class NotificationsServiceTest {

--- a/test/org/sagebionetworks/bridge/services/NotificationsServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/NotificationsServiceTest.java
@@ -9,9 +9,11 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -42,6 +44,7 @@ import com.amazonaws.services.sns.model.PublishResult;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.newrelic.agent.deps.com.google.common.collect.Iterables;
 
 @RunWith(MockitoJUnitRunner.class)
 public class NotificationsServiceTest {
@@ -199,26 +202,40 @@ public class NotificationsServiceTest {
         }
     }
     
-    // In this test, we create no less than two amazon exceptions, and verify that we throw one exception 
-    // that summarizes the sorry situation for the user, while also hiding all the Amazon gobbledy-gook. 
-    // This is thrown as a 400 error because the most common ways you can trigger it are to submit bad 
-    // data, like an invalid device token. 
+    // Publish to two devices, where one device fails but the other sends to the user. 
+    // Method succeeds but returns the GUID of the failed call for reporting back to the user.
     @Test
+    public void sendNotificationWithPartialErrors() {
+        NotificationRegistration reg1 = getNotificationRegistration();
+        NotificationRegistration reg2 = getNotificationRegistration();
+        reg2.setGuid("registrationGuid2");
+        List<NotificationRegistration> list = Lists.newArrayList(reg1, reg2);
+        doReturn(list).when(mockRegistrationDao).listRegistrations(HEALTH_CODE);
+        
+        when(mockSnsClient.publish(any()))
+            .thenReturn(mockPublishResult)
+            .thenThrow(new InvalidParameterException("bad parameter"));
+        
+        NotificationMessage message = getNotificationMessage();
+        Set<String> erroredNotifications = service.sendNotificationToUser(STUDY_ID, HEALTH_CODE, message);
+        assertEquals(1, erroredNotifications.size());
+        assertEquals("registrationGuid2", Iterables.getFirst(erroredNotifications, null));        
+    }
+    
+    // Publish to two devices, where all the devices fail. This should throw an exception as nothing 
+    // was successfully returned to the user.
+    @Test(expected = BadRequestException.class)
     public void sendNotificationAmazonExceptionConverted() {
         NotificationRegistration reg1 = getNotificationRegistration();
         NotificationRegistration reg2 = getNotificationRegistration();
+        reg2.setGuid("registrationGuid2"); // This has to be different
         List<NotificationRegistration> list = Lists.newArrayList(reg1, reg2);
         doReturn(list).when(mockRegistrationDao).listRegistrations(HEALTH_CODE);
         
         doThrow(new InvalidParameterException("bad parameter")).when(mockSnsClient).publish(any());
         
         NotificationMessage message = getNotificationMessage();
-        try {
-            service.sendNotificationToUser(STUDY_ID, HEALTH_CODE, message);
-            fail("Should have thrown exception.");
-        } catch(BadRequestException e) {
-            assertEquals("Error sending push notification: bad parameter; bad parameter.", e.getMessage());
-        }
+        service.sendNotificationToUser(STUDY_ID, HEALTH_CODE, message);
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -78,6 +78,7 @@ import org.sagebionetworks.bridge.services.AuthenticationService.ChannelType;
 import org.sagebionetworks.bridge.sms.SmsMessageProvider;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
@@ -1097,9 +1098,14 @@ public class ParticipantServiceTest {
     @Test
     public void sendNotification() {
         mockHealthCodeAndAccountRetrieval();
+        
+        Set<String> erroredNotifications = ImmutableSet.of("ABC");
         NotificationMessage message = TestUtils.getNotificationMessage();
         
-        participantService.sendNotification(STUDY, ID, message);
+        when(notificationsService.sendNotificationToUser(any(), any(), any())).thenReturn(erroredNotifications);
+        
+        Set<String> returnedErrors = participantService.sendNotification(STUDY, ID, message);
+        assertEquals(erroredNotifications, returnedErrors);
         
         verify(notificationsService).sendNotificationToUser(STUDY.getStudyIdentifier(), HEALTH_CODE, message);
     }

--- a/test/org/sagebionetworks/bridge/services/SchedulePlanServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/SchedulePlanServiceMockTest.java
@@ -40,8 +40,8 @@ import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.surveys.Survey;
 import org.sagebionetworks.bridge.models.surveys.TestSurvey;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import com.newrelic.agent.deps.com.google.common.collect.Lists;
 
 public class SchedulePlanServiceMockTest {
 


### PR DESCRIPTION
JIRA: https://sagebionetworks.jira.com/browse/BRIDGE-2270

It's quite possible when people uninstall and reinstall to get multiple registrations, some of which are going to fail and be disabled by AWS. In these situations... the message is still sent successfully to the user. So we want to report the situation where some but not all registrations succeed as a form of success, not an error. We do this now.