### PR TITLE
increase SMS limit to 600

### DIFF
--- a/app/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/app/org/sagebionetworks/bridge/BridgeConstants.java
@@ -106,13 +106,11 @@ public class BridgeConstants {
     
     public static final String EXPIRATION_PERIOD_KEY = "expirationPeriod";
     
-    public static final String CONSENT_URL = "consentUrl"; 
-    
-    /**
-     * Limited to 140 characters (Java is UTF-16, so two bytes per character, assuming for now that 
-     * SNS converts these to ASCII.
-     */
-    public static final int SMS_CHARACTER_LIMIT = 140;
+    public static final String CONSENT_URL = "consentUrl";
+
+    /** We want app links to fit in a single SMS, so limit them to 140 chars. */
+    public static final int APP_LINK_MAX_LENGTH = 140;
+
     /**
      * 11 character label as to who sent the SMS message. Only in some supported countries (not US):
      * https://support.twilio.com/hc/en-us/articles/223133767-International-support-for-Alphanumeric-Sender-ID

--- a/app/org/sagebionetworks/bridge/validators/StudyValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/StudyValidator.java
@@ -173,8 +173,9 @@ public class StudyValidator implements Validator {
             for (Map.Entry<String,String> entry : study.getInstallLinks().entrySet()) {
                 if (isBlank(entry.getValue())) {
                     errors.rejectValue("installLinks", "cannot be blank");
-                } else if (entry.getValue().length() > BridgeConstants.SMS_CHARACTER_LIMIT) {
-                    errors.rejectValue("installLinks", "cannot be longer than "+BridgeConstants.SMS_CHARACTER_LIMIT+" characters");
+                } else if (entry.getValue().length() > BridgeConstants.APP_LINK_MAX_LENGTH) {
+                    errors.rejectValue("installLinks", "cannot be longer than " +
+                            BridgeConstants.APP_LINK_MAX_LENGTH + " characters");
                 }
             }
         }        

--- a/test/org/sagebionetworks/bridge/services/NotificationsServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/NotificationsServiceTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Map;
@@ -440,7 +439,7 @@ public class NotificationsServiceTest {
     public void sendSMSMessageTooLongInvalid() {
         doReturn(mockPublishResult).when(mockSnsClient).publish(any());
         String message = "This is my SMS message.";
-        for (int i=0; i < 3; i++) {
+        for (int i=0; i < 5; i++) {
             message += message;
         }
         SmsMessageProvider provider = new SmsMessageProvider.Builder()

--- a/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
@@ -628,12 +628,13 @@ public class StudyValidatorTest {
     @Test
     public void installAppLinksCannotExceedSMSLength() {
         String msg = "";
-        for (int i=0; i < BridgeConstants.SMS_CHARACTER_LIMIT; i++) {
+        for (int i = 0; i < BridgeConstants.APP_LINK_MAX_LENGTH; i++) {
             msg += "A";
         }
         msg += "A";
         study.getInstallLinks().put("foo", msg);
-        assertValidatorMessage(INSTANCE, study, "installLinks", "cannot be longer than "+BridgeConstants.SMS_CHARACTER_LIMIT+" characters");
+        assertValidatorMessage(INSTANCE, study, "installLinks", "cannot be longer than " +
+                BridgeConstants.APP_LINK_MAX_LENGTH + " characters");
     }
     
     @Test


### PR DESCRIPTION
mPower 2.0 study burst notifications can be up to 600 characters. The only functional change here is increasing the SMS character limit on the send SMS message API.

There's also a small refactor to move the app install link validation to use a differently named constant.

Testing done:
* Manually tested with a ~200 character lorem ipsum to myself. I received the message in a single SMS (Android, Verizon).