### PR TITLE
expose get upload APIs to worker

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/UploadController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/UploadController.java
@@ -156,7 +156,7 @@ public class UploadController extends BaseController {
     }
     
     public Result getUpload(String uploadId) {
-        getAuthenticatedSession(Roles.ADMIN);
+        getAuthenticatedSession(Roles.ADMIN, Roles.WORKER);
 
         if (uploadId.startsWith("recordId:")) {
             String recordId = uploadId.split(":")[1];

--- a/test/org/sagebionetworks/bridge/play/controllers/UploadControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/UploadControllerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
+import static org.sagebionetworks.bridge.Roles.WORKER;
 
 import java.net.URL;
 
@@ -293,7 +294,7 @@ public class UploadControllerTest {
     @Test
     public void getUploadById() throws Exception {
         TestUtils.mockPlayContext();
-        doReturn(researcherSession).when(controller).getAuthenticatedSession(ADMIN);
+        doReturn(researcherSession).when(controller).getAuthenticatedSession(ADMIN, WORKER);
         
         HealthDataRecord record = HealthDataRecord.create();
         record.setHealthCode(HEALTH_CODE);
@@ -317,7 +318,7 @@ public class UploadControllerTest {
     @Test
     public void getUploadByRecordId() throws Exception {
         TestUtils.mockPlayContext();
-        doReturn(researcherSession).when(controller).getAuthenticatedSession(ADMIN);
+        doReturn(researcherSession).when(controller).getAuthenticatedSession(ADMIN, WORKER);
         
         HealthDataRecord record = HealthDataRecord.create();
         record.setUploadId(UPLOAD_ID);
@@ -343,7 +344,7 @@ public class UploadControllerTest {
     @Test(expected = EntityNotFoundException.class)
     public void getUploadByRecordIdRecordMissing() throws Exception {
         TestUtils.mockPlayContext();
-        doReturn(researcherSession).when(controller).getAuthenticatedSession(ADMIN);
+        doReturn(researcherSession).when(controller).getAuthenticatedSession(ADMIN, WORKER);
         
         when(healthDataService.getRecordById("record-id")).thenReturn(null);
 


### PR DESCRIPTION
This is also needed for the redrive worker. We may need to redrive using record ID, which in some cases, may be different from upload ID (generally for older uploads before we consolidated IDs in March). The worker needs an API to get upload IDs from record IDs. Currently, this is exposed only to the admin.