### PR TITLE
Remove admin role from some participant api methods

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
@@ -4,7 +4,6 @@ import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.NO_CALLER_ROLES;
 import static org.sagebionetworks.bridge.BridgeUtils.getDateTimeOrDefault;
 import static org.sagebionetworks.bridge.BridgeUtils.getIntOrDefault;
-import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.Roles.WORKER;
 import static org.sagebionetworks.bridge.models.ResourceList.START_TIME;
@@ -226,7 +225,7 @@ public class ParticipantController extends BaseController {
     }
     
     public Result getParticipant(String userId, boolean consents) throws Exception {
-        UserSession session = getAuthenticatedSession(ADMIN, RESEARCHER);
+        UserSession session = getAuthenticatedSession(RESEARCHER);
         Study study = studyService.getStudy(session.getStudyIdentifier());
 
         AccountId accountId = BridgeUtils.parseAccountId(study.getIdentifier(), userId);
@@ -268,7 +267,7 @@ public class ParticipantController extends BaseController {
     }
     
     public Result updateParticipant(String userId) {
-        UserSession session = getAuthenticatedSession(ADMIN, RESEARCHER);
+        UserSession session = getAuthenticatedSession(RESEARCHER);
         Study study = studyService.getStudy(session.getStudyIdentifier());
 
         StudyParticipant participant = parseJson(request(), StudyParticipant.class);

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -322,9 +322,8 @@ public class ParticipantService {
         }
         updateAccountAndRoles(study, callerRoles, account, participant);
         
-        // Only Admin and Worker accounts controlled by us should be able to bypass email verification. This is
-        // primarily used for integration tests, but is sometimes used to bootstrap external developers and
-        // researchers.
+        // Allow admin and worker accounts to toggle status; in particular, to disable/enable accounts. Note 
+        // however that admins can bypass phone/email verification as a result.
         if (participant.getStatus() != null) {
             if (callerRoles.contains(Roles.ADMIN) || callerRoles.contains(Roles.WORKER)) {
                 account.setStatus(participant.getStatus());


### PR DESCRIPTION
Instead, admin account should be assigned the researcher role so it can assume the capabilities of a researcher.