### PR TITLE
clean up S3 when cleaning up study consents

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/StudyConsentDao.java
+++ b/app/org/sagebionetworks/bridge/dao/StudyConsentDao.java
@@ -22,12 +22,9 @@ public interface StudyConsentDao {
      */
     StudyConsent getConsent(SubpopulationGuid subpopGuid, long consentCreatedOn);
 
-    /**
-     * Delete all the consents for a subpopulation. Only call when physically deleting a subpopulation
-     * (usually as part of a test).
-     */
-    void deleteAllConsents(SubpopulationGuid subpopGuid);
-    
+    /** Permanently deletes the specified consent. */
+    void deleteConsentPermanently(StudyConsent consent);
+
     /**
      * Gets all the consents in reverse order of the timestamp, for a particularly subpopulation.
      */

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoStudyConsentDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoStudyConsentDao.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import javax.annotation.Resource;
 
-import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.dao.StudyConsentDao;
 import org.sagebionetworks.bridge.models.subpopulations.StudyConsent;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
@@ -14,7 +13,6 @@ import com.amazonaws.services.dynamodbv2.datamodeling.QueryResultPage;
 import org.springframework.stereotype.Component;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper.FailedBatch;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
 import com.amazonaws.services.dynamodbv2.datamodeling.PaginatedQueryList;
 
@@ -78,20 +76,10 @@ public class DynamoStudyConsentDao implements StudyConsentDao {
         }
         return results;
     }
-    
+
+    /** {@inheritDoc} */
     @Override
-    public void deleteAllConsents(SubpopulationGuid subpopGuid) {
-        DynamoStudyConsent1 hashKey = new DynamoStudyConsent1();
-        hashKey.setSubpopulationGuid(subpopGuid.getGuid());
-        DynamoDBQueryExpression<DynamoStudyConsent1> queryExpression = 
-                new DynamoDBQueryExpression<DynamoStudyConsent1>()
-                .withHashKeyValues(hashKey)
-                .withScanIndexForward(false);
-        
-        List<? extends StudyConsent> consentsToDelete = mapper.query(DynamoStudyConsent1.class, queryExpression);
-        if (!consentsToDelete.isEmpty()) {
-            List<FailedBatch> failures = mapper.batchDelete(consentsToDelete);
-            BridgeUtils.ifFailuresThrowException(failures);
-        }
+    public void deleteConsentPermanently(StudyConsent consent) {
+        mapper.delete(consent);
     }
 }

--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDao.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDao.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Component;
 
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.dao.CriteriaDao;
-import org.sagebionetworks.bridge.dao.StudyConsentDao;
 import org.sagebionetworks.bridge.dao.SubpopulationDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
