### PR TITLE
Fixing ability to lookup user by external ID, adding API to migrate managed external IDs to have substudy association.

### DIFF
--- a/app/org/sagebionetworks/bridge/dynamodb/DynamoExternalIdentifier.java
+++ b/app/org/sagebionetworks/bridge/dynamodb/DynamoExternalIdentifier.java
@@ -6,8 +6,11 @@ import org.sagebionetworks.bridge.models.accounts.ExternalIdentifier;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIndexHashKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIndexRangeKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
+import com.amazonaws.services.dynamodbv2.model.ProjectionType;
 
 /**
  * Implementation of external identifier.
@@ -27,6 +30,7 @@ public final class DynamoExternalIdentifier implements ExternalIdentifier {
         this.identifier = identifier;
     }
     
+    @DynamoDBIndexHashKey(attributeName = "studyId", globalSecondaryIndexName = "studyId-substudyId-index")
     @DynamoDBHashKey
     @Override
     public String getStudyId() {
@@ -37,6 +41,8 @@ public final class DynamoExternalIdentifier implements ExternalIdentifier {
         this.studyId = studyId;
     }
     
+    @DynamoDBIndexRangeKey(attributeName = "substudyId", globalSecondaryIndexName = "studyId-substudyId-index")
+    @DynamoProjection(projectionType = ProjectionType.ALL, globalSecondaryIndexName = "studyId-substudyId-index")
     @DynamoDBAttribute
     @Override
     public String getSubstudyId() {

--- a/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
@@ -450,7 +450,7 @@ public class HibernateAccountDao implements AccountDao {
                         "number", unguarded.getPhone().getNumber(),
                         "regionCode", unguarded.getPhone().getRegionCode());
             } else {
-                builder.append("AND acct.externalId=:externalId", "externalId", unguarded.getExternalId());
+                builder.append("AND (acctSubstudy.externalId=:externalId OR acct.externalId=:externalId)", "externalId", unguarded.getExternalId());
             }
         }
         if (search != null) {

--- a/app/org/sagebionetworks/bridge/hibernate/HibernateAccountSubstudy.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateAccountSubstudy.java
@@ -50,6 +50,9 @@ public final class HibernateAccountSubstudy implements AccountSubstudy {
     public void setExternalId(String externalId) {
         this.externalId = externalId;
     }
+    public void setSubstudyId(String substudyId) {
+        this.substudyId = substudyId;
+    }
 
     @Override
     public int hashCode() {

--- a/app/org/sagebionetworks/bridge/models/substudies/AccountSubstudy.java
+++ b/app/org/sagebionetworks/bridge/models/substudies/AccountSubstudy.java
@@ -18,4 +18,5 @@ public interface AccountSubstudy {
     String getAccountId();
     String getExternalId();
     void setExternalId(String externalId);
+    void setSubstudyId(String substudyId); // for migration, then can be removed
 }

--- a/app/org/sagebionetworks/bridge/play/controllers/ExternalIdControllerV4.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ExternalIdControllerV4.java
@@ -3,8 +3,12 @@ package org.sagebionetworks.bridge.play.controllers;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.Roles;
+import org.sagebionetworks.bridge.json.JsonUtils;
 import org.sagebionetworks.bridge.models.ForwardCursorPagedResourceList;
 import org.sagebionetworks.bridge.models.accounts.ExternalIdentifier;
 import org.sagebionetworks.bridge.models.accounts.ExternalIdentifierInfo;
@@ -24,6 +28,19 @@ public class ExternalIdControllerV4 extends BaseController {
     @Autowired
     final void setExternalIdService(ExternalIdService externalIdService) {
         this.externalIdService = externalIdService;
+    }
+    
+    public Result migrateExternalIdentifier() {
+        UserSession session = getAuthenticatedSession(Roles.ADMIN);
+        Study study = studyService.getStudy(session.getStudyIdentifier());
+        
+        JsonNode node = parseJson(request(), JsonNode.class);
+        String externalId = JsonUtils.asText(node, "externalId");
+        String substudyId = JsonUtils.asText(node, "substudyId");
+        
+        externalIdService.migrateExternalIdentifier(study, externalId, substudyId);
+
+        return okResult("External ID '" + externalId + "' associated to substudy '" + substudyId + "'.");
     }
     
     public Result getExternalIdentifiers(String offsetKey, String pageSizeString, String idFilter,

--- a/app/org/sagebionetworks/bridge/services/ExternalIdService.java
+++ b/app/org/sagebionetworks/bridge/services/ExternalIdService.java
@@ -3,20 +3,24 @@ package org.sagebionetworks.bridge.services;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
 
+import java.util.Optional;
 import java.util.Set;
 
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dao.ExternalIdDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.ForwardCursorPagedResourceList;
 import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.ExternalIdentifier;
 import org.sagebionetworks.bridge.models.accounts.ExternalIdentifierInfo;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
+import org.sagebionetworks.bridge.models.substudies.AccountSubstudy;
 import org.sagebionetworks.bridge.validators.ExternalIdValidator;
 import org.sagebionetworks.bridge.validators.Validate;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,6 +43,8 @@ public class ExternalIdService {
     
     private SubstudyService substudyService;
     
+    private AccountDao accountDao;
+
     @Autowired
     public final void setExternalIdDao(ExternalIdDao externalIdDao) {
         this.externalIdDao = externalIdDao;
@@ -47,6 +53,46 @@ public class ExternalIdService {
     @Autowired
     public final void setSubstudyService(SubstudyService substudyService) {
         this.substudyService = substudyService;
+    }
+    
+    @Autowired
+    public final void setAccountDao(AccountDao accountDao) {
+        this.accountDao = accountDao;
+    }
+    
+    public void migrateExternalIdentifier(Study study, String externalId, String substudyId) {
+        checkNotNull(study);
+        checkNotNull(externalId);
+        checkNotNull(substudyId);
+        
+        // Both getters throw exceptions if the entities do not exist. 
+        substudyService.getSubstudy(study.getStudyIdentifier(), substudyId, true);
+        ExternalIdentifier externalIdentifier = getExternalId(study.getStudyIdentifier(), externalId, true);
+        
+        externalIdentifier.setSubstudyId(substudyId);
+        // This just calls DDB's save method, and can be used to persist an update for this temporary migration method.
+        externalIdDao.createExternalId(externalIdentifier);
+        
+        AccountId accountId = AccountId.forExternalId(study.getIdentifier(), externalId);
+        Account account = accountDao.getAccount(accountId);
+        if (account != null) {
+            Optional<AccountSubstudy> selected = account.getAccountSubstudies().stream()
+                    //.filter(acctSubstudy -> externalId.equals(acctSubstudy.getExternalId()))
+                    .filter(acctSubstudy -> substudyId.equals(acctSubstudy.getSubstudyId()))
+                    .findAny();
+            if (selected.isPresent()) {
+                account.getAccountSubstudies().remove(selected.get());
+            }
+            AccountSubstudy newOne = AccountSubstudy.create(study.getIdentifier(), substudyId, account.getId());
+            newOne.setExternalId(externalId);
+            account.getAccountSubstudies().add(newOne);
+            // we still need to set this to support the exporter, we will not be able to add a second 
+            // external ID until we export the substudy/external ID mappings. But I'd like to migrate 
+            // first so that once we start exporting, we're exporting the relationship for all accounts
+            // at the same time (seems cleaner).
+            account.setExternalId(externalId);  
+            accountDao.updateAccount(account, null);
+        }
     }
     
     public ExternalIdentifier getExternalId(StudyIdentifier studyId, String externalId, boolean throwException) {

--- a/conf/routes
+++ b/conf/routes
@@ -300,6 +300,7 @@ POST   /v3/externalIds                      @org.sagebionetworks.bridge.play.con
 DELETE /v3/externalIds                      @org.sagebionetworks.bridge.play.controllers.ExternalIdController.deleteExternalIds
 POST   /v3/externalIds/:externalId/password @org.sagebionetworks.bridge.play.controllers.ExternalIdController.generatePassword(externalId: String, createAccount: Boolean ?= true)
 
+POST   /v4/externalids/migrate              @org.sagebionetworks.bridge.play.controllers.ExternalIdControllerV4.migrateExternalIdentifier
 GET    /v4/externalids                      @org.sagebionetworks.bridge.play.controllers.ExternalIdControllerV4.getExternalIdentifiers(offsetKey: String ?= null, pageSize: String ?= null, idFilter: String ?= null, assignmentFilter: String ?= null)
 POST   /v4/externalids                      @org.sagebionetworks.bridge.play.controllers.ExternalIdControllerV4.createExternalIdentifier
 DELETE /v4/externalids/:externalId          @org.sagebionetworks.bridge.play.controllers.ExternalIdControllerV4.deleteExternalIdentifier(externalId: String)

--- a/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
+++ b/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
@@ -1240,8 +1240,8 @@ public class HibernateAccountDaoTest {
     @Test
     public void getByExternalId() throws Exception {
         String expQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies AS "+
-                "acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND "+
-                "acct.externalId=:externalId GROUP BY acct.id";
+                "acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId "+
+                "AND (acctSubstudy.externalId=:externalId OR acct.externalId=:externalId) GROUP BY acct.id";
         
         HibernateAccount hibernateAccount = makeValidHibernateAccount(false, false);
         // mock hibernate
@@ -1265,8 +1265,8 @@ public class HibernateAccountDaoTest {
     @Test
     public void getByExternalIdAfterAuthentication() throws Exception {
         String expQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies "+
-                "AS acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND "+
-                "acct.externalId=:externalId GROUP BY acct.id";
+                "AS acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId "+
+                "AND (acctSubstudy.externalId=:externalId OR acct.externalId=:externalId) GROUP BY acct.id";
         
         HibernateAccount hibernateAccount = makeValidHibernateAccount(false, false);
         // mock hibernate

--- a/test/org/sagebionetworks/bridge/hibernate/HibernateAccountSubstudyTest.java
+++ b/test/org/sagebionetworks/bridge/hibernate/HibernateAccountSubstudyTest.java
@@ -27,5 +27,8 @@ public class HibernateAccountSubstudyTest {
         assertEquals("substudyId", accountSubstudy.getSubstudyId());
         assertEquals("accountId", accountSubstudy.getAccountId());
         assertEquals("externalId", accountSubstudy.getExternalId());
+        
+        accountSubstudy.setSubstudyId("newSubstudyId");
+        assertEquals("newSubstudyId", accountSubstudy.getSubstudyId());
     }
 }

--- a/test/org/sagebionetworks/bridge/services/ExternalIdServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ExternalIdServiceTest.java
@@ -160,8 +160,11 @@ public class ExternalIdServiceTest {
         
         Account account = Account.create();
         account.setId(USER_ID);
-        // This was already a managed external ID, and will be updated correctly
-        account.setExternalId(ID);  
+        // This starts as a different value and is changed to ID in the test. This would only 
+        // happen in the real world if we migrate an account associated to multiple external 
+        // IDs. We intend to finish this migration (and export) before allowing multiple 
+        // external IDs in production.
+        account.setExternalId("differentExternalId");
         
         AccountId accountId = AccountId.forExternalId(TestConstants.TEST_STUDY_IDENTIFIER, ID);
         when(accountDao.getAccount(accountId)).thenReturn(account);

--- a/test/org/sagebionetworks/bridge/services/ExternalIdServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ExternalIdServiceTest.java
@@ -101,6 +101,7 @@ public class ExternalIdServiceTest {
         // verify
         assertEquals(SUBSTUDY_ID, extId.getSubstudyId());
         assertEquals(1, account.getAccountSubstudies().size());
+        assertEquals(ID, account.getExternalId());
         
         AccountSubstudy acctSubstudy = Iterables.getFirst(account.getAccountSubstudies(), null);
         assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, acctSubstudy.getStudyId());

--- a/test/org/sagebionetworks/bridge/services/ExternalIdServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ExternalIdServiceTest.java
@@ -20,22 +20,27 @@ import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.RequestContext;
 import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dao.ExternalIdDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.ExternalIdentifier;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
+import org.sagebionetworks.bridge.models.substudies.AccountSubstudy;
 import org.sagebionetworks.bridge.models.substudies.Substudy;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ExternalIdServiceTest {
 
+    private static final String USER_ID = "userId";
     private static final String ID = "AAA";
     private static final String SUBSTUDY_ID = "substudyId";
     private static final Set<String> SUBSTUDIES = ImmutableSet.of(SUBSTUDY_ID);
@@ -50,6 +55,9 @@ public class ExternalIdServiceTest {
     @Mock
     private SubstudyService substudyService;
     
+    @Mock
+    private AccountDao accountDao;
+    
     private ExternalIdService externalIdService;
 
     @Before
@@ -63,11 +71,135 @@ public class ExternalIdServiceTest {
         externalIdService = new ExternalIdService();
         externalIdService.setExternalIdDao(externalIdDao);
         externalIdService.setSubstudyService(substudyService);
+        externalIdService.setAccountDao(accountDao);
     }
     
     @After
     public void after() {
         BridgeUtils.setRequestContext(null);
+    }
+    
+    @Test
+    public void migrateExternalIdentifier() throws Exception {
+        // setup
+        when(substudyService.getSubstudy(TestConstants.TEST_STUDY,  SUBSTUDY_ID, true))
+            .thenReturn(Substudy.create());
+        
+        ExternalIdentifier extId = ExternalIdentifier.create(TestConstants.TEST_STUDY, ID);
+        when(externalIdDao.getExternalId(TestConstants.TEST_STUDY, ID))
+            .thenReturn(extId);
+        
+        Account account = Account.create();
+        account.setId(USER_ID);
+        
+        AccountId accountId = AccountId.forExternalId(TestConstants.TEST_STUDY_IDENTIFIER, ID);
+        when(accountDao.getAccount(accountId)).thenReturn(account);
+        
+        // execute
+        externalIdService.migrateExternalIdentifier(study, ID,  SUBSTUDY_ID);
+        
+        // verify
+        assertEquals(SUBSTUDY_ID, extId.getSubstudyId());
+        assertEquals(1, account.getAccountSubstudies().size());
+        
+        AccountSubstudy acctSubstudy = Iterables.getFirst(account.getAccountSubstudies(), null);
+        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, acctSubstudy.getStudyId());
+        assertEquals(ID, acctSubstudy.getExternalId());
+        assertEquals(SUBSTUDY_ID, acctSubstudy.getSubstudyId());
+        
+        verify(externalIdDao).createExternalId(extId);
+        verify(accountDao).updateAccount(account, null);
+    }
+    
+    @Test
+    public void migrateExternalIdentifierWithExistingSubstudyAssociation() throws Exception {
+        // setup
+        when(substudyService.getSubstudy(TestConstants.TEST_STUDY, ID, true))
+            .thenReturn(Substudy.create());
+        
+        ExternalIdentifier extId = ExternalIdentifier.create(TestConstants.TEST_STUDY, ID);
+        when(externalIdDao.getExternalId(TestConstants.TEST_STUDY, ID))
+            .thenReturn(extId);
+        
+        Account account = Account.create();
+        account.setId(USER_ID);
+        // This exists, but has no external ID
+        AccountSubstudy acctSubstudy = AccountSubstudy.create(TestConstants.TEST_STUDY_IDENTIFIER, SUBSTUDY_ID, USER_ID);
+        account.getAccountSubstudies().add(acctSubstudy);
+        
+        AccountId accountId = AccountId.forExternalId(TestConstants.TEST_STUDY_IDENTIFIER, ID);
+        when(accountDao.getAccount(accountId)).thenReturn(account);
+        
+        // execute
+        externalIdService.migrateExternalIdentifier(study, ID, SUBSTUDY_ID);
+        
+        // verify
+        assertEquals(SUBSTUDY_ID, extId.getSubstudyId());
+        assertEquals(1, account.getAccountSubstudies().size());
+        assertEquals(ID, account.getExternalId());
+        
+        acctSubstudy = Iterables.getFirst(account.getAccountSubstudies(), null);
+        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, acctSubstudy.getStudyId());
+        assertEquals(ID, acctSubstudy.getExternalId()); // now it does
+        assertEquals(SUBSTUDY_ID, acctSubstudy.getSubstudyId());
+        
+        verify(externalIdDao).createExternalId(extId);
+        verify(accountDao).updateAccount(account, null);
+    }
+    
+    @Test
+    public void migrateExternalIdentifierFromSingularToSubstudyAssociation() throws Exception {
+        // setup
+        when(substudyService.getSubstudy(TestConstants.TEST_STUDY, ID, true))
+            .thenReturn(Substudy.create());
+        
+        ExternalIdentifier extId = ExternalIdentifier.create(TestConstants.TEST_STUDY, ID);
+        when(externalIdDao.getExternalId(TestConstants.TEST_STUDY, ID))
+            .thenReturn(extId);
+        
+        Account account = Account.create();
+        account.setId(USER_ID);
+        // This was already a managed external ID, and will be updated correctly
+        account.setExternalId(ID);  
+        
+        AccountId accountId = AccountId.forExternalId(TestConstants.TEST_STUDY_IDENTIFIER, ID);
+        when(accountDao.getAccount(accountId)).thenReturn(account);
+        
+        // execute
+        externalIdService.migrateExternalIdentifier(study, ID, SUBSTUDY_ID);
+        
+        // verify
+        assertEquals(SUBSTUDY_ID, extId.getSubstudyId());
+        assertEquals(1, account.getAccountSubstudies().size());
+        assertEquals(ID, account.getExternalId());
+        
+        AccountSubstudy acctSubstudy = Iterables.getFirst(account.getAccountSubstudies(), null);
+        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, acctSubstudy.getStudyId());
+        assertEquals(ID, acctSubstudy.getExternalId());
+        assertEquals(SUBSTUDY_ID, acctSubstudy.getSubstudyId());
+        
+        verify(externalIdDao).createExternalId(extId);
+        verify(accountDao).updateAccount(account, null);
+    }
+    
+    @Test
+    public void migrateExternalIdentifierWithNoAccount() throws Exception {
+        // setup
+        when(substudyService.getSubstudy(TestConstants.TEST_STUDY, ID, true))
+            .thenReturn(Substudy.create());
+        
+        ExternalIdentifier extId = ExternalIdentifier.create(TestConstants.TEST_STUDY, ID);
+        when(externalIdDao.getExternalId(TestConstants.TEST_STUDY, ID))
+            .thenReturn(extId);
+        
+        // execute
+        externalIdService.migrateExternalIdentifier(study, ID, SUBSTUDY_ID);
+        
+        // verify
+        assertEquals(SUBSTUDY_ID, extId.getSubstudyId());
+        
+        verify(externalIdDao).createExternalId(extId);
+        verify(accountDao, never()).updateAccount(any(), any());
     }
     
     @Test


### PR DESCRIPTION
Also adding the annotations to create a GSI although this table already exists, and our DDB initialization code will not add the index, so we need to add it manually on initial deployment. Will check with Khai if this needs to be added to stack scripts.