### PR TITLE
Removing test of admin role when deleting surveys, now that admins can assume any study directly.

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/SurveyController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/SurveyController.java
@@ -166,12 +166,12 @@ public class SurveyController extends BaseController {
         GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl(surveyGuid, createdOn);
         
         // This call will return logically deleted surveys, which allows them to be physically deleted.
-        Survey survey = surveyService.getSurvey(session.getParticipant().getRoles(), studyId, keys, false, false);
+        Survey survey = surveyService.getSurvey(studyId, keys, false, false);
         if (survey == null) {
             throw new EntityNotFoundException(Survey.class);
         }
         if ("true".equals(physical) && session.isInRole(ADMIN)) {
-            surveyService.deleteSurveyPermanently(session.getParticipant().getRoles(), studyId, survey);
+            surveyService.deleteSurveyPermanently(studyId, survey);
         } else {
             surveyService.deleteSurvey(studyId, survey);
         }

--- a/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SurveyControllerTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -24,7 +23,6 @@ import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.joda.time.DateTime;
@@ -60,7 +58,6 @@ import org.sagebionetworks.bridge.models.surveys.TestSurvey;
 import org.sagebionetworks.bridge.services.StudyService;
 import org.sagebionetworks.bridge.services.SurveyService;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -84,7 +81,6 @@ public class SurveyControllerTest {
     private static final String SURVEY_GUID = "bbb";
     private static final DateTime CREATED_ON = DateTime.now();
     private static final GuidCreatedOnVersionHolder KEYS = new GuidCreatedOnVersionHolderImpl(SURVEY_GUID, CREATED_ON.getMillis());
-    private static final Set<Roles> ADMIN_ROLE = ImmutableSet.of(Roles.ADMIN);
     
     private SurveyController controller;
     
@@ -359,12 +355,12 @@ public class SurveyControllerTest {
         setupContext(API_STUDY_ID, ADMIN, UNCONSENTED, null);
         
         Survey survey = getSurvey(false);
-        when(service.getSurvey(ImmutableSet.of(ADMIN), TestConstants.TEST_STUDY, KEYS, false, false)).thenReturn(survey);
+        when(service.getSurvey(TestConstants.TEST_STUDY, KEYS, false, false)).thenReturn(survey);
         
         Result result = controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "nonsense");
         TestUtils.assertResult(result, 200, "Survey deleted.");
         
-        verify(service).getSurvey(ImmutableSet.of(ADMIN), TestConstants.TEST_STUDY, KEYS, false, false);
+        verify(service).getSurvey(TestConstants.TEST_STUDY, KEYS, false, false);
         verify(service).deleteSurvey(TestConstants.TEST_STUDY, survey);
         verifyNoMoreInteractions(service);
     }
@@ -374,12 +370,12 @@ public class SurveyControllerTest {
         setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, null);
         
         Survey survey = getSurvey(false);
-        when(service.getSurvey(ImmutableSet.of(DEVELOPER), TestConstants.TEST_STUDY, KEYS, false, false)).thenReturn(survey);
+        when(service.getSurvey(TestConstants.TEST_STUDY, KEYS, false, false)).thenReturn(survey);
         
         Result result = controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "false");
         TestUtils.assertResult(result, 200, "Survey deleted.");
         
-        verify(service).getSurvey(ImmutableSet.of(DEVELOPER), TestConstants.TEST_STUDY, KEYS, false, false);
+        verify(service).getSurvey(TestConstants.TEST_STUDY, KEYS, false, false);
         verify(service).deleteSurvey(TestConstants.TEST_STUDY, survey);
         verifyNoMoreInteractions(service);
     }
@@ -389,12 +385,12 @@ public class SurveyControllerTest {
         setupContext(API_STUDY_ID, ADMIN, UNCONSENTED, null);
         
         Survey survey = getSurvey(false);
-        when(service.getSurvey(ImmutableSet.of(ADMIN), TestConstants.TEST_STUDY, KEYS, false, false)).thenReturn(survey);
+        when(service.getSurvey(TestConstants.TEST_STUDY, KEYS, false, false)).thenReturn(survey);
         
         Result result = controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "false");
         TestUtils.assertResult(result, 200, "Survey deleted.");
         
