### PR TITLE
fix NullPointerException in notifyAccountExists()

### DIFF
--- a/app/org/sagebionetworks/bridge/services/AccountWorkflowService.java
+++ b/app/org/sagebionetworks/bridge/services/AccountWorkflowService.java
@@ -318,8 +318,8 @@ public class AccountWorkflowService {
 
         Account account = accountDao.getAccount(accountId);
         
-        boolean verifiedEmail = account.getEmail() != null && account.getEmailVerified();
-        boolean verifiedPhone = account.getPhone() != null && account.getPhoneVerified();
+        boolean verifiedEmail = account.getEmail() != null && Boolean.TRUE.equals(account.getEmailVerified());
+        boolean verifiedPhone = account.getPhone() != null && Boolean.TRUE.equals(account.getPhoneVerified());
         boolean sendEmail = study.isEmailVerificationEnabled() && !study.isAutoVerificationEmailSuppressed();
         boolean sendPhone = !study.isAutoVerificationPhoneSuppressed();
         

--- a/test/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
@@ -742,7 +742,53 @@ public class AccountWorkflowServiceTest {
         verify(mockCacheProvider, never()).setObject(any(), any(), anyInt());
         verify(mockSendMailService, never()).sendEmail(any());
     }
-    
+
+    @Test
+    public void notifyAccountExistsUnverifiedEmailUnverifiedPhone() {
+        // Set study flags so that it would send emails/SMS if they were verified.
+        study.setEmailVerificationEnabled(true);
+        study.setAutoVerificationEmailSuppressed(false);
+        study.setAutoVerificationPhoneSuppressed(false);
+
+        // Mock account DAO.
+        AccountId accountId = AccountId.forId(TEST_STUDY_IDENTIFIER, USER_ID);
+        when(mockAccount.getEmail()).thenReturn(EMAIL);
+        when(mockAccount.getEmailVerified()).thenReturn(Boolean.FALSE);
+        when(mockAccount.getPhone()).thenReturn(TestConstants.PHONE);
+        when(mockAccount.getPhoneVerified()).thenReturn(Boolean.FALSE);
+        when(mockAccountDao.getAccount(accountId)).thenReturn(mockAccount);
+
+        // Execute.
+        service.notifyAccountExists(study, accountId);
+
+        // We never send email nor SMS.
+        verify(mockSendMailService, never()).sendEmail(any());
+        verify(mockSmsService, never()).sendSmsMessage(any(), any());
+    }
+
+    @Test
+    public void notifyAccountExistsEmailVerifiedNullPhoneVerifiedNull() {
+        // Set study flags so that it would send emails/SMS if they were verified.
+        study.setEmailVerificationEnabled(true);
+        study.setAutoVerificationEmailSuppressed(false);
+        study.setAutoVerificationPhoneSuppressed(false);
+
+        // Mock account DAO.
+        AccountId accountId = AccountId.forId(TEST_STUDY_IDENTIFIER, USER_ID);
+        when(mockAccount.getEmail()).thenReturn(EMAIL);
+        when(mockAccount.getEmailVerified()).thenReturn(null);
+        when(mockAccount.getPhone()).thenReturn(TestConstants.PHONE);
+        when(mockAccount.getPhoneVerified()).thenReturn(null);
+        when(mockAccountDao.getAccount(accountId)).thenReturn(mockAccount);
+
+        // Execute.
+        service.notifyAccountExists(study, accountId);
+
+        // We never send email nor SMS.
+        verify(mockSendMailService, never()).sendEmail(any());
+        verify(mockSmsService, never()).sendSmsMessage(any(), any());
+    }
+
     @Test
     public void requestResetPasswordWithEmail() throws Exception {
         when(service.getNextToken()).thenReturn(SPTOKEN);


### PR DESCRIPTION
Some older studies still have unverified accounts with email and no emailVerified flag. If someone tries to sign up again with these emails, we try to dereference the null flag and throw a NullPointerException.

This change explicitly compares the flag to Boolean.TRUE (and assumes null flags are false).