### PR TITLE
downgrade multiple app config error to warning

### DIFF
--- a/app/org/sagebionetworks/bridge/services/AppConfigService.java
+++ b/app/org/sagebionetworks/bridge/services/AppConfigService.java
@@ -118,7 +118,7 @@ public class AppConfigService {
             }
         } else if (matches.size() != 1) {
             // If there is more than one match, return the one created first, but log an error
-            logError("CriteriaContext matches more than one app config: criteriaContext=" + context + ", appConfigs="+matches);
+            LOG.warn("CriteriaContext matches more than one app config: criteriaContext=" + context + ", appConfigs="+matches);
         }
         AppConfig matched = matches.get(0);
         // Resolve survey references to pick up survey identifiers

--- a/test/org/sagebionetworks/bridge/services/AppConfigServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/AppConfigServiceTest.java
@@ -309,8 +309,6 @@ public class AppConfigServiceTest {
         
         AppConfig appConfig = service.getAppConfigForUser(context, false);
 
-        verify(service).logError("CriteriaContext matches more than one app config: criteriaContext=" + 
-                context + ", appConfigs=" + Lists.newArrayList(appConfig2, appConfig1));
         assertEquals(appConfig2, appConfig);
     }
     


### PR DESCRIPTION
Every time this error has come up, it's because someone set up the study wrong and not because there's anything wrong with Bridge. We should downgrade this error to a warning.