### PR TITLE
Accounts are defaulted to unverified, with specific pathways to verify external ID-only accounts.

### DIFF
--- a/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
@@ -167,10 +167,14 @@ public class HibernateAccountDao implements AccountDao {
         if (channelType == ChannelType.EMAIL) {
             hibernateAccount.setStatus(AccountStatus.ENABLED);
             hibernateAccount.setEmailVerified(true);    
-        }
-        if (channelType == ChannelType.PHONE) {
+        } else if (channelType == ChannelType.PHONE) {
             hibernateAccount.setStatus(AccountStatus.ENABLED);
             hibernateAccount.setPhoneVerified(true);    
+        } else if (channelType == null) {
+            // If there's no channel type, we're assuming a password-based sign-in using
+            // external ID (the third identifying credential that can be used), so here
+            // we will enable the account.
+            hibernateAccount.setStatus(AccountStatus.ENABLED);
         }
         hibernateHelper.update(hibernateAccount);
     }

--- a/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
+++ b/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
@@ -414,6 +414,30 @@ public class HibernateAccountDaoTest {
         // execute
         dao.changePassword(account, ChannelType.EMAIL, DUMMY_PASSWORD);
     }
+    
+    @Test
+    public void changePasswordForExternalId() {
+        // mock hibernate
+        HibernateAccount hibernateAccount = new HibernateAccount();
+        hibernateAccount.setId(ACCOUNT_ID);
+        hibernateAccount.setStatus(AccountStatus.UNVERIFIED);
+        when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(hibernateAccount);
+
+        // Set up test account
+        GenericAccount account = new GenericAccount();
+        account.setId(ACCOUNT_ID);
+
+        // execute and verify
+        dao.changePassword(account, null, DUMMY_PASSWORD);
+        ArgumentCaptor<HibernateAccount> updatedAccountCaptor = ArgumentCaptor.forClass(HibernateAccount.class);
+        verify(mockHibernateHelper).update(updatedAccountCaptor.capture());
+
+        // Simpler than changePasswordSuccess() test as we're only verifying phone is verified
+        HibernateAccount updatedAccount = updatedAccountCaptor.getValue();
+        assertNull(updatedAccount.getEmailVerified());
+        assertNull(updatedAccount.getPhoneVerified());
+        assertEquals(AccountStatus.ENABLED, updatedAccount.getStatus());
+    }
 
     @Test
     public void authenticateSuccessWithHealthCode() throws Exception {

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -428,6 +428,7 @@ public class ParticipantServiceTest {
     public void createParticipantPhoneEnabledVerificationWanted() {
         mockHealthCodeAndAccountRetrieval(null, PHONE);
 
+        STUDY.setEmailVerificationEnabled(true);
         participantService.createParticipant(STUDY, CALLER_ROLES, PARTICIPANT, true);
 
         verify(accountWorkflowService).sendPhoneVerificationToken(any(), any(), any());
@@ -441,6 +442,7 @@ public class ParticipantServiceTest {
         study.setAutoVerificationPhoneSuppressed(true);
         mockHealthCodeAndAccountRetrieval(null, PHONE);
 
+        study.setEmailVerificationEnabled(true);
         participantService.createParticipant(study, CALLER_ROLES, PARTICIPANT, true);
 
         verify(accountWorkflowService, never()).sendPhoneVerificationToken(any(), any(), any());
@@ -459,6 +461,31 @@ public class ParticipantServiceTest {
         verify(accountWorkflowService, never()).sendPhoneVerificationToken(any(), any(), any());
         assertEquals(AccountStatus.ENABLED, account.getStatus());
         assertNull(account.getPhoneVerified());
+    }
+
+    @Test
+    public void createParticipantExternalIdNoPasswordIsUnverified() {
+        mockHealthCodeAndAccountRetrieval(null, null);
+        
+        StudyParticipant idParticipant = new StudyParticipant.Builder().withExternalId(EXTERNAL_ID).build();
+        participantService.createParticipant(STUDY, CALLER_ROLES, idParticipant, false);
+        
+        assertEquals(AccountStatus.UNVERIFIED, account.getStatus());
+        assertNull(account.getPhoneVerified());
+        assertNull(account.getEmailVerified());
+    }
+    
+    @Test
+    public void createParticipantExternalIdAndPasswordIsEnabled() {
+        mockHealthCodeAndAccountRetrieval(null, null);
+        
+        StudyParticipant idParticipant = new StudyParticipant.Builder().withExternalId(EXTERNAL_ID)
+                .withPassword(PASSWORD).build();
+        participantService.createParticipant(STUDY, CALLER_ROLES, idParticipant, false);
+        
+        assertEquals(AccountStatus.ENABLED, account.getStatus());
+        assertNull(account.getPhoneVerified());
+        assertNull(account.getEmailVerified());
     }
 
     @Test


### PR DESCRIPTION
Should not be able to sign in with an account that has external ID (it shouldn't be enabled, until there's a password). Also changing logic slightly to assume an account is unverified until something happens to verify it.