### PR TITLE
Remove duplicate scheduled activities when they are sent on update.

### DIFF
--- a/test/org/sagebionetworks/bridge/cache/CacheProviderMockTest.java
+++ b/test/org/sagebionetworks/bridge/cache/CacheProviderMockTest.java
@@ -2,7 +2,6 @@ package org.sagebionetworks.bridge.cache;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -37,7 +36,6 @@ import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 import org.sagebionetworks.bridge.config.Environment;
 import org.sagebionetworks.bridge.crypto.AesGcmEncryptor;
 import org.sagebionetworks.bridge.crypto.Encryptor;
-import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.accounts.SharingScope;


### PR DESCRIPTION
See: https://sagebionetworks.jira.com/browse/BRIDGE-2350

I've verified the two GSIs on this table don't enforce the same uniqueness constraints as the hash key/range key pair, which is what we're checking in this deduplication code.