@@ -33,19 +32,13 @@ public class DynamoSubpopulationDao implements SubpopulationDao {
     
     private static final String CANNOT_DELETE_DEFAULT_SUBPOP_MSG = "Cannot delete the default subpopulation for a study.";
     private DynamoDBMapper mapper;
-    private StudyConsentDao studyConsentDao;
     private CriteriaDao criteriaDao;
 
     @Resource(name = "subpopulationDdbMapper")
     final void setMapper(DynamoDBMapper mapper) {
         this.mapper = mapper;
     }
-    
-    @Autowired
-    final void setStudyConsentDao(StudyConsentDao studyConsentDao) {
-        this.studyConsentDao = studyConsentDao;
-    }
-    
+
     @Autowired
     final void setCriteriaDao(CriteriaDao criteriaDao) {
         this.criteriaDao = criteriaDao;
@@ -176,8 +169,7 @@ public class DynamoSubpopulationDao implements SubpopulationDao {
     @Override
     public void deleteSubpopulationPermanently(StudyIdentifier studyId, SubpopulationGuid subpopGuid) {
         Subpopulation subpop = getSubpopulation(studyId, subpopGuid);
-        
-        studyConsentDao.deleteAllConsents(subpopGuid);
+
         criteriaDao.deleteCriteria(subpop.getCriteria().getKey());
         mapper.delete(subpop);
     }

--- a/app/org/sagebionetworks/bridge/models/subpopulations/StudyConsent.java
+++ b/app/org/sagebionetworks/bridge/models/subpopulations/StudyConsent.java
@@ -1,24 +1,37 @@
 package org.sagebionetworks.bridge.models.subpopulations;
 
+import org.sagebionetworks.bridge.dynamodb.DynamoStudyConsent1;
 import org.sagebionetworks.bridge.json.BridgeTypeName;
 import org.sagebionetworks.bridge.models.BridgeEntity;
 
 @BridgeTypeName("StudyConsent")
 public interface StudyConsent extends BridgeEntity {
+    /** Creates a StudyConsent instance. */
+    static StudyConsent create() {
+        return new DynamoStudyConsent1();
+    }
 
     /**
      * The subpopulation associated with this consent.
      */
     String getSubpopulationGuid();
 
+    /** @see #getSubpopulationGuid */
+    void setSubpopulationGuid(String subpopulationGuid);
+
     /**
      * Timestamp when this consent is created.
      */
     long getCreatedOn();
+
+    /** @see #getCreatedOn */
+    void setCreatedOn(long createdOn);
 
     /**
      * Get the path to the storage of the consent document (probably in S3).
      */
     String getStoragePath();
 
+    /** @see #getStoragePath */
+    void setStoragePath(String storagePath);
 }

--- a/app/org/sagebionetworks/bridge/services/SubpopulationService.java
+++ b/app/org/sagebionetworks/bridge/services/SubpopulationService.java
@@ -221,7 +221,8 @@ public class SubpopulationService {
     public void deleteSubpopulationPermanently(StudyIdentifier studyId, SubpopulationGuid subpopGuid) {
         checkNotNull(studyId);
         checkNotNull(subpopGuid);
-        
+
+        studyConsentService.deleteAllConsentsPermanently(subpopGuid);
         subpopDao.deleteSubpopulationPermanently(studyId, subpopGuid);
         cacheProvider.removeObject(CacheKey.subpop(subpopGuid, studyId));
         cacheProvider.removeObject(CacheKey.subpopList(studyId));
@@ -238,9 +239,7 @@ public class SubpopulationService {
         List<Subpopulation> subpops = getSubpopulations(studyId, true);
         if (!subpops.isEmpty()) {
             for (Subpopulation subpop : subpops) {
-                subpopDao.deleteSubpopulationPermanently(studyId, subpop.getGuid());
-                cacheProvider.removeObject(CacheKey.subpop(subpop.getGuid(), studyId));
-                cacheProvider.removeObject(CacheKey.subpopList(studyId));
+                deleteSubpopulationPermanently(studyId, subpop.getGuid());
             }
         }
     }

--- a/app/org/sagebionetworks/bridge/services/SubpopulationService.java
+++ b/app/org/sagebionetworks/bridge/services/SubpopulationService.java
@@ -222,8 +222,8 @@ public class SubpopulationService {
         checkNotNull(studyId);
         checkNotNull(subpopGuid);
 
-        studyConsentService.deleteAllConsentsPermanently(subpopGuid);
         subpopDao.deleteSubpopulationPermanently(studyId, subpopGuid);
+        studyConsentService.deleteAllConsentsPermanently(subpopGuid);
         cacheProvider.removeObject(CacheKey.subpop(subpopGuid, studyId));
         cacheProvider.removeObject(CacheKey.subpopList(studyId));
     }

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyConsentDaoTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoStudyConsentDaoTest.java
@@ -3,11 +3,13 @@ package org.sagebionetworks.bridge.dynamodb;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.annotation.Resource;
 
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.sagebionetworks.bridge.time.DateUtils;
@@ -26,9 +28,19 @@ public class DynamoStudyConsentDaoTest {
     @Resource
     private DynamoStudyConsentDao studyConsentDao;
 
+    private List<StudyConsent> consentsToDelete;
+
+    @Before
+    public void before() {
+        // Sometimes JUnit doesn't reset member variables.
+        consentsToDelete = new ArrayList<>();
+    }
+
     @After
     public void after() {
-        studyConsentDao.deleteAllConsents(SUBPOP_GUID);
+        for (StudyConsent consent : consentsToDelete) {
+            studyConsentDao.deleteConsentPermanently(consent);
+        }
 
         assertEquals(0, studyConsentDao.getConsents(SUBPOP_GUID).size());
     }
@@ -38,13 +50,13 @@ public class DynamoStudyConsentDaoTest {
         long createdOn = DateUtils.getCurrentMillisFromEpoch();
         
         // Add consent version 1, inactive
-        StudyConsent consent1 = studyConsentDao.addConsent(SUBPOP_GUID, SUBPOP_GUID+"."+createdOn, createdOn);
+        StudyConsent consent1 = addConsent(createdOn);
         assertEquals(createdOn, consent1.getCreatedOn());
         
         createdOn = DateUtils.getCurrentMillisFromEpoch();
         
         // Add version 2
-        StudyConsent consent2 = studyConsentDao.addConsent(SUBPOP_GUID, SUBPOP_GUID+"."+createdOn, createdOn);
+        StudyConsent consent2 = addConsent(createdOn);
         assertEquals(createdOn, consent2.getCreatedOn());
         
         // The most recent consent should be version 2
@@ -57,7 +69,7 @@ public class DynamoStudyConsentDaoTest {
         
         // Add a third consent to test list of consents
         createdOn = DateUtils.getCurrentMillisFromEpoch();
-        final StudyConsent consent3 = studyConsentDao.addConsent(SUBPOP_GUID, SUBPOP_GUID+"."+createdOn, createdOn);
+        final StudyConsent consent3 = addConsent(createdOn);
         
         // Get all consents. Should return in reverse order
         List<? extends StudyConsent> all = studyConsentDao.getConsents(SUBPOP_GUID);
@@ -65,14 +77,30 @@ public class DynamoStudyConsentDaoTest {
         assertConsentsEqual(consent3, all.get(0), false);
         assertConsentsEqual(consent2, all.get(1), true);
         assertConsentsEqual(consent1, all.get(2), false);
+
+        // Delete consent.
+        studyConsentDao.deleteConsentPermanently(consent3);
+        consentsToDelete.remove(consent3);
+
+        all = studyConsentDao.getConsents(SUBPOP_GUID);
+        assertEquals(2, all.size());
+        assertConsentsEqual(consent2, all.get(0), true);
+        assertConsentsEqual(consent1, all.get(1), false);
     }
     
     @Test
-    public void crudStudyConsentWithS3Content() throws Exception {
+    public void crudStudyConsentWithS3Content() {
         long createdOn = DateUtils.getCurrentMillisFromEpoch();
         String key = SUBPOP_GUID + "." + createdOn;
-        StudyConsent consent = studyConsentDao.addConsent(SUBPOP_GUID, key, createdOn);
+        StudyConsent consent = addConsent(createdOn);
         assertEquals(key, consent.getStoragePath());
+    }
+
+    private StudyConsent addConsent(long createdOn) {
+        StudyConsent consent = studyConsentDao.addConsent(SUBPOP_GUID, SUBPOP_GUID + "." + createdOn,
+                createdOn);
+        consentsToDelete.add(consent);
+        return consent;
     }
     
     private void assertConsentsEqual(StudyConsent existing, StudyConsent newOne, boolean isActive) {

--- a/test/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDaoMockTest.java
+++ b/test/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDaoMockTest.java
@@ -30,7 +30,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dao.CriteriaDao;
-import org.sagebionetworks.bridge.dao.StudyConsentDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.models.Criteria;
 import org.sagebionetworks.bridge.models.OperatingSystem;
@@ -57,9 +56,6 @@ public class DynamoSubpopulationDaoMockTest {
     private DynamoDBMapper mapper;
     
     @Mock
-    private StudyConsentDao studyConsentDao;
-    
-    @Mock
     private CriteriaDao criteriaDao;
     
     @Captor
@@ -74,7 +70,6 @@ public class DynamoSubpopulationDaoMockTest {
     @Before
     public void before() {
         dao.setMapper(mapper);
-        dao.setStudyConsentDao(studyConsentDao);
         dao.setCriteriaDao(criteriaDao);
         
         List<DynamoSubpopulation> list = Lists.newArrayList((DynamoSubpopulation)createSubpopulation());
@@ -171,7 +166,6 @@ public class DynamoSubpopulationDaoMockTest {
         doReturn(Criteria.create()).when(criteriaDao).getCriteria(any());
         
         dao.deleteSubpopulationPermanently(TEST_STUDY, SUBPOP_GUID);
-        verify(studyConsentDao).deleteAllConsents(SUBPOP_GUID);
         verify(criteriaDao).deleteCriteria(defaultSubpop.getCriteria().getKey());
         verify(mapper).delete(defaultSubpop);
     }

--- a/test/org/sagebionetworks/bridge/services/StudyConsentServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyConsentServiceMockTest.java
@@ -1,0 +1,56 @@
+package org.sagebionetworks.bridge.services;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.google.common.collect.ImmutableList;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.dao.StudyConsentDao;
+import org.sagebionetworks.bridge.models.subpopulations.StudyConsent;
+import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
+
+public class StudyConsentServiceMockTest {
+    private static final SubpopulationGuid SUBPOP_GUID = SubpopulationGuid.create("my-subpop");
+
+    private StudyConsentService svc;
+    private StudyConsentDao mockDao;
+    private AmazonS3Client mockS3Client;
+
+    @Before
+    public void before() {
+        mockDao = mock(StudyConsentDao.class);
+        mockS3Client = mock(AmazonS3Client.class);
+
+        svc = new StudyConsentService();
+        svc.setStudyConsentDao(mockDao);
+        svc.setS3Client(mockS3Client);
+    }
+
+    @Test
+    public void deleteAll() {
+        // Mock dao. We only care about the storage path.
+        StudyConsent consent1 = StudyConsent.create();
+        consent1.setStoragePath("storagePath1");
+
+        StudyConsent consent2 = StudyConsent.create();
+        consent2.setStoragePath("storagePath2");
+
+        when(mockDao.getConsents(SUBPOP_GUID)).thenReturn(ImmutableList.of(consent1, consent2));
+
+        // Execute and validate.
+        svc.deleteAllConsentsPermanently(SUBPOP_GUID);
+
+        verify(mockDao).deleteConsentPermanently(consent1);
+        verify(mockDao).deleteConsentPermanently(consent2);
+
+        verify(mockS3Client).deleteObject(StudyConsentService.CONSENTS_BUCKET, "storagePath1");
+        verify(mockS3Client).deleteObject(StudyConsentService.CONSENTS_BUCKET, "storagePath2");
+
+        verify(mockS3Client).deleteObject(StudyConsentService.PUBLICATIONS_BUCKET, "my-subpop/consent.html");
+        verify(mockS3Client).deleteObject(StudyConsentService.PUBLICATIONS_BUCKET, "my-subpop/consent.pdf");
+    }
+}

--- a/test/org/sagebionetworks/bridge/services/SubpopulationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SubpopulationServiceTest.java
@@ -302,7 +302,8 @@ public class SubpopulationServiceTest {
     @Test
     public void deleteSubpopulationPermanently() {
         service.deleteSubpopulationPermanently(TEST_STUDY, SUBPOP_GUID);
-        
+
+        verify(studyConsentService).deleteAllConsentsPermanently(SUBPOP_GUID);
         verify(subpopDao).deleteSubpopulationPermanently(TEST_STUDY, SUBPOP_GUID);
         verify(cacheProvider).removeObject(CacheKey.subpop(SUBPOP_GUID, TEST_STUDY));
         verify(cacheProvider).removeObject(CacheKey.subpopList(TEST_STUDY));
@@ -406,10 +407,15 @@ public class SubpopulationServiceTest {
         when(subpopDao.getSubpopulations(TEST_STUDY, true, true)).thenReturn(ImmutableList.of(subpop1, subpop2));
         
         service.deleteAllSubpopulations(TEST_STUDY);
-        
+
+        verify(studyConsentService).deleteAllConsentsPermanently(subpop1.getGuid());
         verify(subpopDao).deleteSubpopulationPermanently(TEST_STUDY, subpop1.getGuid());
-        verify(subpopDao).deleteSubpopulationPermanently(TEST_STUDY, subpop2.getGuid());
         verify(cacheProvider).removeObject(CacheKey.subpop(subpop1.getGuid(), TEST_STUDY));
+
+        verify(studyConsentService).deleteAllConsentsPermanently(subpop2.getGuid());
+        verify(subpopDao).deleteSubpopulationPermanently(TEST_STUDY, subpop2.getGuid());
+        verify(cacheProvider).removeObject(CacheKey.subpop(subpop2.getGuid(), TEST_STUDY));
+
         verify(cacheProvider, times(2)).removeObject(CacheKey.subpopList(TEST_STUDY));
     }
     


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-2312

When deleting a subpop (or a study, which deletes all subpops), we'll delete the entries from DDB, but not from S3. This is a problem, because we suspect all these extra files in S3 is causing a slowdown.

This change refactors deleting study consents to also delete the S3 files.

Testing done:
* Updated unit tests
* Ran integ tests and verified S3 buckets are clean afterward