### PR TITLE
Updating subpopulation deletes to match logical deletion behavior of other objects.

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/SubpopulationDao.java
+++ b/app/org/sagebionetworks/bridge/dao/SubpopulationDao.java
@@ -44,15 +44,13 @@ public interface SubpopulationDao {
     Subpopulation updateSubpopulation(Subpopulation subpop);
 
     /**
-     * Delete a subpopulation. This is a logical delete only, because we cannot be certain that no 
-     * one has signed a consent for this subpopulation and need to keep the consent document around.
-     *
-     * @param physicalDelete physically delete this subpopulation from the database. This is only done via an
-     *      admin-api for the purposes of cleanup after integration tests.
-     * @param allowDeleteOfDefault allow the service to delete the default subpopulation, as part of deleting
-     *      a study. 
+     * Logically delete a subpopulation. You cannot logically delete the default subpopulation for a study. 
      */
-    void deleteSubpopulation(StudyIdentifier studyId, SubpopulationGuid subpopGuid, boolean physicalDelete,
-            boolean allowDeleteOfDefault);
+    void deleteSubpopulation(StudyIdentifier studyId, SubpopulationGuid subpopGuid);
+    
+    /**
+     * Delete a subpopulation permanently. 
+     */
+    void deleteSubpopulationPermanently(StudyIdentifier studyId, SubpopulationGuid subpopGuid);
     
 }

