### PR TITLE
add userId to Metrics for request channel signIn

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/AuthenticationController.java
@@ -40,9 +40,12 @@ public class AuthenticationController extends BaseController {
     
     public Result requestEmailSignIn() { 
         SignIn signInRequest = parseJson(request(), SignIn.class);
-        
-        accountWorkflowService.requestEmailSignIn(signInRequest);
-        
+
+        String userId = accountWorkflowService.requestEmailSignIn(signInRequest);
+        if (userId != null) {
+            getMetrics().setUserId(userId);
+        }
+
         return acceptedResult("Email sent.");
     }
     
@@ -70,8 +73,11 @@ public class AuthenticationController extends BaseController {
 
     public Result requestPhoneSignIn() {
         SignIn signInRequest = parseJson(request(), SignIn.class);
-        
-        accountWorkflowService.requestPhoneSignIn(signInRequest);
+
+        String userId = accountWorkflowService.requestPhoneSignIn(signInRequest);
+        if (userId != null) {
+            getMetrics().setUserId(userId);
+        }
 
         return acceptedResult("Message sent.");
     }

--- a/app/org/sagebionetworks/bridge/services/SmsService.java
+++ b/app/org/sagebionetworks/bridge/services/SmsService.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.dao.SmsMessageDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
@@ -39,6 +40,7 @@ import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
 import org.sagebionetworks.bridge.models.upload.UploadFieldType;
 import org.sagebionetworks.bridge.models.upload.UploadSchema;
 import org.sagebionetworks.bridge.models.upload.UploadSchemaType;
+import org.sagebionetworks.bridge.play.interceptors.RequestUtils;
 import org.sagebionetworks.bridge.sms.SmsMessageProvider;
 import org.sagebionetworks.bridge.upload.UploadValidationException;
 import org.sagebionetworks.bridge.validators.SmsMessageValidator;
@@ -120,7 +122,8 @@ public class SmsService {
         PublishResult result = snsClient.publish(provider.getSmsRequest());
         messageId = result.getMessageId();
 
-        LOG.debug("Sent SMS message, study=" + study.getIdentifier() + ", message ID=" + messageId);
+        LOG.debug("Sent SMS message, study=" + study.getIdentifier() + ", message ID=" + messageId + ", request ID=" +
+                BridgeUtils.getRequestContext().getId());
 
         // Log SMS message.
         DateTime sentOn = DateTime.now();

--- a/test/org/sagebionetworks/bridge/play/controllers/AuthenticationControllerMockTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/AuthenticationControllerMockTest.java
@@ -184,19 +184,43 @@ public class AuthenticationControllerMockTest {
     public void after() {
         DateTimeUtils.setCurrentMillisSystem();
     }
-    
+
     @Test
     public void requestEmailSignIn() throws Exception {
+        // Mock.
         mockPlayContextWithJson(TestUtils.createJson("{'study':'study-key','email':'email@email.com'}"));
-        
+        when(accountWorkflowService.requestEmailSignIn(any())).thenReturn(TEST_ACCOUNT_ID);
+
+        // Execute.
         Result result = controller.requestEmailSignIn();
         assertResult(result, 202, "Email sent.");
-     
+
+        // Verify.
         verify(accountWorkflowService).requestEmailSignIn(signInCaptor.capture());
         assertEquals("study-key", signInCaptor.getValue().getStudyId());
         assertEquals(TEST_EMAIL, signInCaptor.getValue().getEmail());
+
+        verify(metrics).setUserId(TEST_ACCOUNT_ID);
     }
-    
+
+    @Test
+    public void requestEmailSignIn_NoUser() throws Exception {
+        // Mock.
+        mockPlayContextWithJson(TestUtils.createJson("{'study':'study-key','email':'email@email.com'}"));
+        when(accountWorkflowService.requestEmailSignIn(any())).thenReturn(null);
+
+        // Execute.
+        Result result = controller.requestEmailSignIn();
+        assertResult(result, 202, "Email sent.");
+
+        // Verify.
+        verify(accountWorkflowService).requestEmailSignIn(signInCaptor.capture());
+        assertEquals("study-key", signInCaptor.getValue().getStudyId());
+        assertEquals(TEST_EMAIL, signInCaptor.getValue().getEmail());
+
+        verify(metrics, never()).setUserId(any());
+    }
+
     @Test
     public void emailSignIn() throws Exception {
         response = mockPlayContextWithJson(TestUtils.createJson("{'study':'study-key','email':'email@email.com','token':'ABC'}"));
@@ -863,21 +887,47 @@ public class AuthenticationControllerMockTest {
         assertEquals(TEST_EMAIL, captured.getEmail());
         assertEquals(TEST_PASSWORD, captured.getPassword());
     }
-    
+
     @Test
     public void requestPhoneSignIn() throws Exception {
+        // Mock.
         mockPlayContextWithJson(PHONE_SIGN_IN_REQUEST);
-        
+        when(accountWorkflowService.requestPhoneSignIn(any())).thenReturn(TEST_ACCOUNT_ID);
+
+        // Execute.
         Result result = controller.requestPhoneSignIn();
         assertResult(result, 202, "Message sent.");
-        
+
+        // Verify.
         verify(accountWorkflowService).requestPhoneSignIn(signInCaptor.capture());
-        
+
         SignIn captured = signInCaptor.getValue();
         assertEquals(TEST_STUDY_ID_STRING, captured.getStudyId());
         assertEquals(TestConstants.PHONE.getNumber(), captured.getPhone().getNumber());
+
+        verify(metrics).setUserId(TEST_ACCOUNT_ID);
     }
-    
+
+    @Test
+    public void requestPhoneSignIn_NoUser() throws Exception {
+        // Mock.
+        mockPlayContextWithJson(PHONE_SIGN_IN_REQUEST);
+        when(accountWorkflowService.requestPhoneSignIn(any())).thenReturn(null);
+
+        // Execute.
+        Result result = controller.requestPhoneSignIn();
+        assertResult(result, 202, "Message sent.");
+
+        // Verify.
+        verify(accountWorkflowService).requestPhoneSignIn(signInCaptor.capture());
+
+        SignIn captured = signInCaptor.getValue();
+        assertEquals(TEST_STUDY_ID_STRING, captured.getStudyId());
+        assertEquals(TestConstants.PHONE.getNumber(), captured.getPhone().getNumber());
+
+        verify(metrics, never()).setUserId(any());
+    }
+
     @Test
     public void phoneSignIn() throws Exception {
         response = mockPlayContextWithJson(PHONE_SIGN_IN);


### PR DESCRIPTION
So we can look up sign-in attempts for specific users. Also adds request ID to SMS logs so we can trace requests. (This already exists for emails.)

Testing done:
* unit tests
* integ tests
* manually tested and verified logs