### PR TITLE
Remove AccountDao.getAccountAfterAuthentication()

### DIFF
--- a/app/org/sagebionetworks/bridge/dao/AccountDao.java
+++ b/app/org/sagebionetworks/bridge/dao/AccountDao.java
@@ -54,20 +54,9 @@ public interface AccountDao {
     void deleteReauthToken(AccountId accountId);
     
     /**
-     * Retrieve an account where authentication is handled outside of the DAO (If we
-     * retrieve and return a session to the user through a path that does not call
-     * authenticate/reauthenticate, then you will need to call this method to get
-     * the final account). This retrieves the account, and rotates and returns a new
-     * reauthorization token, the same as the authenticate and reauthenticate calls.
-     * This method returns null if the Account does not exist.
-     */
-    Account getAccountAfterAuthentication(AccountId accountId);
-    
-    /**
-     * Create an account. The account object should initially be retrieved from the 
-     * constructAccount() factory method. If the optional consumer is passed to this method and 
-     * it throws an exception, the account will not be persisted (the consumer is executed after 
-     * the persist is executed in a transaction, however).
+     * Create an account. If the optional consumer is passed to this method and it throws an 
+     * exception, the account will not be persisted (the consumer is executed after the persist 
+     * is executed in a transaction, however).
      */
     void createAccount(Study study, Account account, Consumer<Account> afterPersistConsumer);
     

--- a/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
+++ b/app/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
@@ -227,22 +227,6 @@ public class HibernateAccountDao implements AccountDao {
     }
 
     @Override
-    public Account getAccountAfterAuthentication(AccountId accountId) {
-        Account hibernateAccount = getHibernateAccount(accountId);
-
-        if (hibernateAccount != null) {
-            if ( validateHealthCode(hibernateAccount) ) {
-                Account updated = hibernateHelper.update(hibernateAccount, null);
-                hibernateAccount.setVersion(updated.getVersion());
-            }
-            return hibernateAccount;
-        } else {
-            // In keeping with the email implementation, just return null
-            return null;
-        }
-    }
-
-    @Override
     public void deleteReauthToken(AccountId accountId) {
         Account hibernateAccount = getHibernateAccount(accountId);
         if (hibernateAccount != null) {
@@ -312,9 +296,9 @@ public class HibernateAccountDao implements AccountDao {
     @Override
     public Account getAccount(AccountId accountId) {
         Account hibernateAccount = getHibernateAccount(accountId);
+
         if (hibernateAccount != null) {
-            boolean accountUpdated = validateHealthCode(hibernateAccount);
-            if (accountUpdated) {
+            if ( validateHealthCode(hibernateAccount) ) {
                 Account updated = hibernateHelper.update(hibernateAccount, null);
                 hibernateAccount.setVersion(updated.getVersion());
             }

--- a/app/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/app/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -376,7 +376,7 @@ public class AuthenticationService {
         
         // Throws AuthenticationFailedException if the token is missing or incorrect
         AccountId accountId = accountWorkflowService.channelSignIn(channelType, context, signIn, validator);
-        Account account = accountDao.getAccountAfterAuthentication(accountId);
+        Account account = accountDao.getAccount(accountId);
         // This should be unlikely, but if someone deleted the account while the token was outstanding
         if (account == null) {
             throw new EntityNotFoundException(Account.class);

--- a/test/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
+++ b/test/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
@@ -369,7 +369,7 @@ public class AuthenticationServiceMockTest {
         account.setReauthToken(REAUTH_TOKEN);
         doReturn(SIGN_IN_WITH_EMAIL.getAccountId()).when(accountWorkflowService).channelSignIn(ChannelType.EMAIL,
                 CONTEXT, SIGN_IN_WITH_EMAIL, SignInValidator.EMAIL_SIGNIN);
-        doReturn(account).when(accountDao).getAccountAfterAuthentication(SIGN_IN_WITH_EMAIL.getAccountId());
+        doReturn(account).when(accountDao).getAccount(SIGN_IN_WITH_EMAIL.getAccountId());
         doReturn(PARTICIPANT).when(participantService).getParticipant(study, account, false);
         doReturn(CONSENTED_STATUS_MAP).when(consentService).getConsentStatuses(any(), any());
 
@@ -379,7 +379,7 @@ public class AuthenticationServiceMockTest {
         assertEquals(REAUTH_TOKEN, retSession.getReauthToken());
         
         InOrder inOrder = Mockito.inOrder(cacheProvider, accountDao);
-        inOrder.verify(accountDao).getAccountAfterAuthentication(SIGN_IN_WITH_EMAIL.getAccountId());
+        inOrder.verify(accountDao).getAccount(SIGN_IN_WITH_EMAIL.getAccountId());
         inOrder.verify(accountDao).deleteReauthToken(ACCOUNT_ID);
         inOrder.verify(cacheProvider).removeSessionByUserId(USER_ID);
         inOrder.verify(accountDao).verifyChannel(AuthenticationService.ChannelType.EMAIL, account);
@@ -408,7 +408,7 @@ public class AuthenticationServiceMockTest {
         
         doReturn(SIGN_IN_WITH_EMAIL.getAccountId()).when(accountWorkflowService).channelSignIn(ChannelType.EMAIL,
                 CONTEXT, SIGN_IN_WITH_EMAIL, SignInValidator.EMAIL_SIGNIN);
-        doReturn(account).when(accountDao).getAccountAfterAuthentication(SIGN_IN_WITH_EMAIL.getAccountId());
+        doReturn(account).when(accountDao).getAccount(SIGN_IN_WITH_EMAIL.getAccountId());
         
         service.emailSignIn(CONTEXT, SIGN_IN_WITH_EMAIL);
     }
@@ -420,7 +420,7 @@ public class AuthenticationServiceMockTest {
 
         doReturn(SIGN_IN_WITH_EMAIL.getAccountId()).when(accountWorkflowService).channelSignIn(ChannelType.EMAIL,
                 CONTEXT, SIGN_IN_WITH_EMAIL, SignInValidator.EMAIL_SIGNIN);
-        doReturn(account).when(accountDao).getAccountAfterAuthentication(SIGN_IN_WITH_EMAIL.getAccountId());
+        doReturn(account).when(accountDao).getAccount(SIGN_IN_WITH_EMAIL.getAccountId());
         doReturn(participant).when(participantService).getParticipant(study, account, false);
         doReturn(UNCONSENTED_STATUS_MAP).when(consentService).getConsentStatuses(any(), any());
         
@@ -441,7 +441,7 @@ public class AuthenticationServiceMockTest {
         doReturn(participant).when(participantService).getParticipant(study, account, false);
         doReturn(SIGN_IN_WITH_EMAIL.getAccountId()).when(accountWorkflowService).channelSignIn(ChannelType.EMAIL,
                 CONTEXT, SIGN_IN_WITH_EMAIL, SignInValidator.EMAIL_SIGNIN);
-        doReturn(account).when(accountDao).getAccountAfterAuthentication(SIGN_IN_WITH_EMAIL.getAccountId());
+        doReturn(account).when(accountDao).getAccount(SIGN_IN_WITH_EMAIL.getAccountId());
         doReturn(UNCONSENTED_STATUS_MAP).when(consentService).getConsentStatuses(any(), any());
         
         // Does not throw a consent required exception because the participant is an admin. 
@@ -608,7 +608,7 @@ public class AuthenticationServiceMockTest {
         doReturn(participant).when(participantService).getParticipant(study, account, false);
         doReturn(SIGN_IN_WITH_PHONE.getAccountId()).when(accountWorkflowService).channelSignIn(ChannelType.PHONE,
                 CONTEXT, SIGN_IN_WITH_PHONE, SignInValidator.PHONE_SIGNIN);
-        doReturn(account).when(accountDao).getAccountAfterAuthentication(SIGN_IN_WITH_PHONE.getAccountId());
+        doReturn(account).when(accountDao).getAccount(SIGN_IN_WITH_PHONE.getAccountId());
         doReturn(CONSENTED_STATUS_MAP).when(consentService).getConsentStatuses(any(), any());
 
         // Execute and validate.
@@ -643,7 +643,7 @@ public class AuthenticationServiceMockTest {
         doReturn(SIGN_IN_WITH_PHONE.getAccountId()).when(accountWorkflowService).channelSignIn(ChannelType.PHONE,
                 CONTEXT, SIGN_IN_WITH_PHONE, SignInValidator.PHONE_SIGNIN);
         doReturn(UNCONSENTED_STATUS_MAP).when(consentService).getConsentStatuses(any(), any());
-        doReturn(account).when(accountDao).getAccountAfterAuthentication(SIGN_IN_WITH_PHONE.getAccountId());
+        doReturn(account).when(accountDao).getAccount(SIGN_IN_WITH_PHONE.getAccountId());
          
         try {
             service.phoneSignIn(CONTEXT, SIGN_IN_WITH_PHONE);
@@ -940,15 +940,15 @@ public class AuthenticationServiceMockTest {
     @Test
     public void emailSignInWithIntentToParticipate() {
         Account consentedAccount = Account.create();
+        consentedAccount.setId(USER_ID);
 
         when(accountWorkflowService.channelSignIn(ChannelType.EMAIL, CONTEXT, SIGN_IN_WITH_EMAIL,
                 SignInValidator.EMAIL_SIGNIN)).thenReturn(SIGN_IN_WITH_EMAIL.getAccountId());
-        when(accountDao.getAccountAfterAuthentication(any())).thenReturn(account);
+        when(accountDao.getAccount(any())).thenReturn(account, consentedAccount);
         when(participantService.getParticipant(study, account, false)).thenReturn(
                 PARTICIPANT_WITH_ATTRIBUTES);
         when(consentService.getConsentStatuses(any(), eq(account))).thenReturn(UNCONSENTED_STATUS_MAP);
         
-        when(accountDao.getAccount(any())).thenReturn(consentedAccount);
         when(participantService.getParticipant(study, consentedAccount, false)).thenReturn(
                 PARTICIPANT_WITH_ATTRIBUTES);
         when(consentService.getConsentStatuses(any(), eq(consentedAccount))).thenReturn(CONSENTED_STATUS_MAP);
@@ -962,15 +962,15 @@ public class AuthenticationServiceMockTest {
     @Test
     public void phoneSignInWithIntentToParticipate() {
         Account consentedAccount = Account.create();
-
+        consentedAccount.setId(USER_ID);
+        
         when(accountWorkflowService.channelSignIn(ChannelType.PHONE, CONTEXT, SIGN_IN_WITH_PHONE,
                 SignInValidator.PHONE_SIGNIN)).thenReturn(SIGN_IN_WITH_PHONE.getAccountId());
-        when(accountDao.getAccountAfterAuthentication(any())).thenReturn(account);
+        when(accountDao.getAccount(any())).thenReturn(account, consentedAccount);
         when(participantService.getParticipant(study, account, false)).thenReturn(
                 PARTICIPANT_WITH_ATTRIBUTES);
         when(consentService.getConsentStatuses(any(), eq(account))).thenReturn(UNCONSENTED_STATUS_MAP);
         
-        when(accountDao.getAccount(any())).thenReturn(consentedAccount);
         when(participantService.getParticipant(study, consentedAccount, false)).thenReturn(
                 PARTICIPANT_WITH_ATTRIBUTES);
         when(consentService.getConsentStatuses(any(), eq(consentedAccount))).thenReturn(CONSENTED_STATUS_MAP);
@@ -996,7 +996,7 @@ public class AuthenticationServiceMockTest {
     public void consentedEmailSignInDoesNotExecuteIntentToParticipate() {
         when(accountWorkflowService.channelSignIn(ChannelType.EMAIL, CONTEXT, SIGN_IN_WITH_EMAIL,
                 SignInValidator.EMAIL_SIGNIN)).thenReturn(SIGN_IN_WITH_EMAIL.getAccountId());
-        when(accountDao.getAccountAfterAuthentication(any())).thenReturn(account);
+        when(accountDao.getAccount(any())).thenReturn(account);
         when(participantService.getParticipant(study, account, false)).thenReturn(PARTICIPANT);
         when(consentService.getConsentStatuses(any(), eq(account))).thenReturn(CONSENTED_STATUS_MAP);
         
@@ -1009,7 +1009,7 @@ public class AuthenticationServiceMockTest {
     public void consentedPhoneSignInDoesNotExecuteIntentToParticipate() {
         when(accountWorkflowService.channelSignIn(ChannelType.PHONE, CONTEXT, SIGN_IN_WITH_PHONE,
                 SignInValidator.PHONE_SIGNIN)).thenReturn(SIGN_IN_WITH_PHONE.getAccountId());
-        when(accountDao.getAccountAfterAuthentication(any())).thenReturn(account);
+        when(accountDao.getAccount(any())).thenReturn(account);
         when(participantService.getParticipant(study, account, false)).thenReturn(PARTICIPANT);
         when(consentService.getConsentStatuses(any(), eq(account))).thenReturn(CONSENTED_STATUS_MAP);
         


### PR DESCRIPTION
This method is now identical to getAccount(). Removed.