### PR TITLE
Make it possible to execute code that will rollback a transaction if an exception is thrown.

### DIFF
--- a/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
@@ -121,7 +121,7 @@ public class HibernateAccountDao implements AccountDao {
                 hibernateAccount.setStatus(AccountStatus.ENABLED);
             }
             hibernateAccount.setModifiedOn(DateUtils.getCurrentDateTime());
-            hibernateHelper.update(hibernateAccount);    
+            hibernateHelper.update(hibernateAccount, null);    
         }
     }
 
@@ -158,7 +158,7 @@ public class HibernateAccountDao implements AccountDao {
             // we will enable the account.
             hibernateAccount.setStatus(AccountStatus.ENABLED);
         }
-        hibernateHelper.update(hibernateAccount);
+        hibernateHelper.update(hibernateAccount, null);
     }
 
     /** {@inheritDoc} */
@@ -206,7 +206,7 @@ public class HibernateAccountDao implements AccountDao {
         boolean accountUpdated = validateHealthCode(hibernateAccount);
         accountUpdated = updateReauthToken(study, hibernateAccount) || accountUpdated;
         if (accountUpdated) {
-            Account updated = hibernateHelper.update(hibernateAccount);
+            Account updated = hibernateHelper.update(hibernateAccount, null);
             hibernateAccount.setVersion(updated.getVersion());
         }
         return hibernateAccount;
@@ -220,7 +220,7 @@ public class HibernateAccountDao implements AccountDao {
             boolean accountUpdated = validateHealthCode(hibernateAccount);
             accountUpdated = updateReauthToken(null, hibernateAccount) || accountUpdated;
             if (accountUpdated) {
-                Account updated = hibernateHelper.update(hibernateAccount);
+                Account updated = hibernateHelper.update(hibernateAccount, null);
                 hibernateAccount.setVersion(updated.getVersion());
             }
             return hibernateAccount;
@@ -237,7 +237,7 @@ public class HibernateAccountDao implements AccountDao {
             hibernateAccount.setReauthTokenHash(null);
             hibernateAccount.setReauthTokenAlgorithm(null);
             hibernateAccount.setReauthTokenModifiedOn(null);
-            hibernateHelper.update(hibernateAccount);
+            hibernateHelper.update(hibernateAccount, null);
         }
     }
     
@@ -313,7 +313,7 @@ public class HibernateAccountDao implements AccountDao {
         account.setMigrationVersion(AccountDao.MIGRATION_VERSION);
 
         // Create account. We don't verify substudies because this is handled by validation
-        hibernateHelper.create(account);
+        hibernateHelper.create(account, null);
     }
 
     /** {@inheritDoc} */
@@ -339,7 +339,7 @@ public class HibernateAccountDao implements AccountDao {
         account.setModifiedOn(DateUtils.getCurrentDateTime());
 
         // Update. We don't verify substudies because this is handled by validation
-        hibernateHelper.update(account);            
+        hibernateHelper.update(account, null);            
     }
     
     /** {@inheritDoc} */
@@ -361,7 +361,7 @@ public class HibernateAccountDao implements AccountDao {
         if (hibernateAccount != null) {
             boolean accountUpdated = validateHealthCode(hibernateAccount);
             if (accountUpdated) {
-                Account updated = hibernateHelper.update(hibernateAccount);
+                Account updated = hibernateHelper.update(hibernateAccount, null);
                 hibernateAccount.setVersion(updated.getVersion());
             }
             return hibernateAccount;

--- a/app/org/sagebionetworks/bridge/hibernate/HibernateSubstudyDao.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateSubstudyDao.java
@@ -52,7 +52,7 @@ public class HibernateSubstudyDao implements SubstudyDao {
     public VersionHolder createSubstudy(Substudy substudy) {
         checkNotNull(substudy);
         
-        hibernateHelper.create(substudy);
+        hibernateHelper.create(substudy, null);
         return new VersionHolder(substudy.getVersion());
     }
 
@@ -60,7 +60,7 @@ public class HibernateSubstudyDao implements SubstudyDao {
     public VersionHolder updateSubstudy(Substudy substudy) {
         checkNotNull(substudy);
         
-        hibernateHelper.update(substudy);
+        hibernateHelper.update(substudy, null);
         return new VersionHolder(substudy.getVersion());
     }
 

--- a/app/org/sagebionetworks/bridge/services/SmsService.java
+++ b/app/org/sagebionetworks/bridge/services/SmsService.java
@@ -40,7 +40,6 @@ import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
 import org.sagebionetworks.bridge.models.upload.UploadFieldType;
 import org.sagebionetworks.bridge.models.upload.UploadSchema;
 import org.sagebionetworks.bridge.models.upload.UploadSchemaType;
-import org.sagebionetworks.bridge.play.interceptors.RequestUtils;
 import org.sagebionetworks.bridge.sms.SmsMessageProvider;
 import org.sagebionetworks.bridge.upload.UploadValidationException;
 import org.sagebionetworks.bridge.validators.SmsMessageValidator;

--- a/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
+++ b/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
@@ -133,7 +133,7 @@ public class HibernateAccountDaoTest {
         mockCacheProvider = mock(CacheProvider.class);
         
         // Mock successful update.
-        when(mockHibernateHelper.update(any())).thenAnswer(invocation -> {
+        when(mockHibernateHelper.update(any(), eq(null))).thenAnswer(invocation -> {
             HibernateAccount account = invocation.getArgumentAt(0, HibernateAccount.class);
             if (account != null) {
                 account.setVersion(account.getVersion()+1);    
@@ -177,7 +177,7 @@ public class HibernateAccountDaoTest {
         assertNotNull(hibernateAccount.getModifiedOn());
         assertEquals(AccountStatus.ENABLED, account.getStatus());
         assertEquals(Boolean.TRUE, account.getEmailVerified());
-        verify(mockHibernateHelper).update(hibernateAccount);
+        verify(mockHibernateHelper).update(hibernateAccount, null);
     }
 
     @Test
@@ -200,7 +200,7 @@ public class HibernateAccountDaoTest {
         assertNotNull(hibernateAccount.getModifiedOn());
         assertEquals(AccountStatus.ENABLED, account.getStatus());
         assertEquals(Boolean.TRUE, account.getEmailVerified());
-        verify(mockHibernateHelper).update(hibernateAccount);
+        verify(mockHibernateHelper).update(hibernateAccount, null);
     }
     
     @Test
@@ -217,7 +217,7 @@ public class HibernateAccountDaoTest {
         when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(hibernateAccount);
         
         dao.verifyChannel(AuthenticationService.ChannelType.EMAIL, account);
-        verify(mockHibernateHelper, never()).update(hibernateAccount);
+        verify(mockHibernateHelper, never()).update(hibernateAccount, null);
     }
     
     @Test
@@ -226,7 +226,7 @@ public class HibernateAccountDaoTest {
         account.setStatus(AccountStatus.DISABLED);
         
         dao.verifyChannel(AuthenticationService.ChannelType.EMAIL, account);
-        verify(mockHibernateHelper, never()).update(any());
+        verify(mockHibernateHelper, never()).update(any(), eq(null));
         assertEquals(AccountStatus.DISABLED, account.getStatus());
     }
     
@@ -244,7 +244,7 @@ public class HibernateAccountDaoTest {
         } catch (EntityNotFoundException e) {
             // expected exception
         }
-        verify(mockHibernateHelper, never()).update(any());
+        verify(mockHibernateHelper, never()).update(any(), eq(null));
         assertEquals(AccountStatus.UNVERIFIED, account.getStatus());
         assertNull(account.getEmailVerified());
     }
@@ -269,7 +269,7 @@ public class HibernateAccountDaoTest {
         assertNotNull(hibernateAccount.getModifiedOn());
         assertEquals(AccountStatus.ENABLED, account.getStatus());
         assertEquals(Boolean.TRUE, account.getPhoneVerified());
-        verify(mockHibernateHelper).update(hibernateAccount);
+        verify(mockHibernateHelper).update(hibernateAccount, null);
     }
     
     @Test
@@ -292,7 +292,7 @@ public class HibernateAccountDaoTest {
         assertNotNull(hibernateAccount.getModifiedOn());
         assertEquals(AccountStatus.ENABLED, account.getStatus());
         assertEquals(Boolean.TRUE, account.getPhoneVerified());
-        verify(mockHibernateHelper).update(hibernateAccount);
+        verify(mockHibernateHelper).update(hibernateAccount, null);
     }
     
     @Test
@@ -309,7 +309,7 @@ public class HibernateAccountDaoTest {
         when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(hibernateAccount);
         
         dao.verifyChannel(AuthenticationService.ChannelType.PHONE, account);
-        verify(mockHibernateHelper, never()).update(hibernateAccount);
+        verify(mockHibernateHelper, never()).update(hibernateAccount, null);
     }
     
     @Test
@@ -318,7 +318,7 @@ public class HibernateAccountDaoTest {
         account.setStatus(AccountStatus.DISABLED);
         
         dao.verifyChannel(AuthenticationService.ChannelType.PHONE, account);
-        verify(mockHibernateHelper, never()).update(any());
+        verify(mockHibernateHelper, never()).update(any(), eq(null));
         assertEquals(AccountStatus.DISABLED, account.getStatus());
     }
     
@@ -336,7 +336,7 @@ public class HibernateAccountDaoTest {
         } catch (EntityNotFoundException e) {
             // expected exception
         }
-        verify(mockHibernateHelper, never()).update(any());
+        verify(mockHibernateHelper, never()).update(any(), eq(null));
         assertEquals(AccountStatus.UNVERIFIED, account.getStatus());
         assertNull(account.getPhoneVerified());
     }    
@@ -356,7 +356,7 @@ public class HibernateAccountDaoTest {
         // execute and verify
         dao.changePassword(account, ChannelType.EMAIL, DUMMY_PASSWORD);
         ArgumentCaptor<HibernateAccount> updatedAccountCaptor = ArgumentCaptor.forClass(HibernateAccount.class);
-        verify(mockHibernateHelper).update(updatedAccountCaptor.capture());
+        verify(mockHibernateHelper).update(updatedAccountCaptor.capture(), eq(null));
 
         HibernateAccount updatedAccount = updatedAccountCaptor.getValue();
         assertEquals(ACCOUNT_ID, updatedAccount.getId());
@@ -387,7 +387,7 @@ public class HibernateAccountDaoTest {
         // execute and verify
         dao.changePassword(account, ChannelType.PHONE, DUMMY_PASSWORD);
         ArgumentCaptor<HibernateAccount> updatedAccountCaptor = ArgumentCaptor.forClass(HibernateAccount.class);
-        verify(mockHibernateHelper).update(updatedAccountCaptor.capture());
+        verify(mockHibernateHelper).update(updatedAccountCaptor.capture(), eq(null));
 
         // Simpler than changePasswordSuccess() test as we're only verifying phone is verified
         HibernateAccount updatedAccount = updatedAccountCaptor.getValue();
@@ -424,7 +424,7 @@ public class HibernateAccountDaoTest {
         // execute and verify
         dao.changePassword(account, null, DUMMY_PASSWORD);
         ArgumentCaptor<HibernateAccount> updatedAccountCaptor = ArgumentCaptor.forClass(HibernateAccount.class);
-        verify(mockHibernateHelper).update(updatedAccountCaptor.capture());
+        verify(mockHibernateHelper).update(updatedAccountCaptor.capture(), eq(null));
 
         // Simpler than changePasswordSuccess() test as we're only verifying phone is verified
         HibernateAccount updatedAccount = updatedAccountCaptor.getValue();
@@ -461,7 +461,7 @@ public class HibernateAccountDaoTest {
         ArgumentCaptor<HibernateAccount> accountCaptor = ArgumentCaptor.forClass(HibernateAccount.class);
         
         // We don't create a new health code mapping nor update the account.
-        verify(mockHibernateHelper, times(1)).update(accountCaptor.capture());
+        verify(mockHibernateHelper, times(1)).update(accountCaptor.capture(), eq(null));
         
         // healthCodes have not been changed
         assertEquals("original-" + HEALTH_CODE, accountCaptor.getValue().getHealthCode());
@@ -510,7 +510,7 @@ public class HibernateAccountDaoTest {
         assertEquals(1, account.getVersion());
         
         // No reauthentication token rotation occurs
-        verify(mockHibernateHelper, never()).update(any());
+        verify(mockHibernateHelper, never()).update(any(), eq(null));
         assertNull(account.getReauthToken());
         assertEquals(originalReauthHash, hibernateAccount.getReauthTokenHash());
     }
@@ -531,7 +531,7 @@ public class HibernateAccountDaoTest {
         
         Account account = dao.authenticate(study, PASSWORD_SIGNIN);
         verify(mockCacheProvider).getObject(key, String.class);
-        verify(mockHibernateHelper, never()).update(any());
+        verify(mockHibernateHelper, never()).update(any(), eq(null));
         assertEquals(REAUTH_TOKEN, account.getReauthToken());
         assertEquals(originalReauthHash, hibernateAccount.getReauthTokenHash());
     }
@@ -623,7 +623,7 @@ public class HibernateAccountDaoTest {
         verify(mockHibernateHelper).queryGet(expQuery, EMAIL_QUERY_PARAMS, null, null, HibernateAccount.class);
 
         // We update the account with a reauthentication token
-        verify(mockHibernateHelper).update(hibernateAccount);
+        verify(mockHibernateHelper).update(hibernateAccount, null);
         // The hash has been changed
         assertNotEquals(originalReauthTokenHash, hibernateAccount.getReauthTokenHash());
         // This has been hashed
@@ -641,7 +641,7 @@ public class HibernateAccountDaoTest {
             // expected exception
         }
         verify(mockHibernateHelper, never()).queryGet(any(), any(), any(), any(), eq(HibernateAccount.class));
-        verify(mockHibernateHelper, never()).update(any());
+        verify(mockHibernateHelper, never()).update(any(), eq(null));
     }
     
     @Test(expected = EntityNotFoundException.class)
@@ -736,7 +736,7 @@ public class HibernateAccountDaoTest {
         
         ArgumentCaptor<HibernateAccount> accountCaptor = ArgumentCaptor.forClass(HibernateAccount.class);
         
-        verify(mockHibernateHelper).update(accountCaptor.capture());
+        verify(mockHibernateHelper).update(accountCaptor.capture(), eq(null));
         
         HibernateAccount captured = accountCaptor.getValue();
         
@@ -757,7 +757,7 @@ public class HibernateAccountDaoTest {
         
         dao.deleteReauthToken(ACCOUNT_ID_WITH_EMAIL);
         
-        verify(mockHibernateHelper).update(accountCaptor.capture());
+        verify(mockHibernateHelper).update(accountCaptor.capture(), eq(null));
         HibernateAccount captured = accountCaptor.getValue();
         
         assertNull(captured.getReauthTokenAlgorithm());
@@ -777,7 +777,7 @@ public class HibernateAccountDaoTest {
 
         // Just quietly succeeds without doing any work.
         dao.deleteReauthToken(ACCOUNT_ID_WITH_EMAIL);
-        verify(mockHibernateHelper, never()).update(any());
+        verify(mockHibernateHelper, never()).update(any(), eq(null));
     }
 
     @Test
@@ -785,7 +785,7 @@ public class HibernateAccountDaoTest {
         // Just quietly succeeds without doing any work.
         dao.deleteReauthToken(ACCOUNT_ID_WITH_EMAIL);
         
-        verify(mockHibernateHelper, never()).update(any());
+        verify(mockHibernateHelper, never()).update(any(), eq(null));
     }
 
     @Test
@@ -803,7 +803,7 @@ public class HibernateAccountDaoTest {
         
         dao.getAccountAfterAuthentication(ACCOUNT_ID_WITH_EMAIL);
         
-        verify(mockHibernateHelper).update(accountCaptor.capture());
+        verify(mockHibernateHelper).update(accountCaptor.capture(), eq(null));
         HibernateAccount captured = accountCaptor.getValue();
         
         assertNotEquals(PasswordAlgorithm.BCRYPT, captured.getReauthTokenAlgorithm());
@@ -869,7 +869,7 @@ public class HibernateAccountDaoTest {
         // verify hibernate call
         ArgumentCaptor<HibernateAccount> createdHibernateAccountCaptor = ArgumentCaptor.forClass(
                 HibernateAccount.class);
-        verify(mockHibernateHelper).create(createdHibernateAccountCaptor.capture());
+        verify(mockHibernateHelper).create(createdHibernateAccountCaptor.capture(), eq(null));
 
         HibernateAccount createdHibernateAccount = createdHibernateAccountCaptor.getValue();
         assertEquals(ACCOUNT_ID, createdHibernateAccount.getId());
@@ -913,7 +913,7 @@ public class HibernateAccountDaoTest {
         // verify hibernate update
         ArgumentCaptor<HibernateAccount> updatedHibernateAccountCaptor = ArgumentCaptor.forClass(
                 HibernateAccount.class);
-        verify(mockHibernateHelper).update(updatedHibernateAccountCaptor.capture());
+        verify(mockHibernateHelper).update(updatedHibernateAccountCaptor.capture(), eq(null));
 
         HibernateAccount updatedHibernateAccount = updatedHibernateAccountCaptor.getValue();
         assertEquals(ACCOUNT_ID, updatedHibernateAccount.getId());
@@ -948,7 +948,7 @@ public class HibernateAccountDaoTest {
         ArgumentCaptor<HibernateAccount> updatedHibernateAccountCaptor = ArgumentCaptor.forClass(
                 HibernateAccount.class);
 
-        verify(mockHibernateHelper).update(updatedHibernateAccountCaptor.capture());
+        verify(mockHibernateHelper).update(updatedHibernateAccountCaptor.capture(), eq(null));
         
         // These values were loaded, have not been changed, and were persisted as is.
         HibernateAccount captured = updatedHibernateAccountCaptor.getValue();
@@ -1007,7 +1007,7 @@ public class HibernateAccountDaoTest {
         // Capture the update
         ArgumentCaptor<HibernateAccount> updatedHibernateAccountCaptor = ArgumentCaptor.forClass(
                 HibernateAccount.class);
-        verify(mockHibernateHelper).update(updatedHibernateAccountCaptor.capture());
+        verify(mockHibernateHelper).update(updatedHibernateAccountCaptor.capture(), eq(null));
 
         HibernateAccount updatedHibernateAccount = updatedHibernateAccountCaptor.getValue();
         
@@ -1032,7 +1032,7 @@ public class HibernateAccountDaoTest {
         assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, account.getStudyId());
         assertEquals(EMAIL, account.getEmail());
         assertEquals("original-" + HEALTH_CODE, account.getHealthCode());
-        verify(mockHibernateHelper, never()).update(any());
+        verify(mockHibernateHelper, never()).update(any(), eq(null));
     }
 
     @Test
@@ -1087,7 +1087,7 @@ public class HibernateAccountDaoTest {
         verify(mockHibernateHelper).queryGet(expQuery, EMAIL_QUERY_PARAMS, null, null, HibernateAccount.class);
 
         // We don't create a new health code mapping nor update the account.
-        verify(mockHibernateHelper, never()).update(any());
+        verify(mockHibernateHelper, never()).update(any(), eq(null));
     }
 
     @Test
@@ -1674,7 +1674,7 @@ public class HibernateAccountDaoTest {
         dao.editAccount(TestConstants.TEST_STUDY, HEALTH_CODE, account -> account.setFirstName("ChangedFirstName"));
         
         ArgumentCaptor<HibernateAccount> updatedAccountCaptor = ArgumentCaptor.forClass(HibernateAccount.class);
-        verify(mockHibernateHelper).update(updatedAccountCaptor.capture());
+        verify(mockHibernateHelper).update(updatedAccountCaptor.capture(), eq(null));
         
         assertEquals("ChangedFirstName", updatedAccountCaptor.getValue().getFirstName());
     }
@@ -1686,7 +1686,7 @@ public class HibernateAccountDaoTest {
         
         dao.editAccount(TestConstants.TEST_STUDY, "bad-health-code", account -> account.setEmail("JUNK"));
         
-        verify(mockHibernateHelper, never()).update(any());
+        verify(mockHibernateHelper, never()).update(any(), eq(null));
     }
 
     @Test
@@ -1905,7 +1905,7 @@ public class HibernateAccountDaoTest {
     public void deleteReauthTokenFailsAcrossSubstudies() throws Exception {
         testSubstudyMatch(CALLER_SUBSTUDIES, ACCOUNT_SUBSTUDIES, (accountId) -> {
             dao.deleteReauthToken(accountId);
-            verify(mockHibernateHelper, never()).update(any());
+            verify(mockHibernateHelper, never()).update(any(), eq(null));
         });
     }
 
@@ -1913,7 +1913,7 @@ public class HibernateAccountDaoTest {
     public void deleteReauthTokenSucceedsOnSubstudyMatch() throws Exception {
         testSubstudyMatch(ImmutableSet.of(SUBSTUDY_A), ACCOUNT_SUBSTUDIES, (accountId) -> {
             dao.deleteReauthToken(accountId);
-            verify(mockHibernateHelper).update(any());
+            verify(mockHibernateHelper).update(any(), eq(null));
         });
     }
     
@@ -1930,7 +1930,7 @@ public class HibernateAccountDaoTest {
             fail("Should have thrown exception");
         });
         
-        verify(mockHibernateHelper, never()).update(any());
+        verify(mockHibernateHelper, never()).update(any(), eq(null));
         BridgeUtils.setRequestContext(null);
     }
     
@@ -1982,7 +1982,7 @@ public class HibernateAccountDaoTest {
     
     private void verifyCreatedHealthCode() {
         ArgumentCaptor<HibernateAccount> updatedAccountCaptor = ArgumentCaptor.forClass(HibernateAccount.class);
-        verify(mockHibernateHelper).update(updatedAccountCaptor.capture());
+        verify(mockHibernateHelper).update(updatedAccountCaptor.capture(), eq(null));
 
         HibernateAccount updatedAccount = updatedAccountCaptor.getValue();
         assertEquals(ACCOUNT_ID, updatedAccount.getId());

--- a/test/org/sagebionetworks/bridge/hibernate/HibernateHelperTest.java
+++ b/test/org/sagebionetworks/bridge/hibernate/HibernateHelperTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -15,11 +16,13 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import javax.persistence.OptimisticLockException;
 import javax.persistence.PersistenceException;
 
+import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughputExceededException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -30,10 +33,16 @@ import org.hibernate.exception.ConstraintViolationException;
 import org.hibernate.query.Query;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
+import org.sagebionetworks.bridge.models.accounts.Account;
 
+@RunWith(MockitoJUnitRunner.class)
 @SuppressWarnings("unchecked")
 public class HibernateHelperTest {
     private static final String QUERY = "from DummyTable";
@@ -42,17 +51,19 @@ public class HibernateHelperTest {
     private static final RuntimeException TEST_EXCEPTION = new RuntimeException();
 
     private HibernateHelper helper;
+    @Mock
     private Session mockSession;
+    @Mock
     private SessionFactory mockSessionFactory;
+    @Mock
     private PersistenceExceptionConverter mockExceptionConverter;
+    @Mock
+    private Consumer<Account> mockConsumer;
+    @Mock
+    private Transaction mockTransaction;
     
     @Before
     public void setup() {
-        // mock session
-        mockSession = mock(Session.class);
-        mockSessionFactory = mock(SessionFactory.class);
-        mockExceptionConverter = mock(PersistenceExceptionConverter.class);
-
         // Spy Hibernate helper. This allows us to mock execute() and test it independently later.
         helper = spy(new HibernateHelper(mockSessionFactory, mockExceptionConverter));
         doAnswer(invocation -> {
@@ -64,8 +75,47 @@ public class HibernateHelperTest {
     @Test
     public void createSuccess() {
         Object testObj = new Object();
-        helper.create(testObj);
+        helper.create(testObj, null);
         verify(mockSession).save(testObj);
+    }
+    
+    @Test
+    public void createCallsConsumer() { 
+        reset(helper); // clear @Before setup
+        when(mockSessionFactory.openSession()).thenReturn(mockSession);
+        when(mockSession.beginTransaction()).thenReturn(mockTransaction);
+        
+        Account testObj = Account.create();
+        
+        helper.create(testObj, mockConsumer);
+        
+        InOrder inOrder = Mockito.inOrder(mockConsumer, mockSession, mockTransaction);
+        inOrder.verify(mockSession).beginTransaction();
+        inOrder.verify(mockSession).save(testObj);
+        inOrder.verify(mockConsumer).accept(testObj);
+        inOrder.verify(mockTransaction).commit();
+    }
+    
+    @Test
+    public void createConsumerTriggersRollback() { 
+        reset(helper); // clear @Before setup
+        when(mockSessionFactory.openSession()).thenReturn(mockSession);
+        when(mockSession.beginTransaction()).thenReturn(mockTransaction);
+        Account testObj = Account.create();
+        doThrow(new ProvisionedThroughputExceededException("message")).when(mockConsumer).accept(testObj);
+        
+        try {
+            helper.create(testObj, mockConsumer);
+            fail("Should have thrown exception");
+        } catch(ProvisionedThroughputExceededException e) {
+            InOrder inOrder = Mockito.inOrder(mockConsumer, mockSession, mockTransaction);
+            inOrder.verify(mockSession).beginTransaction();
+            inOrder.verify(mockSession).save(testObj);
+            inOrder.verify(mockConsumer).accept(testObj);
+            inOrder.verify(mockSession).close();
+            
+            verify(mockTransaction, never()).commit();
+        }
     }
 
     @Test
@@ -77,7 +127,7 @@ public class HibernateHelperTest {
         when(mockExceptionConverter.convert(ex, testObj)).thenReturn(TEST_EXCEPTION);
         
         try {
-            helper.create(testObj);
+            helper.create(testObj, null);
             fail("Should have thrown exception");
         } catch(Exception e) {
             assertSame(TEST_EXCEPTION, e);
@@ -226,16 +276,53 @@ public class HibernateHelperTest {
     @Test
     public void update() {
         Object testObj = new Object();
-        Object received = helper.update(testObj);
+        Object received = helper.update(testObj, null);
         assertSame(testObj, received);
         verify(mockSession).update(testObj);
     }
 
     @Test
+    public void updateCallsConsumer() { 
+        reset(helper); // clear @Before setup
+        when(mockSessionFactory.openSession()).thenReturn(mockSession);
+        when(mockSession.beginTransaction()).thenReturn(mockTransaction);
+        
+        Account testObj = Account.create();
+        
+        helper.update(testObj, mockConsumer);
+        
+        InOrder inOrder = Mockito.inOrder(mockConsumer, mockSession, mockTransaction);
+        inOrder.verify(mockSession).beginTransaction();
+        inOrder.verify(mockSession).update(testObj);
+        inOrder.verify(mockConsumer).accept(testObj);
+        inOrder.verify(mockTransaction).commit();
+        inOrder.verify(mockSession).close();
+    }
+    
+    @Test
+    public void updateConsumerTriggersRollback() { 
+        reset(helper); // clear @Before setup
+        when(mockSessionFactory.openSession()).thenReturn(mockSession);
+        when(mockSession.beginTransaction()).thenReturn(mockTransaction);
+        Account testObj = Account.create();
+        doThrow(new ProvisionedThroughputExceededException("message")).when(mockConsumer).accept(testObj);
+        
+        try {
+            helper.update(testObj, mockConsumer);
+            fail("Should have thrown exception");
+        } catch(ProvisionedThroughputExceededException e) {
+            InOrder inOrder = Mockito.inOrder(mockConsumer, mockSession, mockTransaction);
+            inOrder.verify(mockSession).beginTransaction();
+            inOrder.verify(mockSession).update(testObj);
+            inOrder.verify(mockConsumer).accept(testObj);
+            inOrder.verify(mockSession).close();
+            
+            verify(mockTransaction, never()).commit();
+        }
+    }
+    
+    @Test
     public void execute() {
-        // mock transaction
-        Transaction mockTransaction = mock(Transaction.class);
-
         // mock session to produce transaction
         when(mockSession.beginTransaction()).thenReturn(mockTransaction);
 
@@ -280,7 +367,7 @@ public class HibernateHelperTest {
         when(mockExceptionConverter.convert(ex, account)).thenReturn(TEST_EXCEPTION);
         
         try {
-            helper.create(account);
+            helper.create(account, null);
             fail("Should have thrown exception");
         } catch(Exception e) {
             assertSame(TEST_EXCEPTION, e);
@@ -413,7 +500,7 @@ public class HibernateHelperTest {
         when(mockExceptionConverter.convert(ex, account)).thenReturn(TEST_EXCEPTION);
 
         try {
-            helper.update(account);
+            helper.update(account, null);
             fail("Should have thrown exception");
         } catch(Exception e) {
             assertSame(TEST_EXCEPTION, e);
@@ -436,7 +523,7 @@ public class HibernateHelperTest {
         when(mockExceptionConverter.convert(pe, account)).thenReturn(pe);
         
         try {
-            helper.update(account);
+            helper.update(account, null);
             fail("Should have thrown exception");
         } catch(BridgeServiceException e) {
             // So we wrap it with a BridgeServiceException

--- a/test/org/sagebionetworks/bridge/hibernate/HibernateSubstudyDaoTest.java
+++ b/test/org/sagebionetworks/bridge/hibernate/HibernateSubstudyDaoTest.java
@@ -112,7 +112,7 @@ public class HibernateSubstudyDaoTest {
         VersionHolder holder = dao.createSubstudy(substudy);
         assertEquals(new Long(2), holder.getVersion());
         
-        verify(hibernateHelper).create(substudyCaptor.capture());
+        verify(hibernateHelper).create(substudyCaptor.capture(), eq(null));
         
         Substudy persisted = substudyCaptor.getValue();
         assertEquals(new Long(2), persisted.getVersion());
@@ -126,7 +126,7 @@ public class HibernateSubstudyDaoTest {
         VersionHolder holder = dao.updateSubstudy(substudy);
         assertEquals(new Long(2), holder.getVersion());
         
-        verify(hibernateHelper).update(substudyCaptor.capture());
+        verify(hibernateHelper).update(substudyCaptor.capture(), eq(null));
         
         Substudy persisted = substudyCaptor.getValue();
         assertEquals(new Long(2), persisted.getVersion());


### PR DESCRIPTION
HibernateHelper.create/update now takes a consumer that it'll execute as part of a database transaction. That'll allow me to run DynamoDB persistence code and if it fails, it'll rollback the transaction and the database changes.

This was a part of the externalId/substudy association refactor that could be cleanly taken out, reviewed, and committed first. I will use this functionality in the main PR being prepared.