### PR TITLE
SQL keywords are now allowed as Synapse column names

### DIFF
--- a/app/org/sagebionetworks/bridge/upload/UploadUtil.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadUtil.java
@@ -66,6 +66,12 @@ public class UploadUtil {
     public static final String INVALID_FIELD_NAME_ERROR_MESSAGE = INVALID_ANSWER_CHOICE_ERROR_MESSAGE +
             ", and can't be a reserved keyword";
 
+    // Synapse allows column names of up to 256 characters. Synapse columns are created for each schema field, as well
+    // as for each multiple choice answer. For multiple choice answers, we append the field name with the answer,
+    // delimited by a '.'. If we set the max length to 127, this all but guarantees we will never have a Synapse column
+    // name longer than 256 characters
+    private static final int FIELD_NAME_MAX_LENGTH = 127;
+
     // Misc constants
     private static final int DEFAULT_MAX_LENGTH = 100;
 
@@ -133,7 +139,7 @@ public class UploadUtil {
                     .build();
 
     // List of Synapse keywords that can't be used as field names.
-    private static final Set<String> RESERVED_FIELD_NAME_LIST = ImmutableSet.of("row_id", "row_version");
+    private static final Set<String> RESERVED_FIELD_NAME_LIST = ImmutableSet.of("row_etag", "row_id", "row_version");
 
     /*
      * Suffix used for unit fields in schemas. For example, if we had a field called "jogtime", we would have a field
@@ -493,6 +499,7 @@ public class UploadUtil {
      * 1. must start and end with an alphanumeric character
      * 2. can only contain alphanumeric characters, spaces, dashes, underscores, and periods
      * 3. can't contain two or more non-alphanumeric characters in a row
+     * 4. can't be longer than the max length
      * </p>
      *
      * @param name
@@ -527,6 +534,11 @@ public class UploadUtil {
             return false;
         }
 
+        // Can't be too long.
+        if (name.length() > FIELD_NAME_MAX_LENGTH) {
+            return false;
+        }
+
         // Exhausted all our rules, so it must be valid.
         return true;
     }
@@ -541,7 +553,7 @@ public class UploadUtil {
      */
     public static boolean isValidSchemaFieldName(String name) {
         // Valid schema field name follows all the same rules as a valid survey answer choice. (This also checks for
-        // nulls and blanks.)
+        // nulls and blanks and names that are too long.)
         if (!isValidAnswerChoice(name)) {
             return false;
         }

--- a/app/org/sagebionetworks/bridge/upload/UploadUtil.java
+++ b/app/org/sagebionetworks/bridge/upload/UploadUtil.java
@@ -132,19 +132,8 @@ public class UploadUtil {
                     .put(UploadFieldType.TIME_V2, 12)
                     .build();
 
-    // List of reserved SQL keywords and Synapse keywords that can't be used as field names.
-    private static final Set<String> RESERVED_FIELD_NAME_LIST = ImmutableSet.<String>builder().add("access", "add",
-            "all", "alter", "and", "any", "as", "asc", "audit", "between", "by", "char", "check", "cluster", "column",
-            "column_value", "comment", "compress", "connect", "create", "current", "date", "decimal", "default",
-            "delete", "desc", "distinct", "drop", "else", "exclusive", "exists", "false", "file", "float", "for", "from",
-            "grant", "group", "having", "identified", "immediate", "in", "increment", "index", "initial", "insert",
-            "integer", "intersect", "into", "is", "level", "like", "lock", "long", "maxextents", "minus", "mlslabel",
-            "mode", "modify", "nested_table_id", "noaudit", "nocompress", "not", "nowait", "null", "number", "of",
-            "offline", "on", "online", "option", "or", "order", "pctfree", "prior", "public", "raw", "rename",
-            "resource", "revoke", "row", "row_id", "row_version", "rowid", "rownum", "rows", "select", "session", "set",
-            "share", "size", "smallint", "start", "successful", "synonym", "sysdate", "table", "then", "time", "to",
-            "trigger", "true", "uid", "union", "unique", "update", "user", "validate", "values", "varchar", "varchar2", "view",
-            "whenever", "where", "with").build();
+    // List of Synapse keywords that can't be used as field names.
+    private static final Set<String> RESERVED_FIELD_NAME_LIST = ImmutableSet.of("row_id", "row_version");
 
     /*
      * Suffix used for unit fields in schemas. For example, if we had a field called "jogtime", we would have a field
@@ -557,8 +546,9 @@ public class UploadUtil {
             return false;
         }
 
-        // In addition, it can't be a reserved keyword.
-        if (RESERVED_FIELD_NAME_LIST.contains(name)) {
+        // In addition, it can't be a reserved keyword. Reserved keywords are case-insensitive, so flatten the name to
+        // lowercase.
+        if (RESERVED_FIELD_NAME_LIST.contains(name.toLowerCase())) {
             return false;
         }
 

--- a/test/org/sagebionetworks/bridge/upload/UploadUtilTest.java
+++ b/test/org/sagebionetworks/bridge/upload/UploadUtilTest.java
@@ -316,11 +316,10 @@ public class UploadUtilTest {
     @Test
     public void invalidFieldNameValidAnswerChoice() {
         String[] testCases = {
-                "select",
-                "where",
-                "time",
-                "true",
-                "false",
+                "row_id",
+                "row_ID",
+                "row_version",
+                "Row_Version",
         };
 
         for (String oneTestCase : testCases) {
@@ -338,6 +337,11 @@ public class UploadUtilTest {
                 "foo.bar",
                 "foo bar",
                 "foo-bar_baz.qwerty asdf",
+                "select",
+                "where",
+                "time",
+                "true",
+                "false",
         };
 
         for (String oneTestCase : testCases) {

--- a/test/org/sagebionetworks/bridge/upload/UploadUtilTest.java
+++ b/test/org/sagebionetworks/bridge/upload/UploadUtilTest.java
@@ -316,6 +316,7 @@ public class UploadUtilTest {
     @Test
     public void invalidFieldNameValidAnswerChoice() {
         String[] testCases = {
+                "row_etag",
                 "row_id",
                 "row_ID",
                 "row_version",
@@ -348,6 +349,19 @@ public class UploadUtilTest {
             assertTrue(oneTestCase + " should be valid answer choice", UploadUtil.isValidAnswerChoice(oneTestCase));
             assertTrue(oneTestCase + " should be valid field name", UploadUtil.isValidSchemaFieldName(oneTestCase));
         }
+    }
+
+    @Test
+    public void fieldNameAndAnswerChoiceTooLong() {
+        // Generate name with 130 characters.
+        StringBuilder nameBuilder = new StringBuilder();
+        for (int i = 0; i < 13; i++) {
+            nameBuilder.append("abcdefghij");
+        }
+        String name = nameBuilder.toString();
+
+        assertFalse(UploadUtil.isValidAnswerChoice(name));
+        assertFalse(UploadUtil.isValidSchemaFieldName(name));
     }
 
     @Test


### PR DESCRIPTION
This means Bridge should no longer block these as Schema field names.

Note that Synapse still has Synapse-specific reserved keywords for column names, and that these are case-insensitive, so I've updated the list and logic and unit tests accordingly.

Note: Do not merge this until we confirm with Synapse team that this is okay https://sagebionetworks.jira.com/browse/PLFM-5301