-        verify(service).getSurvey(ImmutableSet.of(ADMIN), TestConstants.TEST_STUDY, KEYS, false, false);
+        verify(service).getSurvey(TestConstants.TEST_STUDY, KEYS, false, false);
         verify(service).deleteSurvey(TestConstants.TEST_STUDY, survey);
         verifyNoMoreInteractions(service);
     }
@@ -411,13 +407,13 @@ public class SurveyControllerTest {
         setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, null);
         
         Survey survey = getSurvey(false);
-        when(service.getSurvey(ImmutableSet.of(DEVELOPER), TestConstants.TEST_STUDY, KEYS, false, false))
+        when(service.getSurvey(TestConstants.TEST_STUDY, KEYS, false, false))
                 .thenReturn(survey);
         
         Result result = controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "false");
         TestUtils.assertResult(result, 200, "Survey deleted.");
 
-        verify(service).getSurvey(ImmutableSet.of(DEVELOPER), TestConstants.TEST_STUDY, KEYS, false, false);
+        verify(service).getSurvey(TestConstants.TEST_STUDY, KEYS, false, false);
         verify(service).deleteSurvey(TestConstants.TEST_STUDY, survey);
         verifyNoMoreInteractions(service);
     }
@@ -427,12 +423,12 @@ public class SurveyControllerTest {
         setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, null);
         
         Survey survey = getSurvey(false);
-        when(service.getSurvey(ImmutableSet.of(DEVELOPER), TestConstants.TEST_STUDY, KEYS, false, false)).thenReturn(survey);
+        when(service.getSurvey(TestConstants.TEST_STUDY, KEYS, false, false)).thenReturn(survey);
         
         Result result = controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "true");
         TestUtils.assertResult(result, 200, "Survey deleted.");
         
-        verify(service).getSurvey(ImmutableSet.of(DEVELOPER), TestConstants.TEST_STUDY, KEYS, false, false);
+        verify(service).getSurvey(TestConstants.TEST_STUDY, KEYS, false, false);
         verify(service).deleteSurvey(TestConstants.TEST_STUDY, survey);
         verifyNoMoreInteractions(service);
     }
@@ -441,13 +437,13 @@ public class SurveyControllerTest {
         setupContext(API_STUDY_ID, ADMIN, UNCONSENTED, null);
         
         Survey survey = getSurvey(false);
-        when(service.getSurvey(ImmutableSet.of(ADMIN), TestConstants.TEST_STUDY, KEYS, true, false)).thenReturn(survey);
+        when(service.getSurvey(TestConstants.TEST_STUDY, KEYS, true, false)).thenReturn(survey);
         
         Result result = controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "true");
         TestUtils.assertResult(result, 200, "Survey deleted.");
         
-        verify(service).getSurvey(ImmutableSet.of(ADMIN), TestConstants.TEST_STUDY, KEYS, true, true);
-        verify(service).deleteSurveyPermanently(ADMIN_ROLE, API_STUDY_ID, survey);
+        verify(service).getSurvey(TestConstants.TEST_STUDY, KEYS, true, true);
+        verify(service).deleteSurveyPermanently(API_STUDY_ID, survey);
         verifyNoMoreInteractions(service);
     }
     
@@ -455,7 +451,7 @@ public class SurveyControllerTest {
     public void deleteSurveyThrowsGoodExceptionIfSurveyDoesntExist() throws Exception {
         setupContext(API_STUDY_ID, DEVELOPER, UNCONSENTED, null);
         
-        when(service.getSurvey(ImmutableSet.of(DEVELOPER), TestConstants.TEST_STUDY, KEYS, false, false)).thenReturn(null);
+        when(service.getSurvey(TestConstants.TEST_STUDY, KEYS, false, false)).thenReturn(null);
         
         controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), "false");
     }
