### PR TITLE
Fix for BRIDGE-2410

### DIFF
--- a/app/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -208,34 +208,41 @@ public class AuthenticationService {
         // First look to see if reauthCacheKey is in cache. If it is, return the existing session. This 
         // creates a grace period during which concurrent requests with the same reauth token will work.
         Tuple<String> persisedReauthTuple = cacheProvider.getObject(reauthCacheKey, TUPLE_TYPE);
-        
-        Account account = null;
-        boolean cacheReauthentication = false;
         if (persisedReauthTuple != null) {
             String sessionToken = persisedReauthTuple.getLeft();
-            // reauthToken is no longer needed, as a new one will be created by re-creating the session
-            // Leaving the tuple data structure in place for compatibility.
+            String reauthToken = persisedReauthTuple.getRight();
             
             // Is it possible for this not to resolve to a session? Play it safe and check
             UserSession session = cacheProvider.getUserSession(sessionToken);
             if (session == null) {
                 throw new EntityNotFoundException(Account.class);
             }
-            AccountId accountId = AccountId.forId(session.getStudyIdentifier().getIdentifier(), session.getId());
-            account = accountDao.getAccountAfterAuthentication(accountId);
-        } else {
-            account = accountDao.reauthenticate(study, signIn);
-            cacheReauthentication = true;
+            
+            // Update the session consent status (only), in case an upgrade with consent change has
+            // occurred. 
+            AccountId accountId = AccountId.forId(signIn.getStudyId(), session.getId());
+            Account account = accountDao.getAccount(accountId);
+            CriteriaContext newContext = updateContextFromSession(context, session);
+            session.setConsentStatuses(consentService.getConsentStatuses(newContext, account));
+            cacheProvider.setUserSession(session);
+            
+            if (!session.doesConsent() && !session.isInRole(Roles.ADMINISTRATIVE_ROLES)) {
+                throw new ConsentRequiredException(session);
+            }
+            
+            session.setReauthToken(reauthToken);
+            return session;
         }
+        
+        Account account = accountDao.reauthenticate(study, signIn);
 
         UserSession session = getSessionFromAccount(study, context, account);
+
+        Tuple<String> reauthTuple = new Tuple<>(session.getSessionToken(), session.getReauthToken());
         cacheProvider.setUserSession(session);
+        // Longer than the caching of the reauthentication token, which provides a grace period for sign ins.
+        cacheProvider.setObject(reauthCacheKey, reauthTuple, BridgeConstants.REAUTH_TOKEN_GRACE_PERIOD_SECONDS);
         
-        if (cacheReauthentication) {
-            // We do not reset the expiration period on re-retrievals of a successful reauthentication.
-            Tuple<String> reauthTuple = new Tuple<>(session.getSessionToken(), session.getReauthToken());
-            cacheProvider.setObject(reauthCacheKey, reauthTuple, BridgeConstants.REAUTH_TOKEN_GRACE_PERIOD_SECONDS);
-        }
         if (!session.doesConsent() && !session.isInRole(Roles.ADMINISTRATIVE_ROLES)) {
             throw new ConsentRequiredException(session);
         }

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
@@ -461,27 +461,23 @@ public class AuthenticationServiceMockTest {
     
     @Test
     public void reauthenticationFromCache() {
-        Tuple<String> tuple = new Tuple<>(TOKEN, "newReauthToken");
+        Tuple<String> tuple = new Tuple<>("sessionToken", TOKEN);
         
         StudyParticipant participant = new StudyParticipant.Builder().withId(USER_ID).build();
         UserSession oldSession = new UserSession();
         oldSession.setStudyIdentifier(study.getStudyIdentifier());
         oldSession.setParticipant(participant);
         oldSession.setConsentStatuses(UNCONSENTED_STATUS_MAP);
+        oldSession.setSessionToken("sessionToken");
         
         doReturn(tuple).when(cacheProvider).getObject(REAUTH_CACHE_TOKEN, AuthenticationService.TUPLE_TYPE);
-        doReturn(oldSession).when(cacheProvider).getUserSession(TOKEN);
-        doReturn(participant).when(participantService).getParticipant(study, account, false);
-        // Re-checking the consent status, we see the user is consented, despite the 
-        // cached session.
+        doReturn(oldSession).when(cacheProvider).getUserSession("sessionToken");
+        // Re-checking the consent status, we see the user is consented, despite the cached session.
         doReturn(CONSENTED_STATUS_MAP).when(consentService).getConsentStatuses(any(), any());
-        
-        AccountId accountId = AccountId.forId(study.getIdentifier(), USER_ID);
-        doReturn(account).when(accountDao).getAccountAfterAuthentication(accountId);
-        account.setReauthToken("newReauthToken");
-        
+
         UserSession returned = service.reauthenticate(study, CONTEXT, REAUTH_REQUEST);
-        assertEquals("newReauthToken", returned.getReauthToken());
+        assertEquals("sessionToken", returned.getSessionToken());
+        assertEquals(TOKEN, returned.getReauthToken());
         
         // We don't have to retrieve this.
         verify(accountDao, never()).reauthenticate(any(), any());
@@ -489,7 +485,7 @@ public class AuthenticationServiceMockTest {
     
     @Test(expected = ConsentRequiredException.class)
     public void reauthenticationFromCacheFailsOnConsent() {
-        Tuple<String> tuple = new Tuple<>(TOKEN, "newReauthToken");
+        Tuple<String> tuple = new Tuple<>("sessionToken", TOKEN);
         
         StudyParticipant participant = new StudyParticipant.Builder().withId(USER_ID).build();
         UserSession oldSession = new UserSession();
@@ -498,14 +494,11 @@ public class AuthenticationServiceMockTest {
         oldSession.setConsentStatuses(CONSENTED_STATUS_MAP);
         
         doReturn(tuple).when(cacheProvider).getObject(REAUTH_CACHE_TOKEN, AuthenticationService.TUPLE_TYPE);
-        doReturn(oldSession).when(cacheProvider).getUserSession(TOKEN);
-        doReturn(participant).when(participantService).getParticipant(study, account, false);
-        // Re-checking the consent status, we see the user is no longer consented, 
-        // despite the cached session.
+        doReturn(oldSession).when(cacheProvider).getUserSession("sessionToken");
         doReturn(UNCONSENTED_STATUS_MAP).when(consentService).getConsentStatuses(any(), any());
         
         AccountId accountId = AccountId.forId(study.getIdentifier(), USER_ID);
-        doReturn(account).when(accountDao).getAccountAfterAuthentication(accountId);
+        doReturn(account).when(accountDao).getAccount(accountId);
         
         service.reauthenticate(study, CONTEXT, REAUTH_REQUEST);
     }


### PR DESCRIPTION
Reverting to older reauthentication method, and then added a very specific update of consent status only when the session is retrieved with a cached reauthentication token. This addresses the need to pick up consent changes on app update, if the client is making multiple concurrent reauthentication requests. You would think this is rare, but apparently it is not, at least not when testing upgrade of an existing app.

Note that the reauth token returned to the client will expire because it only persists in the cache (again the pending PR changes address this).