### PR TITLE
Do not return substudy IDs for substudies the caller is not a member of.

### DIFF
--- a/app/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/app/org/sagebionetworks/bridge/BridgeUtils.java
@@ -30,6 +30,7 @@ import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.json.BridgeTypeName;
 import org.sagebionetworks.bridge.time.DateUtils;
+import org.sagebionetworks.bridge.util.BridgeCollectors;
 import org.sagebionetworks.bridge.models.Tuple;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
@@ -105,10 +106,13 @@ public class BridgeUtils {
             if (BridgeUtils.isEmpty(callerSubstudies)) {
                 return account;
             }
-            for (AccountSubstudy accountSubstudy : account.getAccountSubstudies()) {
-                if (callerSubstudies.contains(accountSubstudy.getSubstudyId())) {
-                    return account;
-                }
+            Set<AccountSubstudy> matched = account.getAccountSubstudies().stream()
+                    .filter(as -> callerSubstudies.isEmpty() || callerSubstudies.contains(as.getSubstudyId()))
+                    .collect(BridgeCollectors.toImmutableSet());
+            
+            if (!matched.isEmpty()) {
+                account.setAccountSubstudies(matched);
+                return account;
             }
         }
         return null;


### PR DESCRIPTION
Ultimately, if you are a partner contributing users, you shouldn't know the other partners contributing users to that study (unless for some reason we want to share that information). So after doing the search, we remove substudies that the caller is not associated to.