@@ -609,7 +605,7 @@ public class SurveyControllerTest {
     
     @Test
     public void deleteSurveyInvalidatesCache() throws Exception {
-        assertCacheIsCleared((guid, dateString) -> controller.deleteSurvey(guid, dateString, "false"));
+        assertCacheIsCleared((guid, dateString) -> controller.deleteSurvey(guid, dateString, "false"), 2);
     }
     
     @Test
@@ -633,6 +629,10 @@ public class SurveyControllerTest {
     }
    
     private void assertCacheIsCleared(ExecuteSurvey executeSurvey) throws Exception {
+        assertCacheIsCleared(executeSurvey, 1);
+    }
+    
+    private void assertCacheIsCleared(ExecuteSurvey executeSurvey, int getCount) throws Exception {
         // Setup the cache to return content and verify the cache returns content
         Survey survey = new DynamoSurvey();
         survey.setStudyIdentifier("api");
@@ -640,7 +640,7 @@ public class SurveyControllerTest {
         survey.setCreatedOn(CREATED_ON.getMillis());
         
         setupContext(TEST_STUDY, DEVELOPER, false, survey);
-        when(service.getSurvey(any(), eq(TEST_STUDY), any(), anyBoolean(), anyBoolean())).thenReturn(survey);
+        when(service.getSurvey(eq(TEST_STUDY), any(), anyBoolean(), anyBoolean())).thenReturn(survey);
         
         viewCache.getView(viewCache.getCacheKey(
                 Survey.class, SURVEY_GUID, CREATED_ON.toString(), "api"), () -> { return survey; });
@@ -659,9 +659,9 @@ public class SurveyControllerTest {
         // execute the test method, this should delete the cache
         executeSurvey.execute(SURVEY_GUID, CREATED_ON.toString());
         
-        // This call now hits the service, not the cache, for a total of two calls to the service
+        // This call now hits the service, not the cache, for what should be one hit
         controller.getSurvey(SURVEY_GUID, CREATED_ON.toString());
-        verify(service).getSurvey(any(), any(), anyBoolean(), anyBoolean());
+        verify(service, times(getCount)).getSurvey(any(), any(), anyBoolean(), anyBoolean());
     }
     
     private Survey getSurvey(boolean makeNew) {

--- a/test/org/sagebionetworks/bridge/services/SharedModuleMetadataServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SharedModuleMetadataServiceTest.java
@@ -35,7 +35,6 @@ import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolder;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolderImpl;
 import org.sagebionetworks.bridge.models.sharedmodules.SharedModuleMetadata;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
-import org.sagebionetworks.bridge.models.surveys.Survey;
 
 public class SharedModuleMetadataServiceTest {
     private static final String MODULE_ID = "test-module";
@@ -98,7 +97,7 @@ public class SharedModuleMetadataServiceTest {
         svcInputMetadata.setSurveyCreatedOn(1L);
         svcInputMetadata.setSurveyGuid("test-survey-guid");
         GuidCreatedOnVersionHolder holder = new GuidCreatedOnVersionHolderImpl("test-survey-guid", 1L);
-        when(mockSurveyService.getSurvey(eq(ImmutableSet.of()), eq(TestConstants.TEST_STUDY), eq(holder), eq(false), eq(true))).thenThrow(EntityNotFoundException.class);
+        when(mockSurveyService.getSurvey(eq(TestConstants.TEST_STUDY), eq(holder), eq(false), eq(true))).thenThrow(EntityNotFoundException.class);
         svc.createMetadata(svcInputMetadata);
     }
 
@@ -551,7 +550,7 @@ public class SharedModuleMetadataServiceTest {
     @Test(expected = BadRequestException.class)
     public void updateNotFoundSurvey() {
         SharedModuleMetadata svcInputMetadata = makeValidMetadata();
-        when(mockSurveyService.getSurvey(eq(ImmutableSet.of()), eq(TestConstants.TEST_STUDY), any(), eq(false), eq(true))).thenReturn(null);
+        when(mockSurveyService.getSurvey(eq(TestConstants.TEST_STUDY), any(), eq(false), eq(true))).thenReturn(null);
         when(mockDao.getMetadataByIdAndVersion(anyString(), anyInt())).thenReturn(svcInputMetadata);
         svcInputMetadata.setSchemaId(null);
         svcInputMetadata.setSchemaRevision(null);

--- a/test/org/sagebionetworks/bridge/services/SurveyServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/SurveyServiceMockTest.java
@@ -204,7 +204,7 @@ public class SurveyServiceMockTest {
         Survey survey = createSurvey();
         when(mockSurveyDao.getSurvey(any(), eq(false))).thenReturn(survey);
         
-        service.deleteSurveyPermanently(ADMIN_ROLE, TEST_STUDY, survey);
+        service.deleteSurveyPermanently(TEST_STUDY, survey);
 
         // verify query args
         verify(mockSharedModuleMetadataService).queryAllMetadata(eq(false), eq(false), queryCaptor.capture(),
@@ -239,7 +239,7 @@ public class SurveyServiceMockTest {
         Survey survey = createSurvey();
         when(mockSurveyDao.getSurvey(any(), eq(false))).thenReturn(survey);
         
-        service.deleteSurveyPermanently(ADMIN_ROLE, TEST_STUDY, survey);
+        service.deleteSurveyPermanently(TEST_STUDY, survey);
     }
 
     @Test
@@ -287,7 +287,7 @@ public class SurveyServiceMockTest {
         when(mockSurveyDao.getSurvey(any(), eq(false))).thenReturn(survey);
         
         try {
-            service.deleteSurveyPermanently(ADMIN_ROLE, TEST_STUDY, survey);
+            service.deleteSurveyPermanently(TEST_STUDY, survey);
             fail("Should have thrown exception");
         } catch(ConstraintViolationException e) {
             assertTrue(e.getMessage().contains("Cannot delete survey: it is referenced by a schedule plan that is still accessible through the API"));
@@ -313,7 +313,7 @@ public class SurveyServiceMockTest {
         when(mockSurveyDao.getSurvey(any(), eq(false))).thenReturn(survey);
         
         try {
-            service.deleteSurveyPermanently(ADMIN_ROLE, TEST_STUDY, survey);
+            service.deleteSurveyPermanently(TEST_STUDY, survey);
             fail("Should have thrown exception");
         } catch(ConstraintViolationException e) {
             assertTrue(e.getMessage().contains("Cannot delete survey: it is referenced by a schedule plan that is still accessible through the API"));
@@ -337,7 +337,7 @@ public class SurveyServiceMockTest {
         doReturn(Lists.newArrayList(survey)).when(mockSurveyDao).getSurveyAllVersions(TEST_STUDY, SURVEY_GUID, false);
         
         try {
-            service.deleteSurveyPermanently(ADMIN_ROLE, TEST_STUDY, survey);
+            service.deleteSurveyPermanently(TEST_STUDY, survey);
             fail("Should have thrown exception");
         } catch(ConstraintViolationException e) {
             assertTrue(e.getMessage().contains("Cannot delete survey: it is referenced by a schedule plan that is still accessible through the API"));
@@ -365,7 +365,7 @@ public class SurveyServiceMockTest {
         doReturn(Lists.newArrayList(survey1, survey2)).when(mockSurveyDao).getSurveyAllVersions(TEST_STUDY, SURVEY_GUID, false);
         
         //Does not throw an exception
-        service.deleteSurveyPermanently(ADMIN_ROLE, TEST_STUDY, survey1);
+        service.deleteSurveyPermanently(TEST_STUDY, survey1);
     }
     
     @Test
@@ -377,7 +377,7 @@ public class SurveyServiceMockTest {
         Survey survey = createSurvey();
         when(mockSurveyDao.getSurvey(any(), eq(false))).thenReturn(survey);
         
-        service.deleteSurveyPermanently(ADMIN_ROLE, TEST_STUDY, survey);
+        service.deleteSurveyPermanently(TEST_STUDY, survey);
     }
     
     @Test
@@ -389,7 +389,7 @@ public class SurveyServiceMockTest {
         when(mockSurveyDao.getSurvey(any(), eq(false))).thenReturn(survey);
         
         try {
-            service.deleteSurveyPermanently(ADMIN_ROLE, TEST_STUDY, survey);
+            service.deleteSurveyPermanently(TEST_STUDY, survey);
             fail("Should have thrown exception");
         } catch(ConstraintViolationException e) {
             assertTrue(e.getMessage().contains("Cannot delete survey: it is referenced by a schedule plan that is still accessible through the API"));
@@ -415,7 +415,7 @@ public class SurveyServiceMockTest {
         when(mockSurveyDao.getSurvey(any(), eq(false))).thenReturn(survey);
         
         try {
-            service.deleteSurveyPermanently(ADMIN_ROLE, TEST_STUDY, survey);
+            service.deleteSurveyPermanently(TEST_STUDY, survey);
             fail("Should have thrown exception");
         } catch(ConstraintViolationException e) {
             assertTrue(e.getMessage().contains("Cannot delete survey: it is referenced by a schedule plan that is still accessible through the API"));
@@ -436,7 +436,7 @@ public class SurveyServiceMockTest {
         Survey survey = createSurvey();
         when(mockSurveyDao.getSurvey(any(), eq(false))).thenReturn(survey);
         
-        service.deleteSurveyPermanently(ADMIN_ROLE, TEST_STUDY, survey);
+        service.deleteSurveyPermanently(TEST_STUDY, survey);
     }   
     
     @Test(expected = EntityNotFoundException.class)
@@ -519,7 +519,7 @@ public class SurveyServiceMockTest {
     public void deleteSurveyPermanentlyFailsOnMissingSurvey() {
         when(mockSurveyDao.getSurvey(any(), eq(false))).thenReturn(null);
         
-        service.deleteSurveyPermanently(ADMIN_ROLE, TEST_STUDY, SURVEY_KEYS);
+        service.deleteSurveyPermanently(TEST_STUDY, SURVEY_KEYS);
     }
     
     @Test(expected = EntityNotFoundException.class)
@@ -621,23 +621,13 @@ public class SurveyServiceMockTest {
         
         try {
             // Does not have admin role, and so will throw an exception
-            service.deleteSurveyPermanently(ImmutableSet.of(), OTHER_STUDY, SURVEY_KEYS);
+            service.deleteSurveyPermanently(OTHER_STUDY, SURVEY_KEYS);
             fail("Should have thrown an exception");
         } catch(EntityNotFoundException e) {
         }
         verify(mockSurveyDao, never()).deleteSurveyPermanently(any());
     }
     
-    @Test
-    public void deleteSurveyPermanentlyInOtherStudyAdminOK() {
-        Survey survey = Survey.create();
-        survey.setStudyIdentifier(TestConstants.TEST_STUDY_IDENTIFIER);
-        when(mockSurveyDao.getSurvey(SURVEY_KEYS, false)).thenReturn(survey);
-        
-        service.deleteSurveyPermanently(ADMIN_ROLE, OTHER_STUDY, SURVEY_KEYS);
-        verify(mockSurveyDao).deleteSurveyPermanently(any());
-    }
-
     @Test(expected = EntityNotFoundException.class)
     public void getSurveyMostRecentlyPublishedVersionInOtherStudy() {
         Survey survey = Survey.create();

--- a/test/org/sagebionetworks/bridge/services/SurveyServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SurveyServiceTest.java
@@ -20,7 +20,6 @@ import java.util.Set;
 import javax.annotation.Resource;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import org.junit.After;
 import org.junit.Before;
@@ -30,7 +29,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.dynamodb.DynamoSurveyInfoScreen;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.exceptions.ConcurrentModificationException;
@@ -56,7 +54,6 @@ import org.sagebionetworks.bridge.models.surveys.UIHint;
 public class SurveyServiceTest {
 
     private static Logger logger = LoggerFactory.getLogger(SurveyServiceTest.class);
-    private static final Set<Roles> ADMIN_ROLE = ImmutableSet.of(Roles.ADMIN);
     
     @Resource
     UploadSchemaService schemaService;
@@ -85,7 +82,7 @@ public class SurveyServiceTest {
         // clean up surveys
         for (GuidCreatedOnVersionHolder oneSurvey : surveysToDelete) {
             try {
-                surveyService.deleteSurveyPermanently(ADMIN_ROLE, TEST_STUDY, oneSurvey);
+                surveyService.deleteSurveyPermanently(TEST_STUDY, oneSurvey);
             } catch (Exception ex) {
                 logger.error(ex.getMessage(), ex);
             }
@@ -386,7 +383,7 @@ public class SurveyServiceTest {
         assertTrue(surveyService.getSurveyAllVersions(TEST_STUDY, survey.getGuid(), true).stream().anyMatch(Survey::isDeleted));
         assertTrue(surveyService.getSurveyAllVersions(TEST_STUDY, survey.getGuid(), false).stream().noneMatch(Survey::isDeleted));
         
-        surveyService.deleteSurveyPermanently(ADMIN_ROLE, TEST_STUDY, new GuidCreatedOnVersionHolderImpl(toDelete));
+        surveyService.deleteSurveyPermanently(TEST_STUDY, new GuidCreatedOnVersionHolderImpl(toDelete));
         assertTrue(surveyService.getSurveyAllVersions(TEST_STUDY, survey.getGuid(), true).stream().noneMatch(Survey::isDeleted));
         assertTrue(surveyService.getSurveyAllVersions(TEST_STUDY, survey.getGuid(), false).stream().noneMatch(Survey::isDeleted));
     }


### PR DESCRIPTION
Integration tests can now be rewritten to switch the admin between the shared and api projects.