### PR TITLE
remove researcher send SMS API

### DIFF
--- a/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
+++ b/app/org/sagebionetworks/bridge/play/controllers/ParticipantController.java
@@ -432,15 +432,6 @@ public class ParticipantController extends BaseController {
 
         return okResult(participantService.getActivityEvents(study, userId));
     }
-    
-    public Result sendSmsMessage(String userId) throws Exception {
-        UserSession session = getAuthenticatedSession(Roles.RESEARCHER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
-        SmsTemplate template = parseJson(request(), SmsTemplate.class);
-        
-        participantService.sendSmsMessage(study, userId, template);
-        return acceptedResult("Message sent.");
-    }
 
     public Result sendSmsMessageForWorker(String studyId, String userId) {
         getAuthenticatedSession(WORKER);

--- a/conf/routes
+++ b/conf/routes
@@ -111,7 +111,6 @@ POST   /v3/participants/:userId/consents/withdraw                      @org.sage
 POST   /v3/participants/:userId/consents/:guid/resendConsent           @org.sagebionetworks.bridge.play.controllers.ParticipantController.resendConsentAgreement(userId: String, guid: String)
 POST   /v3/participants/:userId/consents/:guid/withdraw                @org.sagebionetworks.bridge.play.controllers.ParticipantController.withdrawConsent(userId: String, guid: String)
 GET    /v3/participants/:userId/activityEvents                         @org.sagebionetworks.bridge.play.controllers.ParticipantController.getActivityEvents(userId: String)
-POST   /v3/participants/:userId/sendSmsMessage                         @org.sagebionetworks.bridge.play.controllers.ParticipantController.sendSmsMessage(userId: String)
 
 # Shared Module
 POST   /v3/sharedmodules/:id/import                   @org.sagebionetworks.bridge.play.controllers.SharedModuleController.importModuleByIdLatestPublishedVersion(id: String)

--- a/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
+++ b/test/org/sagebionetworks/bridge/play/controllers/ParticipantControllerTest.java
@@ -1195,20 +1195,7 @@ public class ParticipantControllerTest {
         
         verify(mockParticipantService).getParticipant(study, ID, false);
     }
-    
-    @Test
-    public void sendSMS() throws Exception {
-        TestUtils.mockPlay().withBody(new SmsTemplate("This is a message")).mock();
-        
-        Result result = controller.sendSmsMessage(ID);
-        
-        TestUtils.assertResult(result, 202, "Message sent.");
-        verify(mockParticipantService).sendSmsMessage(eq(study), eq(ID), templateCaptor.capture());
-        
-        SmsTemplate resultTemplate = templateCaptor.getValue();
-        assertEquals("This is a message", resultTemplate.getMessage());
-    }
-    
+
     @Test
     public void sendSMSForWorker() throws Exception {
         session.setParticipant(new StudyParticipant.Builder().copyOf(session.getParticipant())


### PR DESCRIPTION
No one is currently using this in production, and there's a lot of risk in letting researchers use this API, so we're removing it.