### PR TITLE
Publish an event when a user first accesses scheduled activities.

### DIFF
--- a/app/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/app/org/sagebionetworks/bridge/BridgeConstants.java
@@ -27,6 +27,9 @@ public class BridgeConstants {
     /** A common string constraint Synapse places on model identifiers. */
     public static final String SYNAPSE_IDENTIFIER_PATTERN = "^[a-zA-Z0-9_-]+$";
     
+    /** The pattern used to validate activity event keys and automatic custom event keys. */
+    public static final String BRIDGE_EVENT_ID_PATTERN = "^[a-zA-Z0-9_-]+$";
+    
     /** The pattern of a valid JavaScript variable/object property name. */
     public  static final String JS_IDENTIFIER_PATTERN = "^[a-zA-Z0-9_][a-zA-Z0-9_-]*$";
     

--- a/app/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/app/org/sagebionetworks/bridge/BridgeUtils.java
@@ -30,8 +30,10 @@ import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.json.BridgeTypeName;
 import org.sagebionetworks.bridge.time.DateUtils;
+import org.sagebionetworks.bridge.models.Tuple;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
+import org.sagebionetworks.bridge.models.activities.ActivityEventObjectType;
 import org.sagebionetworks.bridge.models.schedules.Activity;
 import org.sagebionetworks.bridge.models.schedules.ActivityType;
 import org.sagebionetworks.bridge.models.studies.PasswordPolicy;
@@ -66,6 +68,15 @@ public class BridgeUtils {
     // "request context" object into every method of every class.
     private static final ThreadLocal<String> REQUEST_ID_THREAD_LOCAL = ThreadLocal.withInitial(() -> null);
 
+    public static Tuple<String> parseAutoEventValue(String automaticEventValue) {
+        // Will property split something like "custom:myEvent:P3W"
+        int lastIndex = automaticEventValue.lastIndexOf(":P");
+        if (lastIndex == -1) {
+            return new Tuple<>(ActivityEventObjectType.ENROLLMENT.name().toLowerCase(), automaticEventValue); 
+        }
+        return new Tuple<>(automaticEventValue.substring(0, lastIndex), automaticEventValue.substring(lastIndex+1));
+    }
+    
     public static boolean isExternalIdAccount(StudyParticipant participant) {
         return (StringUtils.isNotBlank(participant.getExternalId()) && 
                 StringUtils.isBlank(participant.getEmail()) && 

--- a/app/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/app/org/sagebionetworks/bridge/BridgeUtils.java
@@ -33,7 +33,6 @@ import org.sagebionetworks.bridge.time.DateUtils;
 import org.sagebionetworks.bridge.models.Tuple;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
-import org.sagebionetworks.bridge.models.activities.ActivityEventObjectType;
 import org.sagebionetworks.bridge.models.schedules.Activity;
 import org.sagebionetworks.bridge.models.schedules.ActivityType;
 import org.sagebionetworks.bridge.models.studies.PasswordPolicy;
@@ -69,10 +68,10 @@ public class BridgeUtils {
     private static final ThreadLocal<String> REQUEST_ID_THREAD_LOCAL = ThreadLocal.withInitial(() -> null);
 
     public static Tuple<String> parseAutoEventValue(String automaticEventValue) {
-        // Will property split something like "custom:myEvent:P3W"
         int lastIndex = automaticEventValue.lastIndexOf(":P");
         if (lastIndex == -1) {
-            return new Tuple<>(ActivityEventObjectType.ENROLLMENT.name().toLowerCase(), automaticEventValue); 
+            // This will certainly not pass validation
+            return new Tuple<>(null, automaticEventValue); 
         }
         return new Tuple<>(automaticEventValue.substring(0, lastIndex), automaticEventValue.substring(lastIndex+1));
     }

--- a/app/org/sagebionetworks/bridge/dao/ActivityEventDao.java
+++ b/app/org/sagebionetworks/bridge/dao/ActivityEventDao.java
@@ -9,14 +9,13 @@ public interface ActivityEventDao {
 
     /**
      * Publish an event into this user's event stream. This event becomes available 
-     * for scheduling activities for this user.
+     * for scheduling activities for this user. Returns true if the event is recorded.
      */
-    void publishEvent(ActivityEvent event);
+    boolean publishEvent(ActivityEvent event);
     
     /**
      * Get a map of events, where the string key is an event identifier, and the value 
-     * is the timestamp of the event. This map will include calculated events like 
-     * "two_weeks_before_enrollment".
+     * is the timestamp of the event.
      * 
      * @see org.sagebionetworks.bridge.models.activities.ActivityEventObjectType
      */

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoActivityEvent.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoActivityEvent.java
@@ -65,7 +65,7 @@ public class DynamoActivityEvent implements ActivityEvent {
     public static class Builder {
         private String healthCode;
         private Long timestamp;
-        private ActivityEventObjectType type;
+        private ActivityEventObjectType objectType;
         private String objectId;
         private ActivityEventType eventType;
         private String answerValue;
@@ -83,15 +83,15 @@ public class DynamoActivityEvent implements ActivityEvent {
             return this;
         }
         public Builder withObjectType(ActivityEventObjectType type) {
-            this.type = type;
+            this.objectType = type;
             return this;
         }
         public Builder withObjectId(String objectId) {
             this.objectId = objectId;
             return this;
         }
-        public Builder withEventType(ActivityEventType type) {
-            this.eventType = type;
+        public Builder withEventType(ActivityEventType objectType) {
+            this.eventType = objectType;
             return this;
         }
         public Builder withAnswerValue(String answerValue) {
@@ -99,13 +99,10 @@ public class DynamoActivityEvent implements ActivityEvent {
             return this;
         }
         private String getEventId() {
-            if (type == null) {
+            if (objectType == null) {
                 return null;
             }
-            if (type == ActivityEventObjectType.ENROLLMENT) {
-                return type.name().toLowerCase();
-            }
-            String typeName = type.name().toLowerCase();
+            String typeName = objectType.name().toLowerCase();
             if (objectId != null && eventType != null) {
                 return String.format("%s:%s:%s", typeName, objectId, eventType.name().toLowerCase());
             } else if (objectId != null) {

--- a/app/org/sagebionetworks/bridge/models/activities/ActivityEventObjectType.java
+++ b/app/org/sagebionetworks/bridge/models/activities/ActivityEventObjectType.java
@@ -2,7 +2,15 @@ package org.sagebionetworks.bridge.models.activities;
 
 public enum ActivityEventObjectType {
     /**
-     * An enrollment event. The eventId will be "enrollment".
+     * Event for the first time the user successfully requests scheduled activities from the 
+     * server. This event is not recorded until the activities can be successfully returned to 
+     * the user, so if consent is required, it will have to be provided first. This event does 
+     * not update after creation.
+     */
+    ACTIVITIES_RETRIEVED,
+    /**
+     * An enrollment event. The eventId will be "enrollment". This event does not update after 
+     * creation.
      */
     ENROLLMENT,
     /**
@@ -28,26 +36,6 @@ public enum ActivityEventObjectType {
      * saved in a schedule plan).
      */
     ACTIVITY,
-    /** 
-     * This is a calculated event timestamp based on enrollment. It allows us to create schedules
-     * where the participant joins scheduling "mid-stream". For example, in FPHS, activities are 
-     * all scheduled from Saturday to Saturday using a cron expression, and a user, when they join, 
-     * get the tasks assigned the previous Saturday. This event can be used for periodic tasks 
-     * that happen weekly or biweekly. The eventId will be "two_weeks_before_enrollment".
-     * 
-     * @see org.sagebionetworks.bridge.dao.ActivityEventDao#getActivityEventMap 
-     */
-    TWO_WEEKS_BEFORE_ENROLLMENT,
-    /** 
-     * This is a calculated event timestamp based on enrollment. It allows us to create schedules
-     * where the participant joins scheduling "mid-stream". For example, in FPHS, activities are 
-     * all scheduled from Saturday to Saturday using a cron expression, and a user, when they join, 
-     * get the tasks assigned the previous Saturday. This event can be used for periodic tasks 
-     * that happen monthly or bimonthly. The eventId will be "two_months_before_enrollment".
-     * 
-     * @see org.sagebionetworks.bridge.dao.ActivityEventDao#getActivityEventMap 
-     */
-    TWO_MONTHS_BEFORE_ENROLLMENT,
     /**
      * A custom event defined at the study level.
      */

--- a/app/org/sagebionetworks/bridge/models/activities/ActivityEventObjectType.java
+++ b/app/org/sagebionetworks/bridge/models/activities/ActivityEventObjectType.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.bridge.models.activities;
 
+import java.util.EnumSet;
+
 public enum ActivityEventObjectType {
     /**
      * Event for the first time the user successfully requests scheduled activities from the 
@@ -40,4 +42,6 @@ public enum ActivityEventObjectType {
      * A custom event defined at the study level.
      */
     CUSTOM;
+    
+    public static final EnumSet<ActivityEventObjectType> UNARY_EVENTS = EnumSet.of(ENROLLMENT, ACTIVITIES_RETRIEVED);
 }

--- a/app/org/sagebionetworks/bridge/play/controllers/ScheduledActivityController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ScheduledActivityController.java
@@ -23,6 +23,7 @@ import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.schedules.ActivityType;
 import org.sagebionetworks.bridge.models.schedules.ScheduleContext;
 import org.sagebionetworks.bridge.models.schedules.ScheduledActivity;
+import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.services.ScheduledActivityService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -107,6 +108,7 @@ public class ScheduledActivityController extends BaseController {
     
     public Result getScheduledActivitiesByDateRange(String startTimeString, String endTimeString) throws Exception {
         UserSession session = getAuthenticatedAndConsentedSession();
+        Study study = studyService.getStudy(session.getStudyIdentifier());
         
         DateTime startsOn = BridgeUtils.getDateTimeOrDefault(startTimeString, null);
         DateTime endsOn = BridgeUtils.getDateTimeOrDefault(endTimeString, null);
@@ -121,7 +123,7 @@ public class ScheduledActivityController extends BaseController {
         DateTimeZone requestTimeZone = startsOn.getZone();
         ScheduleContext context = getScheduledActivitiesInternal(session, requestTimeZone, startsOnInclusive, endsOn, 0);
 
-        List<ScheduledActivity> scheduledActivities = scheduledActivityService.getScheduledActivitiesV4(context);
+        List<ScheduledActivity> scheduledActivities = scheduledActivityService.getScheduledActivitiesV4(study, context);
         
         DateTimeRangeResourceList<ScheduledActivity> results = new DateTimeRangeResourceList<>(scheduledActivities)
                 .withRequestParam(ResourceList.START_TIME, startsOn)
@@ -154,6 +156,7 @@ public class ScheduledActivityController extends BaseController {
     private List<ScheduledActivity> getScheduledActivitiesInternalV3(String untilString, String offset,
             String daysAhead, String minimumPerScheduleString) throws Exception {
         UserSession session = getAuthenticatedAndConsentedSession();
+        Study study = studyService.getStudy(session.getStudyIdentifier());
         
         DateTime endsOn = null;
         DateTimeZone requestTimeZone = null;
@@ -173,7 +176,7 @@ public class ScheduledActivityController extends BaseController {
         }
         DateTime now = DateTime.now(requestTimeZone);
         ScheduleContext context = getScheduledActivitiesInternal(session, requestTimeZone, now, endsOn, minimumPerSchedule);
-        return scheduledActivityService.getScheduledActivities(context);
+        return scheduledActivityService.getScheduledActivities(study, context);
     }
     
     private ScheduleContext getScheduledActivitiesInternal(UserSession session, DateTimeZone requestTimeZone,

--- a/app/org/sagebionetworks/bridge/services/ActivityEventService.java
+++ b/app/org/sagebionetworks/bridge/services/ActivityEventService.java
@@ -12,7 +12,7 @@ import org.joda.time.DateTimeZone;
 import org.joda.time.Period;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
+import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.dao.ActivityEventDao;
 import org.sagebionetworks.bridge.dynamodb.DynamoActivityEvent;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
@@ -177,7 +177,7 @@ public class ActivityEventService {
         for (Map.Entry<String, String> oneAutomaticEvent : study.getAutomaticCustomEvents().entrySet()) {
             String automaticEventKey = oneAutomaticEvent.getKey(); // new event key
             // [originEventId:]Period, if originEventId is missing, defaults to "enrollment"
-            Tuple<String> autoEventSpec = parseAutoEventValue(oneAutomaticEvent.getValue());
+            Tuple<String> autoEventSpec = BridgeUtils.parseAutoEventValue(oneAutomaticEvent.getValue());
             
             if (event.getEventId().startsWith(autoEventSpec.getLeft())) {
                 Period automaticEventDelay = Period.parse(autoEventSpec.getRight());
@@ -186,14 +186,4 @@ public class ActivityEventService {
             }
         }        
     }
-    
-    private Tuple<String> parseAutoEventValue(String automaticEventValue) {
-        // Will property split something like "custom:myEvent:P3W"
-        int lastIndex = automaticEventValue.lastIndexOf(":P");
-        if (lastIndex == -1) {
-            return new Tuple<>(ActivityEventObjectType.ENROLLMENT.name().toLowerCase(), automaticEventValue); 
-        }
-        return new Tuple<>(automaticEventValue.substring(0, lastIndex), automaticEventValue.substring(lastIndex+1));
-    }
-    
 }

--- a/app/org/sagebionetworks/bridge/services/ActivityEventService.java
+++ b/app/org/sagebionetworks/bridge/services/ActivityEventService.java
@@ -188,7 +188,7 @@ public class ActivityEventService {
     }
     
     private Tuple<String> parseAutoEventValue(String automaticEventValue) {
-        // though Period serialization does not contain semicolons, limit the split to the first occurrence
+        // Will property split something like "custom:myEvent:P3W"
         int lastIndex = automaticEventValue.lastIndexOf(":P");
         if (lastIndex == -1) {
             return new Tuple<>(ActivityEventObjectType.ENROLLMENT.name().toLowerCase(), automaticEventValue); 

--- a/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
+++ b/app/org/sagebionetworks/bridge/services/ScheduledActivityService.java
@@ -179,6 +179,10 @@ public class ScheduledActivityService {
         checkNotNull(context);
         
         Validate.nonEntityThrowingException(VALIDATOR, context);
+
+        String healthCode = context.getCriteriaContext().getHealthCode();
+        activityEventService.publishActivitiesRetrieved(study, healthCode, DateUtils.getCurrentDateTime());
+        
         // Add events for scheduling
         Map<String, DateTime> events = createEventsMap(context);
         ScheduleContext updatedContext = new ScheduleContext.Builder().withContext(context).withEvents(events).build();
@@ -195,10 +199,7 @@ public class ScheduledActivityService {
         List<ScheduledActivity> saves = performMerge(scheduledActivities, dbMap);
         activityDao.saveActivities(saves);
         
-        List<ScheduledActivity> orderedActivities = orderActivities(scheduledActivities, V3_FILTER);
-        String healthCode = context.getCriteriaContext().getHealthCode();
-        activityEventService.publishActivitiesRetrieved(study, healthCode, DateUtils.getCurrentDateTime());
-        return orderedActivities;
+        return orderActivities(scheduledActivities, V3_FILTER);
     }
     
     public List<ScheduledActivity> getScheduledActivitiesV4(Study study, ScheduleContext context) {
@@ -206,6 +207,10 @@ public class ScheduledActivityService {
         checkNotNull(context);
         
         Validate.nonEntityThrowingException(VALIDATOR, context);
+        
+        String healthCode = context.getCriteriaContext().getHealthCode();
+        activityEventService.publishActivitiesRetrieved(study, healthCode, DateUtils.getCurrentDateTime());
+        
         // Add events for scheduling
         Map<String, DateTime> events = createEventsMap(context);
         ScheduleContext updatedContext = new ScheduleContext.Builder().withContext(context).withEvents(events).build();
@@ -225,10 +230,7 @@ public class ScheduledActivityService {
         // added to the activities that will be returned.
         scheduledActivities.addAll(dbMap.values());
         
-        List<ScheduledActivity> orderedActivities = orderActivities(scheduledActivities, V4_FILTER);
-        String healthCode = context.getCriteriaContext().getHealthCode();
-        activityEventService.publishActivitiesRetrieved(study, healthCode, DateUtils.getCurrentDateTime());
-        return orderedActivities;
+        return orderActivities(scheduledActivities, V4_FILTER);
     }
     
     protected List<ScheduledActivity> performMerge(List<ScheduledActivity> scheduledActivities,

--- a/app/org/sagebionetworks/bridge/validators/StudyValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/StudyValidator.java
@@ -5,6 +5,8 @@ import static org.sagebionetworks.bridge.BridgeUtils.COMMA_SPACE_JOINER;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.time.Period;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -15,7 +17,9 @@ import org.apache.commons.validator.routines.EmailValidator;
 
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.models.Tuple;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
+import org.sagebionetworks.bridge.models.activities.ActivityEventObjectType;
 import org.sagebionetworks.bridge.models.studies.AndroidAppLink;
 import org.sagebionetworks.bridge.models.studies.AppleAppLink;
 import org.sagebionetworks.bridge.models.studies.EmailTemplate;
@@ -34,6 +38,9 @@ import org.springframework.validation.Validator;
 @Component
 public class StudyValidator implements Validator {
     public static final StudyValidator INSTANCE = new StudyValidator();
+    
+    static final String BRIDGE_IDENTIFIER_ERROR = "must contain only lower-case letters and/or numbers with optional dashes";
+    static final String SYNAPSE_IDENTIFIER_ERROR = "must contain only lower- or upper-case letters, numbers, dashes, and/or underscores";
     
     private static final int MAX_SYNAPSE_LENGTH = 250;
     private static final Pattern FINGERPRINT_PATTERN = Pattern.compile("^[0-9a-fA-F:]{95,95}$");
@@ -66,16 +73,39 @@ public class StudyValidator implements Validator {
             errors.rejectValue("identifier", "is required");
         } else {
             if (!study.getIdentifier().matches(BridgeConstants.BRIDGE_IDENTIFIER_PATTERN)) {
-                errors.rejectValue("identifier", "must contain only lower-case letters and/or numbers with optional dashes");
+                errors.rejectValue("identifier", BRIDGE_IDENTIFIER_ERROR);
             }
             if (study.getIdentifier().length() < 2) {
                 errors.rejectValue("identifier", "must be at least 2 characters");
             }
         }
         if (study.getActivityEventKeys().stream()
-                .anyMatch(k -> !k.matches(BridgeConstants.BRIDGE_IDENTIFIER_PATTERN))) {
-            errors.rejectValue("activityEventKeys", "must contain only lower-case letters and/or numbers with " +
-                    "optional dashes");
+                .anyMatch(k -> !k.matches(BridgeConstants.SYNAPSE_IDENTIFIER_PATTERN))) {
+            errors.rejectValue("activityEventKeys", SYNAPSE_IDENTIFIER_ERROR);
+        }
+        if (study.getAutomaticCustomEvents() != null) {
+            for (Map.Entry<String, String> entry : study.getAutomaticCustomEvents().entrySet()) {
+                String key = entry.getKey();
+                String value = entry.getValue();
+                
+                // Validate that the key follows the same rules for activity event keys
+                if (!key.matches(BridgeConstants.SYNAPSE_IDENTIFIER_PATTERN)) {
+                    errors.rejectValue("automaticCustomEvents["+key+"]", SYNAPSE_IDENTIFIER_ERROR);
+                }
+                
+                Tuple<String> autoEventSpec = BridgeUtils.parseAutoEventValue(value);
+                
+                String originEventKey = autoEventSpec.getLeft();
+                if (!specifiesValidEventKey(study.getActivityEventKeys(), originEventKey)) {
+                    errors.rejectValue("automaticCustomEvents["+key+"]", "'" + originEventKey + "' is not a valid custom or system event ID");
+                }
+                String periodString = autoEventSpec.getRight();
+                try {
+                    Period.parse(periodString);
+                } catch(DateTimeParseException e) {
+                    errors.rejectValue("automaticCustomEvents["+key+"]", "'" + periodString + "' is not a valid ISO 8601 period");
+                }
+            }
         }
         if (isBlank(study.getName())) {
             errors.rejectValue("name", "is required");
@@ -244,6 +274,21 @@ public class StudyValidator implements Validator {
                 return link.getNamespace() + "." + link.getPackageName();
             });
         }
+    }
+    
+    private boolean specifiesValidEventKey(Set<String> customKeys, String proposedKey) {
+        for (ActivityEventObjectType type : ActivityEventObjectType.UNARY_EVENTS) {
+            if (type.name().toLowerCase().equals(proposedKey)) {
+                return true;
+            }
+        }
+        for (String customKey : customKeys) {
+            String oneCustomKey = "custom:" + customKey;
+            if (oneCustomKey.equals(proposedKey)) {
+                return true;
+            }
+        }
+        return false;
     }
     
     private void validateEmail(Errors errors, String emailString, String fieldName) {

--- a/app/org/sagebionetworks/bridge/validators/StudyValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/StudyValidator.java
@@ -40,7 +40,7 @@ public class StudyValidator implements Validator {
     public static final StudyValidator INSTANCE = new StudyValidator();
     
     static final String BRIDGE_IDENTIFIER_ERROR = "must contain only lower-case letters and/or numbers with optional dashes";
-    static final String SYNAPSE_IDENTIFIER_ERROR = "must contain only lower- or upper-case letters, numbers, dashes, and/or underscores";
+    static final String BRIDGE_EVENT_ID_ERROR = "must contain only lower- or upper-case letters, numbers, dashes, and/or underscores";
     
     private static final int MAX_SYNAPSE_LENGTH = 250;
     private static final Pattern FINGERPRINT_PATTERN = Pattern.compile("^[0-9a-fA-F:]{95,95}$");
@@ -80,8 +80,8 @@ public class StudyValidator implements Validator {
             }
         }
         if (study.getActivityEventKeys().stream()
-                .anyMatch(k -> !k.matches(BridgeConstants.SYNAPSE_IDENTIFIER_PATTERN))) {
-            errors.rejectValue("activityEventKeys", SYNAPSE_IDENTIFIER_ERROR);
+                .anyMatch(k -> !k.matches(BridgeConstants.BRIDGE_EVENT_ID_PATTERN))) {
+            errors.rejectValue("activityEventKeys", BridgeConstants.BRIDGE_EVENT_ID_PATTERN);
         }
         if (study.getAutomaticCustomEvents() != null) {
             for (Map.Entry<String, String> entry : study.getAutomaticCustomEvents().entrySet()) {
@@ -89,8 +89,8 @@ public class StudyValidator implements Validator {
                 String value = entry.getValue();
                 
                 // Validate that the key follows the same rules for activity event keys
-                if (!key.matches(BridgeConstants.SYNAPSE_IDENTIFIER_PATTERN)) {
-                    errors.rejectValue("automaticCustomEvents["+key+"]", SYNAPSE_IDENTIFIER_ERROR);
+                if (!key.matches(BridgeConstants.BRIDGE_EVENT_ID_PATTERN)) {
+                    errors.rejectValue("automaticCustomEvents["+key+"]", BridgeConstants.BRIDGE_EVENT_ID_PATTERN);
                 }
                 
                 Tuple<String> autoEventSpec = BridgeUtils.parseAutoEventValue(value);
@@ -282,13 +282,7 @@ public class StudyValidator implements Validator {
                 return true;
             }
         }
-        for (String customKey : customKeys) {
-            String oneCustomKey = "custom:" + customKey;
-            if (oneCustomKey.equals(proposedKey)) {
-                return true;
-            }
-        }
-        return false;
+        return customKeys.contains(proposedKey);
     }
     
     private void validateEmail(Errors errors, String emailString, String fieldName) {

--- a/test/org/sagebionetworks/bridge/models/activities/ActivityEventTest.java
+++ b/test/org/sagebionetworks/bridge/models/activities/ActivityEventTest.java
@@ -77,10 +77,25 @@ public class ActivityEventTest {
     
     @Test
     public void simpleActivityEventIdIsCorrect() {
-        ActivityEvent event = new DynamoActivityEvent.Builder().withHealthCode("BBB").withObjectType(ActivityEventObjectType.ENROLLMENT)
-                        .withTimestamp(DateTime.now()).build();
+        DateTime now = DateTime.now();
+        ActivityEvent event = new DynamoActivityEvent.Builder().withHealthCode("BBB")
+                .withObjectType(ActivityEventObjectType.ENROLLMENT).withTimestamp(now).build();
         
+        assertEquals("BBB", event.getHealthCode());
+        assertEquals(now, new DateTime(event.getTimestamp()));
         assertEquals("enrollment", event.getEventId());
+    }
+    
+    @Test
+    public void activitiesRetrievedEvent() {
+        DateTime now = DateTime.now();
+        ActivityEvent event = new DynamoActivityEvent.Builder()
+                .withObjectType(ActivityEventObjectType.ACTIVITIES_RETRIEVED).withHealthCode("BBB").withTimestamp(now)
+                .build();
+        
+        assertEquals("BBB", event.getHealthCode());
+        assertEquals(now, new DateTime(event.getTimestamp()));
+        assertEquals("activities_retrieved", event.getEventId());
     }
 
     @Test

--- a/test/org/sagebionetworks/bridge/services/ActivityEventServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ActivityEventServiceTest.java
@@ -4,7 +4,7 @@ import static org.hamcrest.core.StringEndsWith.endsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -57,7 +57,7 @@ public class ActivityEventServiceTest {
         study.setActivityEventKeys(ImmutableSet.of("eventKey1", "eventKey2"));
 
         ArgumentCaptor<ActivityEvent> activityEventArgumentCaptor = ArgumentCaptor.forClass(ActivityEvent.class);
-        doNothing().when(activityEventDao).publishEvent(activityEventArgumentCaptor.capture());
+        when(activityEventDao.publishEvent(activityEventArgumentCaptor.capture())).thenReturn(true);
 
         DateTime timestamp = DateTime.now();
         activityEventService.publishCustomEvent(study, "healthCode", "eventKey1", timestamp);
@@ -75,7 +75,7 @@ public class ActivityEventServiceTest {
         study.setAutomaticCustomEvents(ImmutableMap.of("3-days-after-enrollment", "P3D"));
 
         ArgumentCaptor<ActivityEvent> activityEventArgumentCaptor = ArgumentCaptor.forClass(ActivityEvent.class);
-        doNothing().when(activityEventDao).publishEvent(activityEventArgumentCaptor.capture());
+        when(activityEventDao.publishEvent(activityEventArgumentCaptor.capture())).thenReturn(true);
 
         DateTime timestamp = DateTime.now().plusDays(3);
         activityEventService.publishCustomEvent(study, "healthCode", "3-days-after-enrollment",
@@ -186,8 +186,14 @@ public class ActivityEventServiceTest {
     public void canPublishEnrollmentEventWithAutomaticCustomEvents() {
         // Configure study with automatic custom events
         Study study = Study.create();
-        study.setAutomaticCustomEvents(ImmutableMap.<String, String>builder().put("3-days-after", "P3D")
-                .put("1-week-after", "P1W").put("13-weeks-after", "P13W").build());
+        // Note that these events include events that are implicitly and explicitly related to 
+        // enrollment, and some that are not applicable that should be ignored.
+        study.setAutomaticCustomEvents(ImmutableMap.<String, String>builder()
+                .put("3-days-after", "P3D") // defaults to enrollment
+                .put("1-week-after", "enrollment:P1W")
+                .put("13-weeks-after", "enrollment:P13W")
+                .put("5-years-after", "not_enrollment:P5Y")
+                .put("10-years-after", "not_entrollment:P10Y").build());
 
         // Create consent signature
         DateTime enrollment = DateTime.parse("2018-04-04T16:00-0700");
@@ -197,6 +203,8 @@ public class ActivityEventServiceTest {
                 .withConsentCreatedOn(enrollment.minusDays(10).getMillis())
                 .withSignedOn(enrollment.getMillis()).build();
 
+        when(activityEventDao.publishEvent(any())).thenReturn(true);
+        
         // Execute
         activityEventService.publishEnrollmentEvent(study,"AAA-BBB-CCC", signature);
 
@@ -225,6 +233,95 @@ public class ActivityEventServiceTest {
                 .getTimestamp().longValue());
         assertEquals("AAA-BBB-CCC", publishedEventList.get(3).getHealthCode());
     }
+    
+    @Test
+    public void whenNoEnrollmentEventPublishNoCustomEvents() {
+        // Configure study with automatic custom events
+        Study study = Study.create();
+        // Note that these events include events that are implicitly and explicitly related to 
+        // enrollment, and some that are not applicable that should be ignored.
+        study.setAutomaticCustomEvents(ImmutableMap.<String, String>builder()
+                .put("3-days-after", "P3D") // defaults to enrollment
+                .put("1-week-after", "enrollment:P1W")
+                .put("13-weeks-after", "enrollment:P13W")
+                .put("5-years-after", "not_enrollment:P5Y")
+                .put("10-years-after", "not_entrollment:P10Y").build());
+        
+        when(activityEventDao.publishEvent(any())).thenReturn(false);
+        
+        activityEventService.publishEnrollmentEvent(study,"AAA-BBB-CCC", new ConsentSignature.Builder().build());
+        
+        // Only happens once, none of the other custom events are published.
+        verify(activityEventDao, times(1)).publishEvent(any());
+    }
+    
+    @Test
+    public void whenNoActivitiesRetrievedEventPublishNoCustomEvents() {
+        // Configure study with automatic custom events
+        Study study = Study.create();
+        // Note that these events include events that are implicitly and explicitly related to 
+        // enrollment, and some that are not applicable that should be ignored.
+        study.setAutomaticCustomEvents(ImmutableMap.<String, String>builder()
+                .put("3-days-after", "P3D") // defaults to enrollment
+                .put("1-week-after", "enrollment:P1W")
+                .put("13-weeks-after", "enrollment:P13W")
+                .put("5-years-after", "not_enrollment:P5Y")
+                .put("10-years-after", "not_entrollment:P10Y").build());
+        
+        when(activityEventDao.publishEvent(any())).thenReturn(false);
+        
+        activityEventService.publishActivitiesRetrieved(study,"AAA-BBB-CCC", DateTime.now());
+        
+        // Only happens once, none of the other custom events are published.
+        verify(activityEventDao, times(1)).publishEvent(any());
+    }
+    
+    @Test
+    public void canPublishActivitiesRetrievedEventWithAutomaticCustomEvents() {
+        // Configure study with automatic custom events
+        Study study = Study.create();
+        // Note that these events include events that should be triggered for enrollment, 
+        // not activities retrieved. These are ignore.
+        study.setAutomaticCustomEvents(ImmutableMap.<String, String>builder()
+                .put("3-days-after", "activities_retrieved:P3D")
+                .put("1-week-after", "activities_retrieved:P1W")
+                .put("13-weeks-after", "activities_retrieved:P13W")
+                .put("5-years-after", "enrollment:P5Y")
+                .put("10-years-after", "enrollment:P10Y").build());
+
+        // Create consent signature
+        DateTime retrieved = DateTime.parse("2018-04-04T16:00-0700");
+        
+        when(activityEventDao.publishEvent(any())).thenReturn(true);
+
+        // Execute
+        activityEventService.publishActivitiesRetrieved(study, "AAA-BBB-CCC", retrieved);
+
+        // Verify published events (4)
+        ArgumentCaptor<ActivityEvent> publishedEventCaptor = ArgumentCaptor.forClass(ActivityEvent.class);
+        verify(activityEventDao, times(4)).publishEvent(publishedEventCaptor.capture());
+
+        List<ActivityEvent> publishedEventList = publishedEventCaptor.getAllValues();
+
+        assertEquals("activities_retrieved", publishedEventList.get(0).getEventId());
+        assertEquals(retrieved.getMillis(), publishedEventList.get(0).getTimestamp().longValue());
+        assertEquals("AAA-BBB-CCC", publishedEventList.get(0).getHealthCode());
+
+        assertEquals("custom:3-days-after", publishedEventList.get(1).getEventId());
+        assertEquals(DateUtils.convertToMillisFromEpoch("2018-04-07T16:00-0700"), publishedEventList.get(1)
+                .getTimestamp().longValue());
+        assertEquals("AAA-BBB-CCC", publishedEventList.get(1).getHealthCode());
+
+        assertEquals("custom:1-week-after", publishedEventList.get(2).getEventId());
+        assertEquals(DateUtils.convertToMillisFromEpoch("2018-04-11T16:00-0700"), publishedEventList.get(2)
+                .getTimestamp().longValue());
+        assertEquals("AAA-BBB-CCC", publishedEventList.get(2).getHealthCode());
+
+        assertEquals("custom:13-weeks-after", publishedEventList.get(3).getEventId());
+        assertEquals(DateUtils.convertToMillisFromEpoch("2018-07-04T16:00-0700"), publishedEventList.get(3)
+                .getTimestamp().longValue());
+        assertEquals("AAA-BBB-CCC", publishedEventList.get(3).getHealthCode());
+    }    
 
     @Test
     public void canPublishSurveyAnswer() {

--- a/test/org/sagebionetworks/bridge/services/NotificationsServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/NotificationsServiceTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Map;

--- a/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceDuplicateTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceDuplicateTest.java
@@ -35,6 +35,7 @@ import org.sagebionetworks.bridge.models.schedules.SchedulePlan;
 import org.sagebionetworks.bridge.models.schedules.ScheduleStrategy;
 import org.sagebionetworks.bridge.models.schedules.ScheduleType;
 import org.sagebionetworks.bridge.models.schedules.ScheduledActivity;
+import org.sagebionetworks.bridge.models.studies.Study;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
@@ -152,6 +153,9 @@ public class ScheduledActivityServiceDuplicateTest {
     @Mock
     AppConfigService appConfigService;
     
+    @Mock
+    Study study;
+    
     ScheduledActivityService service;
     
     ScheduleContext.Builder contextBuilder;
@@ -267,7 +271,7 @@ public class ScheduledActivityServiceDuplicateTest {
         // Correctly scheduled one-time tasks coming from scheduler
         doReturn(makeSchedulePlans()).when(schedulePlanService).getSchedulePlans(any(), any(), eq(false));
         
-        List<ScheduledActivity> activities = service.getScheduledActivities(context);
+        List<ScheduledActivity> activities = service.getScheduledActivities(study, context);
         
         verify(activityDao).getActivities(any(), any());
         verify(schedulePlanService).getSchedulePlans(any(), any(), eq(false));
@@ -295,7 +299,7 @@ public class ScheduledActivityServiceDuplicateTest {
         // Correctly scheduled one-time tasks coming from scheduler
         doReturn(makeSchedulePlans()).when(schedulePlanService).getSchedulePlans(any(), any(), eq(false));
         
-        List<ScheduledActivity> activities = service.getScheduledActivities(context);
+        List<ScheduledActivity> activities = service.getScheduledActivities(study, context);
         
         // There's only one of these and they are set to midnight UTC.
         verify(activityDao).getActivities(any(), any());
@@ -319,7 +323,7 @@ public class ScheduledActivityServiceDuplicateTest {
         // Correctly scheduled one-time tasks coming from scheduler
         doReturn(makeSchedulePlans()).when(schedulePlanService).getSchedulePlans(any(), any(), eq(false));
         
-        List<ScheduledActivity> activities = service.getScheduledActivities(context);
+        List<ScheduledActivity> activities = service.getScheduledActivities(study, context);
         
         // There's only one of these and they are set to midnight UTC.
         verify(activityDao).getActivities(any(), any());
@@ -343,7 +347,7 @@ public class ScheduledActivityServiceDuplicateTest {
         // Correctly scheduled one-time tasks coming from scheduler
         doReturn(makeSchedulePlans()).when(schedulePlanService).getSchedulePlans(any(), any(), eq(false));
         
-        List<ScheduledActivity> activities = service.getScheduledActivities(context);
+        List<ScheduledActivity> activities = service.getScheduledActivities(study, context);
         
         // There's only one of these and they are set to midnight UTC.
         verify(activityDao).getActivities(any(), any());

--- a/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceOnceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceOnceTest.java
@@ -98,8 +98,8 @@ public class ScheduledActivityServiceOnceTest {
         schedule.addTimes(LocalTime.parse("13:11"));
         schedulePlanService.updateSchedulePlan(study, schedulePlan);
         
-        List<ScheduledActivity> first = service.getScheduledActivities(getContextWith2DayAdvance(PST));
-        List<ScheduledActivity> second = service.getScheduledActivities(getContextWith2DayAdvance(MSK));
+        List<ScheduledActivity> first = service.getScheduledActivities(study, getContextWith2DayAdvance(PST));
+        List<ScheduledActivity> second = service.getScheduledActivities(study, getContextWith2DayAdvance(MSK));
         assertEquals(1, first.size());
         assertEquals(1, second.size());
         

--- a/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceRecurringTest.java
+++ b/test/org/sagebionetworks/bridge/services/ScheduledActivityServiceRecurringTest.java
@@ -129,7 +129,7 @@ public class ScheduledActivityServiceRecurringTest {
         // You get the schedule from yesterday that hasn't expired just yet (22nd), plus the 
         // 23rd, 24th and 25th
         ScheduleContext context = getContextWith2DayWindow(now, MSK);
-        List<ScheduledActivity> activities = service.getScheduledActivities(context);
+        List<ScheduledActivity> activities = service.getScheduledActivities(study, context);
         
         assertEquals(4, activities.size());
         assertEquals(msk0+"T10:00:00.000+03:00", activities.get(0).getScheduledOn().toString());
@@ -141,7 +141,7 @@ public class ScheduledActivityServiceRecurringTest {
         // (yesterday, today in Russia, tomorrow and the next day). One activity was created beyond
         // the window, over in Moscow... that is not returned because although it exists, we 
         // filter it out from the persisted activities retrieved from the db.
-        activities = service.getScheduledActivities(getContextWith2DayWindow(now, PST));
+        activities = service.getScheduledActivities(study, getContextWith2DayWindow(now, PST));
 
         assertEquals(4, activities.size());
         assertEquals(pst1+"T10:00:00.000-07:00", activities.get(0).getScheduledOn().toString());
@@ -154,7 +154,7 @@ public class ScheduledActivityServiceRecurringTest {
         
         // He hasn't finished any activities. The 22nd expires but it's too early in the day 
         // for the 23rd to expire (earlier than 10am), so, 4 activities, but with different dates.
-        activities = service.getScheduledActivities(getContextWith2DayWindow(now, MSK));
+        activities = service.getScheduledActivities(study, getContextWith2DayWindow(now, MSK));
         assertEquals(4, activities.size());
         assertEquals(msk1+"T10:00:00.000+03:00", activities.get(0).getScheduledOn().toString());
         assertEquals(msk2+"T10:00:00.000+03:00", activities.get(1).getScheduledOn().toString());
@@ -167,7 +167,7 @@ public class ScheduledActivityServiceRecurringTest {
         service.updateScheduledActivities(testUser.getHealthCode(), activities);
         
         // This is easy, Dave has the later activities and that's it, at this point.
-        activities = service.getScheduledActivities(getContextWith2DayWindow(now, MSK));
+        activities = service.getScheduledActivities(study, getContextWith2DayWindow(now, MSK));
         
         assertEquals(2, activities.size()); //2
         assertEquals(msk3+"T10:00:00.000+03:00", activities.get(0).getScheduledOn().toString());
@@ -183,12 +183,12 @@ public class ScheduledActivityServiceRecurringTest {
         // Four days...
         DateTime endsOn = NOW.plusDays(4);
         ScheduleContext context = getContext(NOW, DateTimeZone.UTC, endsOn);
-        List<ScheduledActivity> activities = service.getScheduledActivities(context);
+        List<ScheduledActivity> activities = service.getScheduledActivities(study, context);
         
         // Zero days... there are fewer activities
         endsOn = NOW.plusDays(0);
         context = getContext(NOW, DateTimeZone.UTC, endsOn);
-        List<ScheduledActivity> activities2 = service.getScheduledActivities(context);
+        List<ScheduledActivity> activities2 = service.getScheduledActivities(study, context);
         
         assertTrue(activities2.size() < activities.size());
     }

--- a/test/org/sagebionetworks/bridge/services/SurveyServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/SurveyServiceMockTest.java
@@ -20,11 +20,9 @@ import static org.sagebionetworks.bridge.services.SharedModuleMetadataServiceTes
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import org.joda.time.DateTime;
 import org.junit.Before;
@@ -34,7 +32,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dao.SurveyDao;
 import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
@@ -66,8 +63,6 @@ public class SurveyServiceMockTest {
     private static final String SURVEY_GUID = "surveyGuid";
     private static final DateTime SURVEY_CREATED_ON = DateTime.parse("2017-02-08T20:07:57.179Z");
     private static final GuidCreatedOnVersionHolder SURVEY_KEYS = new GuidCreatedOnVersionHolderImpl(SURVEY_GUID, 1337);
-    private static final Set<Roles> ADMIN_ROLE = ImmutableSet.of(Roles.ADMIN);
-    private static final Set<Roles> NOT_ADMIN_ROLE = ImmutableSet.of(Roles.WORKER);
 
     @Mock
     SurveyPublishValidator mockSurveyPublishValidator;

--- a/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
@@ -127,13 +127,13 @@ public class StudyValidatorTest {
     @Test
     public void rejectEventKeysWithColons() {
         study.setActivityEventKeys(Sets.newHashSet("a-1", "b:2"));
-        assertValidatorMessage(INSTANCE, study, "activityEventKeys", StudyValidator.SYNAPSE_IDENTIFIER_ERROR);
+        assertValidatorMessage(INSTANCE, study, "activityEventKeys", StudyValidator.BRIDGE_EVENT_ID_ERROR);
     }
 
     @Test
     public void cannotCreateIdentifierWithColons() {
         study.setActivityEventKeys(Sets.newHashSet("a-1", "b:2"));
-        assertValidatorMessage(INSTANCE, study, "activityEventKeys", StudyValidator.SYNAPSE_IDENTIFIER_ERROR);
+        assertValidatorMessage(INSTANCE, study, "activityEventKeys", StudyValidator.BRIDGE_EVENT_ID_ERROR);
     }
 
     @Test
@@ -792,14 +792,16 @@ public class StudyValidatorTest {
     @Test
     public void validAutomaticCustomEventWithCustomOriginEvent() {
         study.setActivityEventKeys(ImmutableSet.of("externalEvent"));
-        study.setAutomaticCustomEvents(ImmutableMap.of("myEvent", "custom:externalEvent:P-14D"));
+        study.setAutomaticCustomEvents(ImmutableMap.of("myEvent", "externalEvent:P-14D"));
         Validate.entityThrowingException(INSTANCE, study);
     }
 
+    // This was the original form of this configuration, it will not throw an error until we 
+    // clarify the event we want to trigger off of
     @Test
-    public void validAutomaticCustomEventForDefault() {
+    public void validAutomaticCustomEventWithNoEventSpecified() {
         study.setAutomaticCustomEvents(ImmutableMap.of("myEvent", "P-14D"));
-        Validate.entityThrowingException(INSTANCE, study);
+        assertValidatorMessage(INSTANCE, study, "automaticCustomEvents[myEvent]", "'null' is not a valid custom or system event ID");
     }
     
     @Test
@@ -817,7 +819,7 @@ public class StudyValidatorTest {
     @Test
     public void invalidAutomaticCustomEventKey() {
         study.setAutomaticCustomEvents(ImmutableMap.of("@not-valid", "activities_retrieved:P-14D"));
-        assertValidatorMessage(INSTANCE, study, "automaticCustomEvents[@not-valid]", StudyValidator.SYNAPSE_IDENTIFIER_ERROR);
+        assertValidatorMessage(INSTANCE, study, "automaticCustomEvents[@not-valid]", StudyValidator.BRIDGE_EVENT_ID_ERROR);
     }
     
     @Test
@@ -828,7 +830,7 @@ public class StudyValidatorTest {
     
     @Test
     public void invalidAutomaticCustomEventOriginEvent() {
-        study.setAutomaticCustomEvents(ImmutableMap.of("myEvent", "custom:does-not-exist-event:P2W"));
-        assertValidatorMessage(INSTANCE, study, "automaticCustomEvents[myEvent]", "'custom:does-not-exist-event' is not a valid custom or system event ID");
+        study.setAutomaticCustomEvents(ImmutableMap.of("myEvent", "does-not-exist-event:P2W"));
+        assertValidatorMessage(INSTANCE, study, "automaticCustomEvents[myEvent]", "'does-not-exist-event' is not a valid custom or system event ID");
     }
 }


### PR DESCRIPTION
In addition, remove the "synthetic" events two_weeks_before_enrollment and two_months_before_enrollment because these are now implementable using automatic custom events, and in addition, they are not in use in any study right now (they were created for FHPS).

The event you can now schedule against is "activities_retrieved" and it's similar to enrollment in that it's immutable.