### PR TITLE
Get rid of the unnecessary AccountDao.constructAccount method.

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/AccountDao.java
+++ b/app/org/sagebionetworks/bridge/dao/AccountDao.java
@@ -7,7 +7,6 @@ import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.AccountSummary;
-import org.sagebionetworks.bridge.models.accounts.Phone;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
@@ -63,13 +62,6 @@ public interface AccountDao {
      * This method returns null if the Account does not exist.
      */
     Account getAccountAfterAuthentication(AccountId accountId);
-    
-    /**
-     * A factory method to construct a valid Account object that will work with our
-     * underlying persistence store. This does NOT save the account, you must call
-     * createAccount() after the account has been updated.
-     */
-    Account constructAccount(Study study, String email, Phone phone, String externalId, String password);
     
     /**
      * Create an account. The account object should initially be retrieved from the 

--- a/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
@@ -270,31 +270,6 @@ public class HibernateAccountDao implements AccountDao {
         return true;
     }
     
-    /** {@inheritDoc} */
-    @Override
-    public Account constructAccount(Study study, String email, Phone phone, String externalId, String password) {
-        // Set basic params from inputs.
-        Account account = Account.create();
-        account.setId(generateGUID());
-        account.setStudyId(study.getIdentifier());
-        account.setEmail(email);
-        account.setPhone(phone);
-        account.setEmailVerified(Boolean.FALSE);
-        account.setPhoneVerified(Boolean.FALSE);
-        account.setHealthCode(generateGUID());
-        account.setExternalId(externalId);
-
-        // Hash password if it has been supplied.
-        if (password != null) {
-            PasswordAlgorithm passwordAlgorithm = PasswordAlgorithm.DEFAULT_PASSWORD_ALGORITHM;
-            String passwordHash = hashCredential(passwordAlgorithm, "password", password);
-
-            account.setPasswordAlgorithm(passwordAlgorithm);
-            account.setPasswordHash(passwordHash);
-        }
-        return account;
-    }
-    
     // Provided to override in tests
     protected String generateGUID() {
         return BridgeUtils.generateGuid();

--- a/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
@@ -44,7 +44,6 @@ import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.AccountStatus;
 import org.sagebionetworks.bridge.models.accounts.AccountSummary;
 import org.sagebionetworks.bridge.models.accounts.PasswordAlgorithm;
-import org.sagebionetworks.bridge.models.accounts.Phone;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;

--- a/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
+++ b/test/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
@@ -823,41 +823,6 @@ public class HibernateAccountDaoTest {
     }
     
     @Test
-    public void constructAccount() throws Exception {
-        // execute and validate
-        Account account = dao.constructAccount(study, EMAIL, PHONE, EXTERNAL_ID, DUMMY_PASSWORD);
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, account.getStudyId());
-        assertEquals(EMAIL, account.getEmail());
-        assertEquals(PHONE.getNationalFormat(), account.getPhone().getNationalFormat());
-        assertEquals(Boolean.FALSE, account.getEmailVerified());
-        assertEquals(Boolean.FALSE, account.getPhoneVerified());
-        // These are the same because we've mocked the GUID-creation method to always return
-        // this value.
-        assertEquals(HEALTH_CODE, account.getHealthCode());
-        assertEquals(HEALTH_CODE, account.getId());
-        assertEquals(EXTERNAL_ID, account.getExternalId());
-        assertEquals(PasswordAlgorithm.DEFAULT_PASSWORD_ALGORITHM, account.getPasswordAlgorithm());
-
-        // validate password hash
-        assertTrue(PasswordAlgorithm.DEFAULT_PASSWORD_ALGORITHM.checkHash(account.getPasswordHash(), DUMMY_PASSWORD));
-    }
-    
-    @Test
-    public void constructAccountWithoutPasswordWorks() throws Exception {
-        // execute and validate
-        Account account = dao.constructAccount(study, EMAIL, PHONE, EXTERNAL_ID, null);
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, account.getStudyId());
-        assertEquals(EMAIL, account.getEmail());
-        assertEquals(PHONE.getNationalFormat(), account.getPhone().getNationalFormat());
-        assertEquals(Boolean.FALSE, account.getEmailVerified());
-        assertEquals(Boolean.FALSE, account.getPhoneVerified());
-        assertEquals(HEALTH_CODE, account.getHealthCode());
-        assertEquals(EXTERNAL_ID, account.getExternalId());
-        assertNull(account.getPasswordHash());
-        assertNull(account.getPasswordAlgorithm());
-    }
-
-    @Test
     public void createAccountSuccess() {
         // Study passed into createAccount() takes precedence over StudyId in the Account object. To test this, make
         // the account have a different study.

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -339,21 +339,25 @@ public class ParticipantServiceTest {
         verify(accountWorkflowService).sendEmailVerificationToken(STUDY, ID, EMAIL);
         
         Account account = accountCaptor.getValue();
+        assertEquals(ID, account.getId());
         assertEquals(STUDY.getIdentifier(), account.getStudyId());
+        // Not healthCode because the mock always returns the ID value, but this is
+        // set by calling the generateGUID() method, which is correct.
+        assertEquals(ID, account.getHealthCode());
         assertEquals(EMAIL, account.getEmail());
+        assertFalse(account.getEmailVerified());
         assertEquals(PHONE, account.getPhone());
+        assertFalse(account.getPhoneVerified());
         assertEquals(EXTERNAL_ID, account.getExternalId());
         assertNotNull(account.getPasswordHash());
         assertEquals(PasswordAlgorithm.DEFAULT_PASSWORD_ALGORITHM, account.getPasswordAlgorithm());
         assertNotEquals(PASSWORD, account.getPasswordHash());
-        
         assertEquals(FIRST_NAME, account.getFirstName());
         assertEquals(LAST_NAME, account.getLastName());
         assertEquals("true", account.getAttributes().get("can_be_recontacted"));
         assertEquals(DEV_CALLER_ROLES, account.getRoles());
         assertEquals(TestUtils.getClientData(), account.getClientData());
         assertEquals(AccountStatus.UNVERIFIED, account.getStatus());
-        assertFalse(account.getEmailVerified());
         assertEquals(SharingScope.ALL_QUALIFIED_RESEARCHERS, account.getSharingScope());
         assertEquals(Boolean.TRUE, account.getNotifyByEmail());
         assertEquals(EXTERNAL_ID, account.getExternalId());

--- a/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/test/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge.services;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -42,6 +43,7 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.mockito.invocation.InvocationOnMock;
 
 import org.sagebionetworks.bridge.BridgeUtils;
@@ -71,6 +73,7 @@ import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.accounts.ExternalIdentifier;
 import org.sagebionetworks.bridge.models.accounts.IdentifierHolder;
 import org.sagebionetworks.bridge.models.accounts.IdentifierUpdate;
+import org.sagebionetworks.bridge.models.accounts.PasswordAlgorithm;
 import org.sagebionetworks.bridge.models.accounts.Phone;
 import org.sagebionetworks.bridge.models.accounts.SharingScope;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
@@ -164,8 +167,8 @@ public class ParticipantServiceTest {
             .withPhone(TestConstants.PHONE).withPassword(PASSWORD).build();
     private static final SignIn REAUTH_REQUEST = new SignIn.Builder().withStudy(TestConstants.TEST_STUDY_IDENTIFIER).withEmail(EMAIL)
             .withReauthToken("ASDF").build();
-    private static final ExternalIdentifier EXT_ID = ExternalIdentifier.create(STUDY.getStudyIdentifier(), EXTERNAL_ID);
     
+    @Spy
     private ParticipantService participantService;
     
     @Mock
@@ -233,13 +236,16 @@ public class ParticipantServiceTest {
     
     private Account account;
     
+    private ExternalIdentifier extId;
+
+    
     @Before
     public void before() {
+        extId = ExternalIdentifier.create(STUDY.getStudyIdentifier(), EXTERNAL_ID);
         STUDY.setExternalIdValidationEnabled(false);
         STUDY.setExternalIdRequiredOnSignup(false);
         STUDY.setEmailVerificationEnabled(false);
         STUDY.setAccountLimit(0);
-        participantService = new ParticipantService();
         participantService.setAccountDao(accountDao);
         participantService.setSmsService(smsService);
         participantService.setSubpopulationService(subpopService);
@@ -303,7 +309,8 @@ public class ParticipantServiceTest {
         account.setPhone(phone);
         account.setExternalId(EXTERNAL_ID);
         account.setStudyId(TestConstants.TEST_STUDY_IDENTIFIER);
-        when(accountDao.constructAccount(any(), any(), any(), any(), any())).thenReturn(account);
+        when(participantService.getAccount()).thenReturn(account);
+        when(participantService.generateGUID()).thenReturn(ID);
         when(accountDao.getAccount(ACCOUNT_ID)).thenReturn(account);
         when(externalIdService.getExternalId(any(), any())).thenReturn(Optional.empty());
     }
@@ -320,26 +327,33 @@ public class ParticipantServiceTest {
         STUDY.setEmailVerificationEnabled(true);
         mockHealthCodeAndAccountRetrieval();
         
-        when(externalIdService.getExternalId(STUDY.getStudyIdentifier(), EXTERNAL_ID)).thenReturn(Optional.of(EXT_ID));
+        when(externalIdService.getExternalId(STUDY.getStudyIdentifier(), EXTERNAL_ID)).thenReturn(Optional.of(extId));
         
         IdentifierHolder idHolder = participantService.createParticipant(STUDY, PARTICIPANT, true);
         assertEquals(ID, idHolder.getIdentifier());
         
-        verify(accountDao).constructAccount(STUDY, EMAIL, PHONE, EXTERNAL_ID, PASSWORD);
-        verify(externalIdService).commitAssignExternalId(EXT_ID);
+        verify(externalIdService).commitAssignExternalId(extId);
         
         // suppress email (true) == sendEmail (false)
         verify(accountDao).createAccount(eq(STUDY), accountCaptor.capture(), any());
         verify(accountWorkflowService).sendEmailVerificationToken(STUDY, ID, EMAIL);
         
         Account account = accountCaptor.getValue();
+        assertEquals(STUDY.getIdentifier(), account.getStudyId());
+        assertEquals(EMAIL, account.getEmail());
+        assertEquals(PHONE, account.getPhone());
+        assertEquals(EXTERNAL_ID, account.getExternalId());
+        assertNotNull(account.getPasswordHash());
+        assertEquals(PasswordAlgorithm.DEFAULT_PASSWORD_ALGORITHM, account.getPasswordAlgorithm());
+        assertNotEquals(PASSWORD, account.getPasswordHash());
+        
         assertEquals(FIRST_NAME, account.getFirstName());
         assertEquals(LAST_NAME, account.getLastName());
         assertEquals("true", account.getAttributes().get("can_be_recontacted"));
         assertEquals(DEV_CALLER_ROLES, account.getRoles());
         assertEquals(TestUtils.getClientData(), account.getClientData());
         assertEquals(AccountStatus.UNVERIFIED, account.getStatus());
-        assertNull(account.getEmailVerified());
+        assertFalse(account.getEmailVerified());
         assertEquals(SharingScope.ALL_QUALIFIED_RESEARCHERS, account.getSharingScope());
         assertEquals(Boolean.TRUE, account.getNotifyByEmail());
         assertEquals(EXTERNAL_ID, account.getExternalId());
@@ -382,15 +396,14 @@ public class ParticipantServiceTest {
         STUDY.setExternalIdValidationEnabled(true);
         mockHealthCodeAndAccountRetrieval();
         when(externalIdService.getExternalId(STUDY.getStudyIdentifier(), EXTERNAL_ID))
-            .thenReturn(Optional.of(EXT_ID));
+            .thenReturn(Optional.of(extId));
         
         participantService.createParticipant(STUDY, PARTICIPANT, false);
         
         // The order of these calls matters.
         InOrder inOrder = Mockito.inOrder(accountDao, externalIdService);
-        inOrder.verify(accountDao).constructAccount(STUDY, EMAIL, PHONE, EXTERNAL_ID, PASSWORD);
         inOrder.verify(accountDao).createAccount(eq(STUDY), accountCaptor.capture(), any());
-        inOrder.verify(externalIdService).commitAssignExternalId(EXT_ID);
+        inOrder.verify(externalIdService).commitAssignExternalId(extId);
         
         Account account = accountCaptor.getValue();
         assertEquals(EXTERNAL_ID, account.getExternalId());
@@ -457,7 +470,7 @@ public class ParticipantServiceTest {
 
         verify(accountWorkflowService).sendEmailVerificationToken(any(), any(), any());
         assertEquals(AccountStatus.UNVERIFIED, account.getStatus());
-        assertNull(account.getEmailVerified());
+        assertFalse(account.getEmailVerified());
     }
     
     @Test
@@ -471,7 +484,7 @@ public class ParticipantServiceTest {
 
         verify(accountWorkflowService, never()).sendEmailVerificationToken(any(), any(), any());
         assertEquals(AccountStatus.UNVERIFIED, account.getStatus());
-        assertNull(account.getEmailVerified());
+        assertFalse(account.getEmailVerified());
     }
 
     @Test
@@ -486,7 +499,7 @@ public class ParticipantServiceTest {
 
         verify(accountWorkflowService, never()).sendEmailVerificationToken(any(), any(), any());
         assertEquals(AccountStatus.ENABLED, account.getStatus());
-        assertNull(account.getEmailVerified());
+        assertFalse(account.getEmailVerified());
     }
     
     @Test
@@ -509,7 +522,7 @@ public class ParticipantServiceTest {
 
         verify(accountWorkflowService).sendPhoneVerificationToken(STUDY, ID, PHONE);
         assertEquals(AccountStatus.UNVERIFIED, account.getStatus());
-        assertNull(account.getPhoneVerified());
+        assertFalse(account.getPhoneVerified());
     }
 
     @Test
@@ -523,7 +536,7 @@ public class ParticipantServiceTest {
 
         verify(accountWorkflowService, never()).sendPhoneVerificationToken(any(), any(), any());
         assertEquals(AccountStatus.UNVERIFIED, account.getStatus());
-        assertNull(account.getPhoneVerified());
+        assertFalse(account.getPhoneVerified());
     }
 
     @Test
@@ -536,7 +549,7 @@ public class ParticipantServiceTest {
 
         verify(accountWorkflowService, never()).sendPhoneVerificationToken(any(), any(), any());
         assertEquals(AccountStatus.ENABLED, account.getStatus());
-        assertNull(account.getPhoneVerified());
+        assertFalse(account.getPhoneVerified());
     }
 
     @Test
@@ -557,8 +570,8 @@ public class ParticipantServiceTest {
         participantService.createParticipant(STUDY, idParticipant, false);
         
         assertEquals(AccountStatus.UNVERIFIED, account.getStatus());
-        assertNull(account.getPhoneVerified());
-        assertNull(account.getEmailVerified());
+        assertFalse(account.getPhoneVerified());
+        assertFalse(account.getEmailVerified());
     }
     
     @Test
@@ -570,8 +583,8 @@ public class ParticipantServiceTest {
         participantService.createParticipant(STUDY, idParticipant, false);
         
         assertEquals(AccountStatus.ENABLED, account.getStatus());
-        assertNull(account.getPhoneVerified());
-        assertNull(account.getEmailVerified());
+        assertFalse(account.getPhoneVerified());
+        assertFalse(account.getEmailVerified());
     }
 
     @Test
@@ -953,14 +966,13 @@ public class ParticipantServiceTest {
         assertEquals(EMAIL, accountIdCaptor.getValue().getEmail());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void updateParticipantWithExternalIdValidationAddingId() {
         BridgeUtils.setRequestContext(new RequestContext.Builder().withCallerRoles(RESEARCH_CALLER_ROLES).build());
         
         STUDY.setExternalIdValidationEnabled(true);
         mockHealthCodeAndAccountRetrieval();
-        when(externalIdService.getExternalId(TestConstants.TEST_STUDY, EXTERNAL_ID)).thenReturn(Optional.of(EXT_ID));
+        when(externalIdService.getExternalId(TestConstants.TEST_STUDY, EXTERNAL_ID)).thenReturn(Optional.of(extId));
 
         account.setExternalId(null); // account can be updated because it's null
 
@@ -969,7 +981,7 @@ public class ParticipantServiceTest {
         // The order here is significant.
         InOrder inOrder = Mockito.inOrder(accountDao, externalIdService);
         inOrder.verify(accountDao).updateAccount(accountCaptor.capture(), any());
-        inOrder.verify(externalIdService).commitAssignExternalId(EXT_ID);
+        inOrder.verify(externalIdService).commitAssignExternalId(extId);
         
         Account account = accountCaptor.getValue();
         assertEquals(FIRST_NAME, account.getFirstName());
@@ -1553,12 +1565,12 @@ public class ParticipantServiceTest {
         STUDY.setExternalIdValidationEnabled(true);
         STUDY.setExternalIdRequiredOnSignup(true);
         mockHealthCodeAndAccountRetrieval();
-        when(externalIdService.getExternalId(STUDY.getStudyIdentifier(), EXTERNAL_ID)).thenReturn(Optional.of(EXT_ID));
+        when(externalIdService.getExternalId(STUDY.getStudyIdentifier(), EXTERNAL_ID)).thenReturn(Optional.of(extId));
         
         participantService.createParticipant(STUDY, PARTICIPANT, false);
         
         // Validated and required, use reservation service and don't set as option
-        verify(externalIdService).commitAssignExternalId(EXT_ID);
+        verify(externalIdService).commitAssignExternalId(extId);
     }
 
     @Test
@@ -1617,7 +1629,6 @@ public class ParticipantServiceTest {
         verify(accountDao, never()).updateAccount(any(), any());
     }
     
-    @SuppressWarnings("unchecked")
     @Test
     public void updateIdentifiersAssignsExternalIdEvenWhenAlreadyAssigned() {
         // Fully associated external ID can be changed by an update.
@@ -1880,11 +1891,11 @@ public class ParticipantServiceTest {
         mockHealthCodeAndAccountRetrieval();
         
         STUDY.setExternalIdValidationEnabled(true);
-        when(externalIdService.getExternalId(STUDY.getStudyIdentifier(), EXTERNAL_ID)).thenReturn(Optional.of(EXT_ID));
+        when(externalIdService.getExternalId(STUDY.getStudyIdentifier(), EXTERNAL_ID)).thenReturn(Optional.of(extId));
         
         participantService.createParticipant(STUDY, PARTICIPANT, false);
         
-        verify(externalIdService).commitAssignExternalId(EXT_ID);
+        verify(externalIdService).commitAssignExternalId(extId);
     }
 
     @Test
@@ -1943,8 +1954,11 @@ public class ParticipantServiceTest {
         
         participantService.updateParticipant(STUDY, PARTICIPANT);
         
+        ArgumentCaptor<ExternalIdentifier> extIdCaptor = ArgumentCaptor.forClass(ExternalIdentifier.class);
+        
         assertEquals(EXTERNAL_ID, account.getExternalId());
-        verify(externalIdService).commitAssignExternalId(EXT_ID);
+        verify(externalIdService).commitAssignExternalId(extIdCaptor.capture());
+        assertEquals(HEALTH_CODE, extIdCaptor.getValue().getHealthCode());
     }
 
     @Test
@@ -2145,26 +2159,24 @@ public class ParticipantServiceTest {
     @Test
     public void createParticipantNoExternalIdAddedDoesNothing() {
         BridgeUtils.setRequestContext(new RequestContext.Builder().build());
-        when(accountDao.constructAccount(STUDY, EMAIL, PHONE, null, PASSWORD)).thenReturn(account);
+        when(participantService.getAccount()).thenReturn(account);
         StudyParticipant participant = withParticipant().withExternalId(null).build();
         
         participantService.createParticipant(STUDY, participant, false);
         
-        verify(accountDao).constructAccount(STUDY, EMAIL, PHONE, null, PASSWORD);
         verify(accountDao).createAccount(eq(STUDY), eq(account), any());
         verify(externalIdService).commitAssignExternalId(null);
     }
     @Test
     public void createParticipantExternalIdAddedUpdatesExternalId() {
         BridgeUtils.setRequestContext(new RequestContext.Builder().build());
-        when(accountDao.constructAccount(STUDY, EMAIL, PHONE, EXTERNAL_ID, PASSWORD)).thenReturn(account);
-        when(externalIdService.getExternalId(STUDY.getStudyIdentifier(), EXTERNAL_ID)).thenReturn(Optional.of(EXT_ID));
+        when(externalIdService.getExternalId(STUDY.getStudyIdentifier(), EXTERNAL_ID)).thenReturn(Optional.of(extId));
+        when(participantService.getAccount()).thenReturn(account);
         
         participantService.createParticipant(STUDY, PARTICIPANT, false);
         
-        verify(accountDao).constructAccount(STUDY, EMAIL, PHONE, EXTERNAL_ID, PASSWORD);
         verify(accountDao).createAccount(eq(STUDY), eq(account), any());
-        verify(externalIdService).commitAssignExternalId(EXT_ID);
+        verify(externalIdService).commitAssignExternalId(extId);
     }
     @Test
     public void updateParticipantValidatesManagedExternalId() {
@@ -2210,7 +2222,7 @@ public class ParticipantServiceTest {
         verify(accountDao).updateAccount(account, null);
         assertNull(account.getExternalId());
     }
-    @SuppressWarnings("unchecked")
+
     @Test
     public void updateParticipantNoExternalIdsOneAddedUpdates() {
         BridgeUtils.setRequestContext(new RequestContext.Builder().build());
@@ -2218,13 +2230,13 @@ public class ParticipantServiceTest {
         mockHealthCodeAndAccountRetrieval();
         account.setExternalId(null);
         
-        when(externalIdService.getExternalId(STUDY.getStudyIdentifier(), EXTERNAL_ID)).thenReturn(Optional.of(EXT_ID));
+        when(externalIdService.getExternalId(STUDY.getStudyIdentifier(), EXTERNAL_ID)).thenReturn(Optional.of(extId));
         
         participantService.updateParticipant(STUDY, PARTICIPANT);
         
         verify(accountDao).updateAccount(eq(account), any());
         assertEquals(EXTERNAL_ID, account.getExternalId());
-        verify(externalIdService).commitAssignExternalId(EXT_ID);
+        verify(externalIdService).commitAssignExternalId(extId);
     }
     @Test
     public void updateParticipantExternalIdsExistNoneAddedDoesNothing() {
@@ -2272,22 +2284,22 @@ public class ParticipantServiceTest {
         verify(accountDao).updateAccount(account, null);
         assertNull(account.getExternalId());
     }
-    @SuppressWarnings("unchecked")
+
     @Test
     public void updateParticipantAsResearcherNoExternalIdsOneAddedUpdates() {
         STUDY.setExternalIdValidationEnabled(true);
         mockHealthCodeAndAccountRetrieval();
         account.setExternalId(null);
         
-        when(externalIdService.getExternalId(STUDY.getStudyIdentifier(), EXTERNAL_ID)).thenReturn(Optional.of(EXT_ID));
+        when(externalIdService.getExternalId(STUDY.getStudyIdentifier(), EXTERNAL_ID)).thenReturn(Optional.of(extId));
         
         participantService.updateParticipant(STUDY, PARTICIPANT);
         
         verify(accountDao).updateAccount(eq(account), any());
         assertEquals(EXTERNAL_ID, account.getExternalId());
-        verify(externalIdService).commitAssignExternalId(EXT_ID);
+        verify(externalIdService).commitAssignExternalId(extId);
     }
-    @SuppressWarnings("unchecked")
+
     @Test
     public void updateParticipantAsResearcherExternalIdsExistNoneMatchOneAddedUpdates() {
         STUDY.setExternalIdValidationEnabled(true);
@@ -2312,7 +2324,7 @@ public class ParticipantServiceTest {
         mockAccountRetrievalWithSubstudyD();
         account.setExternalId(null);
 
-        when(externalIdService.getExternalId(STUDY.getStudyIdentifier(), EXTERNAL_ID)).thenReturn(Optional.of(EXT_ID));
+        when(externalIdService.getExternalId(STUDY.getStudyIdentifier(), EXTERNAL_ID)).thenReturn(Optional.of(extId));
 
         participantService.updateParticipant(STUDY, PARTICIPANT);
         
@@ -2376,7 +2388,6 @@ public class ParticipantServiceTest {
         verify(activityEventService).getActivityEventList(HEALTH_CODE);
     }
     
-    @SuppressWarnings("unchecked")
     @Test
     public void normalUserCanAddExternalIdOnUpdate() {
         BridgeUtils.setRequestContext(RequestContext.NULL_INSTANCE);
@@ -2405,7 +2416,6 @@ public class ParticipantServiceTest {
         assertEquals(EXTERNAL_ID, accountCaptor.getValue().getExternalId());
     }
     
-    @SuppressWarnings("unchecked")
     @Test
     public void researcherCanChangeUnmanagedExternalIdOnUpdate() {
         mockHealthCodeAndAccountRetrieval();
@@ -2421,7 +2431,6 @@ public class ParticipantServiceTest {
         verify(externalIdService).commitAssignExternalId(null);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void researcherCanChangeManagedExternalIdOnUpdate() {
         mockHealthCodeAndAccountRetrieval();
@@ -2443,11 +2452,11 @@ public class ParticipantServiceTest {
     @Test
     public void assignExternalId() {
         mockHealthCodeAndAccountRetrieval();
-        when(externalIdService.getExternalId(STUDY.getStudyIdentifier(), EXTERNAL_ID)).thenReturn(Optional.of(EXT_ID));
+        when(externalIdService.getExternalId(STUDY.getStudyIdentifier(), EXTERNAL_ID)).thenReturn(Optional.of(extId));
         
-        participantService.assignExternalId(ACCOUNT_ID, EXT_ID);
+        participantService.assignExternalId(ACCOUNT_ID, extId);
         
-        verify(externalIdService).commitAssignExternalId(EXT_ID);
+        verify(externalIdService).commitAssignExternalId(extId);
     }
     
     @Test(expected = EntityNotFoundException.class)
@@ -2456,7 +2465,7 @@ public class ParticipantServiceTest {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
                 .withCallerSubstudies(ImmutableSet.of("substudyA")).build());
         
-        participantService.assignExternalId(ACCOUNT_ID, EXT_ID);
+        participantService.assignExternalId(ACCOUNT_ID, extId);
     }
     
     @Test(expected = EntityNotFoundException.class)
@@ -2747,8 +2756,8 @@ public class ParticipantServiceTest {
     
     @Test
     public void rollbackCreateParticipantWhenAccountCreationFails() {
-        when(accountDao.constructAccount(STUDY, EMAIL, PHONE, EXTERNAL_ID, PASSWORD)).thenReturn(account);
-        when(externalIdService.getExternalId(STUDY.getStudyIdentifier(), EXTERNAL_ID)).thenReturn(Optional.of(EXT_ID));
+        when(externalIdService.getExternalId(STUDY.getStudyIdentifier(), EXTERNAL_ID)).thenReturn(Optional.of(extId));
+        when(participantService.getAccount()).thenReturn(account);
         doThrow(new ConcurrentModificationException("")).when(accountDao).createAccount(eq(STUDY), eq(account), any());
         
         try {
@@ -2762,7 +2771,7 @@ public class ParticipantServiceTest {
     @Test
     public void rollbackUpdateParticipantWhenAccountUpdateFails() {
         when(accountDao.getAccount(ACCOUNT_ID)).thenReturn(account);
-        when(externalIdService.getExternalId(STUDY.getStudyIdentifier(), EXTERNAL_ID)).thenReturn(Optional.of(EXT_ID));
+        when(externalIdService.getExternalId(STUDY.getStudyIdentifier(), EXTERNAL_ID)).thenReturn(Optional.of(extId));
         doThrow(new ConcurrentModificationException("")).when(accountDao).updateAccount(eq(account), any());
         
         try {
@@ -2829,7 +2838,6 @@ public class ParticipantServiceTest {
         
         participantService.createParticipant(STUDY, participant, false);
         
-        verify(accountDao).constructAccount(STUDY, EMAIL, PHONE, EXTERNAL_ID, PASSWORD);
         verify(accountDao).createAccount(eq(STUDY), accountCaptor.capture(), any());
         Account account = accountCaptor.getValue();
         


### PR DESCRIPTION
The account classes are complicated enough without this unnecessary call into the account DAO.