--- a/app/org/sagebionetworks/bridge/models/subpopulations/Subpopulation.java
+++ b/app/org/sagebionetworks/bridge/models/subpopulations/Subpopulation.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 public interface Subpopulation extends BridgeEntity {
     ObjectWriter SUBPOP_WRITER = new BridgeObjectMapper().writer(
             new SimpleFilterProvider().addFilter("filter",
-            SimpleBeanPropertyFilter.serializeAllExcept("studyIdentifier", "deleted")));
+            SimpleBeanPropertyFilter.serializeAllExcept("studyIdentifier")));
 
     static Subpopulation create() {
         return new DynamoSubpopulation();

--- a/app/org/sagebionetworks/bridge/services/IntentService.java
+++ b/app/org/sagebionetworks/bridge/services/IntentService.java
@@ -129,7 +129,7 @@ public class IntentService {
         }
         boolean consentsUpdated = false;
         StudyParticipant participant = null;
-        List<Subpopulation> subpops = subpopService.getSubpopulations(study.getStudyIdentifier());
+        List<Subpopulation> subpops = subpopService.getSubpopulations(study.getStudyIdentifier(), false);
         for (Subpopulation subpop : subpops) {
             CacheKey cacheKey = CacheKey.itp(subpop.getGuid(), study.getStudyIdentifier(), phone);
             IntentToParticipate intent = cacheProvider.getObject(cacheKey, IntentToParticipate.class);

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -200,7 +200,7 @@ public class ParticipantService {
 
         if (includeHistory) {
             Map<String,List<UserConsentHistory>> consentHistories = Maps.newHashMap();
-            List<Subpopulation> subpopulations = subpopService.getSubpopulations(study.getStudyIdentifier());
+            List<Subpopulation> subpopulations = subpopService.getSubpopulations(study.getStudyIdentifier(), false);
             for (Subpopulation subpop : subpopulations) {
                 // always returns a list, even if empty
                 List<UserConsentHistory> history = getUserConsentHistory(account, subpop.getGuid());

--- a/app/org/sagebionetworks/bridge/services/backfill/ConsentCreatedOnBackfill.java
+++ b/app/org/sagebionetworks/bridge/services/backfill/ConsentCreatedOnBackfill.java
@@ -47,7 +47,7 @@ public class ConsentCreatedOnBackfill extends AsyncBackfillTemplate {
         for (Study study : studies) {
             callback.newRecords(getBackfillRecordFactory().createOnly(task, "Examining study " + study.getIdentifier() + "..."));
             
-            List<Subpopulation> subpopulations = subpopulationService.getSubpopulations(study.getStudyIdentifier());
+            List<Subpopulation> subpopulations = subpopulationService.getSubpopulations(study.getStudyIdentifier(), true);
             for (Subpopulation subpopulation : subpopulations) {
                 StudyConsent consent = studyConsentDao.getConsent(subpopulation.getGuid(),
                         subpopulation.getPublishedConsentCreatedOn());

--- a/conf/routes
+++ b/conf/routes
@@ -123,7 +123,7 @@ POST   /v3/sharedmodules/metadata/:id/versions/:version @org.sagebionetworks.bri
 DELETE /v3/sharedmodules/metadata/:id/versions/:version @org.sagebionetworks.bridge.play.controllers.SharedModuleMetadataController.deleteMetadataByIdAndVersion(id: String, version: Int)
 
 # Study Subpopulations
-GET    /v3/subpopulations        @org.sagebionetworks.bridge.play.controllers.SubpopulationController.getAllSubpopulations
+GET    /v3/subpopulations        @org.sagebionetworks.bridge.play.controllers.SubpopulationController.getAllSubpopulations(includeDeleted: String ?= "false")
 POST   /v3/subpopulations        @org.sagebionetworks.bridge.play.controllers.SubpopulationController.createSubpopulation
 GET    /v3/subpopulations/:guid  @org.sagebionetworks.bridge.play.controllers.SubpopulationController.getSubpopulation(guid: String)
 POST   /v3/subpopulations/:guid  @org.sagebionetworks.bridge.play.controllers.SubpopulationController.updateSubpopulation(guid: String)

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationTest.java
@@ -57,7 +57,9 @@ public class DynamoSubpopulationTest {
         assertTrue(node.get("autoSendConsentSuppressed").booleanValue());
         assertTrue(node.get("deleted").booleanValue()); // users do not see this flag, they never get deleted items
         assertEquals("study-key", node.get("studyIdentifier").textValue());
+        assertTrue(node.get("deleted").booleanValue());
         assertEquals(3L, node.get("version").longValue());
+        assertEquals("Subpopulation", node.get("type").textValue());
         
         JsonNode critNode = node.get("criteria");
         assertEquals(ALL_OF_GROUPS, JsonUtils.asStringSet(critNode, "allOfGroups"));
@@ -68,7 +70,6 @@ public class DynamoSubpopulationTest {
         Subpopulation newSubpop = BridgeObjectMapper.get().treeToValue(node, Subpopulation.class);
         // Not serialized, these values have to be added back to have equal objects 
         newSubpop.setStudyIdentifier("study-key");
-        newSubpop.setDeleted(true);
         
         assertEquals(subpop, newSubpop);
         
@@ -112,7 +113,6 @@ public class DynamoSubpopulationTest {
         JsonNode node = BridgeObjectMapper.get().readTree(json);
 
         assertNull(node.get("studyIdentifier"));
-        assertNull(node.get("deleted"));
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/services/ConsentServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ConsentServiceTest.java
@@ -104,7 +104,7 @@ public class ConsentServiceTest {
         study = studyService.createStudy(study);
         
         // Default is always created, so use it for this test.
-        defaultSubpopulation = subpopService.getSubpopulations(study).get(0);
+        defaultSubpopulation = subpopService.getSubpopulations(study, false).get(0);
         
         testUser = helper.getBuilder(ConsentServiceTest.class).withStudy(study).withConsent(false).build();
         

--- a/test/org/sagebionetworks/bridge/services/IntentServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/IntentServiceTest.java
@@ -228,13 +228,13 @@ public class IntentServiceTest {
         
         when(mockStudy.getStudyIdentifier()).thenReturn(TestConstants.TEST_STUDY);
         when(mockStudy.getIdentifier()).thenReturn(TestConstants.TEST_STUDY_IDENTIFIER);
-        when(mockSubpopService.getSubpopulations(TestConstants.TEST_STUDY))
+        when(mockSubpopService.getSubpopulations(TestConstants.TEST_STUDY, false))
                 .thenReturn(Lists.newArrayList(subpopA, subpopB));
         when(mockCacheProvider.getObject(key, IntentToParticipate.class)).thenReturn(intent);
         
         service.registerIntentToParticipate(mockStudy, account);
         
-        verify(mockSubpopService).getSubpopulations(TestConstants.TEST_STUDY);
+        verify(mockSubpopService).getSubpopulations(TestConstants.TEST_STUDY, false);
         verify(mockCacheProvider).removeObject(key);
         verify(mockConsentService).consentToResearch(eq(mockStudy), eq(SubpopulationGuid.create("BBB")), 
                 any(), eq(intent.getConsentSignature()), eq(intent.getScope()), eq(true));
@@ -282,7 +282,7 @@ public class IntentServiceTest {
         
         when(mockStudy.getStudyIdentifier()).thenReturn(TestConstants.TEST_STUDY);
         when(mockStudy.getIdentifier()).thenReturn(TestConstants.TEST_STUDY_IDENTIFIER);
-        when(mockSubpopService.getSubpopulations(TestConstants.TEST_STUDY))
+        when(mockSubpopService.getSubpopulations(TestConstants.TEST_STUDY, false))
                 .thenReturn(Lists.newArrayList(subpopA, subpopB));
         when(mockCacheProvider.getObject(keyAAA, IntentToParticipate.class)).thenReturn(intentAAA);
         when(mockCacheProvider.getObject(keyBBB, IntentToParticipate.class)).thenReturn(intentBBB);
@@ -290,7 +290,7 @@ public class IntentServiceTest {
         
         service.registerIntentToParticipate(mockStudy, account);
         
-        verify(mockSubpopService).getSubpopulations(TestConstants.TEST_STUDY);
+        verify(mockSubpopService).getSubpopulations(TestConstants.TEST_STUDY, false);
         verify(mockCacheProvider).removeObject(keyAAA);
         verify(mockCacheProvider).removeObject(keyBBB);
         verify(mockConsentService).consentToResearch(eq(mockStudy), eq(SubpopulationGuid.create("AAA")), 
@@ -328,13 +328,13 @@ public class IntentServiceTest {
         
         when(mockStudy.getStudyIdentifier()).thenReturn(TestConstants.TEST_STUDY);
         when(mockStudy.getIdentifier()).thenReturn(TestConstants.TEST_STUDY_IDENTIFIER);
-        when(mockSubpopService.getSubpopulations(TestConstants.TEST_STUDY))
+        when(mockSubpopService.getSubpopulations(TestConstants.TEST_STUDY, false))
                 .thenReturn(Lists.newArrayList(subpopA, subpopB));
         when(mockParticipantService.getParticipant(any(Study.class), any(String.class), eq(false))).thenReturn(participant);
         
         service.registerIntentToParticipate(mockStudy, account);
         
-        verify(mockSubpopService).getSubpopulations(TestConstants.TEST_STUDY);
+        verify(mockSubpopService).getSubpopulations(TestConstants.TEST_STUDY, false);
         verify(mockCacheProvider, never()).removeObject(key);
         verifyNoMoreInteractions(mockConsentService); 
     }

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -594,7 +594,7 @@ public class ParticipantServiceTest {
         subpop2.setPublishedConsentCreatedOn(CONSENT_PUBLICATION_DATE);
         
         subpopulations.add(subpop2);
-        when(subpopService.getSubpopulations(STUDY.getStudyIdentifier())).thenReturn(subpopulations);
+        when(subpopService.getSubpopulations(STUDY.getStudyIdentifier(), false)).thenReturn(subpopulations);
 
         when(subpopService.getSubpopulation(STUDY.getStudyIdentifier(), SUBPOP_GUID_1)).thenReturn(subpop1);
         when(subpopService.getSubpopulation(STUDY.getStudyIdentifier(), SUBPOP_GUID_2)).thenReturn(subpop2);
@@ -856,7 +856,7 @@ public class ParticipantServiceTest {
         
         doReturn(STUDY.getIdentifier()).when(subpopulation).getGuidString();
         doReturn(SUBPOP_GUID).when(subpopulation).getGuid();
-        doReturn(Lists.newArrayList(subpopulation)).when(subpopService).getSubpopulations(STUDY.getStudyIdentifier());
+        doReturn(Lists.newArrayList(subpopulation)).when(subpopService).getSubpopulations(STUDY.getStudyIdentifier(), false);
         
         StudyParticipant participant = participantService.getParticipant(STUDY, ID, false);
 
@@ -888,7 +888,7 @@ public class ParticipantServiceTest {
         
         doReturn(STUDY.getIdentifier()).when(subpopulation).getGuidString();
         doReturn(SUBPOP_GUID).when(subpopulation).getGuid();
-        doReturn(Lists.newArrayList(subpopulation)).when(subpopService).getSubpopulations(STUDY.getStudyIdentifier());
+        doReturn(Lists.newArrayList(subpopulation)).when(subpopService).getSubpopulations(STUDY.getStudyIdentifier(), false);
         
         StudyParticipant participant = participantService.getParticipant(STUDY, ID, true);
 
@@ -902,7 +902,7 @@ public class ParticipantServiceTest {
 
         doReturn(STUDY.getIdentifier()).when(subpopulation).getGuidString();
         doReturn(SUBPOP_GUID).when(subpopulation).getGuid();
-        doReturn(Lists.newArrayList(subpopulation)).when(subpopService).getSubpopulations(STUDY.getStudyIdentifier());
+        doReturn(Lists.newArrayList(subpopulation)).when(subpopService).getSubpopulations(STUDY.getStudyIdentifier(), false);
 
         // Execute and validate
         StudyParticipant participant = participantService.getParticipant(STUDY, ID, true);
@@ -916,7 +916,7 @@ public class ParticipantServiceTest {
 
         doReturn(STUDY.getIdentifier()).when(subpopulation).getGuidString();
         doReturn(SUBPOP_GUID).when(subpopulation).getGuid();
-        doReturn(Lists.newArrayList(subpopulation)).when(subpopService).getSubpopulations(STUDY.getStudyIdentifier());
+        doReturn(Lists.newArrayList(subpopulation)).when(subpopService).getSubpopulations(STUDY.getStudyIdentifier(), false);
 
         when(cacheProvider.getRequestInfo(ID)).thenReturn(REQUEST_INFO);
 

--- a/test/org/sagebionetworks/bridge/services/StudyConsentServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyConsentServiceTest.java
@@ -75,7 +75,7 @@ public class StudyConsentServiceTest {
     @After
     public void after() {
         studyConsentDao.deleteAllConsents(subpopulation.getGuid());
-        subpopService.deleteSubpopulation(study.getStudyIdentifier(), subpopulation.getGuid(), true);
+        subpopService.deleteSubpopulationPermanently(study.getStudyIdentifier(), subpopulation.getGuid());
     }
 
     @Test

--- a/test/org/sagebionetworks/bridge/services/SubpopulationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SubpopulationServiceTest.java
@@ -271,7 +271,7 @@ public class SubpopulationServiceTest {
 
         when(subpopDao.getSubpopulations(TEST_STUDY, true, false)).thenReturn(ImmutableList.of(subpop1, subpop2));
         
-        List<Subpopulation> results = service.getSubpopulations(TEST_STUDY);
+        List<Subpopulation> results = service.getSubpopulations(TEST_STUDY, false);
         assertEquals(2, results.size());
         assertEquals(subpop1, results.get(0));
         assertEquals(subpop2, results.get(1));
@@ -289,12 +289,23 @@ public class SubpopulationServiceTest {
         assertEquals(subpop, result);
         verify(subpopDao).getSubpopulation(TEST_STUDY, SUBPOP_GUID);
     }
-    
+
     @Test
     public void deleteSubpopulation() {
-        service.deleteSubpopulation(TEST_STUDY, SUBPOP_GUID, true);
+        service.deleteSubpopulation(TEST_STUDY, SUBPOP_GUID);
         
-        verify(subpopDao).deleteSubpopulation(TEST_STUDY, SUBPOP_GUID, true, false);
+        verify(subpopDao).deleteSubpopulation(TEST_STUDY, SUBPOP_GUID);
+        verify(cacheProvider).removeObject(CacheKey.subpop(SUBPOP_GUID, TEST_STUDY));
+        verify(cacheProvider).removeObject(CacheKey.subpopList(TEST_STUDY));
+    }
+    
+    @Test
+    public void deleteSubpopulationPermanently() {
+        service.deleteSubpopulationPermanently(TEST_STUDY, SUBPOP_GUID);
+        
+        verify(subpopDao).deleteSubpopulationPermanently(TEST_STUDY, SUBPOP_GUID);
+        verify(cacheProvider).removeObject(CacheKey.subpop(SUBPOP_GUID, TEST_STUDY));
+        verify(cacheProvider).removeObject(CacheKey.subpopList(TEST_STUDY));
     }
     
     @Test
@@ -392,12 +403,12 @@ public class SubpopulationServiceTest {
         subpop1.setDefaultGroup(true);
         Subpopulation subpop2 = createSubpop(SUBPOP_2, null, null, null);
         
-        when(subpopDao.getSubpopulations(TEST_STUDY, true, false)).thenReturn(ImmutableList.of(subpop1, subpop2));
+        when(subpopDao.getSubpopulations(TEST_STUDY, true, true)).thenReturn(ImmutableList.of(subpop1, subpop2));
         
         service.deleteAllSubpopulations(TEST_STUDY);
         
-        verify(subpopDao).deleteSubpopulation(TEST_STUDY, subpop1.getGuid(), true, true);
-        verify(subpopDao).deleteSubpopulation(TEST_STUDY, subpop2.getGuid(), true, true);
+        verify(subpopDao).deleteSubpopulationPermanently(TEST_STUDY, subpop1.getGuid());
+        verify(subpopDao).deleteSubpopulationPermanently(TEST_STUDY, subpop2.getGuid());
         verify(cacheProvider).removeObject(CacheKey.subpop(subpop1.getGuid(), TEST_STUDY));
         verify(cacheProvider, times(2)).removeObject(CacheKey.subpopList(TEST_STUDY));
     }

--- a/test/org/sagebionetworks/bridge/services/SurveyServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/SurveyServiceMockTest.java
@@ -20,11 +20,9 @@ import static org.sagebionetworks.bridge.services.SharedModuleMetadataServiceTes
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import org.joda.time.DateTime;
 import org.junit.Before;
@@ -34,7 +32,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dao.SurveyDao;
 import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
@@ -66,8 +63,6 @@ public class SurveyServiceMockTest {
     private static final String SURVEY_GUID = "surveyGuid";
     private static final DateTime SURVEY_CREATED_ON = DateTime.parse("2017-02-08T20:07:57.179Z");
     private static final GuidCreatedOnVersionHolder SURVEY_KEYS = new GuidCreatedOnVersionHolderImpl(SURVEY_GUID, 1337);
-    private static final Set<Roles> ADMIN_ROLE = ImmutableSet.of(Roles.ADMIN);
-    private static final Set<Roles> NOT_ADMIN_ROLE = ImmutableSet.of(Roles.WORKER);
 
     @Mock
     SurveyPublishValidator mockSurveyPublishValidator;


### PR DESCRIPTION
Logical delete already existed for subpopulations; adjusted it so it's similar to the behavior of other objects where this has recently been added.