### PR TITLE
Associate substudies

### DIFF
--- a/app/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/app/org/sagebionetworks/bridge/BridgeConstants.java
@@ -1,11 +1,7 @@
 package org.sagebionetworks.bridge;
 
-import java.util.Set;
-
 import org.joda.time.DateTimeZone;
 import org.jsoup.safety.Whitelist;
-
-import com.google.common.collect.ImmutableSet;
 
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
@@ -106,8 +102,6 @@ public class BridgeConstants {
     public static final String PAGE_SIZE_ERROR = "pageSize must be from "+API_MINIMUM_PAGE_SIZE+"-"+API_MAXIMUM_PAGE_SIZE+" records";
     
     public static final String TEST_USER_GROUP = "test_user";
-    
-    public static final Set<Roles> NO_CALLER_ROLES = ImmutableSet.of();
     
     public static final String EXPIRATION_PERIOD_KEY = "expirationPeriod";
     

--- a/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
+++ b/app/org/sagebionetworks/bridge/config/BridgeSpringConfig.java
@@ -81,6 +81,7 @@ import org.sagebionetworks.bridge.dynamodb.DynamoUploadSchema;
 import org.sagebionetworks.bridge.dynamodb.DynamoUtils;
 import org.sagebionetworks.bridge.hibernate.AccountPersistenceExceptionConverter;
 import org.sagebionetworks.bridge.hibernate.HibernateAccount;
+import org.sagebionetworks.bridge.hibernate.HibernateAccountSubstudy;
 import org.sagebionetworks.bridge.hibernate.HibernateHelper;
 import org.sagebionetworks.bridge.hibernate.HibernateSharedModuleMetadata;
 import org.sagebionetworks.bridge.hibernate.HibernateSubstudy;
@@ -557,6 +558,7 @@ public class BridgeSpringConfig {
         MetadataSources metadataSources = new MetadataSources(reg);
         metadataSources.addAnnotatedClass(HibernateAccount.class);
         metadataSources.addAnnotatedClass(HibernateSubstudy.class);
+        metadataSources.addAnnotatedClass(HibernateAccountSubstudy.class);
         metadataSources.addAnnotatedClass(HibernateSharedModuleMetadata.class);
 
         return metadataSources.buildMetadata().buildSessionFactory();

--- a/app/org/sagebionetworks/bridge/dao/AccountDao.java
+++ b/app/org/sagebionetworks/bridge/dao/AccountDao.java
@@ -74,7 +74,7 @@ public interface AccountDao {
     
     /**
      * Create an account. The account object should initially be retrieved from the 
-     * constructAccount() factory method. Returns the created account's ID.
+     * constructAccount() factory method.
      */
     void createAccount(Study study, Account account);
     

--- a/app/org/sagebionetworks/bridge/dao/AccountDao.java
+++ b/app/org/sagebionetworks/bridge/dao/AccountDao.java
@@ -76,7 +76,7 @@ public interface AccountDao {
      * Create an account. The account object should initially be retrieved from the 
      * constructAccount() factory method. Returns the created account's ID.
      */
-    String createAccount(Study study, Account account);
+    void createAccount(Study study, Account account);
     
     /**
      * Save account changes. Account should have been retrieved from the getAccount() method 

--- a/app/org/sagebionetworks/bridge/hibernate/HibernateAccount.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateAccount.java
@@ -76,7 +76,7 @@ public class HibernateAccount implements Account {
     private Set<String> dataGroups;
     private List<String> languages;
     private int migrationVersion;
-    private Set<AccountSubstudy> accountSubstudies = new HashSet<>(); 
+    private Set<AccountSubstudy> accountSubstudies; 
     
     /**
      * No args constructor, required and used by Hibernate for full object initialization.
@@ -494,6 +494,9 @@ public class HibernateAccount implements Account {
     @OnDelete(action=OnDeleteAction.CASCADE)
     @Override
     public Set<AccountSubstudy> getAccountSubstudies() {
+        if (accountSubstudies == null) {
+            accountSubstudies = new HashSet<>();
+        }
         return accountSubstudies;
     }
 

--- a/app/org/sagebionetworks/bridge/hibernate/HibernateAccount.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateAccount.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.persistence.CascadeType;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.Convert;
@@ -21,6 +22,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.MapKeyClass;
 import javax.persistence.MapKeyColumn;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 import javax.persistence.Version;
@@ -71,6 +73,7 @@ public class HibernateAccount implements Account {
     private Set<String> dataGroups;
     private List<String> languages;
     private int migrationVersion;
+    private Set<HibernateAccountSubstudy> accountSubstudies = new HashSet<>(); 
 
     /**
      * No args constructor, required and used by Hibernate for full object initialization.
@@ -481,5 +484,16 @@ public class HibernateAccount implements Account {
 
     public void setReauthToken(String reauthToken) {
         this.reauthToken = reauthToken; 
+    }
+    
+    @OneToMany(mappedBy = "account", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Override
+    public Set<HibernateAccountSubstudy> getAccountSubstudies() {
+        return accountSubstudies;
+    }
+
+    @Override
+    public void setAccountSubstudies(Set<HibernateAccountSubstudy> accountSubstudies) {
+        this.accountSubstudies = accountSubstudies;
     }
 }

--- a/app/org/sagebionetworks/bridge/hibernate/HibernateAccount.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateAccount.java
@@ -27,6 +27,8 @@ import javax.persistence.Table;
 import javax.persistence.Transient;
 import javax.persistence.Version;
 
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.sagebionetworks.bridge.Roles;
@@ -35,6 +37,7 @@ import org.sagebionetworks.bridge.models.accounts.AccountStatus;
 import org.sagebionetworks.bridge.models.accounts.PasswordAlgorithm;
 import org.sagebionetworks.bridge.models.accounts.Phone;
 import org.sagebionetworks.bridge.models.accounts.SharingScope;
+import org.sagebionetworks.bridge.models.substudies.AccountSubstudy;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -73,8 +76,8 @@ public class HibernateAccount implements Account {
     private Set<String> dataGroups;
     private List<String> languages;
     private int migrationVersion;
-    private Set<HibernateAccountSubstudy> accountSubstudies = new HashSet<>(); 
-
+    private Set<AccountSubstudy> accountSubstudies = new HashSet<>(); 
+    
     /**
      * No args constructor, required and used by Hibernate for full object initialization.
      */
@@ -486,14 +489,16 @@ public class HibernateAccount implements Account {
         this.reauthToken = reauthToken; 
     }
     
-    @OneToMany(mappedBy = "account", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "accountId", cascade = CascadeType.ALL, orphanRemoval = true, 
+        fetch = FetchType.EAGER, targetEntity=HibernateAccountSubstudy.class)
+    @OnDelete(action=OnDeleteAction.CASCADE)
     @Override
-    public Set<HibernateAccountSubstudy> getAccountSubstudies() {
+    public Set<AccountSubstudy> getAccountSubstudies() {
         return accountSubstudies;
     }
 
     @Override
-    public void setAccountSubstudies(Set<HibernateAccountSubstudy> accountSubstudies) {
+    public void setAccountSubstudies(Set<AccountSubstudy> accountSubstudies) {
         this.accountSubstudies = accountSubstudies;
     }
 }

--- a/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
@@ -275,6 +275,7 @@ public class HibernateAccountDao implements AccountDao {
     public Account constructAccount(Study study, String email, Phone phone, String externalId, String password) {
         // Set basic params from inputs.
         Account account = Account.create();
+        account.setId(generateHealthCode());
         account.setStudyId(study.getIdentifier());
         account.setEmail(email);
         account.setPhone(phone);
@@ -302,8 +303,6 @@ public class HibernateAccountDao implements AccountDao {
     /** {@inheritDoc} */
     @Override
     public String createAccount(Study study, Account account) {
-        String userId = BridgeUtils.generateGuid();
-        account.setId(userId);
         account.setStudyId(study.getIdentifier());
         DateTime timestamp = DateUtils.getCurrentDateTime();
         account.setCreatedOn(timestamp);
@@ -313,7 +312,7 @@ public class HibernateAccountDao implements AccountDao {
 
         // Create account
         hibernateHelper.create(account);
-        return userId;
+        return account.getId();
     }
 
     /** {@inheritDoc} */

--- a/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
@@ -302,7 +302,7 @@ public class HibernateAccountDao implements AccountDao {
 
     /** {@inheritDoc} */
     @Override
-    public String createAccount(Study study, Account account) {
+    public void createAccount(Study study, Account account) {
         account.setStudyId(study.getIdentifier());
         DateTime timestamp = DateUtils.getCurrentDateTime();
         account.setCreatedOn(timestamp);
@@ -312,7 +312,6 @@ public class HibernateAccountDao implements AccountDao {
 
         // Create account
         hibernateHelper.create(account);
-        return account.getId();
     }
 
     /** {@inheritDoc} */

--- a/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
@@ -275,13 +275,13 @@ public class HibernateAccountDao implements AccountDao {
     public Account constructAccount(Study study, String email, Phone phone, String externalId, String password) {
         // Set basic params from inputs.
         Account account = Account.create();
-        account.setId(generateHealthCode());
+        account.setId(generateGUID());
         account.setStudyId(study.getIdentifier());
         account.setEmail(email);
         account.setPhone(phone);
         account.setEmailVerified(Boolean.FALSE);
         account.setPhoneVerified(Boolean.FALSE);
-        account.setHealthCode(generateHealthCode());
+        account.setHealthCode(generateGUID());
         account.setExternalId(externalId);
 
         // Hash password if it has been supplied.
@@ -296,7 +296,7 @@ public class HibernateAccountDao implements AccountDao {
     }
     
     // Provided to override in tests
-    protected String generateHealthCode() {
+    protected String generateGUID() {
         return BridgeUtils.generateGuid();
     }
 
@@ -564,7 +564,7 @@ public class HibernateAccountDao implements AccountDao {
     // is necessary.
     private boolean validateHealthCode(HibernateAccount hibernateAccount) {
         if (StringUtils.isBlank(hibernateAccount.getHealthCode())) {
-            hibernateAccount.setHealthCode(generateHealthCode());
+            hibernateAccount.setHealthCode(generateGUID());
 
             // We modified it. Update modifiedOn.
             DateTime modifiedOn = DateUtils.getCurrentDateTime();

--- a/app/org/sagebionetworks/bridge/hibernate/HibernateAccountSubstudy.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateAccountSubstudy.java
@@ -33,25 +33,12 @@ public class HibernateAccountSubstudy implements AccountSubstudy {
     public String getStudyId() {
         return studyId;
     }
-    /*
-    public void setStudyId(String studyId) {
-        this.studyId = studyId;
-    }
-    */
     public String getSubstudyId() {
         return substudyId;
     }
-    /*
-    public void setSubstudyId(String substudyId) {
-        this.substudyId = substudyId;
-    }*/
     public String getAccountId() {
         return accountId;
     }
-    /*
-    public void setAccountId(String accountId) {
-        this.accountId = accountId;
-    }*/
     public String getExternalId() {
         return externalId;
     }

--- a/app/org/sagebionetworks/bridge/hibernate/HibernateAccountSubstudy.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateAccountSubstudy.java
@@ -1,38 +1,61 @@
 package org.sagebionetworks.bridge.hibernate;
 
-import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.ManyToOne;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
 import javax.persistence.Table;
 
 import org.sagebionetworks.bridge.models.substudies.AccountSubstudy;
 import org.sagebionetworks.bridge.models.substudies.AccountSubstudyId;
 
 @Entity
-@Table(name = "AccountSubstudies")
-//@IdClass(AccountSubstudyId.class)
+@Table(name = "AccountsSubstudies")
+@IdClass(AccountSubstudyId.class)
 public class HibernateAccountSubstudy implements AccountSubstudy {
 
-    @EmbeddedId
-    private AccountSubstudyId accountSubstudyId;
-    
+    @Id
+    private String studyId;
+    @Id
+    private String substudyId;
+    @Id
+    private String accountId;
     private String externalId;
     
-    @ManyToOne(fetch = FetchType.EAGER)
-    private HibernateSubstudy substudy;
- 
-    @ManyToOne(fetch = FetchType.EAGER)
-    private HibernateAccount account;
-    
-    @Override
-    public AccountSubstudyId getAccountSubstudyId() {
-        return accountSubstudyId;
+    public HibernateAccountSubstudy() {
     }
-
-    @Override
+    
+    public HibernateAccountSubstudy(String studyId, String substudyId, String accountId) {
+        this.studyId = studyId;
+        this.substudyId = substudyId;
+        this.accountId = accountId;
+    }
+    
+    public String getStudyId() {
+        return studyId;
+    }
+    /*
+    public void setStudyId(String studyId) {
+        this.studyId = studyId;
+    }
+    */
+    public String getSubstudyId() {
+        return substudyId;
+    }
+    /*
+    public void setSubstudyId(String substudyId) {
+        this.substudyId = substudyId;
+    }*/
+    public String getAccountId() {
+        return accountId;
+    }
+    /*
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
+    }*/
     public String getExternalId() {
         return externalId;
     }
-    
+    public void setExternalId(String externalId) {
+        this.externalId = externalId;
+    }
 }

--- a/app/org/sagebionetworks/bridge/hibernate/HibernateAccountSubstudy.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateAccountSubstudy.java
@@ -21,6 +21,7 @@ public class HibernateAccountSubstudy implements AccountSubstudy {
     private String accountId;
     private String externalId;
     
+    // Needed for Hibernate, or else you have to create an instantiation helper class
     public HibernateAccountSubstudy() {
     }
     

--- a/app/org/sagebionetworks/bridge/hibernate/HibernateAccountSubstudy.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateAccountSubstudy.java
@@ -1,0 +1,38 @@
+package org.sagebionetworks.bridge.hibernate;
+
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import org.sagebionetworks.bridge.models.substudies.AccountSubstudy;
+import org.sagebionetworks.bridge.models.substudies.AccountSubstudyId;
+
+@Entity
+@Table(name = "AccountSubstudies")
+//@IdClass(AccountSubstudyId.class)
+public class HibernateAccountSubstudy implements AccountSubstudy {
+
+    @EmbeddedId
+    private AccountSubstudyId accountSubstudyId;
+    
+    private String externalId;
+    
+    @ManyToOne(fetch = FetchType.EAGER)
+    private HibernateSubstudy substudy;
+ 
+    @ManyToOne(fetch = FetchType.EAGER)
+    private HibernateAccount account;
+    
+    @Override
+    public AccountSubstudyId getAccountSubstudyId() {
+        return accountSubstudyId;
+    }
+
+    @Override
+    public String getExternalId() {
+        return externalId;
+    }
+    
+}

--- a/app/org/sagebionetworks/bridge/hibernate/HibernateSubstudyDao.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateSubstudyDao.java
@@ -4,7 +4,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import javax.annotation.Resource;
 

--- a/app/org/sagebionetworks/bridge/hibernate/SubstudyPersistenceExceptionConverter.java
+++ b/app/org/sagebionetworks/bridge/hibernate/SubstudyPersistenceExceptionConverter.java
@@ -4,7 +4,10 @@ import javax.persistence.OptimisticLockException;
 import javax.persistence.PersistenceException;
 
 import org.sagebionetworks.bridge.exceptions.ConcurrentModificationException;
+import org.sagebionetworks.bridge.exceptions.ConstraintViolationException;
 import org.springframework.stereotype.Component;
+
+import com.google.common.base.Throwables;
 
 @Component
 public class SubstudyPersistenceExceptionConverter implements PersistenceExceptionConverter {
@@ -13,6 +16,17 @@ public class SubstudyPersistenceExceptionConverter implements PersistenceExcepti
     public RuntimeException convert(PersistenceException exception, Object entity) {
         if (exception instanceof OptimisticLockException) {
             return new ConcurrentModificationException((HibernateSubstudy)entity);
+        }
+        if (exception.getCause() instanceof org.hibernate.exception.ConstraintViolationException) {
+            // The specific error message is buried in the root MySQLIntegrityConstraintViolationException
+            Throwable cause = Throwables.getRootCause(exception);
+            String message = cause.getMessage();
+
+            String finalMessage = "Substudy table constraint prevented save or update.";
+            if (message.matches(".*a foreign key constraint fails.*REFERENCES `Substudies`.*")) {
+                finalMessage = "Substudy cannot be deleted, it is referenced by an account";
+            }
+            return new ConstraintViolationException.Builder().withMessage(finalMessage).build();
         }
         return exception;
     }

--- a/app/org/sagebionetworks/bridge/models/accounts/Account.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/Account.java
@@ -12,6 +12,7 @@ import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.hibernate.HibernateAccount;
 import org.sagebionetworks.bridge.hibernate.HibernateAccountConsent;
 import org.sagebionetworks.bridge.hibernate.HibernateAccountConsentKey;
+import org.sagebionetworks.bridge.hibernate.HibernateAccountSubstudy;
 import org.sagebionetworks.bridge.models.BridgeEntity;
 import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
@@ -228,4 +229,7 @@ public interface Account extends BridgeEntity {
     
     DateTime getReauthTokenModifiedOn();
     void setReauthTokenModifiedOn(DateTime reauthTokenModifiedOn);
+    
+    void setAccountSubstudies(Set<HibernateAccountSubstudy> accountSubstudies);
+    Set<HibernateAccountSubstudy> getAccountSubstudies();
 }

--- a/app/org/sagebionetworks/bridge/models/accounts/Account.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/Account.java
@@ -12,10 +12,10 @@ import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.hibernate.HibernateAccount;
 import org.sagebionetworks.bridge.hibernate.HibernateAccountConsent;
 import org.sagebionetworks.bridge.hibernate.HibernateAccountConsentKey;
-import org.sagebionetworks.bridge.hibernate.HibernateAccountSubstudy;
 import org.sagebionetworks.bridge.models.BridgeEntity;
 import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
+import org.sagebionetworks.bridge.models.substudies.AccountSubstudy;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
@@ -230,6 +230,6 @@ public interface Account extends BridgeEntity {
     DateTime getReauthTokenModifiedOn();
     void setReauthTokenModifiedOn(DateTime reauthTokenModifiedOn);
     
-    void setAccountSubstudies(Set<HibernateAccountSubstudy> accountSubstudies);
-    Set<HibernateAccountSubstudy> getAccountSubstudies();
+    void setAccountSubstudies(Set<AccountSubstudy> accountSubstudies);
+    Set<AccountSubstudy> getAccountSubstudies();
 }

--- a/app/org/sagebionetworks/bridge/models/accounts/StudyParticipant.java
+++ b/app/org/sagebionetworks/bridge/models/accounts/StudyParticipant.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.models.accounts;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -74,13 +75,14 @@ public final class StudyParticipant implements BridgeEntity {
     private final String id;
     private final DateTimeZone timeZone;
     private final JsonNode clientData;
+    private final Set<String> substudyIds;
     
     private StudyParticipant(String firstName, String lastName, String email, Phone phone, Boolean emailVerified,
             Boolean phoneVerified, String externalId, String password, SharingScope sharingScope, Boolean notifyByEmail,
             Set<String> dataGroups, String healthCode, Map<String, String> attributes,
             Map<String, List<UserConsentHistory>> consentHistories, Boolean consented, Set<Roles> roles,
             List<String> languages, AccountStatus status, DateTime createdOn, String id, DateTimeZone timeZone,
-            JsonNode clientData) {
+            JsonNode clientData, Set<String> substudyIds) {
         
         ImmutableMap.Builder<String, List<UserConsentHistory>> immutableConsentsBuilder = new ImmutableMap.Builder<>();
         if (consentHistories != null) {
@@ -114,6 +116,7 @@ public final class StudyParticipant implements BridgeEntity {
         this.id = id;
         this.timeZone = timeZone;
         this.clientData = clientData;
+        this.substudyIds = (substudyIds == null) ? new HashSet<>() : substudyIds;
     }
     
     public String getFirstName() {
@@ -192,12 +195,15 @@ public final class StudyParticipant implements BridgeEntity {
     public JsonNode getClientData() {
         return clientData;
     }
+    public Set<String> getSubstudyIds() {
+        return substudyIds;
+    }
     
     @Override
     public int hashCode() {
         return Objects.hash(attributes, consentHistories, consented, createdOn, dataGroups, email, phone, emailVerified,
                 phoneVerified, externalId, firstName, healthCode, id, languages, lastName, notifyByEmail, password,
-                roles, sharingScope, status, timeZone, clientData);
+                roles, sharingScope, status, timeZone, clientData, substudyIds);
     }
 
     @Override
@@ -219,7 +225,8 @@ public final class StudyParticipant implements BridgeEntity {
                 && Objects.equals(password, other.password) && Objects.equals(roles, other.roles)
                 && Objects.equals(sharingScope, other.sharingScope) && Objects.equals(status, other.status)
                 && Objects.equals(timeZone, other.timeZone)
-                && Objects.equals(clientData, other.clientData);
+                && Objects.equals(clientData, other.clientData)
+                && Objects.equals(substudyIds, other.substudyIds);
     }
 
     public static class Builder {
@@ -245,6 +252,7 @@ public final class StudyParticipant implements BridgeEntity {
         private String id;
         private DateTimeZone timeZone;
         private JsonNode clientData;
+        private Set<String> substudyIds;
         
         public Builder copyOf(StudyParticipant participant) {
             this.firstName = participant.getFirstName();
@@ -269,6 +277,7 @@ public final class StudyParticipant implements BridgeEntity {
             this.id = participant.getId();
             this.timeZone = participant.getTimeZone();
             this.clientData = participant.getClientData();
+            this.substudyIds = participant.getSubstudyIds();
             return this;
         }
         public Builder copyFieldsOf(StudyParticipant participant, Set<String> fieldNames) {
@@ -337,6 +346,9 @@ public final class StudyParticipant implements BridgeEntity {
             }
             if (fieldNames.contains("clientData")) {
                 withClientData(participant.getClientData());
+            }
+            if (fieldNames.contains("substudyIds")) {
+                withSubstudyIds(participant.getSubstudyIds());
             }
             return this;
         }
@@ -442,7 +454,10 @@ public final class StudyParticipant implements BridgeEntity {
             this.clientData = clientData;
             return this;
         }
-        
+        public Builder withSubstudyIds(Set<String> substudyIds) {
+            this.substudyIds = substudyIds;
+            return this;
+        }
         public StudyParticipant build() {
             Boolean emailVerified = this.emailVerified;
             if (emailVerified == null) {
@@ -458,7 +473,7 @@ public final class StudyParticipant implements BridgeEntity {
             }
             return new StudyParticipant(firstName, lastName, email, phone, emailVerified, phoneVerified, externalId,
                     password, sharingScope, notifyByEmail, dataGroups, healthCode, attributes, consentHistories, consented, roles,
-                    languages, status, createdOn, id, timeZone, clientData);
+                    languages, status, createdOn, id, timeZone, clientData, substudyIds);
         }
     }
 

--- a/app/org/sagebionetworks/bridge/models/substudies/AccountSubstudy.java
+++ b/app/org/sagebionetworks/bridge/models/substudies/AccountSubstudy.java
@@ -1,6 +1,21 @@
 package org.sagebionetworks.bridge.models.substudies;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.sagebionetworks.bridge.hibernate.HibernateAccountSubstudy;
+
 public interface AccountSubstudy {
-    AccountSubstudyId getAccountSubstudyId();
+    
+    static AccountSubstudy create(String studyId, String substudyId, String accountId) {
+        checkNotNull(studyId);
+        checkNotNull(substudyId);
+        checkNotNull(accountId);
+        return new HibernateAccountSubstudy(studyId, substudyId, accountId);
+    }
+    
+    String getStudyId();
+    String getSubstudyId();
+    String getAccountId();
     String getExternalId();
+    void setExternalId(String externalId);
 }

--- a/app/org/sagebionetworks/bridge/models/substudies/AccountSubstudy.java
+++ b/app/org/sagebionetworks/bridge/models/substudies/AccountSubstudy.java
@@ -1,0 +1,6 @@
+package org.sagebionetworks.bridge.models.substudies;
+
+public interface AccountSubstudy {
+    AccountSubstudyId getAccountSubstudyId();
+    String getExternalId();
+}

--- a/app/org/sagebionetworks/bridge/models/substudies/AccountSubstudy.java
+++ b/app/org/sagebionetworks/bridge/models/substudies/AccountSubstudy.java
@@ -16,6 +16,4 @@ public interface AccountSubstudy {
     String getStudyId();
     String getSubstudyId();
     String getAccountId();
-    String getExternalId();
-    void setExternalId(String externalId);
 }

--- a/app/org/sagebionetworks/bridge/models/substudies/AccountSubstudyId.java
+++ b/app/org/sagebionetworks/bridge/models/substudies/AccountSubstudyId.java
@@ -17,15 +17,15 @@ public final class AccountSubstudyId implements Serializable {
     private String substudyId;
     
     @Column(name = "accountId")
-    private String id;
+    private String accountId;
 
     public AccountSubstudyId() {
     }
  
-    public AccountSubstudyId(String studyId, String substudyId, String id) {
+    public AccountSubstudyId(String studyId, String substudyId, String accountId) {
         this.studyId = studyId;
         this.substudyId = substudyId;
-        this.id = id;
+        this.accountId = accountId;
     }
     
     public String getStudyId() {
@@ -36,13 +36,13 @@ public final class AccountSubstudyId implements Serializable {
         return substudyId;
     }
     
-    public String getId() {
-        return id;
+    public String getAccountId() {
+        return accountId;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(studyId, substudyId, id);
+        return Objects.hash(studyId, substudyId, accountId);
     }
 
     @Override
@@ -54,7 +54,7 @@ public final class AccountSubstudyId implements Serializable {
         AccountSubstudyId other = (AccountSubstudyId) obj;
         return Objects.equals(studyId, other.studyId) &&
                 Objects.equals(substudyId, other.substudyId) &&
-                Objects.equals(id, other.id);
+                Objects.equals(accountId, other.accountId);
     }    
     
 }

--- a/app/org/sagebionetworks/bridge/models/substudies/AccountSubstudyId.java
+++ b/app/org/sagebionetworks/bridge/models/substudies/AccountSubstudyId.java
@@ -1,0 +1,113 @@
+package org.sagebionetworks.bridge.models.substudies;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+@Embeddable
+public final class AccountSubstudyId implements Serializable {
+    private static final long serialVersionUID = -2741510011134968409L;
+
+    @Column(name = "studyId")
+    private String studyId;
+
+    @Column(name = "substudyId")
+    private String substudyId;
+    
+    @Column(name = "accountId")
+    private String id;
+
+    public AccountSubstudyId() {
+    }
+ 
+    public AccountSubstudyId(String studyId, String substudyId, String id) {
+        this.studyId = studyId;
+        this.substudyId = substudyId;
+        this.id = id;
+    }
+    
+    public String getStudyId() {
+        return studyId;
+    }
+    
+    public String getSubstudyId() {
+        return substudyId;
+    }
+    
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(studyId, substudyId, id);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null || getClass() != obj.getClass())
+            return false;
+        AccountSubstudyId other = (AccountSubstudyId) obj;
+        return Objects.equals(studyId, other.studyId) &&
+                Objects.equals(substudyId, other.substudyId) &&
+                Objects.equals(id, other.id);
+    }    
+    
+}
+
+
+/*
+package org.sagebionetworks.bridge.models.substudies;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+@Embeddable
+public final class SubstudyId implements Serializable {
+    private static final long serialVersionUID = 3414483917399974708L;
+    
+    @Column(name = "studyId")
+    private String studyId;
+
+    @Column(name = "id")
+    private String id;
+
+    public SubstudyId() {
+    }
+ 
+    public SubstudyId(String studyId, String id) {
+        this.studyId = studyId;
+        this.id = id;
+    }
+    
+    public String getStudyId() {
+        return studyId;
+    }
+    
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(studyId, id);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null || getClass() != obj.getClass())
+            return false;
+        SubstudyId other = (SubstudyId) obj;
+        return Objects.equals(studyId, other.studyId) && Objects.equals(id, other.id);
+    }
+}
+*/

--- a/app/org/sagebionetworks/bridge/models/substudies/AccountSubstudyId.java
+++ b/app/org/sagebionetworks/bridge/models/substudies/AccountSubstudyId.java
@@ -6,9 +6,9 @@ import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 
+@SuppressWarnings("serial")
 @Embeddable
 public final class AccountSubstudyId implements Serializable {
-    private static final long serialVersionUID = -2741510011134968409L;
 
     @Column(name = "studyId")
     private String studyId;

--- a/app/org/sagebionetworks/bridge/models/substudies/AccountSubstudyId.java
+++ b/app/org/sagebionetworks/bridge/models/substudies/AccountSubstudyId.java
@@ -21,7 +21,6 @@ public final class AccountSubstudyId implements Serializable {
 
     public AccountSubstudyId() {
     }
- 
     public AccountSubstudyId(String studyId, String substudyId, String accountId) {
         this.studyId = studyId;
         this.substudyId = substudyId;
@@ -31,11 +30,9 @@ public final class AccountSubstudyId implements Serializable {
     public String getStudyId() {
         return studyId;
     }
-    
     public String getSubstudyId() {
         return substudyId;
     }
-    
     public String getAccountId() {
         return accountId;
     }
@@ -56,58 +53,4 @@ public final class AccountSubstudyId implements Serializable {
                 Objects.equals(substudyId, other.substudyId) &&
                 Objects.equals(accountId, other.accountId);
     }    
-    
 }
-
-
-/*
-package org.sagebionetworks.bridge.models.substudies;
-
-import java.io.Serializable;
-import java.util.Objects;
-
-import javax.persistence.Column;
-import javax.persistence.Embeddable;
-
-@Embeddable
-public final class SubstudyId implements Serializable {
-    private static final long serialVersionUID = 3414483917399974708L;
-    
-    @Column(name = "studyId")
-    private String studyId;
-
-    @Column(name = "id")
-    private String id;
-
-    public SubstudyId() {
-    }
- 
-    public SubstudyId(String studyId, String id) {
-        this.studyId = studyId;
-        this.id = id;
-    }
-    
-    public String getStudyId() {
-        return studyId;
-    }
-    
-    public String getId() {
-        return id;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(studyId, id);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null || getClass() != obj.getClass())
-            return false;
-        SubstudyId other = (SubstudyId) obj;
-        return Objects.equals(studyId, other.studyId) && Objects.equals(id, other.id);
-    }
-}
-*/

--- a/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.bridge.play.controllers;
 
 import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
-import static org.sagebionetworks.bridge.BridgeConstants.NO_CALLER_ROLES;
 import static org.sagebionetworks.bridge.BridgeUtils.getDateTimeOrDefault;
 import static org.sagebionetworks.bridge.BridgeUtils.getIntOrDefault;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
@@ -19,6 +18,7 @@ import java.util.Set;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -112,7 +112,7 @@ public class ParticipantController extends BaseController {
                 .copyOf(existing)
                 .copyFieldsOf(participant, fieldNames)
                 .withId(session.getId()).build();
-        participantService.updateParticipant(study, NO_CALLER_ROLES, updated);
+        participantService.updateParticipant(study, ImmutableSet.of(), existing.getSubstudyIds(), updated);
         
         CriteriaContext context = new CriteriaContext.Builder()
                 .withLanguages(session.getParticipant().getLanguages())
@@ -230,7 +230,7 @@ public class ParticipantController extends BaseController {
         
         StudyParticipant participant = parseJson(request(), StudyParticipant.class);
         IdentifierHolder holder = participantService.createParticipant(study, session.getParticipant().getRoles(),
-                participant, true);
+                session.getParticipant().getSubstudyIds(), participant, true);
         return createdResult(holder);
     }
     
@@ -285,7 +285,8 @@ public class ParticipantController extends BaseController {
         // Force userId of the URL
         participant = new StudyParticipant.Builder().copyOf(participant).withId(userId).build();
         
-        participantService.updateParticipant(study, session.getParticipant().getRoles(), participant);
+        participantService.updateParticipant(study, session.getParticipant().getRoles(),
+                session.getParticipant().getSubstudyIds(), participant);
 
         return okResult("Participant updated.");
     }

--- a/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
@@ -282,9 +282,9 @@ public class ParticipantController extends BaseController {
 
         StudyParticipant participant = parseJson(request(), StudyParticipant.class);
  
-        participant = new StudyParticipant.Builder()
-                .copyOf(participant)
-                .withId(userId).build();
+        // Force userId of the URL
+        participant = new StudyParticipant.Builder().copyOf(participant).withId(userId).build();
+        
         participantService.updateParticipant(study, session.getParticipant().getRoles(), participant);
 
         return okResult("Participant updated.");

--- a/app/org/sagebionetworks/bridge/play/controllers/SubstudyController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/SubstudyController.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.play.controllers;
 
 import static org.sagebionetworks.bridge.Roles.ADMIN;
+import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 
 import java.util.List;
 
@@ -27,7 +28,7 @@ public class SubstudyController extends BaseController {
     }
     
     public Result getSubstudies(String includeDeletedStr) {
-        UserSession session = getAuthenticatedSession(ADMIN);
+        UserSession session = getAuthenticatedSession(RESEARCHER, ADMIN);
         boolean includeDeleted = Boolean.valueOf(includeDeletedStr);
         
         List<Substudy> substudies = service.getSubstudies(session.getStudyIdentifier(), includeDeleted);

--- a/app/org/sagebionetworks/bridge/play/controllers/SubstudyController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/SubstudyController.java
@@ -48,7 +48,7 @@ public class SubstudyController extends BaseController {
     public Result getSubstudy(String id) {
         UserSession session = getAuthenticatedSession(ADMIN);
         
-        Substudy substudy = service.getSubstudy(session.getStudyIdentifier(), id);
+        Substudy substudy = service.getSubstudy(session.getStudyIdentifier(), id, true);
         
         return okResult(substudy);
     }

--- a/app/org/sagebionetworks/bridge/play/controllers/UserProfileController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/UserProfileController.java
@@ -1,7 +1,5 @@
 package org.sagebionetworks.bridge.play.controllers;
 
-import static org.sagebionetworks.bridge.BridgeConstants.NO_CALLER_ROLES;
-
 import java.util.Map;
 import java.util.Set;
 
@@ -31,6 +29,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
@@ -116,7 +115,7 @@ public class UserProfileController extends BaseController {
                 .withLastName(JsonUtils.asText(node, "lastName"))
                 .withAttributes(attributes)
                 .withId(userId).build();
-        participantService.updateParticipant(study, NO_CALLER_ROLES, updated);
+        participantService.updateParticipant(study, ImmutableSet.of(), participant.getSubstudyIds(), updated);
         
         CriteriaContext context = getCriteriaContext(session);
         
@@ -177,7 +176,7 @@ public class UserProfileController extends BaseController {
                 .copyFieldsOf(dataGroups, DATA_GROUPS_SET)
                 .withId(session.getId()).build();
         
-        participantService.updateParticipant(study, NO_CALLER_ROLES, updated);
+        participantService.updateParticipant(study, ImmutableSet.of(), participant.getSubstudyIds(), updated);
         
         CriteriaContext context = new CriteriaContext.Builder()
                 .withLanguages(session.getParticipant().getLanguages())

--- a/app/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -260,7 +260,8 @@ public class AuthenticationService {
         }
 
         try {
-            // Since caller has no roles, no roles can be assigned on sign up.
+            // Since caller has no roles, no roles can be assigned on sign up. Right now public sign up cannot
+            // assign the user to a substudy.
             return participantService.createParticipant(study, ImmutableSet.of(), ImmutableSet.of(), participant, true);
         } catch(EntityAlreadyExistsException e) {
             // Suppress this and send an email to notify the user that the account already exists. From 
@@ -343,6 +344,8 @@ public class AuthenticationService {
         if (account == null) {
             // Create an account with password and external ID assigned. If the external ID has been 
             // assigned to another account, this creation will fail (external ID is a unique column).
+            // Currently this user cannot be assigned to a substudy, but the external ID will eventually 
+            // establish such a relationship.
             StudyParticipant participant = new StudyParticipant.Builder()
                     .withExternalId(externalId).withPassword(password).build();
             userId = participantService.createParticipant(study, ImmutableSet.of(), ImmutableSet.of(), 

--- a/app/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.bridge.services;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.sagebionetworks.bridge.BridgeConstants.NO_CALLER_ROLES;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -262,7 +261,7 @@ public class AuthenticationService {
 
         try {
             // Since caller has no roles, no roles can be assigned on sign up.
-            return participantService.createParticipant(study, NO_CALLER_ROLES, participant, true);
+            return participantService.createParticipant(study, ImmutableSet.of(), ImmutableSet.of(), participant, true);
         } catch(EntityAlreadyExistsException e) {
             // Suppress this and send an email to notify the user that the account already exists. From 
             // this call, we simply return a 200 the same as any other sign up. Otherwise the response 
@@ -346,8 +345,8 @@ public class AuthenticationService {
             // assigned to another account, this creation will fail (external ID is a unique column).
             StudyParticipant participant = new StudyParticipant.Builder()
                     .withExternalId(externalId).withPassword(password).build();
-            userId = participantService.createParticipant(
-                    study, ImmutableSet.of(), participant, false).getIdentifier();
+            userId = participantService.createParticipant(study, ImmutableSet.of(), ImmutableSet.of(), 
+                    participant, false).getIdentifier();
         } else {
             // Account exists, so rotate the password
             accountDao.changePassword(account, null, password);

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -454,7 +454,9 @@ public class ParticipantService {
         Set<AccountSubstudy> updatedSubstudies = participant.getSubstudyIds().stream().map((substudyId) -> {
             return AccountSubstudy.create(account.getStudyId(), substudyId, account.getId());
         }).collect(Collectors.toSet());
-        updatePersistedSet(account.getAccountSubstudies(), updatedSubstudies);
+        
+        account.getAccountSubstudies().clear();
+        account.getAccountSubstudies().addAll(updatedSubstudies);
         
         // Do not copy timezone or external ID. Neither can be updated once set.
         
@@ -467,11 +469,6 @@ public class ParticipantService {
         }
     }
     
-    private <T> void updatePersistedSet(Set<T> persisted, Set<T> updated) {
-        persisted.removeAll(Sets.difference(persisted, updated));
-        persisted.addAll(updated);
-    }
-
     public void requestResetPassword(Study study, String userId) {
         checkNotNull(study);
         checkArgument(isNotBlank(userId));

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -97,6 +97,8 @@ public class ParticipantService {
     private ActivityEventService activityEventService;
 
     private AccountWorkflowService accountWorkflowService;
+    
+    private SubstudyService substudyService;
 
     @Autowired
     public final void setAccountWorkflowService(AccountWorkflowService accountWorkflowService) {
@@ -159,6 +161,11 @@ public class ParticipantService {
         this.activityEventService = activityEventService;
     }
 
+    @Autowired
+    final void setSubstudyService(SubstudyService substudyService) {
+        this.substudyService = substudyService;
+    }
+    
     /**
      * This is a researcher API to backfill SMS notification registrations for a user. We generally prefer the app
      * register notifications, but sometimes the work can't be done on time, so we want study developers to have the
@@ -324,8 +331,10 @@ public class ParticipantService {
         if (study.getAccountLimit() > 0) {
             throwExceptionIfLimitMetOrExceeded(study);
         }
-        Validate.entityThrowingException(
-                new StudyParticipantValidator(externalIdService, study, callerSubstudies, true), participant);
+        
+        StudyParticipantValidator validator = new StudyParticipantValidator(
+                externalIdService, substudyService, study, callerSubstudies, true);
+        Validate.entityThrowingException(validator, participant);
         
         Account account = accountDao.constructAccount(study, participant.getEmail(), participant.getPhone(),
                 participant.getExternalId(), participant.getPassword());
@@ -387,8 +396,9 @@ public class ParticipantService {
         checkNotNull(callerSubstudies);
         checkNotNull(participant);
         
-        Validate.entityThrowingException(
-                new StudyParticipantValidator(externalIdService, study, callerSubstudies, false), participant);
+        StudyParticipantValidator validator = new StudyParticipantValidator(
+                externalIdService, substudyService, study, callerSubstudies, false);
+        Validate.entityThrowingException(validator, participant);
         
         Account account = getAccountThrowingException(study, participant.getId());
         

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -314,16 +314,18 @@ public class ParticipantService {
      * Create a study participant. A password must be provided, even if it is added on behalf of a user before
      * triggering a reset password request.
      */
-    public IdentifierHolder createParticipant(Study study, Set<Roles> callerRoles, StudyParticipant participant,
-            boolean shouldSendVerification) {
+    public IdentifierHolder createParticipant(Study study, Set<Roles> callerRoles, Set<String> callerSubstudies,
+            StudyParticipant participant, boolean shouldSendVerification) {
         checkNotNull(study);
         checkNotNull(callerRoles);
+        checkNotNull(callerSubstudies);
         checkNotNull(participant);
         
         if (study.getAccountLimit() > 0) {
             throwExceptionIfLimitMetOrExceeded(study);
         }
-        Validate.entityThrowingException(new StudyParticipantValidator(externalIdService, study, true), participant);
+        Validate.entityThrowingException(
+                new StudyParticipantValidator(externalIdService, study, callerSubstudies, true), participant);
         
         Account account = accountDao.constructAccount(study, participant.getEmail(), participant.getPhone(),
                 participant.getExternalId(), participant.getPassword());
@@ -378,12 +380,15 @@ public class ParticipantService {
             participant.getExternalId() != null && participant.getPassword() != null;
     }
 
-    public void updateParticipant(Study study, Set<Roles> callerRoles, StudyParticipant participant) {
+    public void updateParticipant(Study study, Set<Roles> callerRoles, Set<String> callerSubstudies,
+            StudyParticipant participant) {
         checkNotNull(study);
         checkNotNull(callerRoles);
+        checkNotNull(callerSubstudies);
         checkNotNull(participant);
         
-        Validate.entityThrowingException(new StudyParticipantValidator(externalIdService, study, false), participant);
+        Validate.entityThrowingException(
+                new StudyParticipantValidator(externalIdService, study, callerSubstudies, false), participant);
         
         Account account = getAccountThrowingException(study, participant.getId());
         

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -351,12 +351,12 @@ public class ParticipantService {
         if (shouldEnableCompleteExternalIdAccount(participant)) {
             account.setStatus(AccountStatus.ENABLED);
         }
-        String accountId = accountDao.createAccount(study, account);
+        accountDao.createAccount(study, account);
         externalIdService.assignExternalId(study, participant.getExternalId(), account.getHealthCode());    
         
         // send verify email
         if (sendEmailVerification && !study.isAutoVerificationEmailSuppressed()) {
-            accountWorkflowService.sendEmailVerificationToken(study, accountId, account.getEmail());
+            accountWorkflowService.sendEmailVerificationToken(study, account.getId(), account.getEmail());
         }
 
         // If you create an account with a phone number, this opts the phone number in to receiving SMS. We do this
@@ -365,14 +365,14 @@ public class ParticipantService {
         Phone phone = account.getPhone();
         if (phone != null) {
             // Note that there is no object with both accountId and phone, so we need to pass them in separately.
-            smsService.optInPhoneNumber(accountId, phone);
+            smsService.optInPhoneNumber(account.getId(), phone);
         }
 
         // send verify phone number
         if (shouldSendVerification && !study.isAutoVerificationPhoneSuppressed()) {
-            accountWorkflowService.sendPhoneVerificationToken(study, accountId, phone);
+            accountWorkflowService.sendPhoneVerificationToken(study, account.getId(), phone);
         }
-        return new IdentifierHolder(accountId);
+        return new IdentifierHolder(account.getId());
     }
     
     private boolean shouldEnableCompleteExternalIdAccount(StudyParticipant participant) {

--- a/app/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/app/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -429,11 +429,6 @@ public class ParticipantService {
         }
     }
     
-    private <T> void updatePersistedSet(Set<T> persisted, Set<T> updated) {
-        persisted.removeAll(Sets.difference(persisted, updated));
-        persisted.addAll(updated);
-    }
-    
     private void updateAccountAndRoles(Study study, Set<Roles> callerRoles, Account account,
             StudyParticipant participant) {
         account.setFirstName(participant.getFirstName());
@@ -460,6 +455,11 @@ public class ParticipantService {
         if (callerIsAdmin(callerRoles)) {
             updateRoles(callerRoles, participant, account);
         }
+    }
+    
+    private <T> void updatePersistedSet(Set<T> persisted, Set<T> updated) {
+        persisted.removeAll(Sets.difference(persisted, updated));
+        persisted.addAll(updated);
     }
 
     public void requestResetPassword(Study study, String userId) {

--- a/app/org/sagebionetworks/bridge/services/StudyService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyService.java
@@ -368,7 +368,7 @@ public class StudyService {
             study.setPasswordPolicy(PasswordPolicy.DEFAULT_PASSWORD_POLICY);
         }
 
-        // validate participants at first
+        // validate participants first
         for (StudyParticipant user : users) {
             Validate.entityThrowingException(new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true), user);
         }

--- a/app/org/sagebionetworks/bridge/services/StudyService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyService.java
@@ -370,7 +370,7 @@ public class StudyService {
 
         // validate participants at first
         for (StudyParticipant user : users) {
-            Validate.entityThrowingException(new StudyParticipantValidator(externalIdService, study, true), user);
+            Validate.entityThrowingException(new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true), user);
         }
 
         // validate roles for each user
@@ -389,7 +389,7 @@ public class StudyService {
         // then create users for that study
         // send verification email from both Bridge and Synapse as well
         for (StudyParticipant user: users) {
-            IdentifierHolder identifierHolder = participantService.createParticipant(study, user.getRoles(), user, false);
+            IdentifierHolder identifierHolder = participantService.createParticipant(study, user.getRoles(), ImmutableSet.of(), user, false);
 
             NewUser synapseUser = new NewUser();
             synapseUser.setEmail(user.getEmail());

--- a/app/org/sagebionetworks/bridge/services/StudyService.java
+++ b/app/org/sagebionetworks/bridge/services/StudyService.java
@@ -115,6 +115,7 @@ public class StudyService {
     private SynapseClient synapseClient;
     private ParticipantService participantService;
     private ExternalIdService externalIdService;
+    private SubstudyService substudyService;
 
     private String defaultEmailVerificationTemplate;
     private String defaultEmailVerificationTemplateSubject;
@@ -270,6 +271,10 @@ public class StudyService {
     final void setExternalIdService(ExternalIdService externalIdService) {
         this.externalIdService = externalIdService;
     }
+    @Autowired
+    final void setSubstudyService(SubstudyService substudyService) {
+        this.substudyService = substudyService;
+    }
     
     @Autowired
     @Qualifier("bridgePFSynapseClient")
@@ -370,7 +375,7 @@ public class StudyService {
 
         // validate participants first
         for (StudyParticipant user : users) {
-            Validate.entityThrowingException(new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true), user);
+            Validate.entityThrowingException(new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), true), user);
         }
 
         // validate roles for each user

--- a/app/org/sagebionetworks/bridge/services/SubstudyService.java
+++ b/app/org/sagebionetworks/bridge/services/SubstudyService.java
@@ -28,12 +28,12 @@ public class SubstudyService {
         this.substudyDao = substudyDao;
     }
     
-    public Substudy getSubstudy(StudyIdentifier studyId, String id) {
+    public Substudy getSubstudy(StudyIdentifier studyId, String id, boolean throwsException) {
         checkNotNull(studyId);
         checkNotNull(id);
         
         Substudy substudy = substudyDao.getSubstudy(studyId, id);
-        if (substudy == null) {
+        if (throwsException && substudy == null) {
             throw new EntityNotFoundException(Substudy.class);
         }
         return substudy;
@@ -73,7 +73,7 @@ public class SubstudyService {
         substudy.setStudyId(studyId.getIdentifier());
         Validate.entityThrowingException(SubstudyValidator.INSTANCE, substudy);
         
-        Substudy existing = getSubstudy(studyId, substudy.getId());
+        Substudy existing = getSubstudy(studyId, substudy.getId(), true);
         if (substudy.isDeleted() && existing.isDeleted()) {
             throw new EntityNotFoundException(Substudy.class);
         }
@@ -87,7 +87,7 @@ public class SubstudyService {
         checkNotNull(studyId);
         checkNotNull(id);
         
-        Substudy existing = getSubstudy(studyId, id);
+        Substudy existing = getSubstudy(studyId, id, true);
         existing.setDeleted(true);
         existing.setModifiedOn(DateTime.now());
         substudyDao.updateSubstudy(existing);
@@ -98,7 +98,7 @@ public class SubstudyService {
         checkNotNull(id);
         
         // Throws exception if the element does not exist.
-        getSubstudy(studyId, id);
+        getSubstudy(studyId, id, true);
         substudyDao.deleteSubstudyPermanently(studyId, id);
     }
 }

--- a/app/org/sagebionetworks/bridge/services/UserAdminService.java
+++ b/app/org/sagebionetworks/bridge/services/UserAdminService.java
@@ -131,6 +131,8 @@ public class UserAdminService {
         
         IdentifierHolder identifier = null;
         try {
+            // No substudies are passed through this method, so the user can be in any substudies, or no substudies
+            // The ADMIN role is passed through this method, so the user can have any role(s)
             identifier = participantService.createParticipant(study, ADMIN_ROLE, ImmutableSet.of(), participant, false);
             StudyParticipant updatedParticipant = participantService.getParticipant(study, identifier.getIdentifier(), false);
             

--- a/app/org/sagebionetworks/bridge/services/UserAdminService.java
+++ b/app/org/sagebionetworks/bridge/services/UserAdminService.java
@@ -28,6 +28,7 @@ import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 import org.sagebionetworks.bridge.validators.SignInValidator;
 import org.sagebionetworks.bridge.validators.Validate;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -130,7 +131,7 @@ public class UserAdminService {
         
         IdentifierHolder identifier = null;
         try {
-            identifier = participantService.createParticipant(study, ADMIN_ROLE, participant, false);
+            identifier = participantService.createParticipant(study, ADMIN_ROLE, ImmutableSet.of(), participant, false);
             StudyParticipant updatedParticipant = participantService.getParticipant(study, identifier.getIdentifier(), false);
             
             // We don't filter users by any of these filtering criteria in the admin API.

--- a/app/org/sagebionetworks/bridge/validators/StudyParticipantValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/StudyParticipantValidator.java
@@ -78,7 +78,7 @@ public class StudyParticipantValidator implements Validator {
 
         // If the caller is not in a substudy, any substudy tags are allowed. If there 
         // are any substudies assigned to the caller, then the participant must be assigned 
-        // to one or more of those specific substudies.
+        // to one or more of those substudies, and only those substudies.
         if (!callerSubstudies.isEmpty()) {
             if (participant.getSubstudyIds().isEmpty()) {
                 errors.rejectValue("substudyIds", "must be assigned to this participant");

--- a/app/org/sagebionetworks/bridge/validators/StudyParticipantValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/StudyParticipantValidator.java
@@ -15,19 +15,23 @@ import org.sagebionetworks.bridge.models.accounts.Phone;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.studies.PasswordPolicy;
 import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.substudies.Substudy;
 import org.sagebionetworks.bridge.services.ExternalIdService;
+import org.sagebionetworks.bridge.services.SubstudyService;
 
 public class StudyParticipantValidator implements Validator {
 
     private static final EmailValidator EMAIL_VALIDATOR = EmailValidator.getInstance();
     private final ExternalIdService externalIdService;
+    private final SubstudyService substudyService;
     private final Study study;
     private final Set<String> callerSubstudies;
     private final boolean isNew;
     
-    public StudyParticipantValidator(ExternalIdService externalIdService, Study study, Set<String> callerSubstudies,
-            boolean isNew) {
+    public StudyParticipantValidator(ExternalIdService externalIdService, SubstudyService substudyService, Study study,
+            Set<String> callerSubstudies, boolean isNew) {
         this.externalIdService = externalIdService;
+        this.substudyService = substudyService;
         this.study = study;
         this.callerSubstudies = callerSubstudies;
         this.isNew = isNew;
@@ -88,6 +92,12 @@ public class StudyParticipantValidator implements Validator {
                         errors.rejectValue("substudyIds["+substudyId+"]", "is not a substudy of the caller");
                     }
                 }
+            }
+        }
+        for (String substudyId : participant.getSubstudyIds()) {
+            Substudy substudy = substudyService.getSubstudy(study.getStudyIdentifier(), substudyId, false);
+            if (substudy == null) {
+                errors.rejectValue("substudyIds["+substudyId+"]", "is not a substudy");
             }
         }
         

--- a/app/org/sagebionetworks/bridge/validators/StudyParticipantValidator.java
+++ b/app/org/sagebionetworks/bridge/validators/StudyParticipantValidator.java
@@ -77,9 +77,8 @@ public class StudyParticipantValidator implements Validator {
         }
 
         // If the caller is not in a substudy, any substudy tags are allowed. If there 
-        // are any substudies assigned to the caller, than the participant must have at 
-        // least one substudy, and all of the participant's assigned substudies need to 
-        // be assigned to that caller.
+        // are any substudies assigned to the caller, then the participant must be assigned 
+        // to one or more of those specific substudies.
         if (!callerSubstudies.isEmpty()) {
             if (participant.getSubstudyIds().isEmpty()) {
                 errors.rejectValue("substudyIds", "must be assigned to this participant");

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -147,6 +147,7 @@ public class TestUtils {
             if (e.getErrors().get(fieldName).contains(fieldNameAsLabel+error)) {
                 return;
             }
+            System.out.println(e.getMessage());
             fail("Did not find error message in errors object");
         }
     }

--- a/test/org/sagebionetworks/bridge/TestUtils.java
+++ b/test/org/sagebionetworks/bridge/TestUtils.java
@@ -147,7 +147,6 @@ public class TestUtils {
             if (e.getErrors().get(fieldName).contains(fieldNameAsLabel+error)) {
                 return;
             }
-            System.out.println(e.getMessage());
             fail("Did not find error message in errors object");
         }
     }

--- a/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
+++ b/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
@@ -132,7 +132,7 @@ public class HibernateAccountDaoTest {
         dao = spy(new HibernateAccountDao());
         dao.setHibernateHelper(mockHibernateHelper);
         dao.setCacheProvider(mockCacheProvider);
-        when(dao.generateHealthCode()).thenReturn(HEALTH_CODE);
+        when(dao.generateGUID()).thenReturn(HEALTH_CODE);
         
         study = Study.create();
         study.setIdentifier(TestConstants.TEST_STUDY_IDENTIFIER);
@@ -804,7 +804,10 @@ public class HibernateAccountDaoTest {
         assertEquals(PHONE.getNationalFormat(), account.getPhone().getNationalFormat());
         assertEquals(Boolean.FALSE, account.getEmailVerified());
         assertEquals(Boolean.FALSE, account.getPhoneVerified());
+        // These are the same because we've mocked the GUID-creation method to always return
+        // this value.
         assertEquals(HEALTH_CODE, account.getHealthCode());
+        assertEquals(HEALTH_CODE, account.getId());
         assertEquals(EXTERNAL_ID, account.getExternalId());
         assertEquals(PasswordAlgorithm.DEFAULT_PASSWORD_ALGORITHM, account.getPasswordAlgorithm());
 

--- a/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
+++ b/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
@@ -834,11 +834,12 @@ public class HibernateAccountDaoTest {
         Account account = makeValidGenericAccount();
         account.setStatus(AccountStatus.ENABLED);
         account.setStudyId("wrong-study");
+        account.setId(ACCOUNT_ID);
 
         // execute - We generate a new account ID.
         String daoOutputAcountId = dao.createAccount(study, account);
         assertNotNull(daoOutputAcountId);
-        assertNotEquals(ACCOUNT_ID, daoOutputAcountId);
+        assertEquals(ACCOUNT_ID, daoOutputAcountId);
 
         // verify hibernate call
         ArgumentCaptor<HibernateAccount> createdHibernateAccountCaptor = ArgumentCaptor.forClass(

--- a/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
+++ b/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
@@ -837,9 +837,7 @@ public class HibernateAccountDaoTest {
         account.setId(ACCOUNT_ID);
 
         // execute - We generate a new account ID.
-        String daoOutputAcountId = dao.createAccount(study, account);
-        assertNotNull(daoOutputAcountId);
-        assertEquals(ACCOUNT_ID, daoOutputAcountId);
+        dao.createAccount(study, account);
 
         // verify hibernate call
         ArgumentCaptor<HibernateAccount> createdHibernateAccountCaptor = ArgumentCaptor.forClass(
@@ -847,7 +845,7 @@ public class HibernateAccountDaoTest {
         verify(mockHibernateHelper).create(createdHibernateAccountCaptor.capture());
 
         HibernateAccount createdHibernateAccount = createdHibernateAccountCaptor.getValue();
-        assertEquals(daoOutputAcountId, createdHibernateAccount.getId());
+        assertEquals(ACCOUNT_ID, createdHibernateAccount.getId());
         assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, createdHibernateAccount.getStudyId());
         assertEquals(MOCK_DATETIME.getMillis(), createdHibernateAccount.getCreatedOn().getMillis());
         assertEquals(MOCK_DATETIME.getMillis(), createdHibernateAccount.getModifiedOn().getMillis());

--- a/test/org/sagebionetworks/bridge/hibernate/HibernateAccountSubstudyTest.java
+++ b/test/org/sagebionetworks/bridge/hibernate/HibernateAccountSubstudyTest.java
@@ -1,0 +1,21 @@
+package org.sagebionetworks.bridge.hibernate;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class HibernateAccountSubstudyTest {
+
+    @Test
+    public void test() {
+        HibernateAccountSubstudy accountSubstudy = new HibernateAccountSubstudy("studyId", "substudyId", "accountId");
+        
+        // not yet used, but coming very shortly
+        accountSubstudy.setExternalId("externalId");
+        
+        assertEquals("studyId", accountSubstudy.getStudyId());
+        assertEquals("substudyId", accountSubstudy.getSubstudyId());
+        assertEquals("accountId", accountSubstudy.getAccountId());
+        assertEquals("externalId", accountSubstudy.getExternalId());
+    }
+}

--- a/test/org/sagebionetworks/bridge/hibernate/HibernateAccountTest.java
+++ b/test/org/sagebionetworks/bridge/hibernate/HibernateAccountTest.java
@@ -276,6 +276,19 @@ public class HibernateAccountTest {
         assertEquals(sig1, account.getAllConsentSignatureHistories().get(guid1).get(3));
     }
     
+    @Test
+    public void collectionsNotNull() {
+        HibernateAccount account = new HibernateAccount();
+        assertTrue(account.getAccountSubstudies().isEmpty());
+        assertTrue(account.getAttributes().isEmpty());
+        assertTrue(account.getConsents().isEmpty());
+        assertTrue(account.getDataGroups().isEmpty());
+        assertTrue(account.getLanguages().isEmpty());
+        assertTrue(account.getRoles().isEmpty());
+        assertTrue(account.getConsentSignatureHistory(SubpopulationGuid.create("nada")).isEmpty());
+        assertTrue(account.getAllConsentSignatureHistories().isEmpty());
+    }
+    
     private HibernateAccountConsent getHibernateAccountConsent(Long withdrewOn) {
         HibernateAccountConsent consent = new HibernateAccountConsent();
         consent.setBirthdate("1980-01-01");

--- a/test/org/sagebionetworks/bridge/hibernate/SubstudyPersistenceExceptionConverterTest.java
+++ b/test/org/sagebionetworks/bridge/hibernate/SubstudyPersistenceExceptionConverterTest.java
@@ -2,14 +2,6 @@ package org.sagebionetworks.bridge.hibernate;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import javax.persistence.OptimisticLockException;

--- a/test/org/sagebionetworks/bridge/models/accounts/StudyParticipantTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/StudyParticipantTest.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -40,8 +41,9 @@ public class StudyParticipantTest {
     private static final DateTime CREATED_ON = DateTime.now();
     private static final DateTime CREATED_ON_UTC = CREATED_ON.withZone(DateTimeZone.UTC);
     private static final Phone PHONE = TestConstants.PHONE;
-    private static final Set<Roles> ROLES = Sets.newHashSet(Roles.ADMIN, Roles.WORKER);
+    private static final Set<Roles> ROLES = ImmutableSet.of(Roles.ADMIN, Roles.WORKER);
     private static final List<String> LANGS = ImmutableList.of("en","fr");
+    private static final Set<String> SUBSTUDIES = ImmutableSet.of("substudyA", "substudyB");
     private static final Set<String> DATA_GROUPS = Sets.newHashSet("group1","group2");
     private static final DateTimeZone TIME_ZONE = DateTimeZone.forOffsetHours(4);
     private static final Map<String,String> ATTRIBUTES = ImmutableMap.<String,String>builder()
@@ -74,6 +76,8 @@ public class StudyParticipantTest {
         assertEquals("enabled", node.get("status").asText());
         assertEquals(CREATED_ON_UTC.toString(), node.get("createdOn").asText());
         assertEquals(ACCOUNT_ID, node.get("id").asText());
+        assertEquals("substudyA", node.get("substudyIds").get(0).textValue());
+        assertEquals("substudyB", node.get("substudyIds").get(1).textValue());
         assertEquals("+04:00", node.get("timeZone").asText());
         assertEquals("StudyParticipant", node.get("type").asText());
         
@@ -99,7 +103,7 @@ public class StudyParticipantTest {
 
         assertEquals("B", node.get("attributes").get("A").asText());
         assertEquals("D", node.get("attributes").get("C").asText());
-        assertEquals(23, node.size());
+        assertEquals(24, node.size());
         
         StudyParticipant deserParticipant = BridgeObjectMapper.get().readValue(node.toString(), StudyParticipant.class);
         assertEquals("firstName", deserParticipant.getFirstName());
@@ -111,6 +115,7 @@ public class StudyParticipantTest {
         assertEquals(SharingScope.SPONSORS_AND_PARTNERS, deserParticipant.getSharingScope());
         assertTrue(deserParticipant.isNotifyByEmail());
         assertEquals(DATA_GROUPS, deserParticipant.getDataGroups());
+        assertEquals(SUBSTUDIES, deserParticipant.getSubstudyIds());
         assertEquals(TestConstants.UNENCRYPTED_HEALTH_CODE, deserParticipant.getHealthCode());
         // This is encrypted with different series of characters each time, so just verify it is there.
         assertNotNull(deserParticipant.getEncryptedHealthCode());
@@ -357,6 +362,7 @@ public class StudyParticipantTest {
                 .withConsented(true)
                 .withRoles(ROLES)
                 .withLanguages(LANGS)
+                .withSubstudyIds(SUBSTUDIES)
                 .withCreatedOn(CREATED_ON)
                 .withId(ACCOUNT_ID)
                 .withStatus(AccountStatus.ENABLED)

--- a/test/org/sagebionetworks/bridge/models/accounts/StudyParticipantTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/StudyParticipantTest.java
@@ -178,6 +178,7 @@ public class StudyParticipantTest {
         assertTrue(copy.isConsented());
         assertEquals(CREATED_ON, copy.getCreatedOn());
         assertEquals(AccountStatus.ENABLED, copy.getStatus());
+        assertEquals(SUBSTUDIES, copy.getSubstudyIds());
         assertEquals(ACCOUNT_ID, copy.getId());
         assertEquals(TestUtils.getClientData(), copy.getClientData());
         
@@ -262,6 +263,10 @@ public class StudyParticipantTest {
     public void canCopyPhoneVerified() {
         assertCopyField("phoneVerified", (builder)-> verify(builder).withPhoneVerified(any()));
     }
+    @Test
+    public void canCopySubstudiesVerified() {
+        assertCopyField("substudyIds", (builder)-> verify(builder).withSubstudyIds(any()));
+    }
     
     @Test
     public void testNullResiliency() {
@@ -276,15 +281,17 @@ public class StudyParticipantTest {
         assertTrue(participant.getAttributes().isEmpty());
         assertTrue(participant.getRoles().isEmpty());
         assertTrue(participant.getLanguages().isEmpty());
+        assertTrue(participant.getSubstudyIds().isEmpty());
     }
     
     @Test
     public void nullParametersBreakNothing() {
         StudyParticipant participant = new StudyParticipant.Builder().withEmail("email@email.com")
-                .withPassword("password").withConsented(null).build();
+                .withPassword("password").withConsented(null).withSubstudyIds(null).build();
         
-        assertEquals(0, participant.getRoles().size());
-        assertEquals(0, participant.getDataGroups().size());
+        assertTrue(participant.getRoles().isEmpty());
+        assertTrue(participant.getDataGroups().isEmpty());
+        assertTrue(participant.getSubstudyIds().isEmpty());
         assertNull(participant.isConsented());
     }
     

--- a/test/org/sagebionetworks/bridge/models/accounts/UserSessionInfoTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/UserSessionInfoTest.java
@@ -15,6 +15,7 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
 public class UserSessionInfoTest {
@@ -28,7 +29,8 @@ public class UserSessionInfoTest {
                 .withNotifyByEmail(false)
                 .withEncryptedHealthCode(TestConstants.ENCRYPTED_HEALTH_CODE)
                 .withId("user-identifier")
-                .withRoles(Sets.newHashSet(RESEARCHER))
+                .withRoles(ImmutableSet.of(RESEARCHER))
+                .withSubstudyIds(ImmutableSet.of("substudyA"))
                 .withSharingScope(SharingScope.ALL_QUALIFIED_RESEARCHERS)
                 .withDataGroups(Sets.newHashSet("foo")).build();
         
@@ -59,6 +61,7 @@ public class UserSessionInfoTest {
         assertEquals("staging", node.get("environment").textValue());
         assertEquals("reauthToken", node.get("reauthToken").textValue());
         assertEquals(participant.getId(), node.get("id").textValue());
+        assertEquals("substudyA", node.get("substudyIds").get(0).textValue());
         assertFalse(node.get("notifyByEmail").booleanValue());
         assertNull(node.get("healthCode"));
         assertNull(node.get("encryptedHealthCode"));
@@ -76,7 +79,7 @@ public class UserSessionInfoTest {
         assertEquals(6, consentStatus.size());
         
         // ... and no things that shouldn't be there
-        assertEquals(20, node.size());
+        assertEquals(21, node.size());
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/models/accounts/UserSessionInfoTest.java
+++ b/test/org/sagebionetworks/bridge/models/accounts/UserSessionInfoTest.java
@@ -61,6 +61,7 @@ public class UserSessionInfoTest {
         assertEquals("staging", node.get("environment").textValue());
         assertEquals("reauthToken", node.get("reauthToken").textValue());
         assertEquals(participant.getId(), node.get("id").textValue());
+        assertEquals(1, node.get("substudyIds").size());
         assertEquals("substudyA", node.get("substudyIds").get(0).textValue());
         assertFalse(node.get("notifyByEmail").booleanValue());
         assertNull(node.get("healthCode"));

--- a/test/org/sagebionetworks/bridge/models/substudies/AccountSubstudyIdTest.java
+++ b/test/org/sagebionetworks/bridge/models/substudies/AccountSubstudyIdTest.java
@@ -1,0 +1,26 @@
+package org.sagebionetworks.bridge.models.substudies;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+
+public class AccountSubstudyIdTest {
+
+    @Test
+    public void hashCodeEquals() {
+        EqualsVerifier.forClass(AccountSubstudyId.class).allFieldsShouldBeUsed().suppress(Warning.NONFINAL_FIELDS)
+                .verify();
+    }
+    
+    @Test
+    public void create() { 
+        AccountSubstudyId key = new AccountSubstudyId("studyId", "substudyId", "accountId");
+        assertEquals("studyId", key.getStudyId());
+        assertEquals("substudyId", key.getSubstudyId());
+        assertEquals("accountId", key.getAccountId());
+    }
+    
+}

--- a/test/org/sagebionetworks/bridge/models/substudies/AccountSubstudyTest.java
+++ b/test/org/sagebionetworks/bridge/models/substudies/AccountSubstudyTest.java
@@ -1,0 +1,17 @@
+package org.sagebionetworks.bridge.models.substudies;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class AccountSubstudyTest {
+
+    @Test
+    public void create() {
+        AccountSubstudy substudy = AccountSubstudy.create("studyId", "substudyId", "accountId");
+        assertEquals("studyId", substudy.getStudyId());
+        assertEquals("substudyId", substudy.getSubstudyId());
+        assertEquals("accountId", substudy.getAccountId());
+    }
+    
+}

--- a/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
@@ -207,7 +207,7 @@ public class ParticipantControllerTest {
         
         participant = new StudyParticipant.Builder()
                 .withRoles(CALLER_ROLES)
-                .withSubstudyIds(ImmutableSet.of("substudyA"))
+                .withSubstudyIds(CALLER_SUBS)
                 .withId(ID).build();
         
         session = new UserSession(participant);
@@ -254,7 +254,7 @@ public class ParticipantControllerTest {
     public void createSmsNotificationRegistration() throws Exception {
         // Requires researcher role.
         session.setParticipant(new StudyParticipant.Builder().copyOf(session.getParticipant())
-                .withRoles(ImmutableSet.of(Roles.RESEARCHER)).build());
+                .withRoles(CALLER_ROLES).build());
 
         // Execute.
         Result result = controller.createSmsRegistration(ID);
@@ -378,7 +378,7 @@ public class ParticipantControllerTest {
         assertResult(result, 200, "Participant updated.");
         
         // Both the caller roles and the caller's substudies are passed to participantService
-        verify(mockParticipantService).updateParticipant(eq(study), eq(CALLER_ROLES), eq(ImmutableSet.of("substudyA")),
+        verify(mockParticipantService).updateParticipant(eq(study), eq(CALLER_ROLES), eq(CALLER_SUBS),
                 participantCaptor.capture());
         
         StudyParticipant participant = participantCaptor.getValue();
@@ -501,7 +501,7 @@ public class ParticipantControllerTest {
         Result result = controller.updateParticipant("id1");
         assertResult(result, 200, "Participant updated.");
         
-        verify(mockParticipantService).updateParticipant(eq(study), eq(CALLER_ROLES), eq(ImmutableSet.of("substudyA")),
+        verify(mockParticipantService).updateParticipant(eq(study), eq(CALLER_ROLES), eq(CALLER_SUBS),
                 participantCaptor.capture());
         
         StudyParticipant persisted = participantCaptor.getValue();

--- a/test/org/sagebionetworks/bridge/play/controllers/SubstudyControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SubstudyControllerTest.java
@@ -63,6 +63,7 @@ public class SubstudyControllerTest {
         controller.setSubstudyService(service);
         
         doReturn(session).when(controller).getAuthenticatedSession(Roles.ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(Roles.RESEARCHER, Roles.ADMIN);
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/play/controllers/SubstudyControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/SubstudyControllerTest.java
@@ -135,7 +135,7 @@ public class SubstudyControllerTest {
         Substudy substudy = Substudy.create();
         substudy.setId("oneId");
         substudy.setName("oneName");
-        when(service.getSubstudy(TestConstants.TEST_STUDY, "id")).thenReturn(substudy);
+        when(service.getSubstudy(TestConstants.TEST_STUDY, "id", true)).thenReturn(substudy);
         
         Result result = controller.getSubstudy("id");
         assertEquals(200, result.status());
@@ -144,7 +144,7 @@ public class SubstudyControllerTest {
         assertEquals("oneId", returnedValue.getId());
         assertEquals("oneName", returnedValue.getName());
 
-        verify(service).getSubstudy(TestConstants.TEST_STUDY, "id");
+        verify(service).getSubstudy(TestConstants.TEST_STUDY, "id", true);
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/play/controllers/UserProfileControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/UserProfileControllerTest.java
@@ -51,6 +51,7 @@ import org.sagebionetworks.bridge.services.StudyService;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
@@ -219,12 +220,12 @@ public class UserProfileControllerTest {
         assertEquals("originalId", node.get("externalId").asText());
                 
         // Verify that existing user information (health code) has been retrieved and used when updating session
-        verify(participantService).updateParticipant(eq(study), any(), participantCaptor.capture());
+        verify(participantService).updateParticipant(eq(study), any(), any(), participantCaptor.capture());
         StudyParticipant capturedParticipant = participantCaptor.getValue();
         assertEquals("existingHealthCode", capturedParticipant.getHealthCode());
         assertEquals("originalId", capturedParticipant.getExternalId());
         
-        verify(participantService).updateParticipant(eq(study), eq(Sets.newHashSet()), participantCaptor.capture());
+        verify(participantService).updateParticipant(eq(study), eq(ImmutableSet.of()), eq(ImmutableSet.of()), participantCaptor.capture());
         
         StudyParticipant persisted = participantCaptor.getValue();
         assertEquals(ID, persisted.getId());
@@ -270,7 +271,7 @@ public class UserProfileControllerTest {
         assertEquals("First", node.get("firstName").asText());
         assertEquals("group1", node.get("dataGroups").get(0).asText());
         
-        verify(participantService).updateParticipant(eq(study), eq(NO_ROLES), participantCaptor.capture());
+        verify(participantService).updateParticipant(eq(study), eq(NO_ROLES), eq(ImmutableSet.of()), participantCaptor.capture());
         verify(consentService).getConsentStatuses(contextCaptor.capture());
         
         StudyParticipant participant = participantCaptor.getValue();
@@ -293,7 +294,7 @@ public class UserProfileControllerTest {
     public void invalidDataGroupsRejected() throws Exception {
         StudyParticipant existing = new StudyParticipant.Builder().withFirstName("First").build();
         doReturn(existing).when(participantService).getParticipant(study, ID, false);
-        doThrow(new InvalidEntityException("Invalid data groups")).when(participantService).updateParticipant(eq(study), eq(NO_ROLES), any());
+        doThrow(new InvalidEntityException("Invalid data groups")).when(participantService).updateParticipant(eq(study), eq(NO_ROLES), eq(ImmutableSet.of()), any());
         
         TestUtils.mockPlayContextWithJson("{\"dataGroups\":[\"completelyInvalidGroup\"]}");
         try {
@@ -340,7 +341,7 @@ public class UserProfileControllerTest {
         JsonNode node = TestUtils.getJson(result);
         assertEquals("First", node.get("firstName").asText());
         
-        verify(participantService).updateParticipant(eq(study), eq(NO_ROLES), participantCaptor.capture());
+        verify(participantService).updateParticipant(eq(study), eq(NO_ROLES), eq(ImmutableSet.of()), participantCaptor.capture());
         
         StudyParticipant updated = participantCaptor.getValue();
         assertEquals(ID, updated.getId());

--- a/test/org/sagebionetworks/bridge/play/interceptors/ExceptionInterceptorTest.java
+++ b/test/org/sagebionetworks/bridge/play/interceptors/ExceptionInterceptorTest.java
@@ -35,8 +35,8 @@ import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 
 import play.mvc.Http;
 import play.mvc.Result;
@@ -80,8 +80,9 @@ public class ExceptionInterceptorTest {
                 .withHealthCode("healthCode")
                 .withNotifyByEmail(true)
                 .withId("userId")
+                .withSubstudyIds(ImmutableSet.of("substudyA"))
                 .withSharingScope(SharingScope.ALL_QUALIFIED_RESEARCHERS)
-                .withDataGroups(Sets.newHashSet("group1")).build();
+                .withDataGroups(ImmutableSet.of("group1")).build();
         
         UserSession session = new UserSession(participant);
         session.setAuthenticated(true);
@@ -114,6 +115,7 @@ public class ExceptionInterceptorTest {
         assertEquals("reauthToken", node.get("reauthToken").textValue());
         assertTrue(node.get("dataSharing").booleanValue());
         assertTrue(node.get("notifyByEmail").booleanValue());
+        assertEquals("substudyA", node.get("substudyIds").get(0).textValue());
         assertEquals("UserSessionInfo", node.get("type").textValue());
         ArrayNode array = (ArrayNode)node.get("roles");
         assertEquals(0, array.size());
@@ -122,7 +124,7 @@ public class ExceptionInterceptorTest {
         assertEquals("group1", array.get(0).textValue());
         assertEquals(0, node.get("consentStatuses").size());
         // And no further properties
-        assertEquals(20, node.size());
+        assertEquals(21, node.size());
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
@@ -17,7 +17,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-import static org.sagebionetworks.bridge.BridgeConstants.NO_CALLER_ROLES;
 
 import java.util.List;
 import java.util.Map;
@@ -458,7 +457,8 @@ public class AuthenticationServiceMockTest {
         
         service.signUp(study, participant);
         
-        verify(participantService).createParticipant(eq(study), eq(NO_CALLER_ROLES), participantCaptor.capture(), eq(true));
+        verify(participantService).createParticipant(eq(study), eq(ImmutableSet.of()), eq(ImmutableSet.of()),
+                participantCaptor.capture(), eq(true));
         StudyParticipant captured = participantCaptor.getValue();
         assertEquals(RECIPIENT_EMAIL, captured.getEmail());
         assertEquals(PASSWORD, captured.getPassword());
@@ -472,7 +472,8 @@ public class AuthenticationServiceMockTest {
         
         service.signUp(study, participant);
         
-        verify(participantService).createParticipant(eq(study), eq(NO_CALLER_ROLES), participantCaptor.capture(), eq(true));
+        verify(participantService).createParticipant(eq(study), eq(ImmutableSet.of()), eq(ImmutableSet.of()),
+                participantCaptor.capture(), eq(true));
         StudyParticipant captured = participantCaptor.getValue();
         assertEquals(TestConstants.PHONE.getNumber(), captured.getPhone().getNumber());
         assertEquals(PASSWORD, captured.getPassword());
@@ -484,13 +485,14 @@ public class AuthenticationServiceMockTest {
         StudyParticipant participant = new StudyParticipant.Builder().withEmail(RECIPIENT_EMAIL).withPassword(PASSWORD)
                 .build();
         doThrow(new EntityAlreadyExistsException(StudyParticipant.class, "userId", "user-id")).when(participantService)
-                .createParticipant(study, NO_CALLER_ROLES, participant, true);
+                .createParticipant(study, ImmutableSet.of(), ImmutableSet.of(), participant, true);
         
         service.signUp(study, participant);
         
         ArgumentCaptor<AccountId> accountIdCaptor = ArgumentCaptor.forClass(AccountId.class);
         
-        verify(participantService).createParticipant(eq(study), eq(NO_CALLER_ROLES), any(), eq(true));
+        verify(participantService).createParticipant(eq(study), eq(ImmutableSet.of()), eq(ImmutableSet.of()), any(),
+                eq(true));
         verify(accountWorkflowService).notifyAccountExists(eq(study), accountIdCaptor.capture());
         
         AccountId captured = accountIdCaptor.getValue();
@@ -676,8 +678,7 @@ public class AuthenticationServiceMockTest {
         when(externalIdService.getExternalId(study.getStudyIdentifier(), EXTERNAL_ID)).thenReturn(externalIdentifier);
         
         IdentifierHolder idHolder = new IdentifierHolder("userId");
-        when(participantService.createParticipant(eq(study), eq(ImmutableSet.of()), participantCaptor.capture(),
-                eq(false))).thenReturn(idHolder);
+        when(participantService.createParticipant(eq(study), eq(ImmutableSet.of()), eq(ImmutableSet.of()), participantCaptor.capture(), eq(false))).thenReturn(idHolder);
         
         GeneratedPassword password = service.generatePassword(study, EXTERNAL_ID, true);
         assertEquals(EXTERNAL_ID, password.getExternalId());
@@ -695,8 +696,9 @@ public class AuthenticationServiceMockTest {
         study.setExternalIdValidationEnabled(true);
         when(externalIdService.getExternalId(study.getStudyIdentifier(), EXTERNAL_ID)).thenReturn(externalIdentifier);
         
-        when(participantService.createParticipant(eq(study), eq(ImmutableSet.of()), participantCaptor.capture(),
-                eq(false))).thenThrow(new EntityAlreadyExistsException(Account.class, "id", "asdf"));
+        when(participantService.createParticipant(eq(study), eq(ImmutableSet.of()), eq(ImmutableSet.of()),
+                participantCaptor.capture(), eq(false)))
+                        .thenThrow(new EntityAlreadyExistsException(Account.class, "id", "asdf"));
         
         try {
             service.generatePassword(study, EXTERNAL_ID, true);
@@ -705,7 +707,7 @@ public class AuthenticationServiceMockTest {
             // expected exception
         }
         verify(accountDao).getAccount(AccountId.forExternalId(TestConstants.TEST_STUDY_IDENTIFIER, EXTERNAL_ID));
-        verify(participantService).createParticipant(eq(study), eq(ImmutableSet.of()), any(), eq(false));
+        verify(participantService).createParticipant(eq(study), eq(ImmutableSet.of()), eq(ImmutableSet.of()), any(), eq(false));
         verifyNoMoreInteractions(accountDao);
         verifyNoMoreInteractions(participantService);
     }
@@ -758,7 +760,7 @@ public class AuthenticationServiceMockTest {
                 .withEmail(null).withPhone(null).withExternalId("id").build();
         service.signUp(study, participant);
         
-        verify(participantService).createParticipant(study, NO_CALLER_ROLES, participant, true);
+        verify(participantService).createParticipant(study, ImmutableSet.of(), ImmutableSet.of(), participant, true);
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
@@ -63,6 +63,7 @@ import org.sagebionetworks.bridge.services.AuthenticationService.ChannelType;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
 @ContextConfiguration("classpath:test-context.xml")
@@ -456,7 +457,7 @@ public class AuthenticationServiceTest {
         StudyParticipant participant = participantService.getParticipant(study, userId, false);
         StudyParticipant updated = new StudyParticipant.Builder().copyOf(participant)
                 .withDataGroups(UPDATED_DATA_GROUPS).withId(userId).build();
-        participantService.updateParticipant(study, CALLER_ROLES, updated);
+        participantService.updateParticipant(study, CALLER_ROLES, ImmutableSet.of(), updated);
         
         // Now update the session, these changes should be reflected
         CriteriaContext context = new CriteriaContext.Builder().withStudyIdentifier(study.getStudyIdentifier())

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -79,6 +79,7 @@ import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
 import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 import org.sagebionetworks.bridge.models.substudies.AccountSubstudy;
+import org.sagebionetworks.bridge.models.substudies.Substudy;
 import org.sagebionetworks.bridge.services.AuthenticationService.ChannelType;
 import org.sagebionetworks.bridge.sms.SmsMessageProvider;
 
@@ -180,6 +181,9 @@ public class ParticipantServiceTest {
     private UploadService uploadService;
     
     @Mock
+    private SubstudyService substudyService;
+    
+    @Mock
     private Subpopulation subpopulation;
     
     @Mock
@@ -235,6 +239,7 @@ public class ParticipantServiceTest {
         participantService.setNotificationsService(notificationsService);
         participantService.setScheduledActivityService(scheduledActivityService);
         participantService.setAccountWorkflowService(accountWorkflowService);
+        participantService.setSubstudyService(substudyService);
 
         account = Account.create();
     }
@@ -306,6 +311,8 @@ public class ParticipantServiceTest {
         Set<String> substudies = ImmutableSet.of("substudyA", "substudyB");
         StudyParticipant participant = new StudyParticipant.Builder()
                 .copyOf(PARTICIPANT).withSubstudyIds(substudies).build();
+        when(substudyService.getSubstudy(STUDY.getStudyIdentifier(), "substudyA", false)).thenReturn(Substudy.create());
+        when(substudyService.getSubstudy(STUDY.getStudyIdentifier(), "substudyB", false)).thenReturn(Substudy.create());
         
         mockHealthCodeAndAccountRetrieval();
         
@@ -408,7 +415,7 @@ public class ParticipantServiceTest {
         assertEquals(AccountStatus.UNVERIFIED, account.getStatus());
         assertNull(account.getEmailVerified());
     }
-
+    
     @Test
     public void createParticipantAutoVerificationEmailSuppressed() {
         Study study = makeStudy();
@@ -904,6 +911,8 @@ public class ParticipantServiceTest {
         Set<String> substudies = ImmutableSet.of("substudyA", "substudyB");
         StudyParticipant participant = new StudyParticipant.Builder()
                 .copyOf(PARTICIPANT).withSubstudyIds(substudies).build();
+        when(substudyService.getSubstudy(STUDY.getStudyIdentifier(), "substudyA", false)).thenReturn(Substudy.create());
+        when(substudyService.getSubstudy(STUDY.getStudyIdentifier(), "substudyB", false)).thenReturn(Substudy.create());
         
         // Make this test more robust by including accountSubstudies that should
         // be either kept or removed. These do not change the final persisted set.

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -113,8 +113,9 @@ public class ParticipantServiceTest {
     private static final String ACTIVITY_GUID = "activityGuid";
     private static final String PAGED_BY = "100";
     private static final int PAGE_SIZE = 50;
-    private static final Set<Roles> CALLER_ROLES = Sets.newHashSet(RESEARCHER);
-    private static final Set<Roles> USER_ROLES = Sets.newHashSet(DEVELOPER);
+    private static final Set<Roles> RESEARCH_CALLER_ROLES = Sets.newHashSet(RESEARCHER);
+    private static final Set<Roles> DEV_CALLER_ROLES = Sets.newHashSet(DEVELOPER);
+    private static final Set<String> CALLER_SUBS = ImmutableSet.of();
     private static final List<String> USER_LANGUAGES = ImmutableList.copyOf(BridgeUtils.commaListToOrderedSet("de,fr"));
     private static final String EMAIL = "email@email.com";
     private static final String ID = "ASDF";
@@ -133,7 +134,7 @@ public class ParticipantServiceTest {
             .withPassword(PASSWORD)
             .withSharingScope(SharingScope.ALL_QUALIFIED_RESEARCHERS)
             .withNotifyByEmail(true)
-            .withRoles(USER_ROLES)
+            .withRoles(DEV_CALLER_ROLES)
             .withDataGroups(STUDY_DATA_GROUPS)
             .withAttributes(ATTRS)
             .withLanguages(USER_LANGUAGES)
@@ -271,7 +272,7 @@ public class ParticipantServiceTest {
         
         when(externalIdService.getExternalId(STUDY.getStudyIdentifier(), EXTERNAL_ID)).thenReturn(EXT_ID);
         
-        IdentifierHolder idHolder = participantService.createParticipant(STUDY, CALLER_ROLES, PARTICIPANT, true);
+        IdentifierHolder idHolder = participantService.createParticipant(STUDY, RESEARCH_CALLER_ROLES, CALLER_SUBS, PARTICIPANT, true);
         assertEquals(ID, idHolder.getIdentifier());
         
         verify(accountDao).constructAccount(STUDY, EMAIL, PHONE, EXTERNAL_ID, PASSWORD);
@@ -286,7 +287,7 @@ public class ParticipantServiceTest {
         assertEquals(FIRST_NAME, account.getFirstName());
         assertEquals(LAST_NAME, account.getLastName());
         assertEquals("true", account.getAttributes().get("can_be_recontacted"));
-        assertEquals(USER_ROLES, account.getRoles());
+        assertEquals(DEV_CALLER_ROLES, account.getRoles());
         assertEquals(TestUtils.getClientData(), account.getClientData());
         assertEquals(AccountStatus.UNVERIFIED, account.getStatus());
         assertNull(account.getEmailVerified());
@@ -308,7 +309,7 @@ public class ParticipantServiceTest {
         STUDY.setExternalIdValidationEnabled(true);
         mockHealthCodeAndAccountRetrieval();
         
-        participantService.createParticipant(STUDY, CALLER_ROLES, PARTICIPANT, false);
+        participantService.createParticipant(STUDY, RESEARCH_CALLER_ROLES, CALLER_SUBS, PARTICIPANT, false);
         verify(accountDao).constructAccount(STUDY, EMAIL, PHONE, EXTERNAL_ID, PASSWORD);
         verify(accountDao).createAccount(eq(STUDY), accountCaptor.capture());
         
@@ -323,7 +324,7 @@ public class ParticipantServiceTest {
         StudyParticipant participant = new StudyParticipant.Builder().build();
         
         try {
-            participantService.createParticipant(STUDY, CALLER_ROLES, participant, false);
+            participantService.createParticipant(STUDY, RESEARCH_CALLER_ROLES, CALLER_SUBS, participant, false);
             fail("Should have thrown exception");
         } catch(InvalidEntityException e) {
         }
@@ -336,7 +337,7 @@ public class ParticipantServiceTest {
         STUDY.setEmailVerificationEnabled(false);
         mockHealthCodeAndAccountRetrieval();
         
-        participantService.createParticipant(STUDY, CALLER_ROLES, PARTICIPANT, false);
+        participantService.createParticipant(STUDY, RESEARCH_CALLER_ROLES, CALLER_SUBS, PARTICIPANT, false);
         
         verify(accountWorkflowService, never()).sendEmailVerificationToken(any(), any(), any());
         assertEquals(AccountStatus.ENABLED, account.getStatus());
@@ -350,7 +351,7 @@ public class ParticipantServiceTest {
         
         StudyParticipant participant = new StudyParticipant.Builder().copyOf(PARTICIPANT).withPhone(null).build();
         
-        participantService.createParticipant(STUDY, CALLER_ROLES, participant, true);
+        participantService.createParticipant(STUDY, RESEARCH_CALLER_ROLES, CALLER_SUBS, participant, true);
         
         verify(accountWorkflowService, never()).sendEmailVerificationToken(any(), any(), any());
         assertEquals(AccountStatus.ENABLED, account.getStatus());
@@ -362,7 +363,7 @@ public class ParticipantServiceTest {
         STUDY.setEmailVerificationEnabled(true);
         mockHealthCodeAndAccountRetrieval();
         
-        participantService.createParticipant(STUDY, CALLER_ROLES, PARTICIPANT, false);
+        participantService.createParticipant(STUDY, RESEARCH_CALLER_ROLES, CALLER_SUBS, PARTICIPANT, false);
         
         verify(accountWorkflowService, never()).sendEmailVerificationToken(any(), any(), any());
         assertEquals(AccountStatus.ENABLED, account.getStatus());
@@ -374,7 +375,7 @@ public class ParticipantServiceTest {
         STUDY.setEmailVerificationEnabled(true);
         mockHealthCodeAndAccountRetrieval();
 
-        participantService.createParticipant(STUDY, CALLER_ROLES, PARTICIPANT, true);
+        participantService.createParticipant(STUDY, RESEARCH_CALLER_ROLES, CALLER_SUBS, PARTICIPANT, true);
 
         verify(accountWorkflowService).sendEmailVerificationToken(any(), any(), any());
         assertEquals(AccountStatus.UNVERIFIED, account.getStatus());
@@ -388,7 +389,7 @@ public class ParticipantServiceTest {
         study.setAutoVerificationEmailSuppressed(true);
         mockHealthCodeAndAccountRetrieval();
 
-        participantService.createParticipant(study, CALLER_ROLES, PARTICIPANT, true);
+        participantService.createParticipant(study, RESEARCH_CALLER_ROLES, CALLER_SUBS, PARTICIPANT, true);
 
         verify(accountWorkflowService, never()).sendEmailVerificationToken(any(), any(), any());
         assertEquals(AccountStatus.UNVERIFIED, account.getStatus());
@@ -403,7 +404,7 @@ public class ParticipantServiceTest {
         
         // Make minimal phone participant.
         StudyParticipant phoneParticipant = new StudyParticipant.Builder().withPhone(PHONE).build();
-        participantService.createParticipant(STUDY, CALLER_ROLES, phoneParticipant, false);
+        participantService.createParticipant(STUDY, RESEARCH_CALLER_ROLES, CALLER_SUBS, phoneParticipant, false);
 
         verify(accountWorkflowService, never()).sendEmailVerificationToken(any(), any(), any());
         assertEquals(AccountStatus.ENABLED, account.getStatus());
@@ -414,7 +415,7 @@ public class ParticipantServiceTest {
     public void createParticipantPhoneDisabledNoVerificationWanted() {
         mockHealthCodeAndAccountRetrieval(null, PHONE);
         
-        participantService.createParticipant(STUDY, CALLER_ROLES, PARTICIPANT, false);
+        participantService.createParticipant(STUDY, RESEARCH_CALLER_ROLES, CALLER_SUBS, PARTICIPANT, false);
         
         verify(accountWorkflowService, never()).sendPhoneVerificationToken(any(), any(), any());
         assertEquals(AccountStatus.ENABLED, account.getStatus());
@@ -426,7 +427,7 @@ public class ParticipantServiceTest {
         mockHealthCodeAndAccountRetrieval(null, PHONE);
 
         STUDY.setEmailVerificationEnabled(true);
-        participantService.createParticipant(STUDY, CALLER_ROLES, PARTICIPANT, true);
+        participantService.createParticipant(STUDY, RESEARCH_CALLER_ROLES, CALLER_SUBS, PARTICIPANT, true);
 
         verify(accountWorkflowService).sendPhoneVerificationToken(STUDY, ID, PHONE);
         assertEquals(AccountStatus.UNVERIFIED, account.getStatus());
@@ -440,7 +441,7 @@ public class ParticipantServiceTest {
         mockHealthCodeAndAccountRetrieval(null, PHONE);
 
         study.setEmailVerificationEnabled(true);
-        participantService.createParticipant(study, CALLER_ROLES, PARTICIPANT, true);
+        participantService.createParticipant(study, RESEARCH_CALLER_ROLES, CALLER_SUBS, PARTICIPANT, true);
 
         verify(accountWorkflowService, never()).sendPhoneVerificationToken(any(), any(), any());
         assertEquals(AccountStatus.UNVERIFIED, account.getStatus());
@@ -453,7 +454,7 @@ public class ParticipantServiceTest {
 
         // Make minimal email participant.
         StudyParticipant emailParticipant = new StudyParticipant.Builder().withEmail(EMAIL).build();
-        participantService.createParticipant(STUDY, CALLER_ROLES, emailParticipant, false);
+        participantService.createParticipant(STUDY, RESEARCH_CALLER_ROLES, CALLER_SUBS, emailParticipant, false);
 
         verify(accountWorkflowService, never()).sendPhoneVerificationToken(any(), any(), any());
         assertEquals(AccountStatus.ENABLED, account.getStatus());
@@ -464,7 +465,7 @@ public class ParticipantServiceTest {
     public void createPhoneParticipant_OptInPhoneNumber() {
         // Set up and execute test.
         mockHealthCodeAndAccountRetrieval(null, PHONE);
-        participantService.createParticipant(STUDY, CALLER_ROLES, PARTICIPANT, false);
+        participantService.createParticipant(STUDY, RESEARCH_CALLER_ROLES, CALLER_SUBS, PARTICIPANT, false);
 
         // Verify calls to SmsService.
         verify(smsService).optInPhoneNumber(ID, PHONE);
@@ -475,7 +476,7 @@ public class ParticipantServiceTest {
         mockHealthCodeAndAccountRetrieval(null, null);
         
         StudyParticipant idParticipant = new StudyParticipant.Builder().withExternalId(EXTERNAL_ID).build();
-        participantService.createParticipant(STUDY, CALLER_ROLES, idParticipant, false);
+        participantService.createParticipant(STUDY, RESEARCH_CALLER_ROLES, CALLER_SUBS, idParticipant, false);
         
         assertEquals(AccountStatus.UNVERIFIED, account.getStatus());
         assertNull(account.getPhoneVerified());
@@ -488,7 +489,7 @@ public class ParticipantServiceTest {
         
         StudyParticipant idParticipant = new StudyParticipant.Builder().withExternalId(EXTERNAL_ID)
                 .withPassword(PASSWORD).build();
-        participantService.createParticipant(STUDY, CALLER_ROLES, idParticipant, false);
+        participantService.createParticipant(STUDY, RESEARCH_CALLER_ROLES, CALLER_SUBS, idParticipant, false);
         
         assertEquals(AccountStatus.ENABLED, account.getStatus());
         assertNull(account.getPhoneVerified());
@@ -854,7 +855,7 @@ public class ParticipantServiceTest {
         oldSession.setStudyIdentifier(STUDY.getStudyIdentifier());
         doReturn(oldSession).when(cacheProvider).getUserSessionByUserId(ID);
         
-        participantService.updateParticipant(STUDY, CALLER_ROLES, PARTICIPANT);
+        participantService.updateParticipant(STUDY, RESEARCH_CALLER_ROLES, ImmutableSet.of(), PARTICIPANT);
         
         verify(accountDao).updateAccount(accountCaptor.capture());
         Account account = accountCaptor.getValue();
@@ -876,7 +877,7 @@ public class ParticipantServiceTest {
         mockHealthCodeAndAccountRetrieval();
         
         // account and participant have the same ID, so externalIdService is not called
-        participantService.updateParticipant(STUDY, CALLER_ROLES, PARTICIPANT);
+        participantService.updateParticipant(STUDY, RESEARCH_CALLER_ROLES, ImmutableSet.of(), PARTICIPANT);
         verify(externalIdService, never()).assignExternalId(any(), any(), any());
     }
     
@@ -887,14 +888,14 @@ public class ParticipantServiceTest {
         StudyParticipant participant = new StudyParticipant.Builder()
                 .withDataGroups(Sets.newHashSet("bogusGroup"))
                 .build();
-        participantService.updateParticipant(STUDY, CALLER_ROLES, participant);
+        participantService.updateParticipant(STUDY, RESEARCH_CALLER_ROLES, ImmutableSet.of(), participant);
     }
     
     @Test
     public void updateParticipantWithNoAccount() {
         doThrow(new EntityNotFoundException(Account.class)).when(accountDao).getAccount(ACCOUNT_ID);
         try {
-            participantService.updateParticipant(STUDY, CALLER_ROLES, PARTICIPANT);
+            participantService.updateParticipant(STUDY, RESEARCH_CALLER_ROLES, ImmutableSet.of(), PARTICIPANT);
             fail("Should have thrown exception.");
         } catch(EntityNotFoundException e) {
         }
@@ -935,7 +936,7 @@ public class ParticipantServiceTest {
         StudyParticipant participant = new StudyParticipant.Builder().copyOf(PARTICIPANT)
                 .withStatus(null).build();
 
-        participantService.updateParticipant(STUDY, EnumSet.of(ADMIN), participant);
+        participantService.updateParticipant(STUDY, ImmutableSet.of(ADMIN), ImmutableSet.of(), participant);
 
         verify(accountDao).updateAccount(accountCaptor.capture());
         Account account = accountCaptor.getValue();
@@ -1317,7 +1318,7 @@ public class ParticipantServiceTest {
         mockHealthCodeAndAccountRetrieval();
         when(externalIdService.getExternalId(STUDY.getStudyIdentifier(), EXTERNAL_ID)).thenReturn(EXT_ID);
         
-        participantService.createParticipant(STUDY, CALLER_ROLES, PARTICIPANT, false);
+        participantService.createParticipant(STUDY, RESEARCH_CALLER_ROLES, CALLER_SUBS, PARTICIPANT, false);
         
         // Validated and required, use reservation service and don't set as option
         verify(externalIdService).assignExternalId(studyCaptor.capture(), eq(EXTERNAL_ID), eq(HEALTH_CODE));
@@ -1332,7 +1333,7 @@ public class ParticipantServiceTest {
         when(accountDao.getPagedAccountSummaries(STUDY, AccountSummarySearch.EMPTY_SEARCH))
                 .thenReturn(accountSummaries);
         
-        participantService.createParticipant(STUDY,  CALLER_ROLES, PARTICIPANT, false);
+        participantService.createParticipant(STUDY,  RESEARCH_CALLER_ROLES, CALLER_SUBS, PARTICIPANT, false);
     }
     
     @Test
@@ -1342,7 +1343,7 @@ public class ParticipantServiceTest {
         when(accountDao.getPagedAccountSummaries(STUDY, AccountSummarySearch.EMPTY_SEARCH)).thenReturn(accountSummaries);
         
         try {
-            participantService.createParticipant(STUDY, CALLER_ROLES, PARTICIPANT, false);
+            participantService.createParticipant(STUDY, RESEARCH_CALLER_ROLES, CALLER_SUBS, PARTICIPANT, false);
             fail("Should have thrown exception");
         } catch(LimitExceededException e) {
             assertEquals("While study is in evaluation mode, it may not exceed 10 accounts.", e.getMessage());
@@ -1355,7 +1356,7 @@ public class ParticipantServiceTest {
         when(accountSummaries.getTotal()).thenReturn(13);
         when(accountDao.getPagedAccountSummaries(STUDY, AccountSummarySearch.EMPTY_SEARCH)).thenReturn(accountSummaries);
         
-        participantService.createParticipant(STUDY, CALLER_ROLES, PARTICIPANT, false);
+        participantService.createParticipant(STUDY, RESEARCH_CALLER_ROLES, CALLER_SUBS, PARTICIPANT, false);
     }
     
 
@@ -1559,7 +1560,7 @@ public class ParticipantServiceTest {
         StudyParticipant participant = new StudyParticipant.Builder().copyOf(PARTICIPANT).withRoles(Sets.newHashSet())
                 .withExternalId(null).build();
         
-        participantService.createParticipant(STUDY, CALLER_ROLES, participant, false);
+        participantService.createParticipant(STUDY, RESEARCH_CALLER_ROLES, CALLER_SUBS, participant, false);
     }
 
     public void createRequiredExternalIdWithRolesOK() {
@@ -1568,7 +1569,7 @@ public class ParticipantServiceTest {
         
         StudyParticipant participant = new StudyParticipant.Builder().copyOf(PARTICIPANT).withExternalId(null).build();
         
-        participantService.createParticipant(STUDY, CALLER_ROLES, participant, false);
+        participantService.createParticipant(STUDY, RESEARCH_CALLER_ROLES, CALLER_SUBS, participant, false);
     }
     
     @Test
@@ -1578,7 +1579,7 @@ public class ParticipantServiceTest {
         STUDY.setExternalIdValidationEnabled(true);
         when(externalIdService.getExternalId(STUDY.getStudyIdentifier(), EXTERNAL_ID)).thenReturn(EXT_ID);
         
-        participantService.createParticipant(STUDY, CALLER_ROLES, PARTICIPANT, false);
+        participantService.createParticipant(STUDY, RESEARCH_CALLER_ROLES, CALLER_SUBS, PARTICIPANT, false);
         
         verify(externalIdService).getExternalId(STUDY.getStudyIdentifier(), EXTERNAL_ID);
         verify(externalIdService).assignExternalId(STUDY, EXTERNAL_ID, HEALTH_CODE);
@@ -1591,7 +1592,7 @@ public class ParticipantServiceTest {
         when(externalIdService.getExternalId(STUDY.getStudyIdentifier(), EXTERNAL_ID)).thenReturn(null);
         
         try {
-            participantService.createParticipant(STUDY, CALLER_ROLES, PARTICIPANT, false);
+            participantService.createParticipant(STUDY, RESEARCH_CALLER_ROLES, CALLER_SUBS, PARTICIPANT, false);
             fail("Should have thrown exception");
         } catch(InvalidEntityException e) {
             verify(accountDao, never()).createAccount(any(), any());
@@ -1612,7 +1613,7 @@ public class ParticipantServiceTest {
         when(accountDao.createAccount(any(), any()))
                 .thenThrow(new EntityAlreadyExistsException(Account.class, (String) null, (Map<String, Object>) null));
         try {
-            participantService.createParticipant(STUDY, CALLER_ROLES, PARTICIPANT, false);
+            participantService.createParticipant(STUDY, RESEARCH_CALLER_ROLES, CALLER_SUBS, PARTICIPANT, false);
             fail("Should have thrown exception");
         } catch(EntityAlreadyExistsException e) {
             verify(externalIdService, never()).assignExternalId(any(), any(), any());    
@@ -1628,7 +1629,7 @@ public class ParticipantServiceTest {
         
         StudyParticipant participant = new StudyParticipant.Builder().copyOf(PARTICIPANT)
                 .withExternalId("newExternalId").build();
-        participantService.updateParticipant(STUDY, CALLER_ROLES, participant);
+        participantService.updateParticipant(STUDY, RESEARCH_CALLER_ROLES, ImmutableSet.of(), participant);
     }
     
     @Test
@@ -1639,7 +1640,7 @@ public class ParticipantServiceTest {
         ExternalIdentifier identifier = ExternalIdentifier.create(STUDY.getStudyIdentifier(), EXTERNAL_ID);
         when(externalIdService.getExternalId(STUDY.getStudyIdentifier(), EXTERNAL_ID)).thenReturn(identifier);
         
-        participantService.updateParticipant(STUDY, CALLER_ROLES, PARTICIPANT);
+        participantService.updateParticipant(STUDY, RESEARCH_CALLER_ROLES, ImmutableSet.of(), PARTICIPANT);
         
         assertEquals(EXTERNAL_ID, account.getExternalId());
         verify(externalIdService).assignExternalId(STUDY, EXTERNAL_ID, HEALTH_CODE);
@@ -1653,7 +1654,7 @@ public class ParticipantServiceTest {
                 .copyOf(PARTICIPANT)
                 .withExternalId("").build();
         try {
-            participantService.updateParticipant(STUDY, CALLER_ROLES, participant);
+            participantService.updateParticipant(STUDY, RESEARCH_CALLER_ROLES, ImmutableSet.of(), participant);
             fail("Should have thrown exception");
         } catch(InvalidEntityException e) {
             
@@ -1671,7 +1672,7 @@ public class ParticipantServiceTest {
         // This record has a different external ID than the mocked account
         StudyParticipant participant = new StudyParticipant.Builder().copyOf(PARTICIPANT)
                 .withExternalId("newExternalId").build();
-        participantService.updateParticipant(STUDY, CALLER_ROLES, participant);
+        participantService.updateParticipant(STUDY, RESEARCH_CALLER_ROLES, ImmutableSet.of(), participant);
         
         assertEquals("newExternalId", account.getExternalId());
         verify(externalIdService).unassignExternalId(STUDY, EXTERNAL_ID, HEALTH_CODE);
@@ -1685,7 +1686,7 @@ public class ParticipantServiceTest {
         // Paticipant has no external ID, so externalIdService is not called
         StudyParticipant participant = new StudyParticipant.Builder().copyOf(PARTICIPANT)
                 .withExternalId(null).build();
-        participantService.updateParticipant(STUDY, CALLER_ROLES, participant);
+        participantService.updateParticipant(STUDY, RESEARCH_CALLER_ROLES, ImmutableSet.of(), participant);
         verify(externalIdService).unassignExternalId(STUDY, EXTERNAL_ID, HEALTH_CODE);
         verify(externalIdService).assignExternalId(STUDY, null, HEALTH_CODE);
     }
@@ -1697,7 +1698,7 @@ public class ParticipantServiceTest {
         ExternalIdentifier identifier = ExternalIdentifier.create(STUDY.getStudyIdentifier(), EXTERNAL_ID);
         when(externalIdService.getExternalId(STUDY.getStudyIdentifier(), EXTERNAL_ID)).thenReturn(identifier);
         
-        participantService.updateParticipant(STUDY, CALLER_ROLES, PARTICIPANT);
+        participantService.updateParticipant(STUDY, RESEARCH_CALLER_ROLES, ImmutableSet.of(), PARTICIPANT);
         
         assertEquals(EXTERNAL_ID, account.getExternalId());
         verify(externalIdService, never()).assignExternalId(STUDY, EXTERNAL_ID, HEALTH_CODE);
@@ -1713,7 +1714,7 @@ public class ParticipantServiceTest {
         // This record has a different external ID than the mocked accound
         StudyParticipant participant = new StudyParticipant.Builder().copyOf(PARTICIPANT)
                 .withExternalId(null).build();
-        participantService.updateParticipant(STUDY, CALLER_ROLES, participant);
+        participantService.updateParticipant(STUDY, RESEARCH_CALLER_ROLES, ImmutableSet.of(), participant);
         
         assertEquals(null, account.getExternalId());
         verify(externalIdService).unassignExternalId(STUDY, EXTERNAL_ID, HEALTH_CODE);
@@ -1726,7 +1727,7 @@ public class ParticipantServiceTest {
         STUDY.setExternalIdValidationEnabled(false);
         when(externalIdService.getExternalId(STUDY.getStudyIdentifier(), EXTERNAL_ID)).thenReturn(null);
         
-        participantService.createParticipant(STUDY, CALLER_ROLES, PARTICIPANT, false);
+        participantService.createParticipant(STUDY, RESEARCH_CALLER_ROLES, CALLER_SUBS, PARTICIPANT, false);
         
         verify(externalIdService).assignExternalId(STUDY, EXTERNAL_ID, HEALTH_CODE);
     }
@@ -1737,7 +1738,7 @@ public class ParticipantServiceTest {
         STUDY.setExternalIdValidationEnabled(false);
         account.setExternalId(null);
         
-        participantService.updateParticipant(STUDY, CALLER_ROLES, PARTICIPANT);
+        participantService.updateParticipant(STUDY, RESEARCH_CALLER_ROLES, ImmutableSet.of(), PARTICIPANT);
         
         assertEquals(EXTERNAL_ID, account.getExternalId());
         verify(externalIdService).assignExternalId(STUDY, EXTERNAL_ID, HEALTH_CODE);
@@ -1748,7 +1749,7 @@ public class ParticipantServiceTest {
         mockHealthCodeAndAccountRetrieval();
         STUDY.setExternalIdValidationEnabled(false);
         
-        participantService.updateParticipant(STUDY, CALLER_ROLES, PARTICIPANT);
+        participantService.updateParticipant(STUDY, RESEARCH_CALLER_ROLES, ImmutableSet.of(), PARTICIPANT);
         
         assertEquals(EXTERNAL_ID, account.getExternalId());
         verify(externalIdService, never()).assignExternalId(any(), any(), any());
@@ -1761,7 +1762,7 @@ public class ParticipantServiceTest {
         
         StudyParticipant participant = new StudyParticipant.Builder().copyOf(PARTICIPANT)
                 .withExternalId("newExternalId").build();
-        participantService.updateParticipant(STUDY, CALLER_ROLES, participant);
+        participantService.updateParticipant(STUDY, RESEARCH_CALLER_ROLES, ImmutableSet.of(), participant);
         
         assertEquals("newExternalId", account.getExternalId());
         verify(externalIdService).unassignExternalId(STUDY, EXTERNAL_ID, HEALTH_CODE);
@@ -1775,7 +1776,7 @@ public class ParticipantServiceTest {
         
         StudyParticipant participant = new StudyParticipant.Builder().copyOf(PARTICIPANT)
                 .withExternalId(null).build();
-        participantService.updateParticipant(STUDY, CALLER_ROLES, participant);
+        participantService.updateParticipant(STUDY, RESEARCH_CALLER_ROLES, ImmutableSet.of(), participant);
         
         assertEquals(null, account.getExternalId());
         verify(externalIdService).unassignExternalId(STUDY, EXTERNAL_ID, HEALTH_CODE);
@@ -1789,7 +1790,7 @@ public class ParticipantServiceTest {
         
         StudyParticipant participant = new StudyParticipant.Builder().copyOf(PARTICIPANT)
                 .withExternalId("someOtherId").build();
-        participantService.updateParticipant(STUDY, ImmutableSet.of(Roles.DEVELOPER), participant);
+        participantService.updateParticipant(STUDY, ImmutableSet.of(Roles.DEVELOPER), ImmutableSet.of(), participant);
         
         assertEquals(EXTERNAL_ID, account.getExternalId());
         verify(externalIdService, never()).unassignExternalId(any(), any(), any());
@@ -1803,7 +1804,7 @@ public class ParticipantServiceTest {
         
         StudyParticipant participant = new StudyParticipant.Builder().copyOf(PARTICIPANT)
                 .withExternalId(null).build();
-        participantService.updateParticipant(STUDY, ImmutableSet.of(Roles.DEVELOPER), participant);
+        participantService.updateParticipant(STUDY, ImmutableSet.of(Roles.DEVELOPER), ImmutableSet.of(), participant);
         
         assertEquals(EXTERNAL_ID, account.getExternalId());
         verify(externalIdService, never()).unassignExternalId(any(), any(), any());
@@ -1865,7 +1866,7 @@ public class ParticipantServiceTest {
         mockHealthCodeAndAccountRetrieval();
         account.setExternalId(null);
         
-        participantService.updateParticipant(STUDY, ImmutableSet.of(), PARTICIPANT);
+        participantService.updateParticipant(STUDY, ImmutableSet.of(), ImmutableSet.of(), PARTICIPANT);
         
         verify(accountDao).updateAccount(accountCaptor.capture());
         assertEquals(EXTERNAL_ID, accountCaptor.getValue().getExternalId());
@@ -1878,7 +1879,7 @@ public class ParticipantServiceTest {
         StudyParticipant participant = new StudyParticipant.Builder().copyOf(PARTICIPANT)
                 .withExternalId("newExternalId").build();
         
-        participantService.updateParticipant(STUDY, ImmutableSet.of(), participant);
+        participantService.updateParticipant(STUDY, ImmutableSet.of(), ImmutableSet.of(), participant);
         
         verify(accountDao).updateAccount(accountCaptor.capture());
         assertEquals(EXTERNAL_ID, accountCaptor.getValue().getExternalId());
@@ -1891,7 +1892,7 @@ public class ParticipantServiceTest {
         StudyParticipant participant = new StudyParticipant.Builder().copyOf(PARTICIPANT)
                 .withExternalId("newExternalId").build();
         
-        participantService.updateParticipant(STUDY, CALLER_ROLES, participant);
+        participantService.updateParticipant(STUDY, RESEARCH_CALLER_ROLES, ImmutableSet.of(), participant);
         
         verify(accountDao).updateAccount(accountCaptor.capture());
         assertEquals("newExternalId", accountCaptor.getValue().getExternalId());
@@ -1908,7 +1909,7 @@ public class ParticipantServiceTest {
         StudyParticipant participant = new StudyParticipant.Builder().copyOf(PARTICIPANT)
                 .withStatus(AccountStatus.ENABLED).build();
         
-        participantService.updateParticipant(STUDY, roles, participant);
+        participantService.updateParticipant(STUDY, roles, ImmutableSet.of(), participant);
 
         verify(accountDao).updateAccount(accountCaptor.capture());
         Account account = accountCaptor.getValue();
@@ -1926,7 +1927,7 @@ public class ParticipantServiceTest {
         StudyParticipant participant = new StudyParticipant.Builder().copyOf(PARTICIPANT)
                 .withRoles(Sets.newHashSet(ADMIN, RESEARCHER, DEVELOPER, WORKER)).build();
         
-        participantService.createParticipant(STUDY, callerRoles, participant, false);
+        participantService.createParticipant(STUDY, callerRoles, CALLER_SUBS, participant, false);
         
         verify(accountDao).constructAccount(STUDY, EMAIL, PHONE, EXTERNAL_ID, PASSWORD);
         verify(accountDao).createAccount(eq(STUDY), accountCaptor.capture());
@@ -1944,7 +1945,7 @@ public class ParticipantServiceTest {
         
         StudyParticipant participant = new StudyParticipant.Builder().copyOf(PARTICIPANT)
                 .withRoles(rolesThatAreSet).build();
-        participantService.updateParticipant(STUDY, callerRoles, participant);
+        participantService.updateParticipant(STUDY, callerRoles, ImmutableSet.of(), participant);
         
         verify(accountDao).updateAccount(accountCaptor.capture());
         Account account = accountCaptor.getValue();

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -251,7 +251,6 @@ public class ParticipantServiceTest {
         account.setExternalId(EXTERNAL_ID);
         account.setStudyId(TestConstants.TEST_STUDY_IDENTIFIER);
         when(accountDao.constructAccount(any(), any(), any(), any(), any())).thenReturn(account);
-        when(accountDao.createAccount(same(STUDY), same(account))).thenReturn(ID);
         when(accountDao.getAccount(ACCOUNT_ID)).thenReturn(account);
     }
     
@@ -260,7 +259,6 @@ public class ParticipantServiceTest {
         account.setId(ID);
         account.setHealthCode(HEALTH_CODE);
         when(accountDao.constructAccount(any(), any(), any(), any(), any())).thenReturn(account);
-        when(accountDao.createAccount(same(STUDY), same(account))).thenReturn(ID);
         when(accountDao.getAccount(ACCOUNT_ID)).thenReturn(account);
     }
     
@@ -1610,8 +1608,8 @@ public class ParticipantServiceTest {
         identifier.setHealthCode("AAA");
         when(externalIdService.getExternalId(STUDY.getStudyIdentifier(), EXTERNAL_ID)).thenReturn(identifier);
         
-        when(accountDao.createAccount(any(), any()))
-                .thenThrow(new EntityAlreadyExistsException(Account.class, (String) null, (Map<String, Object>) null));
+        doThrow(new EntityAlreadyExistsException(Account.class, (String) null, (Map<String, Object>) null))
+                .when(accountDao).createAccount(any(), any());
         try {
             participantService.createParticipant(STUDY, RESEARCH_CALLER_ROLES, CALLER_SUBS, PARTICIPANT, false);
             fail("Should have thrown exception");

--- a/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
@@ -1051,16 +1051,16 @@ public class StudyServiceMockTest {
         when(mockSynapseClient.createTeam(teamCaptor.capture())).thenReturn(mockTeam);
 
         // stub
-        when(participantService.createParticipant(any(), any(), any(), anyBoolean())).thenReturn(mockIdentifierHolder);
+        when(participantService.createParticipant(any(), any(), any(), any(), anyBoolean())).thenReturn(mockIdentifierHolder);
         doNothing().when(mockSynapseClient).newAccountEmailValidation(any(), any());
 
         // execute
         service.createStudyAndUsers(mockStudyAndUsers);
 
         // verify
-        verify(participantService, times(2)).createParticipant(any(), any(), any(), anyBoolean());
-        verify(participantService).createParticipant(eq(study), eq(mockUser1.getRoles()), eq(mockUser1), eq(false));
-        verify(participantService).createParticipant(eq(study), eq(mockUser2.getRoles()), eq(mockUser2), eq(false));
+        verify(participantService, times(2)).createParticipant(any(), any(), any(), any(), anyBoolean());
+        verify(participantService).createParticipant(eq(study), eq(mockUser1.getRoles()), eq(mockUser1.getSubstudyIds()), eq(mockUser1), eq(false));
+        verify(participantService).createParticipant(eq(study), eq(mockUser2.getRoles()), eq(mockUser1.getSubstudyIds()), eq(mockUser2), eq(false));
         verify(participantService, times(2)).requestResetPassword(eq(study), eq(mockIdentifierHolder.getIdentifier()));
         verify(mockSynapseClient, times(2)).newAccountEmailValidation(any(), eq(SYNAPSE_REGISTER_END_POINT));
         verify(service).createStudy(study);
@@ -1265,7 +1265,7 @@ public class StudyServiceMockTest {
         doReturn(study).when(service).createSynapseProjectTeam(any(), any());
 
         // stub
-        when(participantService.createParticipant(any(), any(), any(), anyBoolean())).thenReturn(mockIdentifierHolder);
+        when(participantService.createParticipant(any(), any(), any(), any(), anyBoolean())).thenReturn(mockIdentifierHolder);
         doThrow(SynapseClientException.class).when(mockSynapseClient).newAccountEmailValidation(any(), any());
 
         // execute
@@ -1333,16 +1333,16 @@ public class StudyServiceMockTest {
         doReturn(study).when(service).createSynapseProjectTeam(any(), any());
 
         // stub
-        when(participantService.createParticipant(any(), any(), any(), anyBoolean())).thenReturn(mockIdentifierHolder);
+        when(participantService.createParticipant(any(), any(), any(), any(), anyBoolean())).thenReturn(mockIdentifierHolder);
         doThrow(new SynapseServerException(500, "The email address provided is already used.")).when(mockSynapseClient).newAccountEmailValidation(any(), any());
 
         // execute
         service.createStudyAndUsers(mockStudyAndUsers);
 
         // verify
-        verify(participantService, times(2)).createParticipant(any(), any(), any(), anyBoolean());
-        verify(participantService).createParticipant(eq(study), eq(mockUser1.getRoles()), eq(mockUser1), eq(false));
-        verify(participantService).createParticipant(eq(study), eq(mockUser2.getRoles()), eq(mockUser2), eq(false));
+        verify(participantService, times(2)).createParticipant(any(), any(), any(), any(), anyBoolean());
+        verify(participantService).createParticipant(eq(study), eq(mockUser1.getRoles()), eq(mockUser1.getSubstudyIds()), eq(mockUser1), eq(false));
+        verify(participantService).createParticipant(eq(study), eq(mockUser2.getRoles()), eq(mockUser2.getSubstudyIds()), eq(mockUser2), eq(false));
         verify(participantService, times(2)).requestResetPassword(eq(study), eq(mockIdentifierHolder.getIdentifier()));
         verify(mockSynapseClient, times(2)).newAccountEmailValidation(any(), eq(SYNAPSE_REGISTER_END_POINT));
         verify(service).createStudy(study);

--- a/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
@@ -1059,9 +1059,9 @@ public class StudyServiceMockTest {
 
         // verify
         verify(participantService, times(2)).createParticipant(any(), any(), any(), any(), anyBoolean());
-        verify(participantService).createParticipant(eq(study), eq(mockUser1.getRoles()), eq(mockUser1.getSubstudyIds()), eq(mockUser1), eq(false));
-        verify(participantService).createParticipant(eq(study), eq(mockUser2.getRoles()), eq(mockUser1.getSubstudyIds()), eq(mockUser2), eq(false));
-        verify(participantService, times(2)).requestResetPassword(eq(study), eq(mockIdentifierHolder.getIdentifier()));
+        verify(participantService).createParticipant(study, mockUser1.getRoles(), ImmutableSet.of(), mockUser1, false);
+        verify(participantService).createParticipant(study, mockUser2.getRoles(), ImmutableSet.of(), mockUser2, false);
+        verify(participantService, times(2)).requestResetPassword(study, mockIdentifierHolder.getIdentifier());
         verify(mockSynapseClient, times(2)).newAccountEmailValidation(any(), eq(SYNAPSE_REGISTER_END_POINT));
         verify(service).createStudy(study);
         verify(service).createSynapseProjectTeam(TEST_ADMIN_IDS, study);
@@ -1341,9 +1341,9 @@ public class StudyServiceMockTest {
 
         // verify
         verify(participantService, times(2)).createParticipant(any(), any(), any(), any(), anyBoolean());
-        verify(participantService).createParticipant(eq(study), eq(mockUser1.getRoles()), eq(mockUser1.getSubstudyIds()), eq(mockUser1), eq(false));
-        verify(participantService).createParticipant(eq(study), eq(mockUser2.getRoles()), eq(mockUser2.getSubstudyIds()), eq(mockUser2), eq(false));
-        verify(participantService, times(2)).requestResetPassword(eq(study), eq(mockIdentifierHolder.getIdentifier()));
+        verify(participantService).createParticipant(study, mockUser1.getRoles(), ImmutableSet.of(), mockUser1, false);
+        verify(participantService).createParticipant(study, mockUser2.getRoles(), ImmutableSet.of(), mockUser2, false);
+        verify(participantService, times(2)).requestResetPassword(study, mockIdentifierHolder.getIdentifier());
         verify(mockSynapseClient, times(2)).newAccountEmailValidation(any(), eq(SYNAPSE_REGISTER_END_POINT));
         verify(service).createStudy(study);
         verify(service).createSynapseProjectTeam(TEST_ADMIN_IDS, study);

--- a/test/org/sagebionetworks/bridge/services/SubstudyServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SubstudyServiceTest.java
@@ -54,7 +54,7 @@ public class SubstudyServiceTest {
         Substudy substudy = Substudy.create();
         when(substudyDao.getSubstudy(TestConstants.TEST_STUDY, "id")).thenReturn(substudy);
         
-        Substudy returnedValue = service.getSubstudy(TestConstants.TEST_STUDY, "id");
+        Substudy returnedValue = service.getSubstudy(TestConstants.TEST_STUDY, "id", true);
         assertEquals(substudy, returnedValue);
         
         verify(substudyDao).getSubstudy(TestConstants.TEST_STUDY, "id");
@@ -62,7 +62,7 @@ public class SubstudyServiceTest {
     
     @Test(expected = EntityNotFoundException.class)
     public void getSubstudyNotFound() {
-        service.getSubstudy(TestConstants.TEST_STUDY, "id");
+        service.getSubstudy(TestConstants.TEST_STUDY, "id", true);
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/services/SubstudyServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/SubstudyServiceTest.java
@@ -61,8 +61,14 @@ public class SubstudyServiceTest {
     }
     
     @Test(expected = EntityNotFoundException.class)
-    public void getSubstudyNotFound() {
+    public void getSubstudyNotFoundThrowingException() {
         service.getSubstudy(TestConstants.TEST_STUDY, "id", true);
+    }
+    
+    @Test
+    public void getSubstudyNotFoundNotThrowingException() {
+        Substudy substudy = service.getSubstudy(TestConstants.TEST_STUDY, "id", false);
+        assertNull(substudy);
     }
     
     @Test

--- a/test/org/sagebionetworks/bridge/services/UserAdminServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/UserAdminServiceMockTest.java
@@ -119,6 +119,7 @@ public class UserAdminServiceMockTest {
         session.setConsentStatuses(statuses);
         
         when(authenticationService.signIn(any(), any(), any())).thenReturn(session);
+        
         doReturn(new IdentifierHolder("ABC")).when(participantService).createParticipant(anyObject(), anySet(),
                 anySet(), anyObject(), anyBoolean());
         doReturn(session).when(authenticationService).getSession(anyObject(), anyObject());

--- a/test/org/sagebionetworks/bridge/services/UserAdminServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/UserAdminServiceMockTest.java
@@ -40,8 +40,8 @@ import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UserAdminServiceMockTest {
@@ -120,7 +120,7 @@ public class UserAdminServiceMockTest {
         
         when(authenticationService.signIn(any(), any(), any())).thenReturn(session);
         doReturn(new IdentifierHolder("ABC")).when(participantService).createParticipant(anyObject(), anySet(),
-                anyObject(), anyBoolean());
+                anySet(), anyObject(), anyBoolean());
         doReturn(session).when(authenticationService).getSession(anyObject(), anyObject());
         doReturn(new StudyParticipant.Builder().withId("ABC").build()).when(participantService).getParticipant(any(),
                 anyString(), anyBoolean());
@@ -145,7 +145,8 @@ public class UserAdminServiceMockTest {
         
         service.createUser(study, participant, null, true, true);
         
-        verify(participantService).createParticipant(study, Sets.newHashSet(Roles.ADMIN), participant, false);
+        verify(participantService).createParticipant(study, ImmutableSet.of(Roles.ADMIN), ImmutableSet.of(),
+                participant, false);
         verify(authenticationService).signIn(eq(study), contextCaptor.capture(), signInCaptor.capture());
         
         CriteriaContext context = contextCaptor.getValue();
@@ -171,7 +172,8 @@ public class UserAdminServiceMockTest {
 
         service.createUser(study, participant, null, true, true);
         
-        verify(participantService).createParticipant(study, Sets.newHashSet(Roles.ADMIN), participant, false);
+        verify(participantService).createParticipant(study, ImmutableSet.of(Roles.ADMIN), ImmutableSet.of(),
+                participant, false);
         verify(authenticationService).signIn(eq(study), contextCaptor.capture(), signInCaptor.capture());
         
         CriteriaContext context = contextCaptor.getValue();
@@ -200,7 +202,8 @@ public class UserAdminServiceMockTest {
         
         UserSession session = service.createUser(study, participant, consentedGuid, true, true);
         
-        verify(participantService).createParticipant(study, Sets.newHashSet(Roles.ADMIN), participant, false);
+        verify(participantService).createParticipant(study, ImmutableSet.of(Roles.ADMIN), ImmutableSet.of(),
+                participant, false);
         
         // consented to the indicated subpopulation
         verify(consentService).consentToResearch(eq(study), eq(consentedGuid), any(StudyParticipant.class), any(), eq(SharingScope.NO_SHARING), eq(false));

--- a/test/org/sagebionetworks/bridge/validators/StudyParticipantValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/StudyParticipantValidatorTest.java
@@ -21,7 +21,9 @@ import org.sagebionetworks.bridge.models.accounts.Phone;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.studies.PasswordPolicy;
 import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.substudies.Substudy;
 import org.sagebionetworks.bridge.services.ExternalIdService;
+import org.sagebionetworks.bridge.services.SubstudyService;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
@@ -40,6 +42,12 @@ public class StudyParticipantValidatorTest {
     @Mock
     private ExternalIdService externalIdService;
     
+    @Mock
+    private SubstudyService substudyService;
+    
+    @Mock
+    private Substudy substudy;
+    
     @Before
     public void before() {
         study = Study.create();
@@ -54,7 +62,7 @@ public class StudyParticipantValidatorTest {
     
     @Test
     public void validatesNew() throws Exception {
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), true);
         study.setExternalIdValidationEnabled(true);
         study.setExternalIdRequiredOnSignup(true);
         
@@ -79,7 +87,7 @@ public class StudyParticipantValidatorTest {
     // Password, email address, and externalId (if being validated) cannot be updated, so these don't need to be validated.
     @Test
     public void validatesUpdate() {
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), false);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), false);
         
         Map<String,String> attrs = Maps.newHashMap();
         attrs.put("badValue", "value");
@@ -104,136 +112,136 @@ public class StudyParticipantValidatorTest {
     @Test
     public void validatesIdForNew() {
         // not new, this succeeds
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true); 
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), true); 
         Validate.entityThrowingException(validator, withEmail("email@email.com"));
     }
     
     @Test(expected = InvalidEntityException.class)
     public void validatesIdForExisting() {
         // not new, this should fail, as there's no ID in participant.
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), false); 
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), false); 
         Validate.entityThrowingException(validator, withEmail("email@email.com"));
     }
     
     @Test
     public void validPasses() {
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), true);
         Validate.entityThrowingException(validator, withEmail("email@email.com"));
         Validate.entityThrowingException(validator, withDataGroup("bluebell"));
     }
     
     @Test
     public void emailPhoneOrExternalIdRequired() {
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withEmail(null), "StudyParticipant", "email, phone, or externalId is required");
     }
     
     @Test
     public void emailCannotBeEmptyString() {
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withEmail(""), "email", "does not appear to be an email address");
     }
     
     @Test
     public void emailCannotBeBlankString() {
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withEmail("    \n    \t "), "email", "does not appear to be an email address");
     }
     
     @Test
     public void emailCannotBeInvalid() {
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withEmail("a"), "email", "does not appear to be an email address");
     }
     
     @Test
     public void externalIdOnlyOK() {
         StudyParticipant participant = new StudyParticipant.Builder().withExternalId("external-id").build();
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), true);
         Validate.entityThrowingException(validator, participant);
     }
     
     @Test
     public void emptyStringPasswordRequired() {
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withPassword(""), "password", "is required");
     }
     
     @Test
     public void nullPasswordOK() {
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), true);
         Validate.entityThrowingException(validator, withPassword(null));
     }
     
     @Test
     public void validEmail() {
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withEmail("belgium"), "email", "does not appear to be an email address");
     }
     
     @Test
     public void minLength() {
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withPassword("a1A~"), "password", "must be at least 8 characters");
     }
     
     @Test
     public void numberRequired() {
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withPassword("aaaaaaaaA~"), "password", "must contain at least one number (0-9)");
     }
     
     @Test
     public void symbolRequired() {
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withPassword("aaaaaaaaA1"), "password", "must contain at least one symbol ( !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~ )");
     }
     
     @Test
     public void lowerCaseRequired() {
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withPassword("AAAAA!A1"), "password", "must contain at least one lowercase letter (a-z)");
     }
     
     @Test
     public void upperCaseRequired() {
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withPassword("aaaaa!a1"), "password", "must contain at least one uppercase letter (A-Z)");
     }
     
     @Test
     public void validatesDataGroupsValidIfSupplied() {
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withDataGroup("squirrel"), "dataGroups", "'squirrel' is not defined for study (use group1, group2, bluebell)");
     }
     
     @Test
     public void validatePhoneRegionRequired() {
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withPhone("1234567890", null), "phone", "does not appear to be a phone number");
     }
     
     @Test
     public void validatePhoneRegionIsCode() {
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withPhone("1234567890", "esg"), "phone", "does not appear to be a phone number");
     }
     
     @Test
     public void validatePhoneRequired() {
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withPhone(null, "US"), "phone", "does not appear to be a phone number");
     }
     
     @Test
     public void validatePhonePattern() {
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withPhone("234567890", "US"), "phone", "does not appear to be a phone number");
     }
     
     @Test
     public void validatePhone() {
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), true);
         StudyParticipant participant = new StudyParticipant.Builder().withEmail("email@email.com")
                 .withPassword("pAssword1@").withPhone(TestConstants.PHONE).build();
         Validate.entityThrowingException(validator, participant);
@@ -241,7 +249,7 @@ public class StudyParticipantValidatorTest {
     
     @Test
     public void validateTotallyWrongPhone() {
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withPhone("this isn't a phone number", "US"), "phone", "does not appear to be a phone number");
     }
     
@@ -251,7 +259,7 @@ public class StudyParticipantValidatorTest {
         study.setExternalIdValidationEnabled(true);
         StudyParticipant participant = withExternalId("foo");
 
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), true);
         Validate.entityThrowingException(validator, participant);
     }
     @Test
@@ -260,7 +268,7 @@ public class StudyParticipantValidatorTest {
         study.setExternalIdValidationEnabled(true);
         StudyParticipant participant = withExternalId("wrong-external-id");
         
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, participant, "externalId", "is not a valid external ID");
     }
     @Test
@@ -268,7 +276,7 @@ public class StudyParticipantValidatorTest {
         study.setExternalIdValidationEnabled(false);
         StudyParticipant participant = withExternalId("foo");
         
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), true);
         Validate.entityThrowingException(validator, participant);
     }
     @Test
@@ -277,7 +285,7 @@ public class StudyParticipantValidatorTest {
         study.setExternalIdValidationEnabled(true);
         StudyParticipant participant = withEmail("email@email.com");
         
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), true);
         Validate.entityThrowingException(validator, participant);
     }
     @Test
@@ -287,7 +295,7 @@ public class StudyParticipantValidatorTest {
         study.setExternalIdRequiredOnSignup(true);
         StudyParticipant participant = withEmail("email@email.com");
         
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, participant, "externalId", "is required");
     }
     @Test
@@ -298,7 +306,7 @@ public class StudyParticipantValidatorTest {
         StudyParticipant participant = new StudyParticipant.Builder().withEmail("email@email.com")
                 .withRoles(Sets.newHashSet(Roles.DEVELOPER)).build();
         
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), true);
         Validate.entityThrowingException(validator, participant);
     }
     @Test
@@ -306,7 +314,7 @@ public class StudyParticipantValidatorTest {
         study.setExternalIdValidationEnabled(false);
         StudyParticipant participant = withEmail("email@email.com");
         
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), true);
         Validate.entityThrowingException(validator, participant);
     }
     @Test
@@ -315,7 +323,7 @@ public class StudyParticipantValidatorTest {
         study.setExternalIdValidationEnabled(true);
         StudyParticipant participant = withExternalIdAndId("foo");
         
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), false);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), false);
         Validate.entityThrowingException(validator, participant);
     }
     @Test
@@ -324,7 +332,7 @@ public class StudyParticipantValidatorTest {
         study.setExternalIdValidationEnabled(true);
         StudyParticipant participant = withExternalId("does-not-exist");
         
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), false);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), false);
         assertValidatorMessage(validator, participant, "externalId", "is not a valid external ID");
     }
     @Test
@@ -332,7 +340,7 @@ public class StudyParticipantValidatorTest {
         study.setExternalIdValidationEnabled(false);
         StudyParticipant participant = withExternalIdAndId("foo");
         
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), false);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), false);
         Validate.entityThrowingException(validator, participant);
     }
     @Test
@@ -341,7 +349,7 @@ public class StudyParticipantValidatorTest {
         study.setExternalIdValidationEnabled(true);
         StudyParticipant participant = withEmailAndId("email@email.com");
         
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), false);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), false);
         Validate.entityThrowingException(validator, participant);
     }
     @Test
@@ -349,21 +357,21 @@ public class StudyParticipantValidatorTest {
         study.setExternalIdValidationEnabled(false);
         StudyParticipant participant = withEmailAndId("email@email.com");
         
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), false);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), false);
         Validate.entityThrowingException(validator, participant);
     }
     @Test
     public void emptyExternalIdInvalidOnCreate() {
         StudyParticipant participant = withExternalId(" ");
         
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, participant, "externalId", "cannot be blank");
     }
     @Test
     public void emptyExternalIdInvalidOnUpdate() {
         StudyParticipant participant = withExternalId(" ");
         
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), false);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), false);
         assertValidatorMessage(validator, participant, "externalId", "cannot be blank");
     }
     @Test
@@ -371,7 +379,10 @@ public class StudyParticipantValidatorTest {
         // In other words, you can "taint" a user with substudies, putting them in a limited security role.
         StudyParticipant participant = withSubstudies("substudyA", "substudyB");
         
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
+        when(substudyService.getSubstudy(study.getStudyIdentifier(), "substudyA", false)).thenReturn(substudy);
+        when(substudyService.getSubstudy(study.getStudyIdentifier(), "substudyB", false)).thenReturn(substudy);
+        
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of(), true);
         Validate.entityThrowingException(validator, participant);
     }
     @Test
@@ -379,7 +390,7 @@ public class StudyParticipantValidatorTest {
         // Once a user has a substudy taint, it must be passed to any accounts that user creates (or a subset of it)
         StudyParticipant participant = withEmail("email@email.com");
         
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of("substudyA"), true);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of("substudyA"), true);
         assertValidatorMessage(validator, participant, "substudyIds", "must be assigned to this participant");
     }
     @Test
@@ -387,7 +398,7 @@ public class StudyParticipantValidatorTest {
         // Nor can the user add a participant to substudies that they do not belong to
         StudyParticipant participant = withSubstudies("substudyA", "substudyB");
         
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of("substudyA", "substudyC"), true);
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of("substudyA", "substudyC"), true);
         assertValidatorMessage(validator, participant, "substudyIds[substudyB]", "is not a substudy of the caller");
     }
     @Test
@@ -395,8 +406,17 @@ public class StudyParticipantValidatorTest {
         // The user (in three substudies) can create a participant in only one of those substudies
         StudyParticipant participant = withSubstudies("substudyB");
         
-        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of("substudyA", "substudyB", "substudyC"), true);
+        when(substudyService.getSubstudy(study.getStudyIdentifier(), "substudyB", false)).thenReturn(substudy);
+        
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of("substudyA", "substudyB", "substudyC"), true);
         Validate.entityThrowingException(validator, participant);
+    }
+    @Test
+    public void nonexistentSubstudyIds() {
+        StudyParticipant participant = withSubstudies("substudyA");
+        
+        validator = new StudyParticipantValidator(externalIdService, substudyService, study, ImmutableSet.of("substudyA", "substudyC"), true);
+        assertValidatorMessage(validator, participant, "substudyIds[substudyA]", "is not a substudy");
     }
     
     private StudyParticipant withSubstudies(String... substudyIds) {

--- a/test/org/sagebionetworks/bridge/validators/StudyParticipantValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/StudyParticipantValidatorTest.java
@@ -368,6 +368,7 @@ public class StudyParticipantValidatorTest {
     }
     @Test
     public void substudyAllowedIfCallerHasNoSubstudies() {
+        // In other words, you can "taint" a user with substudies, putting them in a limited security role.
         StudyParticipant participant = withSubstudies("substudyA", "substudyB");
         
         validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
@@ -375,6 +376,7 @@ public class StudyParticipantValidatorTest {
     }
     @Test
     public void substudyRequiredIfCallerHasSubstudies() {
+        // Once a user has a substudy taint, it must be passed to any accounts that user creates (or a subset of it)
         StudyParticipant participant = withEmail("email@email.com");
         
         validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of("substudyA"), true);
@@ -382,13 +384,15 @@ public class StudyParticipantValidatorTest {
     }
     @Test
     public void invalidSubstudyIfCallerHasSubstudies() { 
+        // Nor can the user add a participant to substudies that they do not belong to
         StudyParticipant participant = withSubstudies("substudyA", "substudyB");
         
         validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of("substudyA", "substudyC"), true);
         assertValidatorMessage(validator, participant, "substudyIds[substudyB]", "is not a substudy of the caller");
     }
     @Test
-    public void substudiesOK() {
+    public void subsetOfsubstudiesOK() {
+        // The user (in three substudies) can create a participant in only one of those substudies
         StudyParticipant participant = withSubstudies("substudyB");
         
         validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of("substudyA", "substudyB", "substudyC"), true);

--- a/test/org/sagebionetworks/bridge/validators/StudyParticipantValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/StudyParticipantValidatorTest.java
@@ -23,6 +23,7 @@ import org.sagebionetworks.bridge.models.studies.PasswordPolicy;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.services.ExternalIdService;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
@@ -53,7 +54,7 @@ public class StudyParticipantValidatorTest {
     
     @Test
     public void validatesNew() throws Exception {
-        validator = new StudyParticipantValidator(externalIdService, study, true);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
         study.setExternalIdValidationEnabled(true);
         study.setExternalIdRequiredOnSignup(true);
         
@@ -78,7 +79,7 @@ public class StudyParticipantValidatorTest {
     // Password, email address, and externalId (if being validated) cannot be updated, so these don't need to be validated.
     @Test
     public void validatesUpdate() {
-        validator = new StudyParticipantValidator(externalIdService, study, false);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), false);
         
         Map<String,String> attrs = Maps.newHashMap();
         attrs.put("badValue", "value");
@@ -103,136 +104,136 @@ public class StudyParticipantValidatorTest {
     @Test
     public void validatesIdForNew() {
         // not new, this succeeds
-        validator = new StudyParticipantValidator(externalIdService, study, true); 
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true); 
         Validate.entityThrowingException(validator, withEmail("email@email.com"));
     }
     
     @Test(expected = InvalidEntityException.class)
     public void validatesIdForExisting() {
         // not new, this should fail, as there's no ID in participant.
-        validator = new StudyParticipantValidator(externalIdService, study, false); 
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), false); 
         Validate.entityThrowingException(validator, withEmail("email@email.com"));
     }
     
     @Test
     public void validPasses() {
-        validator = new StudyParticipantValidator(externalIdService, study, true);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
         Validate.entityThrowingException(validator, withEmail("email@email.com"));
         Validate.entityThrowingException(validator, withDataGroup("bluebell"));
     }
     
     @Test
     public void emailPhoneOrExternalIdRequired() {
-        validator = new StudyParticipantValidator(externalIdService, study, true);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withEmail(null), "StudyParticipant", "email, phone, or externalId is required");
     }
     
     @Test
     public void emailCannotBeEmptyString() {
-        validator = new StudyParticipantValidator(externalIdService, study, true);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withEmail(""), "email", "does not appear to be an email address");
     }
     
     @Test
     public void emailCannotBeBlankString() {
-        validator = new StudyParticipantValidator(externalIdService, study, true);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withEmail("    \n    \t "), "email", "does not appear to be an email address");
     }
     
     @Test
     public void emailCannotBeInvalid() {
-        validator = new StudyParticipantValidator(externalIdService, study, true);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withEmail("a"), "email", "does not appear to be an email address");
     }
     
     @Test
     public void externalIdOnlyOK() {
         StudyParticipant participant = new StudyParticipant.Builder().withExternalId("external-id").build();
-        validator = new StudyParticipantValidator(externalIdService, study, true);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
         Validate.entityThrowingException(validator, participant);
     }
     
     @Test
     public void emptyStringPasswordRequired() {
-        validator = new StudyParticipantValidator(externalIdService, study, true);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withPassword(""), "password", "is required");
     }
     
     @Test
     public void nullPasswordOK() {
-        validator = new StudyParticipantValidator(externalIdService, study, true);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
         Validate.entityThrowingException(validator, withPassword(null));
     }
     
     @Test
     public void validEmail() {
-        validator = new StudyParticipantValidator(externalIdService, study, true);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withEmail("belgium"), "email", "does not appear to be an email address");
     }
     
     @Test
     public void minLength() {
-        validator = new StudyParticipantValidator(externalIdService, study, true);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withPassword("a1A~"), "password", "must be at least 8 characters");
     }
     
     @Test
     public void numberRequired() {
-        validator = new StudyParticipantValidator(externalIdService, study, true);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withPassword("aaaaaaaaA~"), "password", "must contain at least one number (0-9)");
     }
     
     @Test
     public void symbolRequired() {
-        validator = new StudyParticipantValidator(externalIdService, study, true);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withPassword("aaaaaaaaA1"), "password", "must contain at least one symbol ( !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~ )");
     }
     
     @Test
     public void lowerCaseRequired() {
-        validator = new StudyParticipantValidator(externalIdService, study, true);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withPassword("AAAAA!A1"), "password", "must contain at least one lowercase letter (a-z)");
     }
     
     @Test
     public void upperCaseRequired() {
-        validator = new StudyParticipantValidator(externalIdService, study, true);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withPassword("aaaaa!a1"), "password", "must contain at least one uppercase letter (A-Z)");
     }
     
     @Test
     public void validatesDataGroupsValidIfSupplied() {
-        validator = new StudyParticipantValidator(externalIdService, study, true);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withDataGroup("squirrel"), "dataGroups", "'squirrel' is not defined for study (use group1, group2, bluebell)");
     }
     
     @Test
     public void validatePhoneRegionRequired() {
-        validator = new StudyParticipantValidator(externalIdService, study, true);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withPhone("1234567890", null), "phone", "does not appear to be a phone number");
     }
     
     @Test
     public void validatePhoneRegionIsCode() {
-        validator = new StudyParticipantValidator(externalIdService, study, true);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withPhone("1234567890", "esg"), "phone", "does not appear to be a phone number");
     }
     
     @Test
     public void validatePhoneRequired() {
-        validator = new StudyParticipantValidator(externalIdService, study, true);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withPhone(null, "US"), "phone", "does not appear to be a phone number");
     }
     
     @Test
     public void validatePhonePattern() {
-        validator = new StudyParticipantValidator(externalIdService, study, true);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withPhone("234567890", "US"), "phone", "does not appear to be a phone number");
     }
     
     @Test
     public void validatePhone() {
-        validator = new StudyParticipantValidator(externalIdService, study, true);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
         StudyParticipant participant = new StudyParticipant.Builder().withEmail("email@email.com")
                 .withPassword("pAssword1@").withPhone(TestConstants.PHONE).build();
         Validate.entityThrowingException(validator, participant);
@@ -240,7 +241,7 @@ public class StudyParticipantValidatorTest {
     
     @Test
     public void validateTotallyWrongPhone() {
-        validator = new StudyParticipantValidator(externalIdService, study, true);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, withPhone("this isn't a phone number", "US"), "phone", "does not appear to be a phone number");
     }
     
@@ -250,7 +251,7 @@ public class StudyParticipantValidatorTest {
         study.setExternalIdValidationEnabled(true);
         StudyParticipant participant = withExternalId("foo");
 
-        validator = new StudyParticipantValidator(externalIdService, study, true);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
         Validate.entityThrowingException(validator, participant);
     }
     @Test
@@ -259,7 +260,7 @@ public class StudyParticipantValidatorTest {
         study.setExternalIdValidationEnabled(true);
         StudyParticipant participant = withExternalId("wrong-external-id");
         
-        validator = new StudyParticipantValidator(externalIdService, study, true);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, participant, "externalId", "is not a valid external ID");
     }
     @Test
@@ -267,7 +268,7 @@ public class StudyParticipantValidatorTest {
         study.setExternalIdValidationEnabled(false);
         StudyParticipant participant = withExternalId("foo");
         
-        validator = new StudyParticipantValidator(externalIdService, study, true);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
         Validate.entityThrowingException(validator, participant);
     }
     @Test
@@ -276,7 +277,7 @@ public class StudyParticipantValidatorTest {
         study.setExternalIdValidationEnabled(true);
         StudyParticipant participant = withEmail("email@email.com");
         
-        validator = new StudyParticipantValidator(externalIdService, study, true);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
         Validate.entityThrowingException(validator, participant);
     }
     @Test
@@ -286,7 +287,7 @@ public class StudyParticipantValidatorTest {
         study.setExternalIdRequiredOnSignup(true);
         StudyParticipant participant = withEmail("email@email.com");
         
-        validator = new StudyParticipantValidator(externalIdService, study, true);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, participant, "externalId", "is required");
     }
     @Test
@@ -297,7 +298,7 @@ public class StudyParticipantValidatorTest {
         StudyParticipant participant = new StudyParticipant.Builder().withEmail("email@email.com")
                 .withRoles(Sets.newHashSet(Roles.DEVELOPER)).build();
         
-        validator = new StudyParticipantValidator(externalIdService, study, true);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
         Validate.entityThrowingException(validator, participant);
     }
     @Test
@@ -305,7 +306,7 @@ public class StudyParticipantValidatorTest {
         study.setExternalIdValidationEnabled(false);
         StudyParticipant participant = withEmail("email@email.com");
         
-        validator = new StudyParticipantValidator(externalIdService, study, true);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
         Validate.entityThrowingException(validator, participant);
     }
     @Test
@@ -314,7 +315,7 @@ public class StudyParticipantValidatorTest {
         study.setExternalIdValidationEnabled(true);
         StudyParticipant participant = withExternalIdAndId("foo");
         
-        validator = new StudyParticipantValidator(externalIdService, study, false);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), false);
         Validate.entityThrowingException(validator, participant);
     }
     @Test
@@ -323,7 +324,7 @@ public class StudyParticipantValidatorTest {
         study.setExternalIdValidationEnabled(true);
         StudyParticipant participant = withExternalId("does-not-exist");
         
-        validator = new StudyParticipantValidator(externalIdService, study, false);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), false);
         assertValidatorMessage(validator, participant, "externalId", "is not a valid external ID");
     }
     @Test
@@ -331,7 +332,7 @@ public class StudyParticipantValidatorTest {
         study.setExternalIdValidationEnabled(false);
         StudyParticipant participant = withExternalIdAndId("foo");
         
-        validator = new StudyParticipantValidator(externalIdService, study, false);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), false);
         Validate.entityThrowingException(validator, participant);
     }
     @Test
@@ -340,7 +341,7 @@ public class StudyParticipantValidatorTest {
         study.setExternalIdValidationEnabled(true);
         StudyParticipant participant = withEmailAndId("email@email.com");
         
-        validator = new StudyParticipantValidator(externalIdService, study, false);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), false);
         Validate.entityThrowingException(validator, participant);
     }
     @Test
@@ -348,24 +349,56 @@ public class StudyParticipantValidatorTest {
         study.setExternalIdValidationEnabled(false);
         StudyParticipant participant = withEmailAndId("email@email.com");
         
-        validator = new StudyParticipantValidator(externalIdService, study, false);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), false);
         Validate.entityThrowingException(validator, participant);
     }
     @Test
     public void emptyExternalIdInvalidOnCreate() {
         StudyParticipant participant = withExternalId(" ");
         
-        validator = new StudyParticipantValidator(externalIdService, study, true);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
         assertValidatorMessage(validator, participant, "externalId", "cannot be blank");
     }
     @Test
     public void emptyExternalIdInvalidOnUpdate() {
         StudyParticipant participant = withExternalId(" ");
         
-        validator = new StudyParticipantValidator(externalIdService, study, false);
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), false);
         assertValidatorMessage(validator, participant, "externalId", "cannot be blank");
     }
+    @Test
+    public void substudyAllowedIfCallerHasNoSubstudies() {
+        StudyParticipant participant = withSubstudies("substudyA", "substudyB");
+        
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of(), true);
+        Validate.entityThrowingException(validator, participant);
+    }
+    @Test
+    public void substudyRequiredIfCallerHasSubstudies() {
+        StudyParticipant participant = withEmail("email@email.com");
+        
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of("substudyA"), true);
+        assertValidatorMessage(validator, participant, "substudyIds", "must be assigned to this participant");
+    }
+    @Test
+    public void invalidSubstudyIfCallerHasSubstudies() { 
+        StudyParticipant participant = withSubstudies("substudyA", "substudyB");
+        
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of("substudyA", "substudyC"), true);
+        assertValidatorMessage(validator, participant, "substudyIds[substudyB]", "is not a substudy of the caller");
+    }
+    @Test
+    public void substudiesOK() {
+        StudyParticipant participant = withSubstudies("substudyB");
+        
+        validator = new StudyParticipantValidator(externalIdService, study, ImmutableSet.of("substudyA", "substudyB", "substudyC"), true);
+        Validate.entityThrowingException(validator, participant);
+    }
     
+    private StudyParticipant withSubstudies(String... substudyIds) {
+        return new StudyParticipant.Builder().withEmail("email@email.com").withSubstudyIds(ImmutableSet.copyOf(substudyIds)).build();
+        
+    }
     private StudyParticipant withPhone(String phone, String phoneRegion) {
         return new StudyParticipant.Builder().withPhone(new Phone(phone, phoneRegion)).build();
     }

--- a/test/org/sagebionetworks/bridge/validators/StudyParticipantValidatorTest.java
+++ b/test/org/sagebionetworks/bridge/validators/StudyParticipantValidatorTest.java
@@ -45,11 +45,12 @@ public class StudyParticipantValidatorTest {
     @Mock
     private SubstudyService substudyService;
     
-    @Mock
     private Substudy substudy;
     
     @Before
     public void before() {
+        substudy = Substudy.create();
+        
         study = Study.create();
         study.setIdentifier("test-study");
         study.setHealthCodeExportEnabled(true);


### PR DESCRIPTION
Associate accounts to substudy. Administrative users can create users with any substudies (or no substudies) if they have no substudy tag. But if a user is tagged with a substudy, they cannot create users unless those users are tagged with one or more of their substudies.

We are not doing any filtering on this or anything in this checkin... currently substudy association can be completely ignored.

The following SQL needs to be run on the database before deploying:
```
    CREATE TABLE `AccountsSubstudies` (
      `studyId` VARCHAR(60) NOT NULL,
      `substudyId` VARCHAR(60) NOT NULL,
      `accountId`  VARCHAR(255) NOT NULL,
      `externalId` VARCHAR(255) NULL,
      PRIMARY KEY (`studyId`,`substudyId`,`accountId`),
      CONSTRAINT `fk_substudy` FOREIGN KEY (`substudyId`,`studyId`) REFERENCES `Substudies` (`id`,`studyId`),
      CONSTRAINT `fk_account` FOREIGN KEY (`accountId`) REFERENCES `Accounts` (`id`)
    ) DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
```