### PR TITLE
Increasing the grace period for the reauth token to determine if this improves Android's ability to reauthenticate.

### DIFF
--- a/app/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/app/org/sagebionetworks/bridge/BridgeConstants.java
@@ -85,8 +85,8 @@ public class BridgeConstants {
     // 15 seconds
     public static final int REAUTH_TOKEN_CACHE_LOOKUP_IN_SECONDS = 15;
 
-    // 5 min
-    public static final int REAUTH_TOKEN_GRACE_PERIOD_SECONDS = 300;
+    // 3 days
+    public static final int REAUTH_TOKEN_GRACE_PERIOD_SECONDS = (3*24*60*60);
 
     public static final String SCHEDULE_STRATEGY_PACKAGE = "org.sagebionetworks.bridge.models.schedules.";
 


### PR DESCRIPTION
If it does, we've verified that the Android libraries are having trouble retrieving or persisting the reauthentication call's session, like intermediate network errors that require the client to call reauthenticate again. If it doesn't help, it suggests there is a different issue, either on the client or the server. 