### PR TITLE
disable throttling for phone sign-in

### DIFF
--- a/app/org/sagebionetworks/bridge/services/AccountWorkflowService.java
+++ b/app/org/sagebionetworks/bridge/services/AccountWorkflowService.java
@@ -685,6 +685,13 @@ public class AccountWorkflowService {
 
     // Check if the request is throttled. Key is either email address or phone, depending on the type.
     private boolean isRequestThrottled(ThrottleRequestType type, String userId) {
+        if (type == ThrottleRequestType.PHONE_SIGNIN) {
+            // mPower 2.0 is currently blocked because of issues with phone sign-in. Long-term, we'll want to add a
+            // grace period for the phone token, similar to reauth. Short-term, we disable throttling for phone sign-in
+            // (but not for email, so it doesn't impact our spam rating).
+            return false;
+        }
+
         // Generate key, which is in the form of channel-throttling:[type]:[userId].
         String cacheKey = "channel-throttling:" + type.toString().toLowerCase() + ":" + userId;
 

--- a/test/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
@@ -1150,11 +1150,11 @@ public class AccountWorkflowServiceTest {
         when(mockAccountDao.getAccount(any())).thenReturn(mockAccount);
         when(mockStudyService.getStudy(study.getIdentifier())).thenReturn(study);
 
-        // Throttle limit is 2. Request 3 times. Get 2 texts.
+        // This is currently disabled. Request 3 times, get 3 texts.
         service.requestPhoneSignIn(SIGN_IN_REQUEST_WITH_PHONE);
         service.requestPhoneSignIn(SIGN_IN_REQUEST_WITH_PHONE);
         service.requestPhoneSignIn(SIGN_IN_REQUEST_WITH_PHONE);
-        verify(mockNotificationsService, times(2)).sendSmsMessage(any());
+        verify(mockNotificationsService, times(3)).sendSmsMessage(any());
     }
 
     @Test


### PR DESCRIPTION
We need throttling for email sign-in, or else we might double-send, and this hurts our spam rating.

However, we currently don't want throttling for phone sign-in, since there can be a network hiccup that causes phone token to be used up, but the app doesn't receive the session.

This is a simple short-term fix to disable throttling for phone sign-in.

Testing done:

* Manually tested phone sign-in and make sure it doesn't throttle.
* Manually tested email sign-in and make sure it _does_ throttle.